### PR TITLE
Make gymnasium/mujoco dependencies optional with graceful fallback

### DIFF
--- a/environments/__init__.py
+++ b/environments/__init__.py
@@ -18,16 +18,13 @@ gymnasium/mujoco are not installed::
 
 import logging as _logging
 
-_logger = _logging.getLogger(__name__)
-
 try:
     from environments.brachiosaurus.envs import brachio_env as _brachio_env  # noqa: F401
     from environments.trex.envs import trex_env as _trex_env  # noqa: F401
     from environments.velociraptor.envs import raptor_env as _raptor_env  # noqa: F401
-except ImportError as _exc:
-    _logger.debug(
-        "Species environments not loaded (gymnasium/mujoco may not be installed): %s",
-        _exc,
+except ImportError:
+    _logging.getLogger(__name__).debug(
+        "Species environments not loaded (gymnasium/mujoco may not be installed)",
     )
 
 

--- a/environments/__init__.py
+++ b/environments/__init__.py
@@ -9,11 +9,26 @@ Individual species can also be imported directly::
 
     from environments.velociraptor.envs import RaptorEnv
     env = RaptorEnv()
+
+Shared utilities (config, curriculum, metrics) are available even when
+gymnasium/mujoco are not installed::
+
+    from environments.shared.curriculum import RewardRampCallback
 """
 
-from environments.brachiosaurus.envs import brachio_env as _brachio_env  # noqa: F401
-from environments.trex.envs import trex_env as _trex_env  # noqa: F401
-from environments.velociraptor.envs import raptor_env as _raptor_env  # noqa: F401
+import logging as _logging
+
+_logger = _logging.getLogger(__name__)
+
+try:
+    from environments.brachiosaurus.envs import brachio_env as _brachio_env  # noqa: F401
+    from environments.trex.envs import trex_env as _trex_env  # noqa: F401
+    from environments.velociraptor.envs import raptor_env as _raptor_env  # noqa: F401
+except ImportError as _exc:
+    _logger.debug(
+        "Species environments not loaded (gymnasium/mujoco may not be installed): %s",
+        _exc,
+    )
 
 
 def register_all():

--- a/environments/shared/__init__.py
+++ b/environments/shared/__init__.py
@@ -1,9 +1,21 @@
 """Shared utilities for Mesozoic Labs dinosaur environments."""
 
-from .base_env import BaseDinoEnv
+import logging as _logging
+
+_logger = _logging.getLogger(__name__)
+
 from .config import load_all_stages, load_stage_config
 from .curriculum import CurriculumManager
 from .metrics import LocomotionMetrics
+
+try:
+    from .base_env import BaseDinoEnv
+except ImportError as _exc:
+    BaseDinoEnv = None  # type: ignore[assignment,misc]
+    _logger.debug(
+        "BaseDinoEnv not available (gymnasium/mujoco may not be installed): %s",
+        _exc,
+    )
 
 __all__ = [
     "BaseDinoEnv",

--- a/environments/shared/__init__.py
+++ b/environments/shared/__init__.py
@@ -2,11 +2,11 @@
 
 import logging as _logging
 
-_logger = _logging.getLogger(__name__)
-
 from .config import load_all_stages, load_stage_config
 from .curriculum import CurriculumManager
 from .metrics import LocomotionMetrics
+
+_logger = _logging.getLogger(__name__)
 
 try:
     from .base_env import BaseDinoEnv


### PR DESCRIPTION
## Summary
This PR makes gymnasium and mujoco optional dependencies by wrapping environment imports in try-except blocks. Shared utilities (config, curriculum, metrics) remain available even when gymnasium/mujoco are not installed, improving the package's flexibility for users who only need the shared components.

## Key Changes
- **environments/__init__.py**: Wrapped species environment imports (brachio_env, trex_env, raptor_env) in a try-except block with debug logging when imports fail
- **environments/shared/__init__.py**: Wrapped BaseDinoEnv import in a try-except block, setting it to None if gymnasium/mujoco are unavailable, while keeping config, curriculum, and metrics imports unconditional
- Added logging infrastructure to both modules to provide visibility into import failures
- Updated module docstring to clarify that shared utilities are available independently

## Implementation Details
- Uses debug-level logging to avoid alarming users when optional dependencies are missing
- Maintains backward compatibility - existing code continues to work when dependencies are installed
- Allows partial imports of the package for users who only need shared utilities like RewardRampCallback, load_stage_config, etc.