### PR TITLE
Rebalance stage 2 reward weights to prioritize survival over speed

### DIFF
--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -8,6 +8,7 @@ alive_bonus = 2.0
 energy_penalty_weight = 0.05
 tail_stability_weight = 0.1
 posture_weight = 1.5
+nosedive_weight = 2.0
 bite_bonus = 0.0
 bite_approach_weight = 0.0
 prey_distance_range = [10.0, 15.0]

--- a/configs/trex/stage2_locomotion.toml
+++ b/configs/trex/stage2_locomotion.toml
@@ -4,9 +4,13 @@ description = "Learn forward walking/running"
 
 [env]
 forward_vel_weight = 1.0
-alive_bonus = 0.5
+alive_bonus = 1.0
 energy_penalty_weight = 0.001
 tail_stability_weight = 0.05
+posture_weight = 0.4
+nosedive_weight = 0.8
+heading_weight = 0.5
+lateral_penalty_weight = 0.3
 bite_bonus = 0.0
 bite_approach_weight = 5.0
 prey_distance_range = [8.0, 12.0]
@@ -33,4 +37,5 @@ ent_coef = "auto"
 timesteps = 4000000
 min_avg_reward = 100.0
 min_avg_episode_length = 800
+min_avg_forward_vel = 0.4
 required_consecutive = 3

--- a/configs/trex/stage3_bite.toml
+++ b/configs/trex/stage3_bite.toml
@@ -7,6 +7,7 @@ forward_vel_weight = 1.0
 alive_bonus = 0.1
 energy_penalty_weight = 0.001
 tail_stability_weight = 0.02
+nosedive_weight = 0.2
 bite_bonus = 500.0
 bite_approach_weight = 15.0
 prey_distance_range = [3.0, 8.0]

--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -3,15 +3,16 @@ name = "locomotion"
 description = "Learn forward walking/running"
 
 [env]
-forward_vel_weight = 1.0
-alive_bonus = 0.5
+forward_vel_weight = 0.8
+alive_bonus = 1.5
 energy_penalty_weight = 0.001
 tail_stability_weight = 0.05
-posture_weight = 0.2
+posture_weight = 0.5
+nosedive_weight = 0.5
 gait_symmetry_weight = 0.1
-smoothness_weight = 0.05
+smoothness_weight = 0.1
 strike_bonus = 0.0
-strike_approach_weight = 2.0
+strike_approach_weight = 0.5
 heading_weight = 0.5
 lateral_penalty_weight = 0.3
 prey_distance_range = [8.0, 12.0]


### PR DESCRIPTION
This pull request updates the reward configuration parameters for the T. rex and Velociraptor reinforcement learning environments across several training stages. The main focus is on tuning weights for posture, nosedive, heading, and other behavioral metrics to improve training stability and desired behaviors.

**Reward function tuning for T. rex:**

* Added `nosedive_weight` to all T. rex training stages to penalize head-first falls, with different values for each stage (`stage1_balance.toml`, `stage2_locomotion.toml`, `stage3_bite.toml`). [[1]](diffhunk://#diff-45ae85f2f1569e380a39e61e0e03196b4ad78106254631d6c214d8283c467e34R11) [[2]](diffhunk://#diff-bfe66ee4857bacfc7bab6809046318547d888558597efd8b64552f4534a18d2fL7-R13) [[3]](diffhunk://#diff-4359aeb7ba409e51982c906de9be105d58651f643f6d09460397100120405bcdR10)
* Increased `alive_bonus` and adjusted other weights (e.g., `posture_weight`, `heading_weight`, `lateral_penalty_weight`) in `stage2_locomotion.toml` to encourage more stable and forward-directed movement.
* Added `min_avg_forward_vel` as a new training success criterion in `stage2_locomotion.toml` to ensure agents achieve a minimum average speed.

**Reward function tuning for Velociraptor:**

* Adjusted multiple reward weights in `stage2_locomotion.toml`, including increasing `alive_bonus`, `posture_weight`, and `smoothness_weight`, and decreasing `forward_vel_weight` and `strike_approach_weight`, to better balance locomotion and stability. Added a new `nosedive_weight` parameter.