### PR TITLE
Remove jaw joint and simplify T-Rex bite mechanics

### DIFF
--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -20,10 +20,6 @@
       <joint damping="20.0" stiffness="40.0" armature="0.05" range="-12 12"/>
     </default>
 
-    <!-- Jaw joint -->
-    <default class="jaw_joint">
-      <joint damping="5.0" armature="0.02"/>
-    </default>
   </default>
 
   <asset>
@@ -66,7 +62,7 @@
       Total mass: ~80kg (scaled)
 
     T-Rex anatomy:
-      - Massive skull with powerful jaws (~60% of body force)
+      - Massive skull (~60% of body force)
       - Tiny vestigial forelimbs (2 fingers)
       - Powerful digitigrade hind legs
       - Heavy muscular tail as counterbalance to skull
@@ -121,16 +117,9 @@
           <!-- Head tip sensor for bite detection -->
           <site name="head_tip" pos="0.48 0 0" size="0.02"/>
 
-          <!-- Jaw (lower mandible) -->
-          <body name="jaw" pos="0.05 0 -0.06">
-            <joint name="jaw_joint" class="jaw_joint" type="hinge" axis="0 1 0" range="0 35"/>
-            <geom name="jaw_geom" type="capsule" fromto="0 0 0  0.38 0 0.02" size="0.07"
-                  mass="3.0" material="head_mat"/>
-            <!-- Jaw contact geom for bite detection -->
-            <geom name="jaw_bite" type="box" pos="0.35 0 0.04" size="0.06 0.05 0.02"
-                  mass="0.2" material="tooth_mat" contype="2" conaffinity="2"/>
-            <site name="jaw_tip" pos="0.38 0 0.02" size="0.015"/>
-          </body>
+          <!-- Head contact geom for bite detection (at snout tip) -->
+          <geom name="head_bite" type="box" pos="0.46 0 -0.02" size="0.06 0.05 0.04"
+                mass="0.2" material="tooth_mat" contype="2" conaffinity="2"/>
         </body>
       </body>
 
@@ -298,7 +287,7 @@
   </worldbody>
 
   <!-- ==================== ACTUATORS ==================== -->
-  <!-- Position actuators for locomotion, motor for jaw -->
+  <!-- Position actuators for locomotion -->
 
   <actuator>
     <!-- NOTE: ctrlrange must be in radians — the compiler angle="degree" setting
@@ -308,7 +297,6 @@
     <position name="neck_pitch_act" joint="neck_pitch" kp="150" ctrlrange="-0.5236 0.6981"/>
     <position name="neck_yaw_act" joint="neck_yaw" kp="100" ctrlrange="-0.3491 0.3491"/>
     <position name="head_pitch_act" joint="head_pitch" kp="80" ctrlrange="-0.4363 0.6109"/>
-    <motor name="jaw_act" joint="jaw_joint" gear="80" ctrlrange="-1 1"/>
 
     <!-- Right leg -->
     <position name="r_hip_pitch_act" joint="r_hip_pitch" kp="200" ctrlrange="-0.8727 1.3963"/>
@@ -346,9 +334,8 @@
     <touch name="r_foot_touch" site="r_foot"/>
     <touch name="l_foot_touch" site="l_foot"/>
 
-    <!-- Head/jaw positions for bite detection -->
+    <!-- Head position for bite detection -->
     <framepos name="head_tip_pos" objtype="site" objname="head_tip"/>
-    <framepos name="jaw_tip_pos" objtype="site" objname="jaw_tip"/>
 
     <!-- Tail tip for stability monitoring -->
     <framepos name="tail_tip_pos" objtype="site" objname="tail_tip"/>
@@ -362,7 +349,6 @@
     <!-- Neck/head chain -->
     <exclude body1="pelvis" body2="neck"/>
     <exclude body1="neck" body2="skull"/>
-    <exclude body1="skull" body2="jaw"/>
 
     <!-- Tail chain -->
     <exclude body1="pelvis" body2="tail_1"/>
@@ -389,11 +375,11 @@
   <keyframe>
     <key name="home"
          qpos="0 0 0.90 1 0 0 0
-               0 0 0 0 0 0 0 0 0 0
+               0 0 0 0 0 0 0 0 0
                0.261799 0 -1.221730 1.570796 0.261799 0.261799 0.261799
                0.261799 0 -1.221730 1.570796 0.261799 0.261799 0.261799
                1 0 0 0 0 1 0 0 0 0"
-         ctrl="0 0 0 0
+         ctrl="0 0 0
                0.261799 0 -1.221730 1.570796 0.261799 0.261799 0.261799
                0.261799 0 -1.221730 1.570796 0.261799 0.261799 0.261799
                0 0 0"/>

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -1,9 +1,9 @@
 """
 Tyrannosaurus Rex Gymnasium Environment
 
-A large bipedal predator with a massive skull, powerful jaws, and
-vestigial forelimbs.  The T-Rex hunts by sprinting toward prey and
-delivering a bite with its jaw.
+A large bipedal predator with a massive skull and vestigial forelimbs.
+The T-Rex hunts by sprinting toward prey and delivering a bite with
+its head.
 
 Observation space:
     - Joint positions (qpos) excluding root freejoint
@@ -17,7 +17,7 @@ Observation space:
 
 Action space:
     - Continuous control for all actuators [-1, 1] normalized
-    - 18 actuators: 3 neck/head + 1 jaw + 7 per leg (hip pitch/roll, knee, ankle, 3 toe digits)
+    - 17 actuators: 3 neck/head + 7 per leg (hip pitch/roll, knee, ankle, 3 toe digits)
 
 Reward components:
     - Forward velocity (toward prey)
@@ -25,7 +25,7 @@ Reward components:
     - Fall penalty
     - Energy penalty
     - Tail stability
-    - Bite bonus (jaw contacts prey)
+    - Bite bonus (head contacts prey)
     - Approach shaping (distance to prey)
 """
 
