### PR TITLE
Fix logo and image paths in Docusaurus config

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -62,7 +62,7 @@ const config: Config = {
   ],
 
   themeConfig: {
-    image: 'img/mesozoic-labs-social-card.png',
+    // Social card image for Open Graph - add 'img/mesozoic-labs-social-card.png' when available
     navbar: {
       title: 'Mesozoic Labs',
       logo: {


### PR DESCRIPTION
Remove reference to img/mesozoic-labs-social-card.png which doesn't exist. This prevents potential build failures since onBrokenLinks is set to 'throw'. Added a comment to note the image should be added when available.