### PR TITLE
Fix pickle serialization of curriculum schedules in Colab/Jupyter

### DIFF
--- a/environments/shared/curriculum.py
+++ b/environments/shared/curriculum.py
@@ -51,6 +51,21 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+class _ConstantSchedule:
+    """Picklable callable that returns a constant value.
+
+    Replaces inline lambdas (e.g. ``lambda _: 0.02``) which capture the
+    notebook cell's ``__globals__`` and fail to pickle in Colab/Jupyter
+    because of ``zmq.Context`` objects in that namespace.
+    """
+
+    def __init__(self, value: float) -> None:
+        self.value = value
+
+    def __call__(self, _progress: float) -> float:
+        return self.value
+
+
 @dataclass
 class StageThreshold:
     """Performance thresholds that must be met to advance past a stage."""
@@ -607,7 +622,7 @@ class StageWarmupCallback(BaseCallback):  # type: ignore[misc]
 
         self._original_clip_range = self.model.clip_range
         self._original_ent_coef = self.model.ent_coef
-        self.model.clip_range = lambda _progress: self.warmup_clip_range
+        self.model.clip_range = _ConstantSchedule(self.warmup_clip_range)
         self.model.ent_coef = self.warmup_ent_coef
         logger.info(
             "StageWarmupCallback: warm-up active for %d timesteps (clip_range=%.3f, ent_coef=%.3f)",

--- a/environments/shared/tests/test_curriculum.py
+++ b/environments/shared/tests/test_curriculum.py
@@ -11,6 +11,7 @@ from environments.shared.curriculum import (
     RewardRampCallback,
     StageThreshold,
     StageWarmupCallback,
+    _ConstantSchedule,
     load_vecnorm_stats,
     thresholds_from_configs,
 )
@@ -420,6 +421,48 @@ class TestCallbacksWithoutSB3:
     def test_load_vecnorm_stats_returns_false_without_sb3(self):
         result = load_vecnorm_stats("/any/path.pkl", MagicMock())
         assert result is False
+
+
+class TestPickleSafety:
+    """Ensure objects assigned to model attributes survive cloudpickle round-trips.
+
+    In Colab/Jupyter, cloudpickle serialises the __globals__ of lambdas
+    defined in notebook cells, which pulls in zmq.Context and fails.
+    These tests verify that our replacements are safely picklable.
+    """
+
+    def test_constant_schedule_roundtrips(self):
+        """_ConstantSchedule survives pickle and returns the same value."""
+        import cloudpickle
+        import pickle
+
+        sched = _ConstantSchedule(0.02)
+        restored = pickle.loads(cloudpickle.dumps(sched))
+        assert restored(0.5) == pytest.approx(0.02)
+        assert restored(1.0) == pytest.approx(0.02)
+
+    def test_warmup_clip_range_is_picklable(self):
+        """After StageWarmupCallback sets clip_range, the model can be pickled."""
+        import cloudpickle
+        import pickle
+
+        cb = object.__new__(StageWarmupCallback)
+        cb.warmup_clip_range = 0.02
+        cb.warmup_ent_coef = 0.02
+        cb.warmup_timesteps = 100_000
+        cb._warmup_done = False
+
+        mock_model = MagicMock()
+        mock_model.clip_range = lambda _: 0.2  # original PPO schedule
+        mock_model.ent_coef = 0.01
+        cb.model = mock_model
+
+        # Simulate _on_training_start
+        cb._on_training_start()
+
+        # The clip_range assigned by the callback must be picklable
+        restored = pickle.loads(cloudpickle.dumps(mock_model.clip_range))
+        assert restored(0.5) == pytest.approx(0.02)
 
 
 class TestLoadVecnormStatsMocked:

--- a/environments/shared/tests/test_curriculum.py
+++ b/environments/shared/tests/test_curriculum.py
@@ -433,8 +433,9 @@ class TestPickleSafety:
 
     def test_constant_schedule_roundtrips(self):
         """_ConstantSchedule survives pickle and returns the same value."""
-        import cloudpickle
         import pickle
+
+        import cloudpickle
 
         sched = _ConstantSchedule(0.02)
         restored = pickle.loads(cloudpickle.dumps(sched))
@@ -443,8 +444,9 @@ class TestPickleSafety:
 
     def test_warmup_clip_range_is_picklable(self):
         """After StageWarmupCallback sets clip_range, the model can be pickled."""
-        import cloudpickle
         import pickle
+
+        import cloudpickle
 
         cb = object.__new__(StageWarmupCallback)
         cb.warmup_clip_range = 0.02


### PR DESCRIPTION
## Summary
Replace inline lambda functions with a picklable `_ConstantSchedule` class to fix serialization failures in Colab and Jupyter environments.

## Key Changes
- Added `_ConstantSchedule` class: A picklable callable that returns a constant value, replacing lambda functions that capture notebook cell globals containing unpicklable `zmq.Context` objects
- Updated `StageWarmupCallback._on_training_start()`: Changed `lambda _progress: self.warmup_clip_range` to `_ConstantSchedule(self.warmup_clip_range)` for the `clip_range` schedule

## Implementation Details
The new `_ConstantSchedule` class is a simple callable wrapper that:
- Takes a constant value in `__init__`
- Implements `__call__` to accept a progress parameter and return the constant value
- Avoids capturing the notebook's `__globals__` namespace, which prevents pickle serialization failures in interactive environments like Colab and Jupyter