### PR TITLE
Fix workflow: remove npm cache requirement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,11 +32,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: ./website/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build website
         run: npm run build

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -92,7 +92,7 @@ const config: Config = {
           items: [
             {
               label: 'Getting Started',
-              to: '/docs/intro',
+              to: '/docs/',
             },
           ],
         },


### PR DESCRIPTION
- Remove npm cache configuration that requires package-lock.json
- Change npm ci to npm install since lockfile doesn't exist