### PR TITLE
Update docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /app
 # is a no-op, but all *dependencies* get cached in this layer.
 COPY pyproject.toml README.md ./
 RUN mkdir -p environments && \
-    pip install --no-cache-dir ".[train]"
+    pip install --no-cache-dir ".[train,viz]"
 
 # Copy project source code
 COPY environments/ environments/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,16 +16,19 @@ ENV MUJOCO_GL=osmesa
 
 WORKDIR /app
 
-# Install Python dependencies first (for Docker layer caching)
-COPY pyproject.toml .
-RUN pip install --no-cache-dir -e ".[train]"
+# Install Python dependencies first (for Docker layer caching).
+# Copy only pyproject.toml + README (needed by metadata) and install the
+# package non-editable.  Because environments/ is empty the package itself
+# is a no-op, but all *dependencies* get cached in this layer.
+COPY pyproject.toml README.md ./
+RUN mkdir -p environments && \
+    pip install --no-cache-dir ".[train]"
 
 # Copy project source code
 COPY environments/ environments/
 COPY configs/ configs/
 
-# Install the package in editable mode
-COPY README.md .
-RUN pip install --no-cache-dir -e ".[train]"
+# Re-install in editable mode (deps already cached, so this is fast)
+RUN pip install --no-cache-dir --no-deps -e .
 
 ENTRYPOINT ["python"]


### PR DESCRIPTION
This pull request updates the Docker build process to improve dependency caching and installation efficiency. The main focus is on optimizing Python dependency installation and reducing build times by leveraging Docker layer caching more effectively.

**Docker build and dependency installation improvements:**

* Only `pyproject.toml` and `README.md` are copied initially, and dependencies are installed in non-editable mode to maximize Docker layer caching and avoid redundant installs; this ensures that dependencies are cached even when the main source code changes.
* The package is re-installed in editable mode after copying the full source code, but with `--no-deps` to avoid reinstalling already-cached dependencies, making this step faster.
* The installation now includes both `train` and `viz` extras in the initial dependency install, ensuring all relevant dependencies are pre-cached.
* The `environments/` directory is created before dependency installation to satisfy package structure requirements, even though it is empty at that stage.