### PR TITLE
Fix HyperparameterTuningJob: use CustomJob instead of worker_pool_specs

### DIFF
--- a/environments/shared/scripts/sweep.py
+++ b/environments/shared/scripts/sweep.py
@@ -408,13 +408,18 @@ def _submit_stage_sweep(
     if load_path:
         logger.info("  Warm-start model: %s", load_path)
 
+    custom_job = aiplatform.CustomJob(
+        display_name=f"{display_name}-trial",
+        worker_pool_specs=worker_pool_specs,
+    )
+
     hpt_job = aiplatform.HyperparameterTuningJob(
         display_name=display_name,
+        custom_job=custom_job,
         metric_spec={"best_mean_reward": "maximize"},
         parameter_spec=parameter_spec,
         max_trial_count=trials,
         parallel_trial_count=parallel,
-        worker_pool_specs=worker_pool_specs,
     )
 
     hpt_job.run(sync=sync)


### PR DESCRIPTION
This pull request updates the hyperparameter tuning workflow in `sweep.py` to use a `CustomJob` object when creating a `HyperparameterTuningJob`, rather than passing `worker_pool_specs` directly. This change aligns the job submission process with the latest Vertex AI API requirements and improves clarity.

**Vertex AI job submission improvements:**

* [`environments/shared/scripts/sweep.py`](diffhunk://#diff-83a6c02d21019e79959acb9850df835a92f4edaf2f47e881c371769b55951e60R411-L417): Refactored the `_submit_stage_sweep` function to instantiate a `CustomJob` with `worker_pool_specs` and provide it to the `HyperparameterTuningJob` via the `custom_job` parameter, instead of passing `worker_pool_specs` directly.