@@ -117,7 +117,7 @@ class TRexEnv(BaseDinoEnv):
 
         # Geom IDs for contact detection
         self.prey_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "prey_geom")
-        self.jaw_bite_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "jaw_bite")
+        self.head_bite_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "head_bite")
         self.torso_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "torso")
         self.floor_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "floor")
 
@@ -125,7 +125,6 @@ class TRexEnv(BaseDinoEnv):
         # Note: neck_geom and brow_ridge have contype=0, so they never produce floor contacts
         self.skull_upper_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "skull_upper")
         self.snout_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "snout")
-        self.jaw_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "jaw_geom")
 
         # Tail geom IDs (distal segments that should not contact floor)
         self.tail_3_geom_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "tail_3_geom")
@@ -137,12 +136,11 @@ class TRexEnv(BaseDinoEnv):
             self.torso_geom_id,
             self.skull_upper_geom_id,
             self.snout_geom_id,
-            self.jaw_geom_id,
             self.tail_3_geom_id,
             self.tail_4_geom_id,
             self.tail_5_geom_id,
         }
-        self._head_ground_geoms = {self.skull_upper_geom_id, self.snout_geom_id, self.jaw_geom_id}
+        self._head_ground_geoms = {self.skull_upper_geom_id, self.snout_geom_id}
         self._tail_ground_geoms = {self.tail_3_geom_id, self.tail_4_geom_id, self.tail_5_geom_id}
 
         # Site IDs for sensors
@@ -260,14 +258,14 @@ class TRexEnv(BaseDinoEnv):
         info["tail_instability"] = tail_instability
         info["reward_tail"] = reward_tail
 
-        # 5. Bite bonus (check jaw_bite-prey contact)
+        # 5. Bite bonus (check head_bite-prey contact)
         bite_reward = 0.0
         for i in range(self.data.ncon):
             contact = self.data.contact[i]
             geom1, geom2 = contact.geom1, contact.geom2
 
-            if (geom1 == self.jaw_bite_geom_id and geom2 == self.prey_geom_id) or (
-                geom2 == self.jaw_bite_geom_id and geom1 == self.prey_geom_id
+            if (geom1 == self.head_bite_geom_id and geom2 == self.prey_geom_id) or (
+                geom2 == self.head_bite_geom_id and geom1 == self.prey_geom_id
             ):
                 bite_reward = self.bite_bonus
                 info["bite_success"] = 1.0

--- a/environments/trex/tests/test_trex_env.py
+++ b/environments/trex/tests/test_trex_env.py
@@ -16,9 +16,9 @@ def env():
 
 class TestBasicFunctionality:
     def test_spaces_are_valid(self, env):
-        assert env.observation_space.shape == (85,)
+        assert env.observation_space.shape == (83,)
         assert env.observation_space.dtype == np.float32
-        assert env.action_space.shape == (21,)
+        assert env.action_space.shape == (20,)
         assert np.all(env.action_space.low == -1.0)
         assert np.all(env.action_space.high == 1.0)
 
@@ -119,7 +119,7 @@ class TestHeadFloorTermination:
     def test_head_geom_ids_cached(self, env):
         """Head geom IDs should be resolved and present in termination sets."""
         env.reset(seed=42)
-        for attr in ("skull_upper_geom_id", "snout_geom_id", "jaw_geom_id"):
+        for attr in ("skull_upper_geom_id", "snout_geom_id"):
             gid = getattr(env, attr)
             assert gid >= 0, f"{attr} was not resolved"
             assert gid in env._body_ground_geoms


### PR DESCRIPTION
## Summary
This PR removes the articulated jaw joint from the T-Rex model and simplifies the bite mechanics to use head contact instead. The jaw was previously a separate body with its own joint, actuator, and sensors, but is now integrated into the skull geometry.

## Key Changes

**Model Changes (trex.xml):**
- Removed `jaw_joint` default class definition
- Removed the `jaw` body element (lower mandible) with its joint, geometry, and sensors
- Replaced jaw bite detection with a `head_bite` contact geometry positioned at the snout tip
- Removed `jaw_act` motor actuator from the actuators section
- Updated documentation to reflect "massive skull" instead of "powerful jaws"
- Removed jaw-related collision exclusions and sensor definitions
- Updated keyframe qpos/ctrl arrays to account for removed jaw joint (18→17 actuators)

**Environment Changes (trex_env.py):**
- Renamed `jaw_bite_geom_id` to `head_bite_geom_id` for contact detection
- Removed `jaw_geom_id` from cached geometry IDs and termination sets
- Updated bite reward logic to check `head_bite` contact instead of `jaw_bite`
- Updated docstring to reflect bite delivery via head instead of jaw
- Reduced actuator count from 18 to 17 in documentation

**Test Changes (test_trex_env.py):**
- Updated observation space shape from 85 to 83 dimensions
- Updated action space shape from 21 to 20 dimensions
- Removed `jaw_geom_id` from head geometry validation test

## Implementation Details
The bite detection mechanism now uses a single contact geometry (`head_bite`) positioned at the snout tip rather than a separate jaw body. This simplification reduces model complexity while maintaining bite reward functionality. The reward system continues to detect prey contact through the same contact-checking mechanism, just with the updated geometry reference.