### PR TITLE
Fix model/environment configs for Vertex AI sweep readiness

### DIFF
--- a/configs/brachiosaurus/stage1_balance.toml
+++ b/configs/brachiosaurus/stage1_balance.toml
@@ -23,6 +23,9 @@ gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.01
 
+[ppo.policy_kwargs]
+net_arch = [256, 256]
+
 [sac]
 learning_rate = 3e-4
 batch_size = 256

--- a/configs/brachiosaurus/stage2_locomotion.toml
+++ b/configs/brachiosaurus/stage2_locomotion.toml
@@ -8,7 +8,7 @@ alive_bonus = 0.5
 energy_penalty_weight = 0.001
 gait_stability_weight = 0.05
 food_reach_bonus = 0.0
-food_approach_weight = 3.0
+food_approach_weight = 0.0
 food_distance_range = [8.0, 12.0]
 food_height_range = [2.0, 3.0]
 max_episode_steps = 1000
@@ -22,6 +22,9 @@ gamma = 0.99
 gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.005
+
+[ppo.policy_kwargs]
+net_arch = [256, 256]
 
 [sac]
 learning_rate = 1e-4

--- a/configs/brachiosaurus/stage3_food_reach.toml
+++ b/configs/brachiosaurus/stage3_food_reach.toml
@@ -7,9 +7,9 @@ forward_vel_weight = 1.0
 alive_bonus = 0.1
 energy_penalty_weight = 0.001
 gait_stability_weight = 0.02
-food_reach_bonus = 500.0
+food_reach_bonus = 10.0
 food_reach_threshold = 0.5
-food_approach_weight = 10.0
+food_approach_weight = 1.0
 food_distance_range = [3.0, 8.0]
 food_lateral_range = [-1.5, 1.5]
 food_height_range = [2.5, 4.0]
@@ -24,6 +24,9 @@ gamma = 0.995
 gae_lambda = 0.95
 clip_range = 0.1
 ent_coef = 0.001
+
+[ppo.policy_kwargs]
+net_arch = [256, 256]
 
 [sac]
 learning_rate = 5e-5

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -28,6 +28,9 @@ gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.005
 
+[ppo.policy_kwargs]
+net_arch = [256, 256]
+
 [sac]
 learning_rate = 3e-4
 batch_size = 256

--- a/configs/trex/stage2_locomotion.toml
+++ b/configs/trex/stage2_locomotion.toml
@@ -12,7 +12,7 @@ nosedive_weight = 0.8
 heading_weight = 0.5
 lateral_penalty_weight = 0.3
 bite_bonus = 0.0
-bite_approach_weight = 5.0
+bite_approach_weight = 0.0
 prey_distance_range = [8.0, 12.0]
 max_episode_steps = 1000
 
@@ -25,6 +25,9 @@ gamma = 0.99
 gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.005
+
+[ppo.policy_kwargs]
+net_arch = [256, 256]
 
 [sac]
 learning_rate = 1e-4

--- a/configs/trex/stage3_bite.toml
+++ b/configs/trex/stage3_bite.toml
@@ -8,8 +8,8 @@ alive_bonus = 0.1
 energy_penalty_weight = 0.001
 tail_stability_weight = 0.02
 nosedive_weight = 0.2
-bite_bonus = 500.0
-bite_approach_weight = 15.0
+bite_bonus = 10.0
+bite_approach_weight = 1.0
 prey_distance_range = [3.0, 8.0]
 prey_lateral_range = [-1.5, 1.5]
 max_episode_steps = 1000
@@ -23,6 +23,9 @@ gamma = 0.995
 gae_lambda = 0.95
 clip_range = 0.1
 ent_coef = 0.001
+
+[ppo.policy_kwargs]
+net_arch = [256, 256]
 
 [sac]
 learning_rate = 5e-5

--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -31,6 +31,9 @@ gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.01
 
+[ppo.policy_kwargs]
+net_arch = [256, 256]
+
 [sac]
 learning_rate = 1e-4
 batch_size = 256

--- a/configs/velociraptor/stage3_strike.toml
+++ b/configs/velociraptor/stage3_strike.toml
@@ -27,6 +27,9 @@ gae_lambda = 0.95
 clip_range = 0.1
 ent_coef = 0.001
 
