### PR TITLE
Format logger.error call for better readability

### DIFF
--- a/environments/shared/scripts/sweep.py
+++ b/environments/shared/scripts/sweep.py
@@ -183,7 +183,8 @@ def run_trial(args: argparse.Namespace, extra_args: list[str]) -> None:
             if value not in NET_ARCH_PRESETS:
                 logger.error(
                     "Unknown net_arch preset %r. Valid presets: %s",
-                    value, list(NET_ARCH_PRESETS.keys()),
+                    value,
+                    list(NET_ARCH_PRESETS.keys()),
                 )
                 sys.exit(1)
             net_arch_preset = value


### PR DESCRIPTION
## Summary
Improved code formatting in the sweep script's error logging to enhance readability and maintain consistent line length.

## Key Changes
- Split the `logger.error()` call arguments across multiple lines for better code formatting
- Moved the `list(NET_ARCH_PRESETS.keys())` argument to its own line, separating it from the format string argument

## Implementation Details
This is a formatting-only change that improves code readability by breaking up a long function call. The functionality remains identical - the error message and its arguments are unchanged, only their presentation on separate lines has been modified.