### PR TITLE
Add comprehensive locomotion logging across training pipeline

### DIFF
--- a/environments/shared/curriculum.py
+++ b/environments/shared/curriculum.py
@@ -35,6 +35,7 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 
 from environments.shared.config import load_all_stages
+from environments.shared.metrics import LocomotionMetrics
 
 try:
     from stable_baselines3.common.callbacks import BaseCallback
@@ -337,12 +338,15 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
 
         self._last_eval_step = self.num_timesteps
 
-        # Run evaluation episodes
+        # Run evaluation episodes with full locomotion metrics
         rewards: List[float] = []
         lengths: List[float] = []
         forward_vels: List[float] = []
-        for _ in range(self.n_eval_episodes):
+        episode_reports: List[Dict[str, Any]] = []
+
+        for ep_idx in range(self.n_eval_episodes):
             obs = self.eval_env.reset()
+            metrics = LocomotionMetrics()
             episode_reward = 0.0
             episode_length = 0
             ep_forward_vels: List[float] = []
@@ -350,8 +354,10 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
             while not done:
                 action, _ = self.model.predict(obs, deterministic=True)
                 obs, reward, dones, infos = self.eval_env.step(action)
-                episode_reward += float(reward[0])
+                step_reward = float(reward[0])
+                episode_reward += step_reward
                 episode_length += 1
+                metrics.record_step(infos[0], step_reward)
                 if "forward_vel" in infos[0]:
                     ep_forward_vels.append(float(infos[0]["forward_vel"]))
                 done = bool(dones[0])
@@ -359,6 +365,42 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
             lengths.append(float(episode_length))
             if ep_forward_vels:
                 forward_vels.append(float(np.mean(ep_forward_vels)))
+            episode_reports.append(metrics.compute())
+
+        # Log aggregated locomotion metrics
+        if episode_reports:
+            agg = LocomotionMetrics.aggregate_episodes(episode_reports)
+            stage = self.curriculum_manager.current_stage
+
+            # Log key locomotion metrics
+            metric_keys = [
+                "mean_forward_velocity", "mean_total_distance",
+                "mean_cost_of_transport", "mean_gait_symmetry",
+                "mean_stride_frequency", "mean_pelvis_height",
+                "mean_mean_tilt_angle", "mean_velocity_consistency",
+            ]
+            metric_parts = []
+            for k in metric_keys:
+                if k in agg:
+                    short_name = k.replace("mean_", "")
+                    metric_parts.append(f"{short_name}={agg[k]:.3f}")
+            if metric_parts:
+                logger.info(
+                    "Stage %d locomotion: %s",
+                    stage,
+                    ", ".join(metric_parts),
+                )
+
+            # Log termination reason breakdown
+            term_counts = agg.get("termination_counts")
+            if term_counts:
+                parts = [f"{reason}={count}" for reason, count in sorted(term_counts.items())]
+                logger.info(
+                    "Stage %d terminations (%d eps): %s",
+                    stage,
+                    self.n_eval_episodes,
+                    ", ".join(parts),
+                )
 
         fwd_vel_arg = forward_vels if forward_vels else None
         if self.curriculum_manager.should_advance(rewards, lengths, fwd_vel_arg):

--- a/environments/shared/curriculum.py
+++ b/environments/shared/curriculum.py
@@ -36,6 +36,7 @@ import numpy as np
 
 from environments.shared.config import load_all_stages
 from environments.shared.metrics import LocomotionMetrics
+from environments.shared.wandb_integration import log_eval_metrics
 
 try:
     from stable_baselines3.common.callbacks import BaseCallback
@@ -401,6 +402,9 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
                     self.n_eval_episodes,
                     ", ".join(parts),
                 )
+
+            # Send aggregated metrics to W&B
+            log_eval_metrics(agg, stage, step=self.num_timesteps)
 
         fwd_vel_arg = forward_vels if forward_vels else None
         if self.curriculum_manager.should_advance(rewards, lengths, fwd_vel_arg):

