### PR TITLE
Add GCS upload for curriculum artifacts and sweep visualizations

### DIFF
--- a/environments/brachiosaurus/scripts/train_sb3.py
+++ b/environments/brachiosaurus/scripts/train_sb3.py
@@ -49,7 +49,7 @@ except ImportError:
     sys.exit(1)
 
 from environments.brachiosaurus.envs.brachio_env import BrachioEnv
-from environments.shared.config import append_stage_result_csv, load_all_stages, save_stage_config
+from environments.shared.config import append_stage_result_csv, load_all_stages, save_stage_config, upload_curriculum_artifacts
 from environments.shared.curriculum import (
     CurriculumCallback,
     CurriculumManager,
@@ -358,6 +358,8 @@ def train_curriculum(
     algorithm: str = "ppo",
     use_wandb: bool = False,
     output_dir: str | None = None,
+    gcs_bucket: str | None = None,
+    gcs_project: str | None = None,
 ):
     """Run the full 3-stage curriculum with automatic advancement."""
     thresholds = thresholds_from_configs(STAGE_CONFIGS)
@@ -561,6 +563,15 @@ def train_curriculum(
                 stage,
             )
             manager.advance()
+
+    # Upload curriculum CSV and best models to GCS (no-op when bucket is None)
+    upload_curriculum_artifacts(
+        base_dir,
+        species="brachiosaurus",
+        algorithm=algorithm,
+        bucket=gcs_bucket,
+        project=gcs_project,
+    )
 
     logger.info("=" * 60)
     logger.info("Curriculum training complete!")
@@ -785,6 +796,18 @@ def main():
         default=None,
         help="Base output directory for all artifacts (preferred for cloud/GCS training)",
     )
+    cur_parser.add_argument(
+        "--gcs-bucket",
+        type=str,
+        default=None,
+        help="GCS bucket name (without gs:// prefix) to upload curriculum CSV and best models",
+    )
+    cur_parser.add_argument(
+        "--gcs-project",
+        type=str,
+        default=None,
+        help="GCP project ID for GCS uploads (uses default credentials if omitted)",
+    )
 
     # Eval command
     eval_parser = subparsers.add_parser("eval", help="Evaluate a trained policy")
@@ -851,6 +874,8 @@ def main():
             algorithm=args.algorithm,
             use_wandb=args.wandb,
             output_dir=args.output_dir,
+            gcs_bucket=args.gcs_bucket,
+            gcs_project=args.gcs_project,
         )
 
     elif args.command == "eval":

