### PR TITLE
Add backward velocity penalty reward component to Raptor

### DIFF
--- a/configs/velociraptor/stage1_balance.toml
+++ b/configs/velociraptor/stage1_balance.toml
@@ -4,6 +4,7 @@ description = "Learn to stand and balance without falling"
 
 [env]
 forward_vel_weight = 0.0
+backward_vel_penalty_weight = 0.5
 alive_bonus = 2.0
 energy_penalty_weight = 0.05
 tail_stability_weight = 0.02

--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -5,6 +5,7 @@ description = "Learn forward walking/running"
 [env]
 forward_vel_weight = 3.0
 forward_vel_max = 3.0
+backward_vel_penalty_weight = 0.0
 alive_bonus = 0.5
 energy_penalty_weight = 0.001
 tail_stability_weight = 0.05

--- a/configs/velociraptor/stage3_strike.toml
+++ b/configs/velociraptor/stage3_strike.toml
@@ -4,6 +4,7 @@ description = "Sprint and strike prey with sickle claw"
 
 [env]
 forward_vel_weight = 1.0
+backward_vel_penalty_weight = 0.0
 alive_bonus = 0.1
 energy_penalty_weight = 0.001
 tail_stability_weight = 0.02

--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -68,6 +68,7 @@ class RaptorEnv(BaseDinoEnv):
         smoothness_weight: float = 0.05,
         heading_weight: float = 0.0,
         lateral_penalty_weight: float = 0.0,
+        backward_vel_penalty_weight: float = 0.0,
         # Environment settings
         prey_distance_range: Tuple[float, float] = (3.0, 8.0),
         prey_lateral_range: Tuple[float, float] = (-2.0, 2.0),
@@ -86,6 +87,7 @@ class RaptorEnv(BaseDinoEnv):
         self.smoothness_weight = smoothness_weight
         self.heading_weight = heading_weight
         self.lateral_penalty_weight = lateral_penalty_weight
+        self.backward_vel_penalty_weight = backward_vel_penalty_weight
 
         # Natural forward pitch (~20°). The nosedive penalty and termination
         # are measured relative to this angle so the raptor isn't punished for
@@ -226,6 +228,15 @@ class RaptorEnv(BaseDinoEnv):
         reward_forward = self.forward_vel_weight * forward_vel_norm
         info["reward_forward"] = reward_forward
 
+        # 1b. Backward velocity penalty (penalize drifting backward without
+        #     rewarding forward movement — useful in balance stages where
+        #     forward_vel_weight is zero)
+        backward_vel = max(0.0, -forward_vel)
+        backward_vel_norm = min(backward_vel / self.forward_vel_max, 1.0)
+        reward_backward = -self.backward_vel_penalty_weight * backward_vel_norm
+        info["backward_vel"] = backward_vel
+        info["reward_backward"] = reward_backward
+
         # 2. Alive bonus
         reward_alive = self.alive_bonus
         info["reward_alive"] = reward_alive