--- a/environments/shared/metrics.py
+++ b/environments/shared/metrics.py
@@ -17,8 +17,9 @@ Usage:
     report = metrics.compute()
 """
 
+from collections import Counter
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 
@@ -42,6 +43,7 @@ class LocomotionMetrics:
     _tilt_angles: List[float] = field(default_factory=list)
     _rewards: List[float] = field(default_factory=list)
     _dt: float = 0.02  # default timestep * frame_skip
+    _termination_reason: Optional[str] = None
 
     def reset(self):
         """Clear all accumulated data."""
@@ -53,6 +55,7 @@ class LocomotionMetrics:
         self._prey_distances.clear()
         self._tilt_angles.clear()
         self._rewards.clear()
+        self._termination_reason = None
 
     def record_step(self, info: Dict[str, Any], reward: float = 0.0):
         """Record a single environment step.
@@ -79,6 +82,10 @@ class LocomotionMetrics:
 
         self._left_contacts.append(info.get("l_foot_contact", 0.0))
         self._right_contacts.append(info.get("r_foot_contact", 0.0))
+
+        # Capture termination reason from the final step
+        if "termination_reason" in info:
+            self._termination_reason = info["termination_reason"]
 
     def compute(self, body_mass: float = 1.0) -> Dict[str, float]:
         """Compute all locomotion metrics from accumulated data.
@@ -162,6 +169,10 @@ class LocomotionMetrics:
         result["mean_step_reward"] = float(np.mean(rewards))
         result["episode_length"] = n
 
+        # --- Termination reason ---
+        if self._termination_reason is not None:
+            result["termination_reason"] = self._termination_reason
+
         return result
 
     @staticmethod
@@ -214,21 +225,24 @@ class LocomotionMetrics:
 
     @staticmethod
     def aggregate_episodes(
-        episode_reports: List[Dict[str, float]],
-    ) -> Dict[str, float]:
+        episode_reports: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
         """Aggregate metrics across multiple episodes.
 
         Args:
             episode_reports: List of dicts from :meth:`compute`.
 
         Returns:
-            Aggregated dict with mean/std for each metric.
+            Aggregated dict with mean/std for each numeric metric and
+            termination reason counts.
         """
         if not episode_reports:
             return {}
 
-        keys = [k for k in episode_reports[0] if k != "error"]
-        result: Dict[str, float] = {}
+        # Separate numeric keys from non-numeric (like termination_reason)
+        non_numeric_keys = {"termination_reason", "error"}
+        keys = [k for k in episode_reports[0] if k not in non_numeric_keys]
+        result: Dict[str, Any] = {}
 
         for key in keys:
             values = [r[key] for r in episode_reports if key in r and r[key] != float("inf")]
@@ -237,4 +251,15 @@ class LocomotionMetrics:
                 result[f"std_{key}"] = float(np.std(values))
 
         result["n_episodes"] = float(len(episode_reports))
+
+        # Aggregate termination reasons
+        reasons = [r["termination_reason"] for r in episode_reports if "termination_reason" in r]
+        if reasons:
+            counts = Counter(reasons)
+            result["termination_counts"] = dict(counts)
+            # Also add truncated count (episodes that ended without termination)
+            n_truncated = len(episode_reports) - len(reasons)
+            if n_truncated > 0:
+                result["termination_counts"]["truncated"] = n_truncated
+
         return result

--- a/environments/shared/wandb_integration.py
+++ b/environments/shared/wandb_integration.py
@@ -112,6 +112,11 @@ def init_wandb(
     )
 
     logger.info("W&B run initialized: %s (%s)", run.name, run.url)
+
+    # Configure metric display and dashboard panels
+    setup_wandb_metrics(stage)
+    create_wandb_dashboard(stage)
+
     return run
 
 
@@ -287,23 +292,151 @@ class WandbCallback(BaseCallback):
 
 
 def log_eval_metrics(
-    eval_results: Dict[str, float],
+    eval_results: Dict[str, Any],
     stage: int,
     step: Optional[int] = None,
 ):
     """Log evaluation metrics to W&B.
 
+    Handles numeric metrics as scalar logs and termination_counts as
+    individual per-reason metrics (for stacked area charts).
+
     Args:
