### PR TITLE
Add video rendering and improve dependency installation

### DIFF
--- a/notebooks/sac_training.ipynb
+++ b/notebooks/sac_training.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "source": "# Clone mesozoic-labs and install\n!pip install stable-baselines3[extra]\n!git clone https://github.com/kuds/mesozoic-labs.git /content/mesozoic-labs 2>/dev/null || echo \"Already cloned\"\n!pip install -e /content/mesozoic-labs\n\nfrom IPython.display import clear_output\nclear_output()\nprint('mesozoic-labs installed.')",
+   "source": "# Clone mesozoic-labs and install\n!pip install 'stable-baselines3[extra]'\n!git clone https://github.com/kuds/mesozoic-labs.git /content/mesozoic-labs 2>/dev/null || echo \"Already cloned\"\n!pip install -e /content/mesozoic-labs\n\n# Ensure the environments package is importable even if editable install\n# doesn't register properly in the running kernel.\nimport sys\nif '/content/mesozoic-labs' not in sys.path:\n    sys.path.insert(0, '/content/mesozoic-labs')\n\nfrom IPython.display import clear_output\nclear_output()\nprint('mesozoic-labs installed.')",
    "metadata": {
     "id": "itOOHUv2CQpj",
     "outputId": "79d2b489-c687-4faa-b6b4-ee4233bc8738",
@@ -160,6 +160,18 @@
   {
    "cell_type": "code",
    "source": "eval_log = os.path.join(stage_dir, \"evaluations.npz\")\n\nif os.path.exists(eval_log):\n    data = np.load(eval_log)\n    timesteps = data[\"timesteps\"]\n    results = data[\"results\"]\n    mean_rewards = np.mean(results, axis=1)\n    std_rewards = np.std(results, axis=1)\n\n    plt.figure(figsize=(10, 5))\n    plt.plot(timesteps, mean_rewards, 'r-', label='Mean Reward')\n    plt.fill_between(timesteps,\n                     mean_rewards - std_rewards,\n                     mean_rewards + std_rewards,\n                     alpha=0.3, color='red')\n    plt.xlabel('Timesteps')\n    plt.ylabel('Reward')\n    plt.title(f'T-Rex SAC - Stage {STAGE} Training Progress')\n    plt.legend()\n    plt.grid(True, alpha=0.3)\n    plt.show()\nelse:\n    print(\"No evaluation log found.\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## Record Final Model Video\n\nRender one episode of the trained policy and save as MP4.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "import mediapy\n\ndef make_render_env(stage, seed=0):\n    \"\"\"Create a single TRexEnv with rgb_array rendering for video capture.\"\"\"\n    def _init():\n        env_kwargs = STAGE_CONFIGS[stage][\"env_kwargs\"].copy()\n        env = TRexEnv(render_mode=\"rgb_array\", **env_kwargs)\n        env = Monitor(env)\n        env.reset(seed=seed)\n        return env\n    return _init\n\n# Build env with rendering and load normalization stats from training\nvideo_env = DummyVecEnv([make_render_env(STAGE, seed=SEED + 2000)])\nvideo_env = VecNormalize.load(final_path + \"_vecnorm.pkl\", video_env)\nvideo_env.training = False\nvideo_env.norm_reward = False\n\nobs = video_env.reset()\nframes = []\nepisode_reward = 0.0\n\nfor _ in range(1000):\n    action, _ = model.predict(obs, deterministic=True)\n    obs, reward, done, info = video_env.step(action)\n    frames.append(video_env.venv.envs[0].render())\n    episode_reward += reward[0]\n    if done[0]:\n        break\n\nvideo_env.close()\n\nvideo_path = os.path.join(stage_dir, f\"stage{STAGE}_final.mp4\")\nmediapy.write_video(video_path, frames, fps=50)\nprint(f\"Episode reward: {episode_reward:.2f} | {len(frames)} frames\")\nprint(f\"Saved to {video_path}\")\nmediapy.show_video(frames, fps=50)",
    "metadata": {},
    "execution_count": null,
    "outputs": []


### PR DESCRIPTION
This pull request improves the usability and completeness of the `notebooks/sac_training.ipynb` notebook. The main changes ensure that package imports work reliably and add a new section for recording and saving a video of the final trained model's performance.

Environment setup improvements:

* Modified the environment setup cell to add `/content/mesozoic-labs` to `sys.path` if necessary, ensuring the package is importable even if the editable install doesn't register properly in the running kernel.

Model evaluation and visualization:

* Added a new markdown section and code cell to record and save a video of the trained policy running one episode, including rendering frames, saving as MP4, and displaying the video inline.