### PR TITLE
Fix raptor head/neck clipping through ground without termination

### DIFF
--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -95,7 +95,12 @@ class RaptorEnv(BaseDinoEnv):
         self.r_claw_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "r_claw_geom")
         self.l_claw_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "l_claw_geom")
         self.torso_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "torso")
+        self.neck_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "neck")
+        self.head_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "head")
         self.floor_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "floor")
+
+        # Geoms that should terminate the episode on ground contact
+        self._body_ground_geoms = {self.torso_geom_id, self.neck_geom_id, self.head_geom_id}
 
         # Site IDs for sensors
         self.imu_site_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_SITE, "imu")
@@ -242,16 +247,16 @@ class RaptorEnv(BaseDinoEnv):
             info["termination_reason"] = "too_high"
             return True, info
 
-        # Check for torso-ground contact (fallen over)
+        # Check for body-ground contact (torso, neck, or head touching floor)
         for i in range(self.data.ncon):
             contact = self.data.contact[i]
             geom1, geom2 = contact.geom1, contact.geom2
 
-            # Torso touching floor = fallen
-            if (geom1 == self.torso_geom_id and geom2 == self.floor_geom_id) or (
-                geom2 == self.torso_geom_id and geom1 == self.floor_geom_id
-            ):
-                info["termination_reason"] = "torso_contact"
+            if geom2 == self.floor_geom_id and geom1 in self._body_ground_geoms:
+                info["termination_reason"] = "body_contact"
+                return True, info
+            if geom1 == self.floor_geom_id and geom2 in self._body_ground_geoms:
+                info["termination_reason"] = "body_contact"
                 return True, info
 
         return False, info


### PR DESCRIPTION
This pull request updates the episode termination logic in the `raptor_env.py` environment to improve how ground contact is detected. Now, the episode will terminate if the torso, neck, or head touches the ground, rather than only the torso. This change makes the simulation more realistic and robust by broadening the set of body parts that can trigger a fall.

**Termination logic improvements:**

* Added caching of geometry IDs for the neck and head (`neck_geom_id`, `head_geom_id`) and grouped them with the torso in a new set `_body_ground_geoms` to track which geoms should terminate the episode on ground contact.
* Updated the `_is_terminated` method to check for contact between any of the body ground geoms (torso, neck, or head) and the floor, and to use a unified termination reason `"body_contact"` instead of only checking the torso.