-        eval_results: Dict of metric name to value (from LocomotionMetrics.compute).
+        eval_results: Aggregated dict from ``LocomotionMetrics.aggregate_episodes``.
         stage: Current curriculum stage.
         step: Training step number for x-axis alignment.
     """
     if not is_available() or wandb.run is None:
         return
 
-    metrics: dict[str, float] = {"eval/stage": float(stage)}
+    metrics: Dict[str, Any] = {"eval/stage": float(stage)}
+
     for key, value in eval_results.items():
-        if isinstance(value, (int, float)):
+        if key == "termination_counts" and isinstance(value, dict):
+            # Log each termination reason as a separate metric for stacked area
+            for reason, count in value.items():
+                metrics[f"eval/termination/{reason}"] = float(count)
+        elif isinstance(value, (int, float)):
             metrics[f"eval/{key}"] = float(value)
 
     wandb.log(metrics, step=step)
+
+
+def setup_wandb_metrics(stage: int) -> None:
+    """Configure W&B metric display properties.
+
+    Defines metric groupings and x-axis relationships so W&B
+    auto-creates well-organised panels. Call once after ``init_wandb``.
+
+    Args:
+        stage: Current curriculum stage number.
+    """
+    if not is_available() or wandb.run is None:
+        return
+
+    # All eval metrics use training timesteps as x-axis
+    wandb.define_metric("eval/*", step_metric="train/timesteps")
+    wandb.define_metric("reward/*", step_metric="train/timesteps")
+
+    # ---- Master panels (all stages) ----
+    # Termination reasons: individual reason metrics for stacked area
+    wandb.define_metric("eval/termination/*", step_metric="train/timesteps")
+    # Cost of transport
+    wandb.define_metric("eval/mean_cost_of_transport", step_metric="train/timesteps")
+
+    # ---- Stage 1: Balance ----
+    wandb.define_metric("reward/pelvis_height", step_metric="train/timesteps")
+    # reward_alive, reward_posture, reward_nosedive already under reward/*
+
+    # ---- Stage 2: Locomotion ----
+    wandb.define_metric("eval/mean_gait_symmetry", step_metric="train/timesteps")
+    wandb.define_metric("eval/mean_stride_frequency", step_metric="train/timesteps")
+    wandb.define_metric("reward/heading_alignment", step_metric="train/timesteps")
+
+    # ---- Stage 3: Strike ----
+    wandb.define_metric("reward/prey_distance", step_metric="train/timesteps")
+    wandb.define_metric("eval/mean_min_prey_distance", step_metric="train/timesteps")
+    wandb.define_metric("reward/strike_success", step_metric="train/timesteps")
+
+
+def create_wandb_dashboard(stage: int) -> None:
+    """Create a W&B custom dashboard with training curve panels.
+
+    Logs a ``wandb.Table`` summarising which panels to display and
+    defines custom charts for the 8 new panels (2 master + 6 stage).
+    This function relies on W&B's Custom Charts (Vega-Lite) to
+    render the panels.
+
+    Args:
+        stage: Current curriculum stage number.
+    """
+    if not is_available() or wandb.run is None:
+        return
+
+    # Define the dashboard panel configuration as run metadata
+    # so it's easy to reconstruct the layout in the W&B UI.
+    panel_config = {
+        "master": [
+            {
+                "title": "Termination Reasons",
+                "metrics": ["eval/termination/*"],
+                "type": "stacked_area",
+            },
+            {
+                "title": "Cost of Transport",
+                "metrics": ["eval/mean_cost_of_transport"],
+                "type": "line",
+            },
+        ],
+        "stage1_balance": [
+            {
+                "title": "Pelvis Height",
+                "metrics": ["reward/pelvis_height"],
+                "type": "line_with_std",
+            },
+            {
+                "title": "Reward Decomposition",
+                "metrics": [
+                    "reward/reward_alive",
+                    "reward/reward_posture",
+                    "reward/reward_nosedive",
+                ],
+                "type": "stacked_area",
+            },
+        ],
+        "stage2_locomotion": [
+            {
+                "title": "Gait Symmetry + Stride Frequency",
+                "metrics": [
+                    "eval/mean_gait_symmetry",
+                    "eval/mean_stride_frequency",
+                ],
+                "type": "dual_axis",
+            },
+            {
+                "title": "Heading Alignment",
+                "metrics": ["reward/heading_alignment"],
+                "type": "line",
+            },
+        ],
+        "stage3_strike": [
+            {
+                "title": "Prey Distance (mean + min)",
+                "metrics": [
+                    "reward/prey_distance",
+                    "eval/mean_min_prey_distance",
+                ],
+                "type": "multi_line",
+            },
+            {
+                "title": "Strike Success Rate",
+                "metrics": ["reward/strike_success"],
+                "type": "line",
+            },
+        ],
+    }
+
+    # Store as run config so it's accessible from the W&B UI
+    wandb.config.update({"dashboard_panels": panel_config}, allow_val_change=True)
+
+    logger.info("W&B dashboard configuration saved for stage %d", stage)

--- a/environments/shared/wandb_integration.py
+++ b/environments/shared/wandb_integration.py
@@ -359,84 +359,186 @@ def setup_wandb_metrics(stage: int) -> None:
     wandb.define_metric("reward/strike_success", step_metric="train/timesteps")
 
 
-def create_wandb_dashboard(stage: int) -> None:
-    """Create a W&B custom dashboard with training curve panels.
+def create_wandb_dashboard(
+    stage: int,
+    entity: Optional[str] = None,
+    project: str = "mesozoic-labs",
+) -> None:
+    """Create a W&B workspace with the training curve panel layout.
 
-    Logs a ``wandb.Table`` summarising which panels to display and
-    defines custom charts for the 8 new panels (2 master + 6 stage).
-    This function relies on W&B's Custom Charts (Vega-Lite) to
-    render the panels.
+    Uses the ``wandb-workspaces`` library to programmatically build a
+    workspace with 4 sections (master + one per stage), each containing
+    2 panels arranged in a 2-column grid. Falls back to saving the
+    panel configuration as run metadata if ``wandb-workspaces`` is not
+    installed.
 
     Args:
         stage: Current curriculum stage number.
+        entity: W&B entity (team/user). Auto-detected from run if None.
+        project: W&B project name.
     """
     if not is_available() or wandb.run is None:
         return
 
