### PR TITLE
Fix VecNormalize stats not carried across curriculum stages in CLI scripts

### DIFF
--- a/environments/brachiosaurus/scripts/train_sb3.py
+++ b/environments/brachiosaurus/scripts/train_sb3.py
@@ -58,6 +58,7 @@ from environments.shared.config import (
 from environments.shared.curriculum import (
     CurriculumCallback,
     CurriculumManager,
+    load_vecnorm_stats,
     thresholds_from_configs,
 )
 from environments.shared.metrics import LocomotionMetrics
@@ -209,6 +210,14 @@ def train(
 
     logger.info("Creating evaluation environment...")
     eval_env = create_vec_env(stage, 1, seed + 1000, use_subproc=False)
+
+    # If resuming from a prior stage, carry forward normalization statistics
+    # so the policy's observation inputs stay correctly scaled.
+    if load_path:
+        _vecnorm_path = load_path.replace(".zip", "") + "_vecnorm.pkl"
+        if not _vecnorm_path.endswith("_vecnorm.pkl"):
+            _vecnorm_path = load_path + "_vecnorm.pkl"
+        load_vecnorm_stats(_vecnorm_path, train_env, eval_env)
 
     alg_cls = SAC if algorithm == "sac" else PPO
     alg_kwargs = config["sac_kwargs"].copy() if algorithm == "sac" else config["ppo_kwargs"].copy()
@@ -396,6 +405,7 @@ def train_curriculum(
 
     model = None
     load_path = None
+    prev_vecnorm_path = None
 
     for stage in range(1, 4):
         config = STAGE_CONFIGS[stage]
@@ -424,6 +434,11 @@ def train_curriculum(
 
         train_env = create_vec_env(stage, n_envs, seed, use_subproc)
         eval_env = create_vec_env(stage, 1, seed + 1000, use_subproc=False)
+
+        # Carry forward normalization statistics from the previous stage so the
+        # policy's observation inputs stay correctly scaled across transitions.
+        if prev_vecnorm_path:
+            load_vecnorm_stats(prev_vecnorm_path, train_env, eval_env)
 
         alg_cls = SAC if algorithm == "sac" else PPO
         alg_kwargs = config["sac_kwargs"].copy() if algorithm == "sac" else config["ppo_kwargs"].copy()
@@ -500,6 +515,7 @@ def train_curriculum(
         model.save(str(final_path))
         train_env.save(str(final_path) + "_vecnorm.pkl")
         load_path = str(final_path)
+        prev_vecnorm_path = str(final_path) + "_vecnorm.pkl"
 
         logger.info("Stage %d complete. Model saved to %s", stage, final_path)
 

--- a/environments/shared/curriculum.py
+++ b/environments/shared/curriculum.py
@@ -555,3 +555,50 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
             return False
 
         return True
+
+
+def load_vecnorm_stats(vecnorm_path: str, train_env, eval_env=None) -> bool:
+    """Load VecNormalize running statistics from a previous stage into new envs.
+
+    This preserves observation/reward normalization across curriculum stage
+    transitions, preventing the policy from receiving scrambled inputs when
+    the environment wrapper is re-created for a new stage.
+
+    Args:
+        vecnorm_path: Path to a ``_vecnorm.pkl`` file saved by a previous stage.
+        train_env: The new stage's training ``VecNormalize`` wrapper.
+            ``training`` is left ``True`` so stats keep updating.
+        eval_env: Optional evaluation ``VecNormalize`` wrapper.
+            ``training`` is set to ``False``; ``norm_reward`` is disabled.
+
+    Returns:
+        ``True`` if stats were loaded, ``False`` if the file was not found.
+    """
+    from pathlib import Path as _Path
+
+    if not _SB3_AVAILABLE:
+        logger.warning("stable-baselines3 not available; skipping VecNormalize load.")
+        return False
+
+    from stable_baselines3.common.vec_env import VecNormalize
+
+    path = _Path(vecnorm_path)
+    if not path.exists():
+        logger.debug("VecNormalize file not found: %s", vecnorm_path)
+        return False
+
+    logger.info("Loading VecNormalize stats from: %s", vecnorm_path)
+    prev_norm = VecNormalize.load(str(path), train_env.venv)
+
+    train_env.obs_rms = prev_norm.obs_rms
+    train_env.ret_rms = prev_norm.ret_rms
+    train_env.training = True
+    train_env.norm_reward = True
+
+    if eval_env is not None:
+        eval_env.obs_rms = prev_norm.obs_rms.copy()
+        eval_env.ret_rms = prev_norm.ret_rms.copy()
+        eval_env.training = False
+        eval_env.norm_reward = False
+
+    return True

--- a/environments/shared/tests/test_curriculum.py
+++ b/environments/shared/tests/test_curriculum.py
@@ -301,3 +301,91 @@ class TestThresholdsFromConfigs:
         configs = load_all_stages("velociraptor")
         thresholds = thresholds_from_configs(configs)
         assert isinstance(thresholds, dict)
+
+
+class TestLoadVecnormStats:
+    """Test that VecNormalize stats are correctly carried across stages."""
+
+    @pytest.fixture
+    def vec_envs(self):
+        """Create a pair of VecNormalize-wrapped dummy envs for stage 1."""
+        from stable_baselines3.common.monitor import Monitor
+        from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
+
+        from environments.velociraptor.envs.raptor_env import RaptorEnv
+
+        def _make():
+            env = RaptorEnv()
+            return Monitor(env)
+
+        train = VecNormalize(DummyVecEnv([_make]), norm_obs=True, norm_reward=True)
+        eval_ = VecNormalize(DummyVecEnv([_make]), norm_obs=True, norm_reward=True)
+        yield train, eval_
+        train.close()
+        eval_.close()
+
+    def test_stats_carried_forward(self, vec_envs, tmp_path):
+        """obs_rms/ret_rms are copied from saved file into fresh envs."""
+        import numpy as np
+        from stable_baselines3.common.monitor import Monitor
+        from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
+
+        from environments.shared.curriculum import load_vecnorm_stats
+        from environments.velociraptor.envs.raptor_env import RaptorEnv
+
+        train_env, _ = vec_envs
+
+        # Run a few steps so the running mean/var diverge from defaults
+        obs = train_env.reset()
+        for _ in range(50):
+            action = [train_env.action_space.sample()]
+            obs, _, dones, _ = train_env.step(action)
+            if dones[0]:
+                obs = train_env.reset()
+
+        # Snapshot the trained stats
+        saved_obs_mean = train_env.obs_rms.mean.copy()
+        saved_obs_var = train_env.obs_rms.var.copy()
+
+        # Save to disk
+        save_path = str(tmp_path / "stage1_final_vecnorm.pkl")
+        train_env.save(save_path)
+
+        # Create fresh envs (simulating a new stage)
+        def _make():
+            return Monitor(RaptorEnv())
+
+        new_train = VecNormalize(DummyVecEnv([_make]), norm_obs=True, norm_reward=True)
+        new_eval = VecNormalize(DummyVecEnv([_make]), norm_obs=True, norm_reward=True)
+
+        # Before loading, stats should be at defaults (mean≈0, var≈1)
+        assert not np.allclose(new_train.obs_rms.mean, saved_obs_mean)
+
+        # Load stats from the "previous stage"
+        loaded = load_vecnorm_stats(save_path, new_train, new_eval)
+        assert loaded is True
+
+        # Stats should now match the saved values
+        np.testing.assert_array_equal(new_train.obs_rms.mean, saved_obs_mean)
+        np.testing.assert_array_equal(new_train.obs_rms.var, saved_obs_var)
+        np.testing.assert_array_equal(new_eval.obs_rms.mean, saved_obs_mean)
+        np.testing.assert_array_equal(new_eval.obs_rms.var, saved_obs_var)
+
+        # Train env should still be in training mode
+        assert new_train.training is True
+        assert new_train.norm_reward is True
+
+        # Eval env should NOT be training or normalizing reward
+        assert new_eval.training is False
+        assert new_eval.norm_reward is False
+
+        new_train.close()
+        new_eval.close()
+
+    def test_missing_file_returns_false(self, vec_envs):
+        """load_vecnorm_stats returns False when file doesn't exist."""
+        from environments.shared.curriculum import load_vecnorm_stats
+
+        train_env, eval_env = vec_envs
+        result = load_vecnorm_stats("/nonexistent/path_vecnorm.pkl", train_env, eval_env)
+        assert result is False

--- a/environments/trex/scripts/train_sb3.py
+++ b/environments/trex/scripts/train_sb3.py
@@ -57,6 +57,7 @@ from environments.shared.config import (
 from environments.shared.curriculum import (
     CurriculumCallback,
     CurriculumManager,
+    load_vecnorm_stats,
     thresholds_from_configs,
 )
 from environments.shared.metrics import LocomotionMetrics
@@ -240,6 +241,14 @@ def train(
 
     logger.info("Creating evaluation environment...")
     eval_env = create_vec_env(stage, 1, seed + 1000, use_subproc=False)
+
+    # If resuming from a prior stage, carry forward normalization statistics
+    # so the policy's observation inputs stay correctly scaled.
+    if load_path:
+        _vecnorm_path = load_path.replace(".zip", "") + "_vecnorm.pkl"
+        if not _vecnorm_path.endswith("_vecnorm.pkl"):
+            _vecnorm_path = load_path + "_vecnorm.pkl"
+        load_vecnorm_stats(_vecnorm_path, train_env, eval_env)
 
     alg_cls = SAC if algorithm == "sac" else PPO
     alg_kwargs = config["sac_kwargs"].copy() if algorithm == "sac" else config["ppo_kwargs"].copy()
@@ -448,6 +457,7 @@ def train_curriculum(
 
     model = None
     load_path = None
+    prev_vecnorm_path = None
 
     for stage in range(1, 4):
         config = STAGE_CONFIGS[stage]
@@ -476,6 +486,11 @@ def train_curriculum(
 
         train_env = create_vec_env(stage, n_envs, seed, use_subproc)
         eval_env = create_vec_env(stage, 1, seed + 1000, use_subproc=False)
+
+        # Carry forward normalization statistics from the previous stage so the
+        # policy's observation inputs stay correctly scaled across transitions.
+        if prev_vecnorm_path:
+            load_vecnorm_stats(prev_vecnorm_path, train_env, eval_env)
 
         alg_cls = SAC if algorithm == "sac" else PPO
         alg_kwargs = config["sac_kwargs"].copy() if algorithm == "sac" else config["ppo_kwargs"].copy()
@@ -554,6 +569,7 @@ def train_curriculum(
         model.save(str(final_path))
         train_env.save(str(final_path) + "_vecnorm.pkl")
         load_path = str(final_path)
+        prev_vecnorm_path = str(final_path) + "_vecnorm.pkl"
 
         logger.info("Stage %d complete. Model saved to %s", stage, final_path)
 

--- a/environments/velociraptor/scripts/train_sb3.py
+++ b/environments/velociraptor/scripts/train_sb3.py
@@ -57,6 +57,7 @@ from environments.shared.config import (
 from environments.shared.curriculum import (
     CurriculumCallback,
     CurriculumManager,
+    load_vecnorm_stats,
     thresholds_from_configs,
 )
 from environments.shared.metrics import LocomotionMetrics
@@ -243,6 +244,14 @@ def train(
 
     logger.info("Creating evaluation environment...")
     eval_env = create_vec_env(stage, 1, seed + 1000, use_subproc=False)
+
+    # If resuming from a prior stage, carry forward normalization statistics
+    # so the policy's observation inputs stay correctly scaled.
+    if load_path:
+        _vecnorm_path = load_path.replace(".zip", "") + "_vecnorm.pkl"
+        if not _vecnorm_path.endswith("_vecnorm.pkl"):
+            _vecnorm_path = load_path + "_vecnorm.pkl"
+        load_vecnorm_stats(_vecnorm_path, train_env, eval_env)
 
     # Create or load model
     alg_cls = SAC if algorithm == "sac" else PPO
@@ -453,6 +462,7 @@ def train_curriculum(
 
     model = None
     load_path = None
+    prev_vecnorm_path = None
 
     for stage in range(1, 4):
         config = STAGE_CONFIGS[stage]
@@ -482,6 +492,11 @@ def train_curriculum(
         # Create environments for this stage
         train_env = create_vec_env(stage, n_envs, seed, use_subproc)
         eval_env = create_vec_env(stage, 1, seed + 1000, use_subproc=False)
+
+        # Carry forward normalization statistics from the previous stage so the
+        # policy's observation inputs stay correctly scaled across transitions.
+        if prev_vecnorm_path:
+            load_vecnorm_stats(prev_vecnorm_path, train_env, eval_env)
 
         # Create or load model
         alg_cls = SAC if algorithm == "sac" else PPO
@@ -563,6 +578,7 @@ def train_curriculum(
         model.save(str(final_path))
         train_env.save(str(final_path) + "_vecnorm.pkl")
         load_path = str(final_path)
+        prev_vecnorm_path = str(final_path) + "_vecnorm.pkl"
 
         logger.info("Stage %d complete. Model saved to %s", stage, final_path)
 


### PR DESCRIPTION
The train_sb3.py scripts for all three species (velociraptor, trex,
brachiosaurus) created fresh VecNormalize wrappers at each stage
transition, resetting observation/reward normalization statistics to
defaults. This caused the policy to receive scrambled inputs at the
start of stages 2 and 3, leading to immediate performance collapse
and catastrophic forgetting of prior-stage skills.

Add a shared `load_vecnorm_stats()` helper in curriculum.py that copies
obs_rms/ret_rms from a saved _vecnorm.pkl into new VecNormalize envs.
Call it in both `train_curriculum()` (multi-stage) and `train()` (single-
stage with --load) for all three species. The training notebooks already
had this fix via their `vecnorm_path` parameter.