### PR TITLE
Fix Vertex AI hyperparameter tuning parameter spec class names

### DIFF
--- a/environments/shared/scripts/sweep.py
+++ b/environments/shared/scripts/sweep.py
@@ -221,15 +221,15 @@ def _build_parameter_spec(search_space: dict, hpt_module: Any) -> dict:
     for param_id, spec in search_space.items():
         kind = spec.get("type", "double")
         if kind == "double":
-            parameter_spec[param_id] = hpt.DoubleValueSpec(
-                min_value=float(spec["min"]),
-                max_value=float(spec["max"]),
+            parameter_spec[param_id] = hpt.DoubleParameterSpec(
+                min=float(spec["min"]),
+                max=float(spec["max"]),
                 scale=spec.get("scale", "linear"),
             )
         elif kind == "discrete":
-            parameter_spec[param_id] = hpt.DiscreteValueSpec(values=[float(v) for v in spec["values"]])
+            parameter_spec[param_id] = hpt.DiscreteParameterSpec(values=[float(v) for v in spec["values"]], scale="linear")
         elif kind == "categorical":
-            parameter_spec[param_id] = hpt.CategoricalValueSpec(values=spec["values"])
+            parameter_spec[param_id] = hpt.CategoricalParameterSpec(values=spec["values"])
         else:
             logger.warning("Unknown parameter type %r for %s — skipping", kind, param_id)
     return parameter_spec

--- a/environments/shared/scripts/sweep.py
+++ b/environments/shared/scripts/sweep.py
@@ -227,7 +227,9 @@ def _build_parameter_spec(search_space: dict, hpt_module: Any) -> dict:
                 scale=spec.get("scale", "linear"),
             )
         elif kind == "discrete":
-            parameter_spec[param_id] = hpt.DiscreteParameterSpec(values=[float(v) for v in spec["values"]], scale="linear")
+            parameter_spec[param_id] = hpt.DiscreteParameterSpec(
+                values=[float(v) for v in spec["values"]], scale="linear"
+            )
         elif kind == "categorical":
             parameter_spec[param_id] = hpt.CategoricalParameterSpec(values=spec["values"])
         else:


### PR DESCRIPTION
This pull request updates the way hyperparameter search spaces are specified in the `sweep.py` script to use the correct parameter spec classes and argument names, ensuring compatibility with the latest hyperparameter tuning (HPT) module API.

**Hyperparameter spec API updates:**

* Replaced usage of `DoubleValueSpec`, `DiscreteValueSpec`, and `CategoricalValueSpec` with their correct counterparts: `DoubleParameterSpec`, `DiscreteParameterSpec`, and `CategoricalParameterSpec` in the `_build_parameter_spec` function (`sweep.py`).
* Updated argument names for double parameters from `min_value`/`max_value` to `min`/`max`, and added a default `scale="linear"` for discrete parameters to match the new API (`sweep.py`).