### PR TITLE
Fix Colab compatibility: auto-detect environment and set paths

### DIFF
--- a/notebooks/brachiosaurus_training.ipynb
+++ b/notebooks/brachiosaurus_training.ipynb
@@ -31,39 +31,14 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Install dependencies (uncomment for Colab)\n",
-    "# !pip install mujoco>=3.0.0 gymnasium>=0.29.0 stable-baselines3[extra]>=2.2.0 mediapy matplotlib\n",
-    "# !git clone https://github.com/kuds/mesozoic-labs.git /content/mesozoic-labs 2>/dev/null || echo \"Already cloned\"\n",
-    "# !pip install -e /content/mesozoic-labs"
-   ]
+   "source": "# Install dependencies (Colab auto-detected; no-op locally)\nimport importlib\nimport os\n\nIN_COLAB = \"COLAB_GPU\" in os.environ or \"COLAB_RELEASE_TAG\" in os.environ or os.path.exists(\"/content\")\n\nif IN_COLAB:\n    # Install packages only if not already present\n    if importlib.util.find_spec(\"mujoco\") is None:\n        get_ipython().system('pip install -q mujoco>=3.0.0 gymnasium>=0.29.0 \"stable-baselines3[extra]>=2.2.0\" mediapy matplotlib')\n    import subprocess, pathlib\n    repo_dir = pathlib.Path(\"/content/mesozoic-labs\")\n    if not repo_dir.exists():\n        subprocess.run([\"git\", \"clone\", \"https://github.com/kuds/mesozoic-labs.git\", str(repo_dir)], check=True)\n    if importlib.util.find_spec(\"environments\") is None:\n        get_ipython().system('pip install -q -e /content/mesozoic-labs')\n    print(\"Colab setup complete.\")\nelse:\n    print(\"Running locally.\")"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from datetime import datetime\n",
-    "from pathlib import Path\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "# Add repo root to path\n",
-    "repo_root = Path(\"..\").resolve()\n",
-    "if str(repo_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(repo_root))\n",
-    "\n",
-    "import gymnasium as gym\n",
-    "import mujoco\n",
-    "\n",
-    "print(f\"MuJoCo version: {mujoco.__version__}\")\n",
-    "print(f\"Gymnasium version: {gym.__version__}\")\n",
-    "print(f\"Repo root: {repo_root}\")"
-   ]
+   "source": "import os\nimport sys\nfrom datetime import datetime\nfrom pathlib import Path\n\nimport matplotlib.pyplot as plt\nimport numpy as np\n\n# Add repo root to path (works both locally from notebooks/ and in Colab)\nif IN_COLAB:\n    repo_root = Path(\"/content/mesozoic-labs\")\nelse:\n    repo_root = Path(\"..\").resolve()\n\nif str(repo_root) not in sys.path:\n    sys.path.insert(0, str(repo_root))\n\nimport gymnasium as gym\nimport mujoco\n\nprint(f\"MuJoCo version: {mujoco.__version__}\")\nprint(f\"Gymnasium version: {gym.__version__}\")\nprint(f\"Repo root: {repo_root}\")"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/trex_training.ipynb
+++ b/notebooks/trex_training.ipynb
@@ -31,39 +31,14 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Install dependencies (uncomment for Colab)\n",
-    "# !pip install mujoco>=3.0.0 gymnasium>=0.29.0 stable-baselines3[extra]>=2.2.0 mediapy matplotlib\n",
-    "# !git clone https://github.com/kuds/mesozoic-labs.git /content/mesozoic-labs 2>/dev/null || echo \"Already cloned\"\n",
-    "# !pip install -e /content/mesozoic-labs"
-   ]
+   "source": "# Install dependencies (Colab auto-detected; no-op locally)\nimport importlib\nimport os\n\nIN_COLAB = \"COLAB_GPU\" in os.environ or \"COLAB_RELEASE_TAG\" in os.environ or os.path.exists(\"/content\")\n\nif IN_COLAB:\n    # Install packages only if not already present\n    if importlib.util.find_spec(\"mujoco\") is None:\n        get_ipython().system('pip install -q mujoco>=3.0.0 gymnasium>=0.29.0 \"stable-baselines3[extra]>=2.2.0\" mediapy matplotlib')\n    import subprocess, pathlib\n    repo_dir = pathlib.Path(\"/content/mesozoic-labs\")\n    if not repo_dir.exists():\n        subprocess.run([\"git\", \"clone\", \"https://github.com/kuds/mesozoic-labs.git\", str(repo_dir)], check=True)\n    if importlib.util.find_spec(\"environments\") is None:\n        get_ipython().system('pip install -q -e /content/mesozoic-labs')\n    print(\"Colab setup complete.\")\nelse:\n    print(\"Running locally.\")"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from datetime import datetime\n",
-    "from pathlib import Path\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "# Add repo root to path\n",
-    "repo_root = Path(\"..\").resolve()\n",
-    "if str(repo_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(repo_root))\n",
-    "\n",
-    "import gymnasium as gym\n",
-    "import mujoco\n",
-    "\n",
-    "print(f\"MuJoCo version: {mujoco.__version__}\")\n",
-    "print(f\"Gymnasium version: {gym.__version__}\")\n",
-    "print(f\"Repo root: {repo_root}\")"
-   ]
+   "source": "import os\nimport sys\nfrom datetime import datetime\nfrom pathlib import Path\n\nimport matplotlib.pyplot as plt\nimport numpy as np\n\n# Add repo root to path (works both locally from notebooks/ and in Colab)\nif IN_COLAB:\n    repo_root = Path(\"/content/mesozoic-labs\")\nelse:\n    repo_root = Path(\"..\").resolve()\n\nif str(repo_root) not in sys.path:\n    sys.path.insert(0, str(repo_root))\n\nimport gymnasium as gym\nimport mujoco\n\nprint(f\"MuJoCo version: {mujoco.__version__}\")\nprint(f\"Gymnasium version: {gym.__version__}\")\nprint(f\"Repo root: {repo_root}\")"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/velociraptor_training.ipynb
+++ b/notebooks/velociraptor_training.ipynb
@@ -31,39 +31,14 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Install dependencies (uncomment for Colab)\n",
-    "# !pip install mujoco>=3.0.0 gymnasium>=0.29.0 stable-baselines3[extra]>=2.2.0 mediapy matplotlib\n",
-    "# !git clone https://github.com/kuds/mesozoic-labs.git /content/mesozoic-labs 2>/dev/null || echo \"Already cloned\"\n",
-    "# !pip install -e /content/mesozoic-labs"
-   ]
+   "source": "# Install dependencies (Colab auto-detected; no-op locally)\nimport importlib\nimport os\n\nIN_COLAB = \"COLAB_GPU\" in os.environ or \"COLAB_RELEASE_TAG\" in os.environ or os.path.exists(\"/content\")\n\nif IN_COLAB:\n    # Install packages only if not already present\n    if importlib.util.find_spec(\"mujoco\") is None:\n        get_ipython().system('pip install -q mujoco>=3.0.0 gymnasium>=0.29.0 \"stable-baselines3[extra]>=2.2.0\" mediapy matplotlib')\n    import subprocess, pathlib\n    repo_dir = pathlib.Path(\"/content/mesozoic-labs\")\n    if not repo_dir.exists():\n        subprocess.run([\"git\", \"clone\", \"https://github.com/kuds/mesozoic-labs.git\", str(repo_dir)], check=True)\n    if importlib.util.find_spec(\"environments\") is None:\n        get_ipython().system('pip install -q -e /content/mesozoic-labs')\n    print(\"Colab setup complete.\")\nelse:\n    print(\"Running locally.\")"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from datetime import datetime\n",
-    "from pathlib import Path\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "# Add repo root to path\n",
-    "repo_root = Path(\"..\").resolve()\n",
-    "if str(repo_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(repo_root))\n",
-    "\n",
-    "import gymnasium as gym\n",
-    "import mujoco\n",
-    "\n",
-    "print(f\"MuJoCo version: {mujoco.__version__}\")\n",
-    "print(f\"Gymnasium version: {gym.__version__}\")\n",
-    "print(f\"Repo root: {repo_root}\")"
-   ]
+   "source": "import os\nimport sys\nfrom datetime import datetime\nfrom pathlib import Path\n\nimport matplotlib.pyplot as plt\nimport numpy as np\n\n# Add repo root to path (works both locally from notebooks/ and in Colab)\nif IN_COLAB:\n    repo_root = Path(\"/content/mesozoic-labs\")\nelse:\n    repo_root = Path(\"..\").resolve()\n\nif str(repo_root) not in sys.path:\n    sys.path.insert(0, str(repo_root))\n\nimport gymnasium as gym\nimport mujoco\n\nprint(f\"MuJoCo version: {mujoco.__version__}\")\nprint(f\"Gymnasium version: {gym.__version__}\")\nprint(f\"Repo root: {repo_root}\")"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
The notebooks failed in Google Colab with "No module named 'environments'" because Path("..").resolve() doesn't point to the repo root in Colab's /content working directory.

Fix: auto-detect Colab via env vars / /content existence, then:
- Clone the repo to /content/mesozoic-labs if not present
- pip install dependencies and the package if not already installed
- Set repo_root to /content/mesozoic-labs instead of Path("..")

All three species notebooks updated with the same fix.