### PR TITLE
Update docker python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11-slim
 
 # MuJoCo runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libgl1-mesa-glx \
+    libgl1 \
     libglib2.0-0 \
     libsm6 \
     libxext6 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # MuJoCo runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This pull request updates the base Python version in the `Dockerfile` and makes a minor adjustment to the MuJoCo runtime dependencies.

- **Environment updates:**
  * Updated the base image from `python:3.11-slim` to `python:3.12-slim` to use the latest Python version.

- **Dependency adjustments:**
  * Replaced the `libgl1-mesa-glx` package with `libgl1` for MuJoCo runtime dependencies, which may improve compatibility or reduce image size.