### PR TITLE
Increase curriculum timesteps from 1M to 2M for stage2 locomotion

### DIFF
--- a/configs/brachiosaurus/stage2_locomotion.toml
+++ b/configs/brachiosaurus/stage2_locomotion.toml
@@ -31,7 +31,7 @@ tau = 0.005
 ent_coef = "auto"
 
 [curriculum]
-timesteps = 1000000
+timesteps = 2000000
 min_avg_reward = 100.0
 min_avg_episode_length = 800
 required_consecutive = 3

--- a/configs/trex/stage2_locomotion.toml
+++ b/configs/trex/stage2_locomotion.toml
@@ -30,7 +30,7 @@ tau = 0.005
 ent_coef = "auto"
 
 [curriculum]
-timesteps = 1000000
+timesteps = 2000000
 min_avg_reward = 100.0
 min_avg_episode_length = 800
 required_consecutive = 3

--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -30,7 +30,7 @@ tau = 0.005
 ent_coef = "auto"
 
 [curriculum]
-timesteps = 1000000
+timesteps = 2000000
 min_avg_reward = 100.0
 min_avg_episode_length = 800
 required_consecutive = 3


### PR DESCRIPTION
This pull request updates the curriculum configuration for stage 2 locomotion training across three dinosaur models. The main change is an increase in the number of timesteps required for the curriculum, which will likely result in longer and potentially more robust training for each model.

Curriculum configuration updates:

* Increased `timesteps` from 1,000,000 to 2,000,000 in `configs/brachiosaurus/stage2_locomotion.toml`
* Increased `timesteps` from 1,000,000 to 2,000,000 in `configs/trex/stage2_locomotion.toml`
* Increased `timesteps` from 1,000,000 to 2,000,000 in `configs/velociraptor/stage2_locomotion.toml`