### PR TITLE
Add joint ref attributes and passive stiffness to fix bipedal standin…

### DIFF
--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -12,7 +12,7 @@
 
     <!-- Leg joints: high stiffness for massive biped -->
     <default class="leg_joint">
-      <joint damping="15.0" armature="0.1"/>
+      <joint damping="15.0" armature="0.1" stiffness="40.0"/>
     </default>
 
     <!-- Tail joints: very stiff, acts as heavy counterbalance to skull -->
@@ -74,7 +74,7 @@
       - Body pivots at hips, skull and tail balance each other
     -->
 
-    <body name="pelvis" pos="0 0 1.15">
+    <body name="pelvis" pos="0 0 0.90">
       <freejoint name="root"/>
 
       <!-- Main torso: forward-leaning, angled ~30 deg from horizontal -->
@@ -176,26 +176,26 @@
 
       <body name="r_thigh" pos="-0.05 -0.14 -0.05">
         <!-- Hip: 2 DOF -->
-        <joint name="r_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0" range="-50 80"/>
+        <joint name="r_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0" range="-50 80" ref="15"/>
         <joint name="r_hip_roll" class="leg_joint" type="hinge" axis="1 0 0" range="-25 25"/>
         <geom name="r_thigh_geom" type="capsule" fromto="0 0 0  0.03 0 -0.35" size="0.09"
               mass="5.0" material="body_mat"/>
 
         <body name="r_tibia" pos="0.03 0 -0.35">
           <!-- Knee: 1 DOF -->
-          <joint name="r_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-110 -10"/>
+          <joint name="r_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-110 -10" ref="-70"/>
           <geom name="r_tibia_geom" type="capsule" fromto="0 0 0  -0.03 0 -0.35" size="0.07"
                 mass="3.5" material="body_mat"/>
 
           <body name="r_metatarsus" pos="-0.03 0 -0.35">
             <!-- Ankle: 1 DOF (digitigrade stance) -->
-            <joint name="r_ankle" class="leg_joint" type="hinge" axis="0 1 0" range="50 150"/>
+            <joint name="r_ankle" class="leg_joint" type="hinge" axis="0 1 0" range="50 150" ref="90"/>
             <geom name="r_metatarsus_geom" type="capsule" fromto="0 0 0  0.08 0 -0.2" size="0.04"
                   mass="1.2" material="body_mat"/>
 
             <!-- Toes (3 forward-facing digits fused as one contact pad) -->
             <body name="r_toe" pos="0.08 0 -0.2">
-              <joint name="r_toe_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-25 50"/>
+              <joint name="r_toe_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-25 50" ref="15"/>
               <geom name="r_toe_geom" type="capsule" fromto="0 0 0  0.12 0 0" size="0.035"
                     mass="0.4" material="claw_mat"/>
               <site name="r_foot" pos="0.06 0 -0.035" size="0.03"/>
@@ -207,23 +207,23 @@
       <!-- ==================== LEFT LEG ==================== -->
 
       <body name="l_thigh" pos="-0.05 0.14 -0.05">
-        <joint name="l_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0" range="-50 80"/>
+        <joint name="l_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0" range="-50 80" ref="15"/>
         <joint name="l_hip_roll" class="leg_joint" type="hinge" axis="1 0 0" range="-25 25"/>
         <geom name="l_thigh_geom" type="capsule" fromto="0 0 0  0.03 0 -0.35" size="0.09"
               mass="5.0" material="body_mat"/>
 
         <body name="l_tibia" pos="0.03 0 -0.35">
-          <joint name="l_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-110 -10"/>
+          <joint name="l_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-110 -10" ref="-70"/>
           <geom name="l_tibia_geom" type="capsule" fromto="0 0 0  -0.03 0 -0.35" size="0.07"
                 mass="3.5" material="body_mat"/>
 
           <body name="l_metatarsus" pos="-0.03 0 -0.35">
-            <joint name="l_ankle" class="leg_joint" type="hinge" axis="0 1 0" range="50 150"/>
+            <joint name="l_ankle" class="leg_joint" type="hinge" axis="0 1 0" range="50 150" ref="90"/>
             <geom name="l_metatarsus_geom" type="capsule" fromto="0 0 0  0.08 0 -0.2" size="0.04"
                   mass="1.2" material="body_mat"/>
 
             <body name="l_toe" pos="0.08 0 -0.2">
-              <joint name="l_toe_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-25 50"/>
+              <joint name="l_toe_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-25 50" ref="15"/>
               <geom name="l_toe_geom" type="capsule" fromto="0 0 0  0.12 0 0" size="0.035"
                     mass="0.4" material="claw_mat"/>
               <site name="l_foot" pos="0.06 0 -0.035" size="0.03"/>

--- a/environments/velociraptor/assets/raptor.xml
+++ b/environments/velociraptor/assets/raptor.xml
@@ -12,7 +12,7 @@
 
     <!-- Leg joints: moderate stiffness for position control -->
     <default class="leg_joint">
-      <joint damping="5.0" armature="0.02"/>
+      <joint damping="5.0" armature="0.02" stiffness="15.0"/>
     </default>
 
     <!-- Tail joints: high stiffness, limited range (rigid rudder behavior) -->
@@ -58,7 +58,7 @@
       Total mass: ~15kg
     -->
 
-    <body name="pelvis" pos="0 0 0.55">
+    <body name="pelvis" pos="0 0 0.50">
       <freejoint name="root"/>
 
       <!-- Main body: elongated ellipsoid -->
@@ -114,27 +114,27 @@
 
       <body name="r_thigh" pos="0 -0.08 0">
         <!-- Hip: 2 DOF (flexion/extension + abduction) -->