-    # Define the dashboard panel configuration as run metadata
-    # so it's easy to reconstruct the layout in the W&B UI.
+    try:
+        import wandb_workspaces.reports.v2 as wr
+        import wandb_workspaces.workspaces as ws
+    except ImportError:
+        logger.info(
+            "wandb-workspaces not installed. Install with: pip install wandb-workspaces. "
+            "Saving panel config as run metadata instead."
+        )
+        _save_dashboard_config_fallback(stage)
+        return
+
+    if entity is None:
+        entity = wandb.run.entity
+
+    x_axis = "train/timesteps"
+
+    # Known termination reasons across all species
+    termination_keys = [
+        "eval/termination/fallen",
+        "eval/termination/excessive_tilt",
+        "eval/termination/nosedive",
+        "eval/termination/body_contact",
+        "eval/termination/tail_contact",
+        "eval/termination/too_high",
+        "eval/termination/truncated",
+    ]
+
+    sections = [
+        # ---- Master (all stages) ----
+        ws.Section(
+            name="Master — All Stages",
+            is_open=True,
+            panels=[
+                wr.LinePlot(
+                    title="Termination Reasons",
+                    x=x_axis,
+                    y=termination_keys,
+                    plot_type="stacked-area",
+                    title_x="Training Steps",
+                    title_y="Count per Eval",
+                ),
+                wr.LinePlot(
+                    title="Cost of Transport",
+                    x=x_axis,
+                    y=["eval/mean_cost_of_transport"],
+                    title_x="Training Steps",
+                    title_y="CoT (lower = more efficient)",
+                ),
+            ],
+        ),
+        # ---- Stage 1: Balance ----
+        ws.Section(
+            name="Stage 1 — Balance",
+            is_open=(stage == 1),
+            panels=[
+                wr.LinePlot(
+                    title="Pelvis Height",
+                    x=x_axis,
+                    y=["reward/pelvis_height"],
+                    title_x="Training Steps",
+                    title_y="Height (m)",
+                ),
+                wr.LinePlot(
+                    title="Reward Decomposition (alive / posture / nosedive)",
+                    x=x_axis,
+                    y=[
+                        "reward/reward_alive",
+                        "reward/reward_posture",
+                        "reward/reward_nosedive",
+                    ],
+                    plot_type="stacked-area",
+                    title_x="Training Steps",
+                    title_y="Reward Component",
+                ),
+            ],
+        ),
+        # ---- Stage 2: Locomotion ----
+        ws.Section(
+            name="Stage 2 — Locomotion",
+            is_open=(stage == 2),
+            panels=[
+                wr.LinePlot(
+                    title="Gait Symmetry + Stride Frequency",
+                    x=x_axis,
+                    y=[
+                        "eval/mean_gait_symmetry",
+                        "eval/mean_stride_frequency",
+                    ],
+                    title_x="Training Steps",
+                    title_y="Value",
+                ),
+                wr.LinePlot(
+                    title="Heading Alignment",
+                    x=x_axis,
+                    y=["reward/heading_alignment"],
+                    title_x="Training Steps",
+                    title_y="Alignment (-1 to +1)",
+                ),
+            ],
+        ),
+        # ---- Stage 3: Strike ----
+        ws.Section(
+            name="Stage 3 — Strike",
+            is_open=(stage == 3),
+            panels=[
+                wr.LinePlot(
+                    title="Prey Distance (mean + min)",
+                    x=x_axis,
+                    y=[
+                        "reward/prey_distance",
+                        "eval/mean_min_prey_distance",
+                    ],
+                    title_x="Training Steps",
+                    title_y="Distance (m)",
+                ),
+                wr.LinePlot(
+                    title="Strike Success Rate",
+                    x=x_axis,
+                    y=["reward/strike_success"],
+                    title_x="Training Steps",
+                    title_y="Success (0 or 1)",
+                ),
+            ],
+        ),
+    ]
+
+    try:
+        workspace = ws.Workspace(
+            name=f"Locomotion Dashboard — Stage {stage}",
+            entity=entity,
+            project=project,
+            sections=sections,
+        )
+        workspace.save()
+        logger.info("W&B workspace dashboard created for stage %d", stage)
+    except Exception as e:
+        logger.warning("Failed to create W&B workspace: %s. Saving config as fallback.", e)
+        _save_dashboard_config_fallback(stage)
+
+
+def _save_dashboard_config_fallback(stage: int) -> None:
+    """Store dashboard panel config as run metadata (fallback)."""
     panel_config = {
         "master": [
-            {
-                "title": "Termination Reasons",
-                "metrics": ["eval/termination/*"],
-                "type": "stacked_area",
-            },
-            {
-                "title": "Cost of Transport",
-                "metrics": ["eval/mean_cost_of_transport"],
-                "type": "line",
-            },
+            {"title": "Termination Reasons", "metrics": ["eval/termination/*"], "type": "stacked_area"},
+            {"title": "Cost of Transport", "metrics": ["eval/mean_cost_of_transport"], "type": "line"},
         ],
         "stage1_balance": [
-            {
-                "title": "Pelvis Height",
-                "metrics": ["reward/pelvis_height"],
-                "type": "line_with_std",
-            },
-            {
-                "title": "Reward Decomposition",
-                "metrics": [
-                    "reward/reward_alive",
-                    "reward/reward_posture",
-                    "reward/reward_nosedive",
-                ],
-                "type": "stacked_area",
-            },
+            {"title": "Pelvis Height", "metrics": ["reward/pelvis_height"], "type": "line"},
+            {"title": "Reward Decomposition", "metrics": ["reward/reward_alive", "reward/reward_posture", "reward/reward_nosedive"], "type": "stacked_area"},
         ],
         "stage2_locomotion": [
-            {
-                "title": "Gait Symmetry + Stride Frequency",
-                "metrics": [
-                    "eval/mean_gait_symmetry",
-                    "eval/mean_stride_frequency",
-                ],
-                "type": "dual_axis",
-            },
-            {
-                "title": "Heading Alignment",
-                "metrics": ["reward/heading_alignment"],
-                "type": "line",
-            },
+            {"title": "Gait Symmetry + Stride Frequency", "metrics": ["eval/mean_gait_symmetry", "eval/mean_stride_frequency"], "type": "dual_axis"},
+            {"title": "Heading Alignment", "metrics": ["reward/heading_alignment"], "type": "line"},
         ],
         "stage3_strike": [
-            {
-                "title": "Prey Distance (mean + min)",
-                "metrics": [
-                    "reward/prey_distance",
-                    "eval/mean_min_prey_distance",
-                ],
-                "type": "multi_line",
-            },
-            {
-                "title": "Strike Success Rate",
-                "metrics": ["reward/strike_success"],
-                "type": "line",
-            },
+            {"title": "Prey Distance (mean + min)", "metrics": ["reward/prey_distance", "eval/mean_min_prey_distance"], "type": "multi_line"},
+            {"title": "Strike Success Rate", "metrics": ["reward/strike_success"], "type": "line"},
         ],
     }
