### PR TITLE
Fix missing WandbCallback in train_curriculum for all species

### DIFF
--- a/environments/brachiosaurus/scripts/train_sb3.py
+++ b/environments/brachiosaurus/scripts/train_sb3.py
@@ -458,6 +458,9 @@ def train_curriculum(
         )
         callbacks.append(checkpoint_callback)
 
+        if use_wandb:
+            callbacks.append(WandbCallback())
+
         curriculum_cb = None
         if stage < 3:
             curriculum_cb = CurriculumCallback(

--- a/environments/trex/scripts/train_sb3.py
+++ b/environments/trex/scripts/train_sb3.py
@@ -458,6 +458,9 @@ def train_curriculum(
         )
         callbacks.append(checkpoint_callback)
 
+        if use_wandb:
+            callbacks.append(WandbCallback())
+
         curriculum_cb = None
         if stage < 3:
             curriculum_cb = CurriculumCallback(

--- a/environments/velociraptor/scripts/train_sb3.py
+++ b/environments/velociraptor/scripts/train_sb3.py
@@ -466,6 +466,9 @@ def train_curriculum(
         )
         callbacks.append(checkpoint_callback)
 
+        if use_wandb:
+            callbacks.append(WandbCallback())
+
         # Add curriculum callback for non-final stages
         curriculum_cb = None
         if stage < 3:


### PR DESCRIPTION
The train_curriculum() method initialized a W&B run but never added a
WandbCallback to the callback list, so per-step reward decomposition
and video recording were silently skipped during curriculum training.

https://claude.ai/code/session_01EwgfFjmXPJiebDe8ayXA2g