### PR TITLE
Fix MuJoCo 3.x sensor compatibility for tail velocity in all XML models

### DIFF
--- a/environments/brachiosaurus/assets/brachiosaurus.xml
+++ b/environments/brachiosaurus/assets/brachiosaurus.xml
@@ -302,8 +302,8 @@
 
     <!-- Tail tip for stability monitoring -->
     <framepos name="tail_tip_pos" objtype="site" objname="tail_tip"/>
-    <framelinvel name="tail_tip_linvel" objtype="site" objname="tail_tip"/>
-    <frameangvel name="tail_tip_angvel" objtype="site" objname="tail_tip"/>
+    <velocimeter name="tail_tip_linvel" site="tail_tip"/>
+    <gyro name="tail_tip_angvel" site="tail_tip"/>
   </sensor>
 
   <!-- ==================== CONTACT EXCLUSIONS ==================== -->

--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -309,8 +309,8 @@
 
     <!-- Tail tip for stability monitoring -->
     <framepos name="tail_tip_pos" objtype="site" objname="tail_tip"/>
-    <framelinvel name="tail_tip_linvel" objtype="site" objname="tail_tip"/>
-    <frameangvel name="tail_tip_angvel" objtype="site" objname="tail_tip"/>
+    <velocimeter name="tail_tip_linvel" site="tail_tip"/>
+    <gyro name="tail_tip_angvel" site="tail_tip"/>
   </sensor>
 
   <!-- ==================== CONTACT EXCLUSIONS ==================== -->

--- a/environments/velociraptor/assets/raptor.xml
+++ b/environments/velociraptor/assets/raptor.xml
@@ -253,8 +253,8 @@
 
     <!-- Tail tip for stability monitoring -->
     <framepos name="tail_tip_pos" objtype="site" objname="tail_tip"/>
-    <framelinvel name="tail_tip_linvel" objtype="site" objname="tail_tip"/>
-    <frameangvel name="tail_tip_angvel" objtype="site" objname="tail_tip"/>
+    <velocimeter name="tail_tip_linvel" site="tail_tip"/>
+    <gyro name="tail_tip_angvel" site="tail_tip"/>
   </sensor>
 
   <!-- ==================== CONTACT EXCLUSIONS ==================== -->


### PR DESCRIPTION
This pull request updates the sensor definitions for the tail tip in the XML asset files for the Brachiosaurus, T-Rex, and Velociraptor environments. The changes replace the use of `framelinvel` and `frameangvel` sensors with the more specific `velocimeter` and `gyro` sensors for measuring linear and angular velocity, respectively.

Sensor definition updates:

* Replaced `framelinvel` with `velocimeter` for tail tip linear velocity measurement in `brachiosaurus.xml`, `trex.xml`, and `raptor.xml`. [[1]](diffhunk://#diff-bf41988661628408f7cf28d97f6d55546737c9589d91f1c9cf9c0cd64acbfa24L305-R306) [[2]](diffhunk://#diff-2092f87f984d2def64c441aeb2c9cea9d9be586da004ba3cf858c82b25f07d0eL312-R313) [[3]](diffhunk://#diff-01715a7cc0285dfdfe55ead31818a5e8fb639d762d835d79349498667fc7e1d7L256-R257)
* Replaced `frameangvel` with `gyro` for tail tip angular velocity measurement in `brachiosaurus.xml`, `trex.xml`, and `raptor.xml`. [[1]](diffhunk://#diff-bf41988661628408f7cf28d97f6d55546737c9589d91f1c9cf9c0cd64acbfa24L305-R306) [[2]](diffhunk://#diff-2092f87f984d2def64c441aeb2c9cea9d9be586da004ba3cf858c82b25f07d0eL312-R313) [[3]](diffhunk://#diff-01715a7cc0285dfdfe55ead31818a5e8fb639d762d835d79349498667fc7e1d7L256-R257)