### PR TITLE
Fix sitemap to use correct base URL

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -10,8 +10,8 @@ const config: Config = {
   tagline: 'Building robotic dinosaurs through simulation and reinforcement learning',
   favicon: 'img/favicon.ico',
 
-  // GitHub Pages deployment configuration
-  url: 'https://mesozoic-labs.github.io',
+  // Production site URL - used for sitemap, canonical URLs, and social sharing
+  url: 'https://mesozoiclabs.com',
   baseUrl: '/',
 
   // GitHub Pages config


### PR DESCRIPTION
Update the url configuration in docusaurus.config.ts from mesozoic-labs.github.io to the production domain mesozoiclabs.com. This ensures the sitemap, canonical URLs, and social sharing metadata use the correct base URL.