### PR TITLE
Tune velociraptor locomotion reward weights and PPO hyperparameters

### DIFF
--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -3,14 +3,14 @@ name = "locomotion"
 description = "Learn forward walking/running"
 
 [env]
-forward_vel_weight = 2.0
+forward_vel_weight = 1.5
 forward_vel_max = 3.0
 backward_vel_penalty_weight = 0.0
-alive_bonus = 1.0
-energy_penalty_weight = 0.001
+alive_bonus = 1.5
+energy_penalty_weight = 0.003
 tail_stability_weight = 0.05
-posture_weight = 0.4
-nosedive_weight = 0.35
+posture_weight = 0.8
+nosedive_weight = 0.7
 gait_symmetry_weight = 0.1
 smoothness_weight = 0.1
 strike_bonus = 0.0
@@ -23,13 +23,13 @@ max_episode_steps = 1000
 [ppo]
 learning_rate = 1e-4
 learning_rate_end = 1e-5
-n_steps = 4096
+n_steps = 8192
 batch_size = 128
 n_epochs = 10
 gamma = 0.99
 gae_lambda = 0.95
 clip_range = 0.2
-ent_coef = 0.01
+ent_coef = 0.02
 
 [ppo.policy_kwargs]
 net_arch = [256, 256]


### PR DESCRIPTION
## Summary
Adjusted reward function weights and PPO training hyperparameters for the velociraptor stage2 locomotion task to improve learning stability and policy quality.

## Key Changes
- **Reward function tuning:**
  - Reduced `forward_vel_weight` from 2.0 to 1.5 to balance forward movement incentive
  - Increased `alive_bonus` from 1.0 to 1.5 to encourage longer episode survival
  - Increased `energy_penalty_weight` from 0.001 to 0.003 to penalize inefficient movement more heavily
  - Doubled `posture_weight` from 0.4 to 0.8 to enforce better body posture during locomotion
  - Doubled `nosedive_weight` from 0.35 to 0.7 to prevent forward-diving behaviors

- **PPO hyperparameter adjustments:**
  - Increased `n_steps` from 4096 to 8192 to collect more experience per update cycle
  - Increased `ent_coef` from 0.01 to 0.02 to encourage greater exploration during training

## Implementation Details
These changes aim to create a more balanced reward signal that encourages stable, energy-efficient forward locomotion while maintaining proper body posture. The increased PPO step collection allows for more stable gradient estimates with the adjusted reward weights.