### PR TITLE
Fix tail-floor collision for all dinosaur models

### DIFF
--- a/environments/brachiosaurus/assets/brachiosaurus.xml
+++ b/environments/brachiosaurus/assets/brachiosaurus.xml
@@ -130,22 +130,22 @@
         <joint name="tail_1_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
         <joint name="tail_1_yaw" class="tail_joint" type="hinge" axis="0 0 1" range="-10 10"/>
         <geom name="tail_1_geom" type="capsule" fromto="0 0 0  -0.4 0 -0.05" size="0.16"
-              mass="6.0" material="body_mat" contype="0" conaffinity="0"/>
+              mass="6.0" material="body_mat"/>
 
         <body name="tail_2" pos="-0.4 0 -0.05">
           <joint name="tail_2_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
           <geom name="tail_2_geom" type="capsule" fromto="0 0 0  -0.4 0 -0.03" size="0.12"
-                mass="4.0" material="body_mat" contype="0" conaffinity="0"/>
+                mass="4.0" material="body_mat"/>
 
           <body name="tail_3" pos="-0.4 0 -0.03">
             <joint name="tail_3_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
             <geom name="tail_3_geom" type="capsule" fromto="0 0 0  -0.35 0 0" size="0.08"
-                  mass="2.0" material="body_mat" contype="0" conaffinity="0"/>
+                  mass="2.0" material="body_mat"/>
 
             <body name="tail_4" pos="-0.35 0 0">
               <joint name="tail_4_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
               <geom name="tail_4_geom" type="capsule" fromto="0 0 0  -0.3 0 0.02" size="0.05"
-                    mass="1.0" material="body_mat" contype="0" conaffinity="0"/>
+                    mass="1.0" material="body_mat"/>
               <site name="tail_tip" pos="-0.3 0 0.02" size="0.02"/>
             </body>
           </body>

--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -142,27 +142,27 @@
         <joint name="tail_1_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
         <joint name="tail_1_yaw" class="tail_joint" type="hinge" axis="0 0 1" range="-8 8"/>
         <geom name="tail_1_geom" type="capsule" fromto="0 0 0  -0.3 0 -0.03" size="0.14"
-              mass="6.0" material="body_mat" contype="0" conaffinity="0"/>
+              mass="6.0" material="body_mat"/>
 
         <body name="tail_2" pos="-0.3 0 -0.03">
           <joint name="tail_2_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
           <geom name="tail_2_geom" type="capsule" fromto="0 0 0  -0.3 0 -0.02" size="0.11"
-                mass="4.5" material="body_mat" contype="0" conaffinity="0"/>
+                mass="4.5" material="body_mat"/>
 
           <body name="tail_3" pos="-0.3 0 -0.02">
             <joint name="tail_3_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
             <geom name="tail_3_geom" type="capsule" fromto="0 0 0  -0.3 0 0" size="0.08"
-                  mass="3.0" material="body_mat" contype="0" conaffinity="0"/>
+                  mass="3.0" material="body_mat"/>
 
             <body name="tail_4" pos="-0.3 0 0">
               <joint name="tail_4_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
               <geom name="tail_4_geom" type="capsule" fromto="0 0 0  -0.25 0 0.01" size="0.06"
-                    mass="1.5" material="body_mat" contype="0" conaffinity="0"/>
+                    mass="1.5" material="body_mat"/>
 
               <body name="tail_5" pos="-0.25 0 0.01">
                 <joint name="tail_5_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
                 <geom name="tail_5_geom" type="capsule" fromto="0 0 0  -0.2 0 0.02" size="0.035"
-                      mass="0.6" material="body_mat" contype="0" conaffinity="0"/>
+                      mass="0.6" material="body_mat"/>
                 <site name="tail_tip" pos="-0.2 0 0.02" size="0.015"/>
               </body>
             </body>

--- a/environments/velociraptor/assets/raptor.xml
+++ b/environments/velociraptor/assets/raptor.xml
@@ -81,27 +81,27 @@
         <joint name="tail_1_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
         <joint name="tail_1_yaw" class="tail_joint" type="hinge" axis="0 0 1" range="-10 10"/>
         <geom name="tail_1_geom" type="capsule" fromto="0 0 0  -0.15 0 -0.02" size="0.045"
-              mass="1.0" material="body_mat" contype="0" conaffinity="0"/>
+              mass="1.0" material="body_mat"/>
 
         <body name="tail_2" pos="-0.15 0 -0.02">
           <joint name="tail_2_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
           <geom name="tail_2_geom" type="capsule" fromto="0 0 0  -0.15 0 -0.01" size="0.04"
-                mass="0.8" material="body_mat" contype="0" conaffinity="0"/>
+                mass="0.8" material="body_mat"/>
 
           <body name="tail_3" pos="-0.15 0 -0.01">
             <joint name="tail_3_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
             <geom name="tail_3_geom" type="capsule" fromto="0 0 0  -0.15 0 0" size="0.035"
-                  mass="0.6" material="body_mat" contype="0" conaffinity="0"/>
+                  mass="0.6" material="body_mat"/>
 
             <body name="tail_4" pos="-0.15 0 0">
               <joint name="tail_4_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
               <geom name="tail_4_geom" type="capsule" fromto="0 0 0  -0.12 0 0.01" size="0.025"
-                    mass="0.4" material="body_mat" contype="0" conaffinity="0"/>
+                    mass="0.4" material="body_mat"/>
 
               <body name="tail_5" pos="-0.12 0 0.01">
                 <joint name="tail_5_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
                 <geom name="tail_5_geom" type="capsule" fromto="0 0 0  -0.1 0 0.02" size="0.015"
-                      mass="0.2" material="body_mat" contype="0" conaffinity="0"/>
+                      mass="0.2" material="body_mat"/>
                 <!-- Tail tip sensor for stability reward -->
                 <site name="tail_tip" pos="-0.1 0 0.02" size="0.01"/>
               </body>


### PR DESCRIPTION
This pull request makes a consistent change across the XML asset files for the Brachiosaurus, T-Rex, and Velociraptor environments. Specifically, it removes the `contype="0"` and `conaffinity="0"` attributes from the tail segment `geom` elements, simplifying the definition of these geometries.

Geometry attribute cleanup:

* Removed the `contype="0"` and `conaffinity="0"` attributes from all tail segment `geom` elements in `brachiosaurus.xml`, `trex.xml`, and `raptor.xml` to streamline the geometry definitions and potentially allow default collision settings to be used. [[1]](diffhunk://#diff-bf41988661628408f7cf28d97f6d55546737c9589d91f1c9cf9c0cd64acbfa24L133-R148) [[2]](diffhunk://#diff-2092f87f984d2def64c441aeb2c9cea9d9be586da004ba3cf858c82b25f07d0eL145-R165) [[3]](diffhunk://#diff-01715a7cc0285dfdfe55ead31818a5e8fb639d762d835d79349498667fc7e1d7L84-R104)