### PR TITLE
Tune stage 1 balance rewards and hyperparams to fix training collapse

### DIFF
--- a/configs/velociraptor/stage1_balance.toml
+++ b/configs/velociraptor/stage1_balance.toml
@@ -5,25 +5,25 @@ description = "Learn to stand and balance without falling"
 [env]
 forward_vel_weight = 0.0
 alive_bonus = 5.0
-energy_penalty_weight = 0.0005
+energy_penalty_weight = 0.0
 tail_stability_weight = 0.02
-posture_weight = 0.2
+posture_weight = 2.0
 gait_symmetry_weight = 0.0
-smoothness_weight = 0.0
+smoothness_weight = 0.1
 strike_bonus = 0.0
 strike_approach_weight = 0.0
 prey_distance_range = [10.0, 15.0]
 max_episode_steps = 500
 
 [ppo]
-learning_rate = 3e-4
+learning_rate = 1e-4
 n_steps = 4096
 batch_size = 64
 n_epochs = 10
 gamma = 0.99
 gae_lambda = 0.95
 clip_range = 0.2
-ent_coef = 0.05
+ent_coef = 0.1
 
 [sac]
 learning_rate = 3e-4
@@ -35,5 +35,5 @@ ent_coef = "auto"
 [curriculum]
 timesteps = 1000000
 min_avg_reward = 50.0
-min_avg_episode_length = 400
+min_avg_episode_length = 300
 required_consecutive = 3


### PR DESCRIPTION
This pull request updates the reinforcement learning configuration for the Velociraptor's stage 1 balance task. The main focus is on tuning reward weights and learning parameters to improve the agent's ability to stand and balance. The most important changes are grouped below:

Reward and environment parameter adjustments:

* Increased `posture_weight` from 0.2 to 2.0 to emphasize maintaining proper posture.
* Set `energy_penalty_weight` to 0.0 (from 0.0005) to remove the penalty for energy use.
* Introduced a small `smoothness_weight` of 0.1 (was 0.0) to encourage smoother movements.

Learning algorithm parameter tuning:

* Reduced PPO `learning_rate` from 3e-4 to 1e-4 and increased `ent_coef` from 0.05 to 0.1 to promote more exploration.

Curriculum criteria update:

* Lowered `min_avg_episode_length` from 400 to 300 to allow curriculum progression with shorter average episodes.