### PR TITLE
Add Vertex AI hyperparameter tuning notebook

### DIFF
--- a/notebooks/vertex_ai_sweep.ipynb
+++ b/notebooks/vertex_ai_sweep.ipynb
@@ -1,0 +1,647 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view-in-github",
+    "colab_type": "text"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/kuds/mesozoic-labs/blob/main/notebooks/vertex_ai_sweep.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sweep-title"
+   },
+   "source": [
+    "# Vertex AI Hyperparameter Sweep\n",
+    "\n",
+    "Submit hyperparameter tuning jobs to Vertex AI using `sweep.py`.\n",
+    "\n",
+    "**Modes:**\n",
+    "- **Single-stage** (`launch`) \u2014 Sweep one curriculum stage at a time\n",
+    "- **All stages** (`launch-all`) \u2014 Sweep stages 1\u21922\u21923 end-to-end, automatically chaining the best checkpoint from each stage to the next\n",
+    "\n",
+    "**What this notebook does:**\n",
+    "1. Authenticates with Google Cloud\n",
+    "2. Builds and pushes the training Docker image to Artifact Registry\n",
+    "3. Submits a Vertex AI Hyperparameter Tuning job via the Python SDK\n",
+    "\n",
+    "**Prerequisites:**\n",
+    "- A Google Cloud project with billing enabled\n",
+    "- Vertex AI and Artifact Registry APIs enabled\n",
+    "- A GCS bucket for training artifacts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup-header"
+   },
+   "source": [
+    "## 1. Setup & Authentication"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install-deps"
+   },
+   "outputs": [],
+   "source": [
+    "# Install the Vertex AI SDK (required for job submission)\n",
+    "!pip install -q google-cloud-aiplatform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "auth"
+   },
+   "outputs": [],
+   "source": [
+    "# Authenticate with Google Cloud\n",
+    "import os\n",
+    "\n",
+    "IN_COLAB = \"COLAB_GPU\" in os.environ or \"COLAB_RELEASE_TAG\" in os.environ or os.path.exists(\"/content\")\n",
+    "\n",
+    "if IN_COLAB:\n",
+    "    from google.colab import auth\n",
+    "    auth.authenticate_user()\n",
+    "    print(\"Authenticated with Google Cloud.\")\n",
+    "else:\n",
+    "    print(\"Not running in Colab \u2014 ensure `gcloud auth login` and `gcloud auth application-default login` are done.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "config-header"
+   },
+   "source": [
+    "## 2. Configuration\n",
+    "\n",
+    "Fill in your GCP project settings below. The `IMAGE_URI` will be set automatically after building the Docker image (Section 3), or you can set it manually if you already have an image pushed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "config"
+   },
+   "outputs": [],
+   "source": [
+    "# ── GCP project settings ─────────────────────────────────────────────────────\n",
+    "PROJECT_ID = \"your-gcp-project-id\"   # @param {type:\"string\"}\n",
+    "REGION = \"us-central1\"               # @param {type:\"string\"}\n",
+    "BUCKET = \"your-gcs-bucket\"           # @param {type:\"string\"} — without gs:// prefix\n",
+    "\n",
+    "# ── Docker image ─────────────────────────────────────────────────────────────\n",
+    "# Set this after building (Section 3), or manually if you already have an image.\n",
+    "REPO_NAME = \"mesozoic-labs\"\n",
+    "IMAGE_TAG = \"latest\"\n",
+    "IMAGE_URI = f\"{REGION}-docker.pkg.dev/{PROJECT_ID}/{REPO_NAME}/trainer:{IMAGE_TAG}\"\n",
+    "\n",
+    "# ── Sweep settings ────────────────────────────────────────────────────────────\n",
+    "SPECIES = \"velociraptor\"  # @param [\"velociraptor\", \"brachiosaurus\", \"trex\"]\n",
+    "ALGORITHM = \"ppo\"         # @param [\"ppo\", \"sac\"]\n",
+    "\n",
+    "# ── Machine settings ──────────────────────────────────────────────────────────\n",
+    "MACHINE_TYPE = \"n1-standard-8\"       # @param {type:\"string\"}\n",
+    "ACCELERATOR_TYPE = \"NVIDIA_TESLA_T4\" # @param [\"NVIDIA_TESLA_T4\", \"NVIDIA_TESLA_V100\", \"NVIDIA_A100_80GB\"]\n",
+    "ACCELERATOR_COUNT = 1                # @param {type:\"integer\"}\n",
+    "\n",
+    "# ── HPT budget ────────────────────────────────────────────────────────────────\n",
+    "MAX_TRIALS = 20    # @param {type:\"integer\"} — total trials per stage\n",
+    "PARALLEL_TRIALS = 5 # @param {type:\"integer\"} — concurrent trials\n",
+    "N_ENVS = 4          # @param {type:\"integer\"} — parallel envs per trial worker\n",
+    "\n",
+    "# ── Optional: W&B logging ─────────────────────────────────────────────────────\n",
+    "WANDB_API_KEY = \"\"  # @param {type:\"string\"} — leave empty to disable\n",
+    "\n",
+    "print(f\"Project:  {PROJECT_ID}\")\n",
+    "print(f\"Region:   {REGION}\")\n",
+    "print(f\"Bucket:   gs://{BUCKET}\")\n",
+    "print(f\"Image:    {IMAGE_URI}\")\n",
+    "print(f\"Species:  {SPECIES}\")\n",
+    "print(f\"Algorithm: {ALGORITHM}\")\n",
+    "print(f\"Trials:   {MAX_TRIALS} (parallel: {PARALLEL_TRIALS})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "docker-header"
+   },
+   "source": [
+    "## 3. Build & Push Docker Image\n",
+    "\n",
+    "This section clones the repo, builds the training container, and pushes it to Artifact Registry. **Skip this section if you already have an image pushed** (e.g. from running `scripts/setup_vertex_ai.sh`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "enable-apis"
+   },
+   "outputs": [],
+   "source": [
+    "# Enable required APIs (idempotent)\n",
+    "!gcloud services enable aiplatform.googleapis.com artifactregistry.googleapis.com \\\n",
+    "    --project={PROJECT_ID} --quiet\n",
+    "print(\"APIs enabled.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "create-repo"
+   },
+   "outputs": [],
+   "source": [
+    "# Create Artifact Registry repository (idempotent)\n",
+    "!gcloud artifacts repositories create {REPO_NAME} \\\n",
+    "    --repository-format=docker \\\n",
+    "    --location={REGION} \\\n",
+    "    --description=\"Mesozoic Labs training containers\" \\\n",
+    "    --project={PROJECT_ID} 2>/dev/null || echo \"Repository already exists.\"\n",
+    "\n",
+    "# Configure Docker authentication\n",
+    "!gcloud auth configure-docker {REGION}-docker.pkg.dev --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "clone-and-build"
+   },
+   "outputs": [],
+   "source": [
+    "import pathlib\n",
+    "import subprocess\n",
+    "\n",
+    "REPO_DIR = pathlib.Path(\"/content/mesozoic-labs\")\n",
+    "if not REPO_DIR.exists():\n",
+    "    subprocess.run(\n",
+    "        [\"git\", \"clone\", \"https://github.com/kuds/mesozoic-labs.git\", str(REPO_DIR)],\n",
+    "        check=True,\n",
+    "    )\n",
+    "    print(f\"Cloned repo to {REPO_DIR}\")\n",
+    "else:\n",
+    "    print(f\"Repo already exists at {REPO_DIR}\")\n",
+    "\n",
+    "# Build the Docker image\n",
+    "print(f\"\\nBuilding image: {IMAGE_URI}\")\n",
+    "!cd /content/mesozoic-labs && docker build -t {IMAGE_URI} ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "push-image"
+   },
+   "outputs": [],
+   "source": [
+    "# Push the image to Artifact Registry\n",
+    "!docker push {IMAGE_URI}\n",
+    "print(f\"\\nImage pushed: {IMAGE_URI}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "init-header"
+   },
+   "source": [
+    "## 4. Initialise Vertex AI SDK"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "init-vertex"
+   },
+   "outputs": [],
+   "source": [
+    "from google.cloud import aiplatform\n",
+    "from google.cloud.aiplatform import hyperparameter_tuning as hpt\n",
+    "\n",
+    "aiplatform.init(\n",
+    "    project=PROJECT_ID,\n",
+    "    location=REGION,\n",
+    "    staging_bucket=f\"gs://{BUCKET}\",\n",
+    ")\n",
+    "print(f\"Vertex AI initialised (project={PROJECT_ID}, region={REGION})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "search-space-header"
+   },
+   "source": [
+    "## 5. Search Space\n",
+    "\n",
+    "Define the hyperparameters to tune. The defaults below match `sweep.py`. Edit as needed.\n",
+    "\n",
+    "**Naming convention:** `{algo}_{param}` (e.g. `ppo_learning_rate`, `sac_batch_size`). These are automatically converted to `--override ppo.learning_rate=X` inside each trial worker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "search-space"
+   },
+   "outputs": [],
+   "source": [
+    "# ── PPO search space (used when ALGORITHM == \"ppo\") ────────────────────────\n",
+    "PPO_PARAMETER_SPEC = {\n",
+    "    \"ppo_learning_rate\": hpt.DoubleParameterSpec(min=1e-5, max=3e-4, scale=\"log\"),\n",
+    "    \"ppo_ent_coef\": hpt.DoubleParameterSpec(min=1e-4, max=0.05, scale=\"log\"),\n",
+    "    \"ppo_batch_size\": hpt.DiscreteParameterSpec(values=[64, 128, 256, 512], scale=\"linear\"),\n",
+    "    \"ppo_gamma\": hpt.DoubleParameterSpec(min=0.97, max=0.999, scale=\"linear\"),\n",
+    "    \"ppo_n_steps\": hpt.DiscreteParameterSpec(values=[1024, 2048, 4096], scale=\"linear\"),\n",
+    "}\n",
+    "\n",
+    "# ── SAC search space (used when ALGORITHM == \"sac\") ────────────────────────\n",
+    "SAC_PARAMETER_SPEC = {\n",
+    "    \"sac_learning_rate\": hpt.DoubleParameterSpec(min=1e-5, max=3e-4, scale=\"log\"),\n",
+    "    \"sac_batch_size\": hpt.DiscreteParameterSpec(values=[128, 256, 512], scale=\"linear\"),\n",
+    "    \"sac_gamma\": hpt.DoubleParameterSpec(min=0.97, max=0.999, scale=\"linear\"),\n",
+    "}\n",
+    "\n",
+    "PARAMETER_SPEC = PPO_PARAMETER_SPEC if ALGORITHM == \"ppo\" else SAC_PARAMETER_SPEC\n",
+    "\n",
+    "print(f\"Search space for {ALGORITHM.upper()}:\")\n",
+    "for name in PARAMETER_SPEC:\n",
+    "    print(f\"  {name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "option-a-header"
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Option A: Single-Stage Sweep (`launch`)\n",
+    "\n",
+    "Submit a sweep for **one curriculum stage**. The job returns immediately (non-blocking). Use this when you want to tune one stage at a time or experiment with a custom search space per stage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "single-stage-config"
+   },
+   "outputs": [],
+   "source": [
+    "# ── Single-stage settings ─────────────────────────────────────────────────────\n",
+    "STAGE = 1             # @param {type:\"integer\"} — curriculum stage (1, 2, or 3)\n",
+    "TIMESTEPS = 500_000   # @param {type:\"integer\"} — training timesteps per trial\n",
+    "\n",
+    "# Optional: warm-start from a previous checkpoint (GCS-mounted path)\n",
+    "LOAD_PATH = \"\"  # @param {type:\"string\"} — e.g. /gcs/BUCKET/sweeps/velociraptor/stage1/1/models/stage1_final.zip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "single-stage-submit"
+   },
+   "outputs": [],
+   "source": [
+    "# Build the trial worker args\n",
+    "output_base = f\"/gcs/{BUCKET}/sweeps/{SPECIES}/stage{STAGE}\"\n",
+    "\n",
+    "trial_args = [\n",
+    "    \"environments/shared/scripts/sweep.py\",\n",
+    "    \"trial\",\n",
+    "    \"--species\", SPECIES,\n",
+    "    \"--stage\", str(STAGE),\n",
+    "    \"--algorithm\", ALGORITHM,\n",
+    "    \"--timesteps\", str(TIMESTEPS),\n",
+    "    \"--n-envs\", str(N_ENVS),\n",
+    "    \"--output-dir\", output_base,\n",
+    "]\n",
+    "if LOAD_PATH:\n",
+    "    trial_args += [\"--load\", LOAD_PATH]\n",
+    "\n",
+    "env_vars = []\n",
+    "if WANDB_API_KEY:\n",
+    "    trial_args.append(\"--wandb\")\n",
+    "    env_vars.append({\"name\": \"WANDB_API_KEY\", \"value\": WANDB_API_KEY})\n",
+    "    env_vars.append({\"name\": \"WANDB_PROJECT\", \"value\": \"mesozoic-labs\"})\n",
+    "\n",
+    "worker_pool_specs = [\n",
+    "    {\n",
+    "        \"machine_spec\": {\n",
+    "            \"machine_type\": MACHINE_TYPE,\n",
+    "            \"accelerator_type\": ACCELERATOR_TYPE,\n",
+    "            \"accelerator_count\": ACCELERATOR_COUNT,\n",
+    "        },\n",
+    "        \"replica_count\": 1,\n",
+    "        \"container_spec\": {\n",
+    "            \"image_uri\": IMAGE_URI,\n",
+    "            \"command\": [\"python\"],\n",
+    "            \"args\": trial_args,\n",
+    "            **(dict(env=env_vars) if env_vars else {}),\n",
+    "        },\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "display_name = f\"{SPECIES}-stage{STAGE}-{ALGORITHM}-sweep\"\n",
+    "\n",
+    "custom_job = aiplatform.CustomJob(\n",
+    "    display_name=f\"{display_name}-trial\",\n",
+    "    worker_pool_specs=worker_pool_specs,\n",
+    ")\n",
+    "\n",
+    "hpt_job = aiplatform.HyperparameterTuningJob(\n",
+    "    display_name=display_name,\n",
+    "    custom_job=custom_job,\n",
+    "    metric_spec={\"best_mean_reward\": \"maximize\"},\n",
+    "    parameter_spec=PARAMETER_SPEC,\n",
+    "    max_trial_count=MAX_TRIALS,\n",
+    "    parallel_trial_count=PARALLEL_TRIALS,\n",
+    ")\n",
+    "\n",
+    "print(f\"Submitting: {display_name}\")\n",
+    "print(f\"  Trials: {MAX_TRIALS}  |  Parallel: {PARALLEL_TRIALS}\")\n",
+    "print(f\"  Timesteps/trial: {TIMESTEPS:,}\")\n",
+    "print(f\"  Output: gs://{BUCKET}/sweeps/{SPECIES}/stage{STAGE}/\")\n",
+    "if LOAD_PATH:\n",
+    "    print(f\"  Warm-start: {LOAD_PATH}\")\n",
+    "\n",
+    "hpt_job.run(sync=False)\n",
+    "\n",
+    "print(f\"\\nJob submitted: {hpt_job.resource_name}\")\n",
+    "print(f\"Monitor: https://console.cloud.google.com/vertex-ai/training/hyperparameter-tuning-jobs?project={PROJECT_ID}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "option-b-header"
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Option B: All-Stages Sweep (`launch-all`)\n",
+    "\n",
+    "Sweep all three curriculum stages sequentially in a single run. Each stage waits for the previous one to finish, then automatically picks the best trial's checkpoint as the warm-start model for the next stage.\n",
+    "\n",
+    "**This cell blocks until all three stages are complete**, which can take several hours depending on your timestep budgets and trial counts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "all-stages-config"
+   },
+   "outputs": [],
+   "source": [
+    "# ── Per-stage timestep budgets ────────────────────────────────────────────────\n",
+    "TIMESTEPS_STAGE1 = 500_000    # @param {type:\"integer\"}\n",
+    "TIMESTEPS_STAGE2 = 1_000_000  # @param {type:\"integer\"}\n",
+    "TIMESTEPS_STAGE3 = 1_500_000  # @param {type:\"integer\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "all-stages-submit"
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "timesteps_per_stage = [TIMESTEPS_STAGE1, TIMESTEPS_STAGE2, TIMESTEPS_STAGE3]\n",
+    "load_path = None\n",
+    "all_jobs = []\n",
+    "\n",
+    "for stage in range(1, 4):\n",
+    "    timesteps = timesteps_per_stage[stage - 1]\n",
+    "    output_base = f\"/gcs/{BUCKET}/sweeps/{SPECIES}/stage{stage}\"\n",
+    "\n",
+    "    print(\"=\" * 60)\n",
+    "    print(f\"Stage {stage} / 3  \u2014  {timesteps:,} timesteps/trial\")\n",
+    "    print(\"=\" * 60)\n",
+    "\n",
+    "    trial_args = [\n",
+    "        \"environments/shared/scripts/sweep.py\",\n",
+    "        \"trial\",\n",
+    "        \"--species\", SPECIES,\n",
+    "        \"--stage\", str(stage),\n",
+    "        \"--algorithm\", ALGORITHM,\n",
+    "        \"--timesteps\", str(timesteps),\n",
+    "        \"--n-envs\", str(N_ENVS),\n",
+    "        \"--output-dir\", output_base,\n",
+    "    ]\n",
+    "    if load_path:\n",
+    "        trial_args += [\"--load\", load_path]\n",
+    "        print(f\"  Warm-start: {load_path}\")\n",
+    "\n",
+    "    env_vars = []\n",
+    "    if WANDB_API_KEY:\n",
+    "        trial_args.append(\"--wandb\")\n",
+    "        env_vars.append({\"name\": \"WANDB_API_KEY\", \"value\": WANDB_API_KEY})\n",
+    "        env_vars.append({\"name\": \"WANDB_PROJECT\", \"value\": \"mesozoic-labs\"})\n",
+    "\n",
+    "    worker_pool_specs = [\n",
+    "        {\n",
+    "            \"machine_spec\": {\n",
+    "                \"machine_type\": MACHINE_TYPE,\n",
+    "                \"accelerator_type\": ACCELERATOR_TYPE,\n",
+    "                \"accelerator_count\": ACCELERATOR_COUNT,\n",
+    "            },\n",
+    "            \"replica_count\": 1,\n",
+    "            \"container_spec\": {\n",
+    "                \"image_uri\": IMAGE_URI,\n",
+    "                \"command\": [\"python\"],\n",
+    "                \"args\": trial_args,\n",
+    "                **(dict(env=env_vars) if env_vars else {}),\n",
+    "            },\n",
+    "        }\n",
+    "    ]\n",
+    "\n",
+    "    display_name = f\"{SPECIES}-stage{stage}-{ALGORITHM}-sweep\"\n",
+    "\n",
+    "    custom_job = aiplatform.CustomJob(\n",
+    "        display_name=f\"{display_name}-trial\",\n",
+    "        worker_pool_specs=worker_pool_specs,\n",
+    "    )\n",
+    "\n",
+    "    hpt_job = aiplatform.HyperparameterTuningJob(\n",
+    "        display_name=display_name,\n",
+    "        custom_job=custom_job,\n",
+    "        metric_spec={\"best_mean_reward\": \"maximize\"},\n",
+    "        parameter_spec=PARAMETER_SPEC,\n",
+    "        max_trial_count=MAX_TRIALS,\n",
+    "        parallel_trial_count=PARALLEL_TRIALS,\n",
+    "    )\n",
+    "\n",
+    "    start = time.time()\n",
+    "    hpt_job.run(sync=True)  # Block until this stage completes\n",
+    "    elapsed = time.time() - start\n",
+    "\n",
+    "    print(f\"\\nStage {stage} complete in {elapsed / 60:.1f} min\")\n",
+    "    print(f\"  Job: {hpt_job.resource_name}\")\n",
+    "    all_jobs.append(hpt_job)\n",
+    "\n",
+    "    # Find the best trial and use its checkpoint for the next stage\n",
+    "    if stage < 3:\n",
+    "        best_trial = None\n",
+    "        best_value = float(\"-inf\")\n",
+    "        for trial in hpt_job.trials:\n",
+    "            if trial.final_measurement and trial.final_measurement.metrics:\n",
+    "                for metric in trial.final_measurement.metrics:\n",
+    "                    if metric.metric_id == \"best_mean_reward\" and metric.value > best_value:\n",
+    "                        best_value = metric.value\n",
+    "                        best_trial = trial\n",
+    "        if best_trial is not None:\n",
+    "            load_path = f\"/gcs/{BUCKET}/sweeps/{SPECIES}/stage{stage}/{best_trial.id}/models/stage{stage}_final.zip\"\n",
+    "            print(f\"  Best trial: {best_trial.id}  (reward={best_value:.2f})\")\n",
+    "            print(f\"  Next stage will load: {load_path}\")\n",
+    "        else:\n",
+    "            print(\"  WARNING: No completed trials found \u2014 next stage starts from scratch.\")\n",
+    "            load_path = None\n",
+    "\n",
+    "print(\"\\n\" + \"=\" * 60)\n",
+    "print(f\"ALL STAGES COMPLETE for {SPECIES} ({ALGORITHM.upper()})\")\n",
+    "print(f\"Results: gs://{BUCKET}/sweeps/{SPECIES}/\")\n",
+    "print(\"=\" * 60)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "monitor-header"
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 6. Monitor & Inspect Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "monitor-status"
+   },
+   "outputs": [],
+   "source": [
+    "# Check the status of the most recently submitted job\n",
+    "# (works for both Option A and Option B)\n",
+    "try:\n",
+    "    job_to_check = hpt_job  # from Option A\n",
+    "except NameError:\n",
+    "    job_to_check = all_jobs[-1] if all_jobs else None  # from Option B\n",
+    "\n",
+    "if job_to_check:\n",
+    "    print(f\"Job:    {job_to_check.display_name}\")\n",
+    "    print(f\"State:  {job_to_check.state}\")\n",
+    "    print(f\"Resource: {job_to_check.resource_name}\")\n",
+    "else:\n",
+    "    print(\"No job found \u2014 run Option A or Option B first.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "inspect-trials"
+   },
+   "outputs": [],
+   "source": [
+    "# Print trial results for a completed HPT job\n",
+    "import pandas as pd\n",
+    "\n",
+    "def trials_to_dataframe(job):\n",
+    "    \"\"\"Extract trial hyperparameters and metrics into a DataFrame.\"\"\"\n",
+    "    rows = []\n",
+    "    for trial in job.trials:\n",
+    "        row = {\"trial_id\": trial.id}\n",
+    "        if hasattr(trial, \"parameters\") and trial.parameters:\n",
+    "            for param in trial.parameters:\n",
+    "                row[param.parameter_id] = param.value\n",
+    "        if trial.final_measurement and trial.final_measurement.metrics:\n",
+    "            for metric in trial.final_measurement.metrics:\n",
+    "                row[metric.metric_id] = metric.value\n",
+    "        rows.append(row)\n",
+    "    return pd.DataFrame(rows).sort_values(\"best_mean_reward\", ascending=False)\n",
+    "\n",
+    "if job_to_check and job_to_check.trials:\n",
+    "    df = trials_to_dataframe(job_to_check)\n",
+    "    display(df)\n",
+    "else:\n",
+    "    print(\"No trial results available yet.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "list-artifacts"
+   },
+   "outputs": [],
+   "source": [
+    "# List sweep artifacts in GCS\n",
+    "!gcloud storage ls gs://{BUCKET}/sweeps/{SPECIES}/ --recursive 2>/dev/null | head -30 || echo \"No artifacts found (job may still be running).\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "download-best"
+   },
+   "outputs": [],
+   "source": [
+    "# Download the best model from a completed sweep\n",
+    "# Adjust STAGE and TRIAL_ID based on the results above.\n",
+    "DOWNLOAD_STAGE = 3   # @param {type:\"integer\"}\n",
+    "TRIAL_ID = \"1\"       # @param {type:\"string\"} — best trial ID from the results table\n",
+    "\n",
+    "src = f\"gs://{BUCKET}/sweeps/{SPECIES}/stage{DOWNLOAD_STAGE}/{TRIAL_ID}/models/stage{DOWNLOAD_STAGE}_final.zip\"\n",
+    "dst = f\"/content/{SPECIES}_stage{DOWNLOAD_STAGE}_best.zip\"\n",
+    "\n",
+    "!gcloud storage cp {src} {dst} && echo \"Downloaded to {dst}\" || echo \"File not found: {src}\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  },
+  "colab": {
+   "provenance": [],
+   "include_colab_link": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Summary
Add a comprehensive Jupyter notebook for submitting hyperparameter tuning jobs to Google Cloud Vertex AI. This notebook provides an end-to-end workflow for training RL agents with curriculum learning across multiple stages.

## Key Changes
- **New notebook**: `notebooks/vertex_ai_sweep.ipynb` with 647 lines of documented cells
- **Setup & Authentication**: Google Cloud authentication and API enablement
- **Docker Image Management**: Build and push training containers to Artifact Registry
- **Two sweep modes**:
  - **Option A (Single-stage)**: Tune one curriculum stage independently
  - **Option B (All-stages)**: Sequentially sweep stages 1→2→3 with automatic checkpoint chaining
- **Configurable hyperparameter search spaces** for PPO and SAC algorithms
- **Monitoring & Results Inspection**: Track job status, view trial metrics, and download best models
- **W&B Integration**: Optional Weights & Biases logging support

## Notable Implementation Details
- Supports multiple species (velociraptor, brachiosaurus, trex) and algorithms (PPO, SAC)
- Automatic warm-start from best trial checkpoint when chaining stages
- Flexible machine configuration (GPU type, count, machine type)
- GCS-based artifact storage with easy download utilities
- Colab-compatible with automatic environment detection
- Comprehensive inline documentation and parameter descriptions