+[ppo.policy_kwargs]
+net_arch = [256, 256]
+
 [sac]
 learning_rate = 5e-5
 batch_size = 256

--- a/environments/brachiosaurus/envs/brachio_env.py
+++ b/environments/brachiosaurus/envs/brachio_env.py
@@ -231,6 +231,7 @@ class BrachioEnv(BaseDinoEnv):
         head_tip_pos = self.data.site_xpos[self.head_tip_site_id]
         head_food_dist = np.linalg.norm(head_tip_pos - food_pos)
         info["head_food_distance"] = head_food_dist
+        info["prey_distance"] = float(head_food_dist)  # alias for LocomotionMetrics
 
         food_reward = 0.0
         if head_food_dist < self.food_reach_threshold:

--- a/environments/brachiosaurus/scripts/train_sb3.py
+++ b/environments/brachiosaurus/scripts/train_sb3.py
@@ -137,7 +137,7 @@ def create_vec_env(stage: int, n_envs: int, seed: int = 0, use_subproc: bool = F
         norm_obs=True,
         norm_reward=True,
         clip_obs=10.0,
-        clip_reward=10.0,
+        clip_reward=50.0,
     )
 
     return env

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -68,6 +68,7 @@ class TRexEnv(BaseDinoEnv):
         smoothness_weight: float = 0.05,
         heading_weight: float = 0.0,
         lateral_penalty_weight: float = 0.0,
+        forward_vel_max: float = 8.0,
         # Environment settings
         prey_distance_range: Tuple[float, float] = (3.0, 8.0),
         prey_lateral_range: Tuple[float, float] = (-2.0, 2.0),
@@ -86,6 +87,7 @@ class TRexEnv(BaseDinoEnv):
         self.smoothness_weight = smoothness_weight
         self.heading_weight = heading_weight
         self.lateral_penalty_weight = lateral_penalty_weight
+        self.forward_vel_max = forward_vel_max
 
         # Natural forward pitch (~10°). The nosedive penalty and termination
         # are measured relative to this angle so the T-Rex isn't punished for
@@ -224,8 +226,7 @@ class TRexEnv(BaseDinoEnv):
 
         vel_2d = self.data.qvel[0:2]
         forward_vel = np.dot(vel_2d, prey_dir_2d)
-        # Assume max sprint speed of ~8.0 m/s for T-Rex
-        forward_vel_norm = np.clip(forward_vel / 8.0, -1.0, 1.0)
+        forward_vel_norm = np.clip(forward_vel / self.forward_vel_max, -1.0, 1.0)
         info["forward_vel"] = forward_vel
         reward_forward = self.forward_vel_weight * forward_vel_norm
         info["reward_forward"] = reward_forward

--- a/environments/trex/scripts/train_sb3.py
+++ b/environments/trex/scripts/train_sb3.py
@@ -137,7 +137,7 @@ def create_vec_env(stage: int, n_envs: int, seed: int = 0, use_subproc: bool = F
         norm_obs=True,
         norm_reward=True,
         clip_obs=10.0,
-        clip_reward=10.0,
+        clip_reward=50.0,
     )
 
     return env


### PR DESCRIPTION
- Fix T-Rex stage 2 bite_approach_weight: 5.0 → 0.0 (locomotion stage
  should not have approach shaping, was polluting gait learning)
- Fix Brachio stage 2 food_approach_weight: 3.0 → 0.0 (same issue)
- Fix T-Rex stage 3 extreme rewards: bite_bonus 500→10, approach 15→1
  (aligned with raptor's strike_bonus=10, prevents gradient variance)
- Fix Brachio stage 3 extreme rewards: food_reach_bonus 500→10,
  food_approach_weight 10→1 (same issue, especially bad since bonus
  was given per-step not per-episode)
- Add net_arch=[256,256] to all T-Rex and Brachio PPO configs, and to
  raptor stages 2-3 (were missing, defaulting to SB3's tiny [64,64])
- Normalize VecNormalize clip_reward to 50.0 across all species
  (T-Rex and Brachio were using 10.0 vs raptor's 50.0)
- Add prey_distance alias in BrachioEnv info dict so LocomotionMetrics
  can track distance-to-target metrics for all species
- Make T-Rex forward_vel_max configurable (was hardcoded to 8.0,
  preventing sweep overrides)

https://claude.ai/code/session_01HNFnmLRc3hJCZLqMtXj925