--- a/environments/shared/config.py
+++ b/environments/shared/config.py
@@ -15,8 +15,11 @@ The [curriculum] table contains per-stage training and advancement settings:
 """
 
 import json
+import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+_logger = logging.getLogger(__name__)
 
 try:
     import tomllib
@@ -204,3 +207,109 @@ def append_stage_result_csv(csv_path: str | Path, data: dict) -> Path:
                 writer.writerow(data)
 
     return csv_path
+
+
+def upload_to_gcs(
+    local_path: str | Path,
+    bucket_name: str,
+    gcs_path: str,
+    project: str | None = None,
+) -> bool:
+    """Upload a local file to Google Cloud Storage.
+
+    Args:
+        local_path: Path to the local file to upload.
+        bucket_name: GCS bucket name (without ``gs://`` prefix).
+        gcs_path: Destination blob path inside the bucket.
+        project: GCP project ID (optional, uses default if *None*).
+
+    Returns:
+        *True* if the upload succeeded, *False* otherwise.
+    """
+    local_path = Path(local_path)
+    if not local_path.exists():
+        _logger.warning("Cannot upload to GCS: local file not found: %s", local_path)
+        return False
+
+    try:
+        from google.cloud import storage as _gcs
+
+        client = _gcs.Client(project=project)
+        bucket = client.bucket(bucket_name)
+        bucket.blob(gcs_path).upload_from_filename(str(local_path))
+        _logger.info("Uploaded to GCS: gs://%s/%s", bucket_name, gcs_path)
+        return True
+    except Exception as exc:
+        _logger.warning(
+            "Failed to upload %s to GCS: %s. Local copy remains at: %s",
+            gcs_path,
+            exc,
+            local_path,
+        )
+        return False
+
+
+def upload_curriculum_artifacts(
+    base_dir: str | Path,
+    species: str,
+    algorithm: str,
+    bucket: str | None = None,
+    project: str | None = None,
+) -> None:
+    """Upload curriculum training artifacts (CSV + best models) to GCS.
+
+    Uploads:
+    * ``curriculum_results.csv`` → ``training/<species>/curriculum_results_<run>.csv``
+    * Each stage's ``best_model.zip`` and ``stage<N>_final.zip`` →
+      ``training/<species>/<run>/stage<N>/models/``
+
+    When *bucket* is ``None`` (no GCP info provided), this function is a
+    no-op and all artifacts remain local only.
+
+    Args:
+        base_dir: The curriculum run's base directory
+            (e.g. ``logs/velociraptor/curriculum_20240228_150000``).
+        species: Species name (``"velociraptor"``, ``"brachiosaurus"``, ``"trex"``).
+        algorithm: Algorithm name (``"ppo"`` or ``"sac"``).
+        bucket: GCS bucket name (without ``gs://`` prefix).  Pass *None* to
+            skip cloud upload and keep artifacts local only.
+        project: GCP project ID (optional, uses default if *None*).
+    """
+    base_dir = Path(base_dir)
+
+    if bucket is None:
+        _logger.info(
+            "No GCS bucket specified — curriculum artifacts saved locally only: %s",
+            base_dir,
+        )
+        return
+
+    run_name = base_dir.name  # e.g. curriculum_20240228_150000
+
+    # 1. Upload curriculum_results.csv
+    csv_path = base_dir / "curriculum_results.csv"
+    if csv_path.exists():
+        gcs_csv = f"training/{species}/{run_name}/curriculum_results.csv"
+        upload_to_gcs(csv_path, bucket, gcs_csv, project=project)
+
+    # 2. Upload best model and final model for each stage
+    for stage in range(1, 4):
+        stage_model_dir = base_dir / f"stage{stage}" / "models"
+        if not stage_model_dir.is_dir():
+            continue
+
+        gcs_model_prefix = f"training/{species}/{run_name}/stage{stage}/models"
+
+        # best_model.zip (from EvalCallback)
+        best_model = stage_model_dir / "best_model.zip"
+        if best_model.exists():
+            upload_to_gcs(best_model, bucket, f"{gcs_model_prefix}/best_model.zip", project=project)
+
+        # stage<N>_final.zip + vecnorm
+        final_model = stage_model_dir / f"stage{stage}_final.zip"
+        if final_model.exists():
+            upload_to_gcs(final_model, bucket, f"{gcs_model_prefix}/stage{stage}_final.zip", project=project)
+
+        vecnorm = stage_model_dir / f"stage{stage}_final_vecnorm.pkl"
+        if vecnorm.exists():
+            upload_to_gcs(vecnorm, bucket, f"{gcs_model_prefix}/stage{stage}_final_vecnorm.pkl", project=project)

--- a/environments/shared/scripts/sweep.py
+++ b/environments/shared/scripts/sweep.py
@@ -398,6 +398,215 @@ def write_results_csv(rows: list[dict], path: str | Path) -> Path:
     return path
 
 
+def plot_sweep_results(csv_path: str | Path, species: str, algorithm: str, save_dir: str | Path | None = None) -> None:
+    """Generate visualisation graphs from sweep results CSV.
+
+    Produces two PNG figures saved alongside the CSV (or to *save_dir*):
+
+    **sweep_trial_metrics.png** — 2x2 grid:
+      - [0,0] Best Mean Reward per trial (grouped by stage)
+      - [0,1] Best Mean Episode Length per trial (grouped by stage)
+      - [1,0] Best vs Last Mean Reward (training stability)
+      - [1,1] Stage Pass/Fail summary (stacked bar)
+
+    **sweep_hyperparameter_analysis.png** — Nx1 column:
+      - One scatter plot per hyperparameter vs best_mean_reward (colour = stage)
+
+    Args:
+        csv_path: Path to the sweep results CSV.
+        species: Species name for titles.
+        algorithm: Algorithm name for titles.
+        save_dir: Directory to save PNGs. Defaults to the CSV's parent directory.
+    """
+    import csv as _csv
+
+    try:
+        import matplotlib
+        matplotlib.use("Agg")  # non-interactive backend for headless environments
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError:
+        logger.warning("matplotlib or numpy not installed — skipping sweep visualisations")
+        return
+
+    csv_path = Path(csv_path)
+    if not csv_path.exists():
+        logger.warning("Sweep CSV not found: %s — skipping visualisations", csv_path)
+        return
+
+    if save_dir is None:
+        save_dir = csv_path.parent
+    save_dir = Path(save_dir)
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    # Read CSV into list of dicts
+    with open(csv_path, newline="") as f:
+        reader = _csv.DictReader(f)
+        rows = list(reader)
+
+    if not rows:
+        logger.warning("Sweep CSV is empty — skipping visualisations")
+        return
+
+    # Parse numeric values
+    def _float(v):
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+
+    stages = sorted({int(r["stage"]) for r in rows if r.get("stage")})
+    stage_colors = {1: "#1f77b4", 2: "#ff7f0e", 3: "#2ca02c"}
+
+    # ── Figure 1: Trial Metrics (2x2) ────────────────────────────────────────
+    fig1, axes1 = plt.subplots(2, 2, figsize=(14, 10))
+    title = f"{species.capitalize()} {algorithm.upper()} Sweep"
+    fig1.suptitle(title, fontsize=14, fontweight="bold")
+
+    for stage in stages:
+        stage_rows = [r for r in rows if int(r["stage"]) == stage]
+        trial_ids = [r["trial_id"] for r in stage_rows]
+        label = f"Stage {stage}"
+        color = stage_colors.get(stage, "#333333")
+
+        # [0,0] Best Mean Reward
+        rewards = [_float(r.get("best_mean_reward")) for r in stage_rows]
+        valid = [(tid, rw) for tid, rw in zip(trial_ids, rewards) if rw is not None]
+        if valid:
+            tids, rws = zip(*valid)
+            x = np.arange(len(tids))
+            axes1[0, 0].bar(x, rws, color=color, alpha=0.7, label=label)
+            axes1[0, 0].set_xticks(x)
+            axes1[0, 0].set_xticklabels(tids, rotation=45, fontsize=7)
+            # Draw threshold line if available
+            threshold = _float(stage_rows[0].get("reward_threshold"))
+            if threshold is not None:
+                axes1[0, 0].axhline(y=threshold, color=color, linestyle="--", alpha=0.5)
+
+        # [0,1] Best Mean Episode Length
+        ep_lengths = [_float(r.get("best_mean_episode_length")) for r in stage_rows]
+        valid_ep = [(tid, el) for tid, el in zip(trial_ids, ep_lengths) if el is not None]
+        if valid_ep:
+            tids_ep, els = zip(*valid_ep)
+            x = np.arange(len(tids_ep))
+            axes1[0, 1].bar(x, els, color=color, alpha=0.7, label=label)
+            axes1[0, 1].set_xticks(x)
+            axes1[0, 1].set_xticklabels(tids_ep, rotation=45, fontsize=7)
+            ep_threshold = _float(stage_rows[0].get("ep_length_threshold"))
+            if ep_threshold is not None:
+                axes1[0, 1].axhline(y=ep_threshold, color=color, linestyle="--", alpha=0.5)
+
+        # [1,0] Best vs Last Mean Reward (training stability)
+        best_last = [
+            (_float(r.get("best_mean_reward")), _float(r.get("last_mean_reward")))
+            for r in stage_rows
+        ]
+        valid_bl = [(b, l) for b, l in best_last if b is not None and l is not None]
+        if valid_bl:
+            bests, lasts = zip(*valid_bl)
+            axes1[1, 0].scatter(bests, lasts, color=color, alpha=0.7, label=label, edgecolors="white", s=50)
+
+    axes1[0, 0].set_xlabel("Trial ID")
+    axes1[0, 0].set_ylabel("Best Mean Reward")
+    axes1[0, 0].set_title("Best Mean Reward per Trial")
+    axes1[0, 0].legend()
+    axes1[0, 0].grid(True, alpha=0.3)
+
+    axes1[0, 1].set_xlabel("Trial ID")
+    axes1[0, 1].set_ylabel("Best Mean Episode Length")
+    axes1[0, 1].set_title("Best Mean Episode Length per Trial")
+    axes1[0, 1].legend()
+    axes1[0, 1].grid(True, alpha=0.3)
+
+    axes1[1, 0].set_xlabel("Best Mean Reward")
+    axes1[1, 0].set_ylabel("Last Mean Reward")
+    axes1[1, 0].set_title("Training Stability (Best vs Last Reward)")
+    # Draw y=x reference line
+    all_rewards = [_float(r.get("best_mean_reward")) for r in rows]
+    all_rewards = [v for v in all_rewards if v is not None]
+    if all_rewards:
+        lo, hi = min(all_rewards), max(all_rewards)
+        axes1[1, 0].plot([lo, hi], [lo, hi], "k--", alpha=0.3, label="y=x")
+    axes1[1, 0].legend()
+    axes1[1, 0].grid(True, alpha=0.3)
+
+    # [1,1] Stage Pass/Fail Summary
+    ax_pf = axes1[1, 1]
+    pass_counts = []
+    fail_counts = []
+    stage_labels = []
+    for stage in stages:
+        stage_rows = [r for r in rows if int(r["stage"]) == stage]
+        passed = sum(1 for r in stage_rows if str(r.get("stage_passed", "")).lower() == "true")
+        failed = len(stage_rows) - passed
+        pass_counts.append(passed)
+        fail_counts.append(failed)
+        stage_labels.append(f"Stage {stage}")
+
+    x_pf = np.arange(len(stages))
+    ax_pf.bar(x_pf, pass_counts, color="#2ca02c", alpha=0.8, label="Passed")
+    ax_pf.bar(x_pf, fail_counts, bottom=pass_counts, color="#d62728", alpha=0.8, label="Failed")
+    ax_pf.set_xticks(x_pf)
+    ax_pf.set_xticklabels(stage_labels)
+    ax_pf.set_ylabel("Number of Trials")
+    ax_pf.set_title("Stage Pass/Fail Summary")
+    ax_pf.legend()
+    ax_pf.grid(True, alpha=0.3, axis="y")
+
+    fig1.tight_layout()
+    fig1_path = save_dir / "sweep_trial_metrics.png"
+    fig1.savefig(fig1_path, dpi=150, bbox_inches="tight")
+    plt.close(fig1)
+    logger.info("Sweep trial metrics graph saved to: %s", fig1_path)
+
+    # ── Figure 2: Hyperparameter Analysis ─────────────────────────────────────
+    # Identify hyperparameter columns (not fixed or metric columns)
+    fixed_cols = {
+        "trial_id", "stage", "best_mean_reward", "best_mean_episode_length",
+        "last_mean_reward", "last_mean_episode_length", "reward_threshold",
+        "ep_length_threshold", "forward_vel_threshold", "success_rate_threshold",
+        "stage_passed",
+    }
+    hparam_cols = [k for k in rows[0].keys() if k not in fixed_cols]
+    # Filter to columns with numeric, varying values
+    numeric_hparams = []
+    for col in hparam_cols:
+        vals = [_float(r.get(col)) for r in rows]
+        vals = [v for v in vals if v is not None]
+        if len(vals) >= 2 and len(set(vals)) > 1:
+            numeric_hparams.append(col)
+
+    if numeric_hparams:
+        n_params = len(numeric_hparams)
+        fig2, axes2 = plt.subplots(n_params, 1, figsize=(10, 4 * n_params), squeeze=False)
+        fig2.suptitle(f"{title} — Hyperparameter vs Reward", fontsize=14, fontweight="bold")
+
+        for idx, hparam in enumerate(numeric_hparams):
+            ax = axes2[idx, 0]
+            for stage in stages:
+                stage_rows = [r for r in rows if int(r["stage"]) == stage]
+                xs = [_float(r.get(hparam)) for r in stage_rows]
+                ys = [_float(r.get("best_mean_reward")) for r in stage_rows]
+                valid_hp = [(x, y) for x, y in zip(xs, ys) if x is not None and y is not None]
+                if valid_hp:
+                    hx, hy = zip(*valid_hp)
+                    ax.scatter(hx, hy, color=stage_colors.get(stage, "#333"), alpha=0.7,
+                               label=f"Stage {stage}", edgecolors="white", s=50)
+            ax.set_xlabel(hparam)
+            ax.set_ylabel("Best Mean Reward")
+            ax.set_title(f"{hparam} vs Best Mean Reward")
+            ax.legend()
+            ax.grid(True, alpha=0.3)
+
+        fig2.tight_layout()
+        fig2_path = save_dir / "sweep_hyperparameter_analysis.png"
+        fig2.savefig(fig2_path, dpi=150, bbox_inches="tight")
+        plt.close(fig2)
+        logger.info("Sweep hyperparameter analysis graph saved to: %s", fig2_path)
+    else:
+        logger.info("No varying numeric hyperparameters found — skipping hyperparameter analysis graph")
+
+
 def _best_trial_model_path(hpt_job: Any, bucket: str, species: str, stage: int) -> str:
     """Return the GCS container-mount path of the best trial's final model.
 
@@ -688,6 +897,20 @@ def launch_all_stages(args: argparse.Namespace) -> None:
         logger.info("Sweep CSV uploaded to: gs://%s/%s", args.bucket, gcs_csv_path)
     except Exception as exc:
         logger.warning("Failed to upload sweep CSV to GCS: %s. Local copy at: %s", exc, csv_path)
+
+    # Generate sweep visualisation graphs
+    plot_sweep_results(csv_path, args.species, args.algorithm)
+
+    # Upload graphs to GCS alongside the CSV
+    for graph_name in ("sweep_trial_metrics.png", "sweep_hyperparameter_analysis.png"):
+        graph_path = csv_path.parent / graph_name
+        if graph_path.exists():
+            gcs_graph_path = f"sweeps/{args.species}/{graph_name}"
+            try:
+                _bucket.blob(gcs_graph_path).upload_from_filename(str(graph_path))
+                logger.info("Sweep graph uploaded to: gs://%s/%s", args.bucket, gcs_graph_path)
+            except Exception as exc:
+                logger.warning("Failed to upload %s to GCS: %s", graph_name, exc)
 
     logger.info("=" * 60)
     logger.info("ALL-STAGES SWEEP COMPLETE for %s (%s)", args.species, args.algorithm)

--- a/environments/trex/scripts/train_sb3.py
+++ b/environments/trex/scripts/train_sb3.py
@@ -48,7 +48,7 @@ except ImportError:
     logger.error("stable-baselines3 not installed. Install with: pip install stable-baselines3[extra]")
     sys.exit(1)
 
-from environments.shared.config import append_stage_result_csv, load_all_stages, save_stage_config
+from environments.shared.config import append_stage_result_csv, load_all_stages, save_stage_config, upload_curriculum_artifacts
 from environments.shared.curriculum import (
     CurriculumCallback,
     CurriculumManager,
@@ -410,6 +410,8 @@ def train_curriculum(
     algorithm: str = "ppo",
     use_wandb: bool = False,
     output_dir: str | None = None,
+    gcs_bucket: str | None = None,
+    gcs_project: str | None = None,
 ):
     """Run the full 3-stage curriculum with automatic advancement."""
     thresholds = thresholds_from_configs(STAGE_CONFIGS)
@@ -618,6 +620,15 @@ def train_curriculum(
                 stage,
             )
             manager.advance()
+
+    # Upload curriculum CSV and best models to GCS (no-op when bucket is None)
+    upload_curriculum_artifacts(
+        base_dir,
+        species="trex",
+        algorithm=algorithm,
+        bucket=gcs_bucket,
+        project=gcs_project,
+    )
 
     logger.info("=" * 60)
     logger.info("Curriculum training complete!")
@@ -836,6 +847,18 @@ def main():
         default=None,
         help="Base output directory for all artifacts (preferred for cloud/GCS training)",
     )
+    cur_parser.add_argument(
+        "--gcs-bucket",
+        type=str,
+        default=None,
+        help="GCS bucket name (without gs:// prefix) to upload curriculum CSV and best models",
+    )
+    cur_parser.add_argument(
+        "--gcs-project",
+        type=str,
+        default=None,
+        help="GCP project ID for GCS uploads (uses default credentials if omitted)",
+    )
 
     # Eval command
     eval_parser = subparsers.add_parser("eval", help="Evaluate a trained policy")
@@ -898,6 +921,8 @@ def main():
             algorithm=args.algorithm,
             use_wandb=args.wandb,
             output_dir=args.output_dir,
+            gcs_bucket=args.gcs_bucket,
+            gcs_project=args.gcs_project,
         )
 
     elif args.command == "eval":

--- a/environments/velociraptor/scripts/train_sb3.py
+++ b/environments/velociraptor/scripts/train_sb3.py
@@ -48,7 +48,7 @@ except ImportError:
     logger.error("stable-baselines3 not installed. Install with: pip install stable-baselines3[extra]")
     sys.exit(1)
 
-from environments.shared.config import append_stage_result_csv, load_all_stages, save_stage_config
+from environments.shared.config import append_stage_result_csv, load_all_stages, save_stage_config, upload_curriculum_artifacts
 from environments.shared.curriculum import (
     CurriculumCallback,
     CurriculumManager,
@@ -415,6 +415,8 @@ def train_curriculum(
     algorithm: str = "ppo",
     use_wandb: bool = False,
     output_dir: str | None = None,
+    gcs_bucket: str | None = None,
+    gcs_project: str | None = None,
 ):
     """Run the full 3-stage curriculum with automatic advancement."""
     thresholds = thresholds_from_configs(STAGE_CONFIGS)
@@ -627,6 +629,15 @@ def train_curriculum(
                 stage,
             )
             manager.advance()
+
+    # Upload curriculum CSV and best models to GCS (no-op when bucket is None)
+    upload_curriculum_artifacts(
+        base_dir,
+        species="velociraptor",
+        algorithm=algorithm,
+        bucket=gcs_bucket,
+        project=gcs_project,
+    )
 
     logger.info("=" * 60)
     logger.info("Curriculum training complete!")
@@ -854,6 +865,18 @@ def main():
         default=None,
         help="Base output directory for all artifacts (preferred for cloud/GCS training)",
     )
+    cur_parser.add_argument(
+        "--gcs-bucket",
+        type=str,
+        default=None,
+        help="GCS bucket name (without gs:// prefix) to upload curriculum CSV and best models",
+    )
+    cur_parser.add_argument(
+        "--gcs-project",
+        type=str,
+        default=None,
+        help="GCP project ID for GCS uploads (uses default credentials if omitted)",
+    )
 
     # Eval command
     eval_parser = subparsers.add_parser("eval", help="Evaluate a trained policy")
@@ -923,6 +946,8 @@ def main():
             algorithm=args.algorithm,
             use_wandb=args.wandb,
             output_dir=args.output_dir,
+            gcs_bucket=args.gcs_bucket,
+            gcs_project=args.gcs_project,
         )
 
     elif args.command == "eval":


### PR DESCRIPTION
Three gaps addressed:

1. Curriculum results CSV now uploads to GCS when --gcs-bucket is provided
   on the curriculum CLI command for all three species.

2. Best model files (best_model.zip, stage<N>_final.zip, vecnorm.pkl) are
   uploaded to GCS alongside the CSV. When no --gcs-bucket is specified,
   everything stays local as before (no-op fallback).

3. Sweep launch-all now generates two visualization PNGs after completion:
   - sweep_trial_metrics.png: reward/ep-length bars, training stability
     scatter, and pass/fail summary per stage
   - sweep_hyperparameter_analysis.png: scatter plots of each swept
     hyperparameter vs best_mean_reward, colored by stage
   Both graphs are uploaded to GCS alongside the sweep CSV.

Shared helpers upload_to_gcs() and upload_curriculum_artifacts() added to
environments/shared/config.py to avoid duplicating GCS upload logic.

https://claude.ai/code/session_01N2mKktCt9UNjgxXVXgxztM