### PR TITLE
Fix repo URL to kuds/mesozoic-labs

### DIFF
--- a/scripts/setup_vertex_ai.sh
+++ b/scripts/setup_vertex_ai.sh
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   # Clone the repo and run the script
-#   git clone https://github.com/mesozoic-labs/mesozoic-labs.git
+#   git clone https://github.com/kuds/mesozoic-labs.git
 #   cd mesozoic-labs
 #   bash scripts/setup_vertex_ai.sh
 #

--- a/website/docs/training/vertex-ai.md
+++ b/website/docs/training/vertex-ai.md
@@ -50,7 +50,7 @@ If the per-stage `timesteps` budget is exhausted before thresholds are met, the 
 If you have access to [Google Cloud Shell](https://shell.cloud.google.com), you can set up everything — Artifact Registry, Docker image, GCS bucket, and optionally submit a training job — with a single interactive script:
 
 ```bash
-git clone https://github.com/mesozoic-labs/mesozoic-labs.git
+git clone https://github.com/kuds/mesozoic-labs.git
 cd mesozoic-labs
 bash scripts/setup_vertex_ai.sh
 ```


### PR DESCRIPTION
This pull request updates the repository URL in both documentation and setup scripts to point to the correct GitHub repository. This ensures users follow the correct instructions and clone the right repository when setting up Vertex AI.

Documentation and script updates:

* Updated the repository URL from `https://github.com/mesozoic-labs/mesozoic-labs.git` to `https://github.com/kuds/mesozoic-labs.git` in the `scripts/setup_vertex_ai.sh` usage instructions.
* Updated the repository URL in the setup instructions in `website/docs/training/vertex-ai.md` to match the new URL.