### PR TITLE
Cast prey distance to float in velociraptor reward calculation

### DIFF
--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -221,7 +221,7 @@ class RaptorEnv(BaseDinoEnv):
         # 6. Approach shaping (reward closing distance to prey, penalise retreating)
         pelvis_pos = self.data.xpos[self.pelvis_id]
         prey_pos = self.data.mocap_pos[0]
-        prey_distance = np.linalg.norm(prey_pos - pelvis_pos)
+        prey_distance = float(np.linalg.norm(prey_pos - pelvis_pos))
 
         if self._prev_prey_distance is not None:
             approach_delta = self._prev_prey_distance - prey_distance


### PR DESCRIPTION
This pull request makes a minor change to the reward calculation logic in the velociraptor environment. Specifically, it ensures that the calculated prey distance is explicitly cast to a Python float, which can help avoid issues with data types in downstream computations.

* Explicitly cast the result of `np.linalg.norm(prey_pos - pelvis_pos)` to a `float` in the `_get_reward_info` method of `raptor_env.py` to ensure consistent data type handling.