-
-    # Store as run config so it's accessible from the W&B UI
     wandb.config.update({"dashboard_panels": panel_config}, allow_val_change=True)
-
-    logger.info("W&B dashboard configuration saved for stage %d", stage)
+    logger.info("W&B dashboard panel config saved as run metadata for stage %d", stage)

--- a/environments/shared/wandb_integration.py
+++ b/environments/shared/wandb_integration.py
@@ -175,22 +175,39 @@ class WandbCallback(BaseCallback):
         # Log info from the most recent environment steps
         if self.locals.get("infos"):
             info_keys = [
+                # Reward components
                 "reward_forward",
+                "reward_backward",
                 "reward_alive",
                 "reward_energy",
                 "reward_tail",
                 "reward_strike",
                 "reward_approach",
+                "reward_posture",
+                "reward_nosedive",
+                "reward_gait",
+                "reward_smoothness",
+                "reward_heading",
+                "reward_lateral",
                 "reward_total",
+                # Raw metrics
                 "forward_vel",
+                "backward_vel",
                 "prey_distance",
                 "strike_success",
                 "tail_instability",
+                "tilt_angle",
+                "pelvis_height",
+                "contact_asymmetry",
+                "heading_alignment",
+                "lateral_vel",
+                "r_foot_contact",
+                "l_foot_contact",
+                # Species-specific (brachiosaurus/trex)
                 "reward_neck",
                 "reward_food_reach",
                 "reward_bite",
                 "jaw_distance",
-                "tilt_angle",
             ]
             for key in info_keys:
                 values = [info[key] for info in self.locals["infos"] if key in info]

