### PR TITLE
Tune velociraptor locomotion training hyperparameters

### DIFF
--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -3,16 +3,16 @@ name = "locomotion"
 description = "Learn forward walking/running"
 
 [env]
-forward_vel_weight = 3.0
+forward_vel_weight = 2.0
 forward_vel_max = 3.0
 backward_vel_penalty_weight = 0.0
-alive_bonus = 0.5
+alive_bonus = 1.0
 energy_penalty_weight = 0.001
 tail_stability_weight = 0.05
-posture_weight = 0.2
-nosedive_weight = 0.2
+posture_weight = 0.4
+nosedive_weight = 0.35
 gait_symmetry_weight = 0.1
-smoothness_weight = 0.05
+smoothness_weight = 0.1
 strike_bonus = 0.0
 strike_approach_weight = 0.0
 heading_weight = 0.3
@@ -22,13 +22,14 @@ max_episode_steps = 1000
 
 [ppo]
 learning_rate = 1e-4
-n_steps = 2048
+learning_rate_end = 1e-5
+n_steps = 4096
 batch_size = 128
 n_epochs = 10
 gamma = 0.99
 gae_lambda = 0.95
 clip_range = 0.2
-ent_coef = 0.005
+ent_coef = 0.01
 
 [sac]
 learning_rate = 1e-4
@@ -38,7 +39,7 @@ tau = 0.005
 ent_coef = "auto"
 
 [curriculum]
-timesteps = 5000000
+timesteps = 8000000
 min_avg_reward = 100.0
 min_avg_episode_length = 800
 min_avg_forward_vel = 0.5


### PR DESCRIPTION
## Summary
Adjusted reward weights and PPO training hyperparameters for the velociraptor stage2 locomotion task to improve training stability and convergence.

## Key Changes
- **Reward function tuning:**
  - Reduced `forward_vel_weight` from 3.0 to 2.0 to balance forward velocity incentive
  - Doubled `alive_bonus` from 0.5 to 1.0 to encourage longer episode survival
  - Increased `posture_weight` from 0.2 to 0.4 for better body posture control
  - Increased `nosedive_weight` from 0.2 to 0.35 to prevent nose-diving behavior
  - Doubled `smoothness_weight` from 0.05 to 0.1 for smoother motion

- **PPO algorithm adjustments:**
  - Increased `n_steps` from 2048 to 4096 for better sample efficiency
  - Added learning rate decay with `learning_rate_end = 1e-5`
  - Doubled `ent_coef` from 0.005 to 0.01 for increased exploration

- **Curriculum learning:**
  - Extended `timesteps` from 5M to 8M for longer training progression

## Implementation Details
These changes aim to create a more balanced reward signal that encourages stable, smooth locomotion while maintaining forward progress. The increased PPO step count and entropy coefficient should improve exploration during training, while the learning rate decay helps with convergence in later training stages.