-        <joint name="r_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0" range="-60 90"/>
+        <joint name="r_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0" range="-60 90" ref="18"/>
         <joint name="r_hip_roll" class="leg_joint" type="hinge" axis="1 0 0" range="-30 30"/>
         <geom name="r_thigh_geom" type="capsule" fromto="0 0 0  0.02 0 -0.18" size="0.04"
               mass="1.2" material="body_mat"/>
 
         <body name="r_tibia" pos="0.02 0 -0.18">
           <!-- Knee: 1 DOF -->
-          <joint name="r_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-120 -10"/>
+          <joint name="r_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-120 -10" ref="-50"/>
           <geom name="r_tibia_geom" type="capsule" fromto="0 0 0  -0.02 0 -0.2" size="0.03"
                 mass="0.8" material="body_mat"/>
 
           <body name="r_metatarsus" pos="-0.02 0 -0.2">
             <!-- Ankle: 1 DOF (digitigrade stance) -->
-            <joint name="r_ankle" class="leg_joint" type="hinge" axis="0 1 0" range="60 160"/>
+            <joint name="r_ankle" class="leg_joint" type="hinge" axis="0 1 0" range="60 160" ref="100"/>
             <geom name="r_metatarsus_geom" type="capsule" fromto="0 0 0  0.06 0 -0.12" size="0.02"
                   mass="0.3" material="body_mat"/>
 
             <!-- Toes -->
             <body name="r_toe_main" pos="0.06 0 -0.12">
               <!-- Main toe (digits 3+4 combined) -->
-              <joint name="r_toe_main_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-30 60"/>
+              <joint name="r_toe_main_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-30 60" ref="10"/>
               <geom name="r_toe_main_geom" type="capsule" fromto="0 0 0  0.08 0 0" size="0.015"
                     mass="0.1" material="body_mat"/>
               <!-- Foot contact sensor -->
@@ -156,23 +156,23 @@
       <!-- ==================== LEFT LEG ==================== -->
 
       <body name="l_thigh" pos="0 0.08 0">
-        <joint name="l_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0" range="-60 90"/>
+        <joint name="l_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0" range="-60 90" ref="18"/>
         <joint name="l_hip_roll" class="leg_joint" type="hinge" axis="1 0 0" range="-30 30"/>
         <geom name="l_thigh_geom" type="capsule" fromto="0 0 0  0.02 0 -0.18" size="0.04"
               mass="1.2" material="body_mat"/>
 
         <body name="l_tibia" pos="0.02 0 -0.18">
-          <joint name="l_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-120 -10"/>
+          <joint name="l_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-120 -10" ref="-50"/>
           <geom name="l_tibia_geom" type="capsule" fromto="0 0 0  -0.02 0 -0.2" size="0.03"
                 mass="0.8" material="body_mat"/>
 
           <body name="l_metatarsus" pos="-0.02 0 -0.2">
-            <joint name="l_ankle" class="leg_joint" type="hinge" axis="0 1 0" range="60 160"/>
+            <joint name="l_ankle" class="leg_joint" type="hinge" axis="0 1 0" range="60 160" ref="100"/>
             <geom name="l_metatarsus_geom" type="capsule" fromto="0 0 0  0.06 0 -0.12" size="0.02"
                   mass="0.3" material="body_mat"/>
 
             <body name="l_toe_main" pos="0.06 0 -0.12">
-              <joint name="l_toe_main_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-30 60"/>
+              <joint name="l_toe_main_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-30 60" ref="10"/>
               <geom name="l_toe_main_geom" type="capsule" fromto="0 0 0  0.08 0 0" size="0.015"
                     mass="0.1" material="body_mat"/>
               <site name="l_foot" pos="0.04 0 -0.015" size="0.02"/>


### PR DESCRIPTION
This pull request updates the XML model definitions for both the T-Rex and Velociraptor environments to improve the realism and control of their leg joints. The main changes include adding stiffness parameters to leg joints, adjusting pelvis positions for both models, and introducing reference angles to major leg joints for more accurate pose initialization.

Leg joint improvements:

* Added a `stiffness` parameter to all leg joints in both `trex.xml` and `raptor.xml`, increasing their resistance to movement and improving position control. [[1]](diffhunk://#diff-2092f87f984d2def64c441aeb2c9cea9d9be586da004ba3cf858c82b25f07d0eL15-R15) [[2]](diffhunk://#diff-01715a7cc0285dfdfe55ead31818a5e8fb639d762d835d79349498667fc7e1d7L15-R15)

Pose and reference angle enhancements:

* Introduced `ref` (reference angle) attributes to all major leg joints (hips, knees, ankles, toes) in both models, which helps define their default pose and improves simulation stability. [[1]](diffhunk://#diff-2092f87f984d2def64c441aeb2c9cea9d9be586da004ba3cf858c82b25f07d0eL179-R198) [[2]](diffhunk://#diff-2092f87f984d2def64c441aeb2c9cea9d9be586da004ba3cf858c82b25f07d0eL210-R226) [[3]](diffhunk://#diff-01715a7cc0285dfdfe55ead31818a5e8fb639d762d835d79349498667fc7e1d7L117-R137) [[4]](diffhunk://#diff-01715a7cc0285dfdfe55ead31818a5e8fb639d762d835d79349498667fc7e1d7L159-R175)

Body position adjustments:

* Lowered the pelvis position for both T-Rex (`pelvis` from `1.15` to `0.90`) and Velociraptor (`pelvis` from `0.55` to `0.50`) to better match anatomical proportions and improve balance. [[1]](diffhunk://#diff-2092f87f984d2def64c441aeb2c9cea9d9be586da004ba3cf858c82b25f07d0eL77-R77) [[2]](diffhunk://#diff-01715a7cc0285dfdfe55ead31818a5e8fb639d762d835d79349498667fc7e1d7L61-R61)