### PR TITLE
Fix raptor and trex flipping on spawn by adding standing keyframes

### DIFF
--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -177,8 +177,11 @@ class BaseDinoEnv(gym.Env, ABC):
         """Reset environment to initial state."""
         super().reset(seed=seed)
 
-        # Reset MuJoCo state
-        mujoco.mj_resetData(self.model, self.data)
+        # Reset MuJoCo state using keyframe if available, otherwise default
+        if self.model.nkey > 0:
+            mujoco.mj_resetDataKeyframe(self.model, self.data, 0)
+        else:
+            mujoco.mj_resetData(self.model, self.data)
 
         # Add small random perturbation to initial pose
         if self.np_random is not None:

--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -337,4 +337,22 @@
     <exclude body1="pelvis" body2="l_arm"/>
   </contact>
 
+  <!-- ==================== KEYFRAMES ==================== -->
+  <!-- Standing pose with COM balanced over feet.
+       Without this, knee (range -110..-10) and ankle (range 50..150)
+       start at 0 deg which is outside their limits, causing violent
+       constraint-force corrections on the first simulation step. -->
+
+  <keyframe>
+    <key name="home"
+         qpos="0 0 0.90 1 0 0 0
+               0 0 0 0 0 0 0 0 0 0
+               0.261799 0 -1.221730 1.570796 0.261799
+               0.261799 0 -1.221730 1.570796 0.261799
+               1 0 0 0 0 1 0 0 0 0"
+         ctrl="0 0 0 0
+               0.261799 0 -1.221730 1.570796 0.261799
+               0.261799 0 -1.221730 1.570796 0.261799"/>
+  </keyframe>
+
 </mujoco>

--- a/environments/velociraptor/assets/raptor.xml
+++ b/environments/velociraptor/assets/raptor.xml
@@ -272,4 +272,21 @@
     <exclude body1="pelvis" body2="l_thigh"/>
   </contact>
 
+  <!-- ==================== KEYFRAMES ==================== -->
+  <!-- Standing pose with COM balanced over feet.
+       Without this, knee (range -120..-10) and ankle (range 60..160)
+       start at 0 deg which is outside their limits, causing violent
+       constraint-force corrections on the first simulation step. -->
+
+  <keyframe>
+    <key name="home"
+         qpos="0 0 0.50 1 0 0 0
+               0 0 0 0 0 0
+               0.314159 0 -0.872665 1.745329 0.174533 0
+               0.314159 0 -0.872665 1.745329 0.174533 0
+               1 0 0 0 1 0 0 0"
+         ctrl="0.314159 0 -0.872665 1.745329 0.174533 0
+               0.314159 0 -0.872665 1.745329 0.174533 0"/>
+  </keyframe>
+
 </mujoco>


### PR DESCRIPTION
This pull request improves the initialization of the MuJoCo-based environments by introducing keyframes for realistic initial poses and updating the reset logic to utilize them if available. This prevents unnatural joint positions and reduces instability during the first simulation steps.

Keyframe initialization improvements:

* Added a `home` keyframe to `trex.xml` that defines a balanced standing pose, ensuring knees and ankles start within their valid ranges and preventing violent constraint-force corrections at simulation start.
* Added a `home` keyframe to `raptor.xml` with a similar balanced pose for the velociraptor model, addressing the same joint limit issues.

Reset logic enhancement:

* Updated the `reset` method in `base_env.py` to use the keyframe for MuJoCo state reset if available, otherwise defaulting to the standard reset, ensuring environments start from the improved pose.