### PR TITLE
Fix cloudml-hypertune version constraint to include dev releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Issues = "https://github.com/kuds/mesozoic-labs/issues"
 train = [
     "stable-baselines3[extra]>=2.2.0",
     "wandb>=0.16.0",
-    "cloudml-hypertune>=0.1.0",
+    "cloudml-hypertune>=0.1.0.dev0",
 ]
 viz = [
     "mediapy>=1.1.0",


### PR DESCRIPTION
cloudml-hypertune only has pre-release versions on PyPI (latest is 0.1.0.dev6). The previous constraint >=0.1.0 excluded pre-releases by default, causing pip install to fail. Using >=0.1.0.dev0 allows pip to match the available dev releases.