--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -321,9 +321,14 @@ class RaptorEnv(BaseDinoEnv):
         info["forward_z"] = forward_z
         info["reward_nosedive"] = reward_nosedive
 
+        # 8b. Pelvis height (for LocomotionMetrics tracking)
+        info["pelvis_height"] = float(self.data.xpos[self.pelvis_id, 2])
+
         # 9. Gait symmetry (reward alternating foot contacts)
         r_contact = self.data.sensordata[self._sensor_r_foot]
         l_contact = self.data.sensordata[self._sensor_l_foot]
+        info["r_foot_contact"] = float(r_contact)
+        info["l_foot_contact"] = float(l_contact)
         contact_sum = r_contact + l_contact + 1e-6
         contact_asymmetry = abs(r_contact - l_contact) / contact_sum
         reward_gait = self.gait_symmetry_weight * contact_asymmetry

--- a/environments/velociraptor/scripts/train_sb3.py
+++ b/environments/velociraptor/scripts/train_sb3.py
@@ -56,6 +56,7 @@ from environments.shared.curriculum import (
     CurriculumManager,
     thresholds_from_configs,
 )
+from environments.shared.metrics import LocomotionMetrics
 from environments.velociraptor.envs.raptor_env import RaptorEnv
 
 # Load curriculum configs from TOML files (configs/velociraptor/)
