### PR TITLE
Format logger.error call for better readability

### DIFF
--- a/environments/shared/scripts/sweep.py
+++ b/environments/shared/scripts/sweep.py
@@ -183,7 +183,8 @@ def run_trial(args: argparse.Namespace, extra_args: list[str]) -> None:
             if value not in NET_ARCH_PRESETS:
                 logger.error(
                     "Unknown net_arch preset %r. Valid presets: %s",
-                    value, list(NET_ARCH_PRESETS.keys()),
+                    value,
+                    list(NET_ARCH_PRESETS.keys()),
                 )
                 sys.exit(1)
             net_arch_preset = value


### PR DESCRIPTION
## Summary
Improved code formatting in the sweep script's error logging to enhance readability and maintain consistent line length.

## Key Changes
- Reformatted the `logger.error()` call in the `run_trial()` function to split arguments across multiple lines
- Moved the `list(NET_ARCH_PRESETS.keys())` argument to its own line for better code organization

## Implementation Details
This is a formatting-only change that improves code readability without altering functionality. The error message and its parameters remain identical; only the argument layout has been adjusted to follow better code style practices.

https://claude.ai/code/session_016d6eLa1z1p8ei7yB6TnDvY