### PR TITLE
Mitigate catastrophic forgetting in trex and raptor stage configs

### DIFF
--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -20,6 +20,7 @@ max_episode_steps = 500
 
 [ppo]
 learning_rate = 3e-4
+learning_rate_end = 1e-5
 n_steps = 4096
 batch_size = 128
 n_epochs = 10

--- a/configs/trex/stage2_locomotion.toml
+++ b/configs/trex/stage2_locomotion.toml
@@ -8,7 +8,7 @@ forward_vel_weight = 0.8               # Reduce slightly: your best run (743 rew
 alive_bonus = 1.5                      # Increase from 1.0: critical for sustaining long episodes
 energy_penalty_weight = 0.001
 tail_stability_weight = 0.08           # Increase from 0.05: T-Rex tail is a major instability source
-posture_weight = 0.4
+posture_weight = 1.0                    # Increase from 0.4: prevent forgetting upright posture from Stage 1
 nosedive_weight = 1.0                  # Increase from 0.8: T-Rex heavy head pitches forward during walking
 gait_symmetry_weight = 0.0            # Keep disabled: formula is inverted
 smoothness_weight = 0.1               # Increase from 0.05: reduce jerky actions that topple the T-Rex
@@ -20,7 +20,8 @@ prey_distance_range = [8.0, 12.0]
 max_episode_steps = 1000
 
 [ppo]
-learning_rate = 1e-4
+learning_rate = 5e-5                    # Reduce from 1e-4: prevent catastrophic forgetting of Stage 1 balance
+learning_rate_end = 1e-5
 n_steps = 4096                          # Increase from 2048: larger rollout buffer for more stable gradients
 batch_size = 128
 n_epochs = 10

--- a/configs/trex/stage3_bite.toml
+++ b/configs/trex/stage3_bite.toml
@@ -4,7 +4,7 @@ description = "Sprint and bite prey with jaws"
 
 [env]
 forward_vel_weight = 1.0
-alive_bonus = 0.1
+alive_bonus = 0.5                       # Increase from 0.1: maintain self-preservation during bite training
 energy_penalty_weight = 0.001
 tail_stability_weight = 0.02
 posture_weight = 0.1
@@ -21,6 +21,7 @@ max_episode_steps = 1000
 
 [ppo]
 learning_rate = 5e-5
+learning_rate_end = 1e-5
 n_steps = 4096
 batch_size = 256
 n_epochs = 10

--- a/configs/velociraptor/stage3_strike.toml
+++ b/configs/velociraptor/stage3_strike.toml
@@ -5,7 +5,7 @@ description = "Sprint and strike prey with sickle claw"
 [env]
 forward_vel_weight = 1.0
 backward_vel_penalty_weight = 0.0
-alive_bonus = 0.1
+alive_bonus = 0.5                       # Increase from 0.1: maintain self-preservation during strike training
 energy_penalty_weight = 0.001
 tail_stability_weight = 0.02
 posture_weight = 0.1
@@ -22,6 +22,7 @@ max_episode_steps = 1000
 
 [ppo]
 learning_rate = 5e-5
+learning_rate_end = 1e-5
 n_steps = 4096
 batch_size = 256
 n_epochs = 10


### PR DESCRIPTION
T-Rex: reduce stage2 learning rate from 1e-4 to 5e-5, add LR decay
schedules (learning_rate_end=1e-5) across all 3 stages, increase
stage2 posture_weight from 0.4 to 1.0, and raise stage3 alive_bonus
from 0.1 to 0.5.

Velociraptor: add missing LR decay schedule to stage3 and raise
alive_bonus from 0.1 to 0.5 for self-preservation during strike.