@@ -398,7 +399,7 @@ def train_curriculum(
 
 
 def evaluate(model_path: str, n_episodes: int = 10, render: bool = True, stage: int | None = None):
-    """Evaluate a trained model.
+    """Evaluate a trained model with full locomotion metrics.
 
     Args:
         model_path: Path to the saved model (.zip file).
@@ -444,32 +445,89 @@ def evaluate(model_path: str, n_episodes: int = 10, render: bool = True, stage: 
 
     logger.info("Evaluating for %d episodes (stage %d: %s)...", n_episodes, stage, STAGE_CONFIGS[stage]["name"])
 
-    episode_rewards = []
-    episode_lengths = []
+    episode_reports = []
 
     for ep in range(n_episodes):
         obs = vec_env.reset()
-        total_reward = 0
+        metrics = LocomotionMetrics()
+        total_reward = 0.0
         step = 0
 
         while True:
             action, _ = model.predict(obs, deterministic=True)
             obs, rewards, dones, infos = vec_env.step(action)
-            total_reward += rewards[0]
+            step_reward = float(rewards[0])
+            total_reward += step_reward
             step += 1
+            metrics.record_step(infos[0], step_reward)
 
             if dones[0]:
                 break
 
-        episode_rewards.append(total_reward)
-        episode_lengths.append(step)
-        logger.info("  Episode %d: reward=%.2f, length=%d", ep + 1, total_reward, step)
+        report = metrics.compute()
+        episode_reports.append(report)
+
+        term_reason = report.get("termination_reason", "truncated")
+        logger.info(
+            "  Episode %d: reward=%.2f, length=%d, fwd_vel=%.3f m/s, tilt=%.2f rad, ended=%s",
+            ep + 1,
+            total_reward,
+            step,
+            report.get("mean_forward_velocity", 0.0),
+            report.get("mean_tilt_angle", 0.0),
+            term_reason,
+        )
 
     vec_env.close()
 
-    logger.info("Results:")
-    logger.info("  Mean reward: %.2f +/- %.2f", np.mean(episode_rewards), np.std(episode_rewards))
-    logger.info("  Mean length: %.1f +/- %.1f", np.mean(episode_lengths), np.std(episode_lengths))
+    # Aggregate and log detailed results
+    agg = LocomotionMetrics.aggregate_episodes(episode_reports)
+
+    logger.info("=" * 60)
+    logger.info("Evaluation Results (%d episodes)", n_episodes)
+    logger.info("=" * 60)
+
+    # Core performance
+    logger.info("--- Core Performance ---")
+    logger.info("  Reward:       %.2f +/- %.2f", agg.get("mean_total_reward", 0), agg.get("std_total_reward", 0))
+    logger.info("  Ep Length:    %.1f +/- %.1f", agg.get("mean_episode_length", 0), agg.get("std_episode_length", 0))
+
+    # Velocity
+    logger.info("--- Velocity ---")
+    logger.info("  Forward vel:  %.3f +/- %.3f m/s", agg.get("mean_mean_forward_velocity", 0), agg.get("std_mean_forward_velocity", 0))
+    logger.info("  Max fwd vel:  %.3f m/s", agg.get("mean_max_forward_velocity", 0))
+    logger.info("  Consistency:  %.3f", agg.get("mean_velocity_consistency", 0))
+    logger.info("  Distance:     %.3f +/- %.3f m", agg.get("mean_total_distance", 0), agg.get("std_total_distance", 0))
+
+    # Gait quality
+    logger.info("--- Gait Quality ---")
+    logger.info("  Symmetry:     %.3f", agg.get("mean_gait_symmetry", 0))
+    logger.info("  Stride freq:  %.3f Hz", agg.get("mean_stride_frequency", 0))
+    logger.info("  Cost of transport: %.4f", agg.get("mean_cost_of_transport", 0))
+
+    # Balance
+    logger.info("--- Balance ---")
+    logger.info("  Pelvis height: %.3f +/- %.3f m", agg.get("mean_mean_pelvis_height", 0), agg.get("std_mean_pelvis_height", 0))
+    logger.info("  Mean tilt:     %.3f +/- %.3f rad", agg.get("mean_mean_tilt_angle", 0), agg.get("std_mean_tilt_angle", 0))
+    logger.info("  Max tilt:      %.3f rad", agg.get("mean_max_tilt_angle", 0))
+
+    # Hunting (stage 3)
+    if "mean_initial_prey_distance" in agg:
+        logger.info("--- Hunting ---")
+        logger.info("  Initial dist: %.3f m", agg.get("mean_initial_prey_distance", 0))
+        logger.info("  Final dist:   %.3f m", agg.get("mean_final_prey_distance", 0))
+        logger.info("  Min dist:     %.3f m", agg.get("mean_min_prey_distance", 0))
+        logger.info("  Time to target: %.3f s", agg.get("mean_time_to_target", -1))
+
+    # Termination reasons
+    term_counts = agg.get("termination_counts")
+    if term_counts:
+        logger.info("--- Termination Reasons ---")
+        for reason, count in sorted(term_counts.items(), key=lambda x: -x[1]):
+            pct = 100.0 * count / n_episodes
+            logger.info("  %-20s %d (%.0f%%)", reason, count, pct)
+
+    logger.info("=" * 60)
 
 
 def main():


### PR DESCRIPTION
- raptor_env: Expose r_foot_contact, l_foot_contact, pelvis_height in
  step info so LocomotionMetrics can consume them directly
- metrics: Track termination reasons per episode and aggregate counts
  across evaluation runs (fallen, excessive_tilt, nosedive, etc.)
- curriculum: CurriculumCallback now collects full LocomotionMetrics
  during eval and logs gait quality, velocity, and termination breakdown
- wandb_integration: Log all 13 reward components and raw metrics
  (was missing posture, nosedive, gait, smoothness, heading, lateral,
  backward, pelvis_height, contacts, heading_alignment)
- train_sb3: evaluate() now reports velocity stats, gait symmetry,
  stride frequency, cost of transport, balance metrics, hunting stats,
  and termination reason percentages

https://claude.ai/code/session_01SDcqJ1pgpLSUM2yaMcPV4v