### PR TITLE
Add Finding Theta link to footer navigation

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -124,6 +124,10 @@ const config: Config = {
               label: 'GitHub',
               href: 'https://github.com/kuds/mesozoic-labs',
             },
+            {
+              label: 'Finding Theta',
+              href: 'https://findingtheta.com',
+            },
           ],
         },
       ],


### PR DESCRIPTION
## Summary
Added a new external link to the footer navigation menu pointing to Finding Theta website.

## Changes
- Added "Finding Theta" link to the footer social links section in the Docusaurus configuration
- Link directs to https://findingtheta.com

## Details
This change extends the existing footer navigation by including an additional resource link alongside the existing GitHub link. The new link follows the same structure and formatting as other footer links in the configuration.