### PR TITLE
Fix linting issues and WandbCallback init when stable_baselines3 is absent

### DIFF
--- a/environments/shared/tests/test_base_env.py
+++ b/environments/shared/tests/test_base_env.py
@@ -1,39 +1,41 @@
-import pytest
 import numpy as np
+
 from environments.velociraptor.envs.raptor_env import RaptorEnv
+
 
 def test_base_env_lifecycle():
     env = RaptorEnv(render_mode="rgb_array")
-    
+
     # Test reset
     obs, info = env.reset(seed=42)
     assert isinstance(obs, np.ndarray)
     assert isinstance(info, dict)
-    
+
     # Test step
     action = env.action_space.sample()
     obs, reward, term, trunc, info = env.step(action)
-    
+
     assert isinstance(obs, np.ndarray)
     assert isinstance(reward, float)
     assert isinstance(term, bool)
     assert isinstance(trunc, bool)
     assert isinstance(info, dict)
-    
+
     # Test render
     frame = env.render()
     assert frame is not None
     assert isinstance(frame, np.ndarray)
-    
+
     # Test close
     env.close()
 
+
 def test_base_env_scale_action():
     env = RaptorEnv()
-    
+
     # Test action scaling
     action = np.zeros(env.action_space.shape, dtype=np.float32)
     scaled = env._scale_action(action)
     assert scaled.shape == action.shape
-    
+
     env.close()

--- a/environments/shared/tests/test_wandb_integration.py
+++ b/environments/shared/tests/test_wandb_integration.py
@@ -1,13 +1,16 @@
-import pytest
 from unittest.mock import MagicMock, patch
+
 import numpy as np
+import pytest
 
 import environments.shared.wandb_integration as wi
+
 
 @pytest.fixture
 def mock_wandb():
     with patch("environments.shared.wandb_integration.wandb") as mock:
         yield mock
+
 
 def test_init_wandb(mock_wandb):
     mock_run = MagicMock()
@@ -17,25 +20,24 @@ def test_init_wandb(mock_wandb):
 
     config = {"name": "test_stage", "env_kwargs": {"foo": "bar"}, "ppo_kwargs": {"lr": 0.001}}
     run = wi.init_wandb("velociraptor", 1, config)
-    
+
     assert run == mock_run
     mock_wandb.init.assert_called_once()
-    
+
+
 def test_wandb_callback_on_step(mock_wandb):
     callback = wi.WandbCallback(log_freq=1)
     callback.num_timesteps = 1
-    
+
     # Mock locals
-    callback.locals = {
-        "infos": [{"reward_forward": 1.0, "reward_alive": 0.5, "forward_vel": 2.0}]
-    }
-    
+    callback.locals = {"infos": [{"reward_forward": 1.0, "reward_alive": 0.5, "forward_vel": 2.0}]}
+
     mock_model = MagicMock()
     mock_model.learning_rate = 0.003
     callback.model = mock_model
-    
+
     callback._on_step()
-    
+
     # wandb.log should be called
     mock_wandb.log.assert_called_once()
     logged_dict = mock_wandb.log.call_args[0][0]
@@ -43,48 +45,50 @@ def test_wandb_callback_on_step(mock_wandb):
     assert "reward/forward_vel" in logged_dict
     assert logged_dict["train/learning_rate"] == 0.003
 
+
 def test_wandb_callback_video(mock_wandb):
     # Mock video env
     mock_env = MagicMock()
     mock_env.reset.return_value = np.zeros((10,))
     mock_env.step.return_value = (np.zeros((10,)), 0, [True], [{}])
     mock_env.render.return_value = np.zeros((64, 64, 3))
-    
+
     callback = wi.WandbCallback(video_env=mock_env, video_freq=1, video_length=2)
     callback.num_timesteps = 1
     callback.locals = {"infos": []}
-    
+
     mock_model = MagicMock()
     mock_model.predict.return_value = (np.array([0.0]), None)
     callback.model = mock_model
-    
+
     callback._record_video()
-    
+
     mock_env.reset.assert_called()
     mock_env.step.assert_called()
     mock_env.render.assert_called()
 
+
 def test_log_eval_metrics(mock_wandb):
-    results = {
-        "mean_gait_symmetry": 0.5,
-        "termination_counts": {"fallen": 5, "truncated": 2}
-    }
+    results = {"mean_gait_symmetry": 0.5, "termination_counts": {"fallen": 5, "truncated": 2}}
     wi.log_eval_metrics(results, stage=1, step=100)
-    
+
     mock_wandb.log.assert_called_once()
     logged = mock_wandb.log.call_args[0][0]
     assert logged["eval/stage"] == 1.0
     assert logged["eval/mean_gait_symmetry"] == 0.5
     assert logged["eval/termination/fallen"] == 5.0
 
+
 def test_setup_wandb_metrics(mock_wandb):
     wi.setup_wandb_metrics(1)
     assert mock_wandb.define_metric.called
 
+
 def test_create_wandb_dashboard(mock_wandb):
     # Just to reach coverage
     wi.create_wandb_dashboard(1)
-    
+
+
 def test_on_rollout_end(mock_wandb):
     callback = wi.WandbCallback()
     callback.num_timesteps = 100
@@ -93,6 +97,6 @@ def test_on_rollout_end(mock_wandb):
     mock_model = MagicMock()
     mock_model.logger = mock_logger
     callback.model = mock_model
-    
+
     callback._on_rollout_end()
     mock_wandb.log.assert_called_once()

--- a/environments/shared/wandb_integration.py
+++ b/environments/shared/wandb_integration.py
@@ -159,7 +159,10 @@ class WandbCallback(BaseCallback):
         video_length: int = 500,
         verbose: int = 0,
     ):
-        super().__init__(verbose)
+        if BaseCallback is not object:
+            super().__init__(verbose)
+        else:
+            super().__init__()
         self.log_freq = log_freq
         self.video_env = video_env
         self.video_freq = video_freq


### PR DESCRIPTION
- Auto-fix 23 ruff lint errors (unsorted imports, unused imports, trailing whitespace)
- Auto-format 2 files with ruff format
- Fix WandbCallback.__init__ to handle fallback BaseCallback=object when
  stable_baselines3 is not installed (super().__init__() takes no args)

https://claude.ai/code/session_01FxyWdGQvw469PAWKQNWDhU