### PR TITLE
Set base output directory for hyperparameter tuning sweeps

### DIFF
--- a/environments/shared/scripts/sweep.py
+++ b/environments/shared/scripts/sweep.py
@@ -452,6 +452,7 @@ def _submit_stage_sweep(
     custom_job = aiplatform.CustomJob(
         display_name=f"{display_name}-trial",
         worker_pool_specs=worker_pool_specs,
+        base_output_dir=f"gs://{bucket}/sweeps/{species}/stage{stage}",
     )
 
     hpt_job = aiplatform.HyperparameterTuningJob(


### PR DESCRIPTION
## Summary
Added explicit configuration of the base output directory for CustomJob instances in the hyperparameter tuning sweep pipeline.

## Key Changes
- Set `base_output_dir` parameter on CustomJob to organize sweep outputs in a structured GCS path format: `gs://{bucket}/sweeps/{species}/stage{stage}`
- This ensures all trial outputs from hyperparameter tuning jobs are stored in a predictable, organized location rather than using default paths

## Implementation Details
The output directory follows a hierarchical structure that includes:
- The GCS bucket name
- A "sweeps" prefix for easy identification
- The species identifier for multi-species experiments
- The stage number to separate different sweep stages

This change improves output organization and makes it easier to locate and manage results from different sweep runs.