@@ -361,6 +372,7 @@ class RaptorEnv(BaseDinoEnv):
         # Total reward
         total_reward = (
             reward_forward
+            + reward_backward
             + reward_alive
             + reward_energy
             + reward_tail

--- a/environments/velociraptor/tests/test_raptor_rewards.py
+++ b/environments/velociraptor/tests/test_raptor_rewards.py
@@ -61,6 +61,7 @@ class TestRewardComponents:
         _, _, terminated, _, info = env.step(action)
         expected = (
             info["reward_forward"]
+            + info["reward_backward"]
             + info["reward_alive"]
             + info["reward_energy"]
             + info["reward_tail"]
@@ -110,6 +111,14 @@ class TestRewardComponents:
         _, _, _, _, info = env.step(action2)
         assert info["reward_smoothness"] < 0.0
         assert info["action_delta"] > 0.0
+
+    def test_backward_vel_penalty_non_positive(self, env):
+        """Backward velocity penalty should be non-positive."""
+        env.reset(seed=42)
+        action = env.action_space.sample()
+        _, _, _, _, info = env.step(action)
+        assert info["reward_backward"] <= 0.0
+        assert info["backward_vel"] >= 0.0
 
 
 class TestRewardWeightEffects:
@@ -167,6 +176,29 @@ class TestRewardWeightEffects:
         assert info["reward_smoothness"] == 0.0
         env.close()
 
+    def test_zero_backward_vel_weight_zeroes_backward_reward(self):
+        env = RaptorEnv(backward_vel_penalty_weight=0.0)
+        env.reset(seed=42)
+        action = env.action_space.sample()
+        _, _, _, _, info = env.step(action)
+        assert info["reward_backward"] == 0.0
+        env.close()
+
+    def test_nonzero_backward_vel_weight_penalizes_backward_motion(self):
+        """Backward penalty should be negative when raptor moves backward."""
+        env = RaptorEnv(backward_vel_penalty_weight=1.0, forward_vel_weight=0.0)
+        env.reset(seed=42)
+        # Run several steps with random actions to induce some velocity
+        for _ in range(10):
+            action = env.action_space.sample()
+            _, _, terminated, _, info = env.step(action)
+            if terminated:
+                break
+            if info["backward_vel"] > 0:
+                assert info["reward_backward"] < 0.0
+                break
+        env.close()
+
     def test_actuator_count(self):
         """All actuators should be enabled (22 total: 14 legs + 4 tail + 4 arms)."""
         env = RaptorEnv()
@@ -179,13 +211,20 @@ class TestCurriculumStageRewards:
     """Test that reward configs from TOML produce expected behavior."""
 
     def test_stage1_balance_no_forward_reward(self):
-        """Stage 1 config disables forward velocity reward."""
-        env = RaptorEnv(forward_vel_weight=0.0, strike_bonus=0.0, strike_approach_weight=0.0)
+        """Stage 1 config disables forward velocity reward but penalizes backward drift."""
+        env = RaptorEnv(
+            forward_vel_weight=0.0,
+            backward_vel_penalty_weight=0.5,
+            strike_bonus=0.0,
+            strike_approach_weight=0.0,
+        )
         env.reset(seed=42)
         action = env.action_space.sample()
         _, _, _, _, info = env.step(action)
         assert info["reward_forward"] == 0.0
         assert info["reward_strike"] == 0.0
+        # Backward penalty should be active (non-positive)
+        assert info["reward_backward"] <= 0.0
         env.close()
 
     def test_stage3_strike_has_approach_shaping(self):


### PR DESCRIPTION
## Summary
This PR introduces a new backward velocity penalty reward component to the Velociraptor environment. This allows the agent to be penalized for moving backward, which is particularly useful in balance-focused training stages where forward velocity rewards are disabled.

## Key Changes

- **New reward component**: Added `backward_vel_penalty_weight` parameter to `RaptorEnv` that penalizes backward motion (negative forward velocity)
  - Backward velocity is clamped to [0, max] and normalized
  - Penalty is applied as `-backward_vel_penalty_weight * normalized_backward_vel`
  - Included in total reward calculation alongside other components

- **Configuration updates**: 
  - Stage 1 (balance): Set `backward_vel_penalty_weight = 0.5` to discourage backward drift while learning to balance
  - Stage 2 (locomotion): Set `backward_vel_penalty_weight = 0.0` to focus on forward movement
  - Stage 3 (strike): Set `backward_vel_penalty_weight = 0.0` to focus on forward sprint and strike

- **Test coverage**:
  - Added `test_backward_vel_penalty_non_positive()` to verify penalty is non-positive and backward velocity is non-negative
  - Added `test_zero_backward_vel_weight_zeroes_backward_reward()` to verify zero weight disables the component
  - Added `test_nonzero_backward_vel_weight_penalizes_backward_motion()` to verify penalty activates on backward motion
  - Updated `test_stage1_balance_no_forward_reward()` to verify backward penalty is active in balance stage
  - Updated `test_total_reward_is_sum_of_components()` to include backward reward in total calculation

## Implementation Details

- Backward velocity is computed as `max(0.0, -forward_vel)` to only penalize negative velocities
- The penalty is normalized by `forward_vel_max` to maintain consistent scaling across configurations
- The component integrates seamlessly with existing reward structure and curriculum stages