### PR TITLE
Add comprehensive tests for sweep tool and improve logging

### DIFF
--- a/environments/shared/scripts/sweep.py
+++ b/environments/shared/scripts/sweep.py
@@ -73,6 +73,7 @@ import json
 import logging
 import os
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -362,7 +363,7 @@ def run_trial(args: argparse.Namespace, extra_args: list[str]) -> None:
         eval_freq=args.eval_freq,
         save_freq=args.save_freq,
         use_subproc=False,
-        verbose=1,
+        verbose=0,
         algorithm=args.algorithm,
         use_wandb=args.wandb,
         output_dir=output_dir,
@@ -445,17 +446,51 @@ def _collect_trial_results(hpt_job: Any, stage: int, stage_config: dict) -> list
         # (e.g. Stage 3 hunting stages), the trial passes by default as
         # long as it produced a valid reward.
         passed = best_reward is not None
-        if reward_threshold is not None:
-            passed = passed and best_reward >= reward_threshold
+        fail_reasons: list[str] = []
+        if best_reward is None:
+            fail_reasons.append("no reward reported (trial may have crashed)")
+        if reward_threshold is not None and (best_reward is None or best_reward < reward_threshold):
+            passed = False
+            fail_reasons.append(
+                f"reward {best_reward} < threshold {reward_threshold}"
+            )
         if passed and ep_length_threshold is not None:
-            passed = best_ep_length is not None and best_ep_length >= ep_length_threshold
+            if best_ep_length is None or best_ep_length < ep_length_threshold:
+                passed = False
+                fail_reasons.append(
+                    f"ep_length {best_ep_length} < threshold {ep_length_threshold}"
+                )
         if passed and forward_vel_threshold is not None:
             trial_fwd_vel = metrics.get("best_mean_forward_vel")
-            passed = trial_fwd_vel is not None and trial_fwd_vel >= forward_vel_threshold
+            if trial_fwd_vel is None or trial_fwd_vel < forward_vel_threshold:
+                passed = False
+                fail_reasons.append(
+                    f"forward_vel {trial_fwd_vel} < threshold {forward_vel_threshold}"
+                )
         if passed and success_rate_threshold is not None:
             trial_success_rate = metrics.get("best_mean_success_rate")
-            passed = trial_success_rate is not None and trial_success_rate >= success_rate_threshold
+            if trial_success_rate is None or trial_success_rate < success_rate_threshold:
+                passed = False
+                fail_reasons.append(
+                    f"success_rate {trial_success_rate} < threshold {success_rate_threshold}"
+                )
         row["stage_passed"] = passed
+
+        # Log per-trial diagnostic summary
+        if passed:
+            logger.info(
+                "  Trial %s stage %d: PASSED (reward=%.2f)",
+                trial.id,
+                stage,
+                best_reward,
+            )
+        else:
+            logger.warning(
+                "  Trial %s stage %d: FAILED — %s",
+                trial.id,
+                stage,
+                "; ".join(fail_reasons),
+            )
 
         rows.append(row)
     return rows
@@ -976,11 +1011,13 @@ def launch_all_stages(args: argparse.Namespace) -> None:
     load_path: str | None = None
     fixed_trial_args: list[str] | None = None
     all_rows: list[dict] = []
+    sweep_start_time = time.monotonic()
 
     # Determine the net_arch HPT key for this algorithm (e.g. "ppo_net_arch")
     net_arch_key = f"{args.algorithm}_net_arch"
 
     for stage in range(1, 4):
+        stage_start_time = time.monotonic()
         search_space = _search_space_for_stage(resolved, stage)
         file_settings = _settings_for_stage(resolved, stage)
 
@@ -1035,6 +1072,17 @@ def launch_all_stages(args: argparse.Namespace) -> None:
         stage_rows = _collect_trial_results(hpt_job, stage, stage_config)
         all_rows.extend(stage_rows)
 
+        stage_elapsed = time.monotonic() - stage_start_time
+        stage_mins = stage_elapsed / 60
+        logger.info(
+            "Stage %d finished in %.1f min (%.0f s). Trials: %d total, %d passed.",
+            stage,
+            stage_mins,
+            stage_elapsed,
+            len(stage_rows),
+            sum(1 for r in stage_rows if r.get("stage_passed")),
+        )
+
         if stage < 3:
             # Find the best trial and chain its checkpoint into the next stage
             load_path, best_row = _best_trial_model_path(stage_rows, args.bucket, args.species, stage)
@@ -1078,8 +1126,16 @@ def launch_all_stages(args: argparse.Namespace) -> None:
             except Exception as exc:
                 logger.warning("Failed to upload %s to GCS: %s", graph_name, exc)
 
+    total_elapsed = time.monotonic() - sweep_start_time
+    total_mins = total_elapsed / 60
     logger.info("=" * 60)
-    logger.info("ALL-STAGES SWEEP COMPLETE for %s (%s)", args.species, args.algorithm)
+    logger.info(
+        "ALL-STAGES SWEEP COMPLETE for %s (%s) in %.1f min (%.0f s)",
+        args.species,
+        args.algorithm,
+        total_mins,
+        total_elapsed,
+    )
     logger.info("All results at: gs://%s/sweeps/%s/", args.bucket, args.species)
 
 

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -1,0 +1,397 @@
+"""Tests for the hyperparameter sweep tool's pure functions."""
+
+import argparse
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from environments.shared.scripts.sweep import (
+    NET_ARCH_PRESETS,
+    _best_trial_model_path,
+    _collect_trial_results,
+    _hpt_arg_to_override,
+    _is_per_stage,
+    _resolve_search_space,
+    _search_space_for_stage,
+    _settings_for_stage,
+    _split_stage_block,
+    write_results_csv,
+)
+
+
+# ── _hpt_arg_to_override ────────────────────────────────────────────────────
+
+
+class TestHptArgToOverride:
+    """Conversion of Vertex AI HPT arg names to --override dot notation."""
+
+    def test_ppo_prefix(self):
+        assert _hpt_arg_to_override("ppo_learning_rate", "0.0003") == "ppo.learning_rate=0.0003"
+
+    def test_sac_prefix(self):
+        assert _hpt_arg_to_override("sac_batch_size", "256") == "sac.batch_size=256"
+
+    def test_env_prefix(self):
+        assert _hpt_arg_to_override("env_alive_bonus", "2.0") == "env.alive_bonus=2.0"
+
+    def test_curriculum_prefix(self):
+        assert (
+            _hpt_arg_to_override("curriculum_warmup_timesteps", "50000")
+            == "curriculum.warmup_timesteps=50000"
+        )
+
+    def test_unknown_prefix_passthrough(self):
+        assert _hpt_arg_to_override("unknown_param", "42") == "unknown_param=42"
+
+    def test_net_arch_preset(self):
+        assert _hpt_arg_to_override("ppo_net_arch", "medium") == "ppo.net_arch=medium"
+
+    def test_multi_underscore_param(self):
+        """Only the first underscore after the prefix becomes the dot separator."""
+        assert _hpt_arg_to_override("ppo_clip_range", "0.2") == "ppo.clip_range=0.2"
+
+    def test_env_multi_word_param(self):
+        assert (
+            _hpt_arg_to_override("env_forward_vel_weight", "1.5")
+            == "env.forward_vel_weight=1.5"
+        )
+
+
+# ── _is_per_stage / _split_stage_block / _search_space_for_stage ─────────
+
+
+class TestPerStageDetection:
+    def test_flat_config(self):
+        flat = {"ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4}}
+        assert _is_per_stage(flat) is False
+
+    def test_per_stage_config(self):
+        per_stage = {
+            "stage1": {"ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4}},
+            "stage2": {"ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 1e-4}},
+        }
+        assert _is_per_stage(per_stage) is True
+
+    def test_partial_stage_keys(self):
+        """Even having just stage1 makes it per-stage."""
+        partial = {"stage1": {"ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4}}}
+        assert _is_per_stage(partial) is True
+
+
+class TestSplitStageBlock:
+    def test_separates_search_space_and_settings(self):
+        block = {
+            "ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4, "scale": "log"},
+            "trials": 30,
+            "timesteps": 1000000,
+            "parallel": 5,
+        }
+        search_space, settings = _split_stage_block(block)
+        assert "ppo_learning_rate" in search_space
+        assert search_space["ppo_learning_rate"]["type"] == "double"
+        assert settings == {"trials": 30, "timesteps": 1000000, "parallel": 5}
+
+    def test_all_search_params(self):
+        block = {
+            "ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4},
+            "ppo_ent_coef": {"type": "double", "min": 0.001, "max": 0.05},
+        }
+        search_space, settings = _split_stage_block(block)
+        assert len(search_space) == 2
+        assert len(settings) == 0
+
+    def test_all_settings(self):
+        block = {"trials": 10, "timesteps": 500000}
+        search_space, settings = _split_stage_block(block)
+        assert len(search_space) == 0
+        assert len(settings) == 2
+
+    def test_empty_block(self):
+        search_space, settings = _split_stage_block({})
+        assert search_space == {}
+        assert settings == {}
+
+
+class TestSearchSpaceForStage:
+    def test_flat_returns_as_is(self):
+        flat = {"ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4}}
+        assert _search_space_for_stage(flat, 1) == flat
+        assert _search_space_for_stage(flat, 2) == flat
+
+    def test_per_stage_extracts_correct_stage(self):
+        per_stage = {
+            "stage1": {
+                "ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4},
+                "trials": 20,
+            },
+            "stage2": {
+                "ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 1e-4},
+            },
+            "stage3": {
+                "ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 5e-5},
+            },
+        }
+        space1 = _search_space_for_stage(per_stage, 1)
+        # Should have only the search space param, not the "trials" setting
+        assert "ppo_learning_rate" in space1
+        assert "trials" not in space1
+
+        space2 = _search_space_for_stage(per_stage, 2)
+        assert space2["ppo_learning_rate"]["max"] == 1e-4
+
+    def test_missing_stage_key_exits(self):
+        per_stage = {"stage1": {"ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4}}}
+        with pytest.raises(SystemExit):
+            _search_space_for_stage(per_stage, 3)
+
+
+class TestSettingsForStage:
+    def test_flat_returns_empty(self):
+        flat = {"ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4}}
+        assert _settings_for_stage(flat, 1) == {}
+
+    def test_per_stage_extracts_settings(self):
+        per_stage = {
+            "stage1": {
+                "ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4},
+                "trials": 30,
+                "timesteps": 1000000,
+            },
+        }
+        settings = _settings_for_stage(per_stage, 1)
+        assert settings == {"trials": 30, "timesteps": 1000000}
+
+    def test_missing_stage_returns_empty(self):
+        per_stage = {"stage1": {"trials": 10}}
+        assert _settings_for_stage(per_stage, 3) == {}
+
+
+# ── _resolve_search_space ────────────────────────────────────────────────
+
+
+class TestResolveSearchSpace:
+    def test_inline_json_takes_priority(self):
+        inline = '{"ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 1e-3}}'
+        result = _resolve_search_space(inline, None, "ppo")
+        assert "ppo_learning_rate" in result
+        assert result["ppo_learning_rate"]["max"] == 1e-3
+
+    def test_invalid_json_exits(self):
+        with pytest.raises(SystemExit):
+            _resolve_search_space("{bad json", None, "ppo")
+
+    def test_default_ppo_space(self):
+        result = _resolve_search_space(None, None, "ppo")
+        assert "ppo_learning_rate" in result
+        assert "ppo_ent_coef" in result
+        assert "ppo_batch_size" in result
+
+    def test_default_sac_space(self):
+        result = _resolve_search_space(None, None, "sac")
+        assert "sac_learning_rate" in result
+        assert "sac_batch_size" in result
+
+    def test_unknown_algorithm_falls_back_to_ppo(self):
+        result = _resolve_search_space(None, None, "unknown_algo")
+        assert "ppo_learning_rate" in result
+
+
+# ── _collect_trial_results ───────────────────────────────────────────────
+
+
+def _make_mock_trial(trial_id, params=None, metrics=None):
+    """Helper to build a mock Vertex AI trial object."""
+    trial = MagicMock()
+    trial.id = trial_id
+    trial.parameters = []
+    if params:
+        for pid, val in params.items():
+            p = MagicMock()
+            p.parameter_id = pid
+            p.value = val
+            trial.parameters.append(p)
+
+    if metrics:
+        measurement = MagicMock()
+        metric_objs = []
+        for mid, val in metrics.items():
+            m = MagicMock()
+            m.metric_id = mid
+            m.value = val
+            metric_objs.append(m)
+        measurement.metrics = metric_objs
+        trial.final_measurement = measurement
+    else:
+        trial.final_measurement = None
+
+    return trial
+
+
+class TestCollectTrialResults:
+    def test_passing_trial(self):
+        trial = _make_mock_trial(
+            "1",
+            params={"ppo_learning_rate": 0.0003},
+            metrics={"best_mean_reward": 150.0, "best_mean_episode_length": 500.0},
+        )
+        job = MagicMock()
+        job.trials = [trial]
+        stage_config = {"curriculum_kwargs": {"min_avg_reward": 100.0}}
+
+        rows = _collect_trial_results(job, 1, stage_config)
+        assert len(rows) == 1
+        assert rows[0]["stage_passed"] is True
+        assert rows[0]["best_mean_reward"] == 150.0
+
+    def test_failing_trial_below_threshold(self):
+        trial = _make_mock_trial(
+            "2",
+            metrics={"best_mean_reward": 50.0},
+        )
+        job = MagicMock()
+        job.trials = [trial]
+        stage_config = {"curriculum_kwargs": {"min_avg_reward": 100.0}}
+
+        rows = _collect_trial_results(job, 1, stage_config)
+        assert rows[0]["stage_passed"] is False
+
+    def test_crashed_trial_no_metrics(self):
+        trial = _make_mock_trial("3")
+        job = MagicMock()
+        job.trials = [trial]
+        stage_config = {"curriculum_kwargs": {}}
+
+        rows = _collect_trial_results(job, 1, stage_config)
+        assert rows[0]["stage_passed"] is False
+        assert rows[0]["best_mean_reward"] is None
+
+    def test_no_thresholds_passes_with_valid_reward(self):
+        trial = _make_mock_trial("4", metrics={"best_mean_reward": 10.0})
+        job = MagicMock()
+        job.trials = [trial]
+        stage_config = {"curriculum_kwargs": {}}
+
+        rows = _collect_trial_results(job, 3, stage_config)
+        assert rows[0]["stage_passed"] is True
+
+    def test_ep_length_threshold_checked(self):
+        trial = _make_mock_trial(
+            "5",
+            metrics={"best_mean_reward": 200.0, "best_mean_episode_length": 100.0},
+        )
+        job = MagicMock()
+        job.trials = [trial]
+        stage_config = {
+            "curriculum_kwargs": {
+                "min_avg_reward": 100.0,
+                "min_avg_episode_length": 500.0,
+            }
+        }
+
+        rows = _collect_trial_results(job, 1, stage_config)
+        assert rows[0]["stage_passed"] is False
+
+    def test_forward_vel_threshold_checked(self):
+        trial = _make_mock_trial(
+            "6",
+            metrics={
+                "best_mean_reward": 200.0,
+                "best_mean_forward_vel": 0.5,
+            },
+        )
+        job = MagicMock()
+        job.trials = [trial]
+        stage_config = {
+            "curriculum_kwargs": {
+                "min_avg_reward": 100.0,
+                "min_avg_forward_vel": 1.0,
+            }
+        }
+
+        rows = _collect_trial_results(job, 2, stage_config)
+        assert rows[0]["stage_passed"] is False
+
+
+# ── _best_trial_model_path ───────────────────────────────────────────────
+
+
+class TestBestTrialModelPath:
+    def test_selects_highest_reward_among_passed(self):
+        rows = [
+            {"trial_id": "1", "stage_passed": True, "best_mean_reward": 100.0},
+            {"trial_id": "2", "stage_passed": True, "best_mean_reward": 200.0},
+            {"trial_id": "3", "stage_passed": False, "best_mean_reward": 300.0},
+        ]
+        path, best_row = _best_trial_model_path(rows, "my-bucket", "velociraptor", 1)
+        assert best_row["trial_id"] == "2"
+        assert "my-bucket" in path
+        assert "stage1" in path
+        assert "/2/" in path
+
+    def test_exits_when_no_trials_pass(self):
+        rows = [
+            {"trial_id": "1", "stage_passed": False, "best_mean_reward": 50.0},
+        ]
+        with pytest.raises(SystemExit):
+            _best_trial_model_path(rows, "bucket", "trex", 2)
+
+    def test_gcs_path_format(self):
+        rows = [{"trial_id": "7", "stage_passed": True, "best_mean_reward": 150.0}]
+        path, _ = _best_trial_model_path(rows, "my-bucket", "velociraptor", 2)
+        assert path == "/gcs/my-bucket/sweeps/velociraptor/stage2/7/models/stage2_final.zip"
+
+
+# ── write_results_csv ────────────────────────────────────────────────────
+
+
+class TestWriteResultsCsv:
+    def test_writes_csv(self, tmp_path):
+        rows = [
+            {
+                "trial_id": "1",
+                "stage": 1,
+                "ppo_learning_rate": 0.0003,
+                "best_mean_reward": 100.0,
+                "best_mean_episode_length": 500.0,
+                "last_mean_reward": 95.0,
+                "last_mean_episode_length": 480.0,
+                "reward_threshold": 80.0,
+                "ep_length_threshold": None,
+                "forward_vel_threshold": None,
+                "success_rate_threshold": None,
+                "stage_passed": True,
+            }
+        ]
+        csv_path = tmp_path / "results.csv"
+        result = write_results_csv(rows, csv_path)
+        assert result == csv_path
+        assert csv_path.exists()
+
+        import csv
+
+        with open(csv_path) as f:
+            reader = csv.DictReader(f)
+            written = list(reader)
+        assert len(written) == 1
+        assert written[0]["trial_id"] == "1"
+        assert written[0]["ppo_learning_rate"] == "0.0003"
+
+    def test_empty_rows_skipped(self, tmp_path):
+        csv_path = tmp_path / "empty.csv"
+        write_results_csv([], csv_path)
+        assert not csv_path.exists()
+
+
+# ── NET_ARCH_PRESETS ─────────────────────────────────────────────────────
+
+
+class TestNetArchPresets:
+    def test_all_presets_are_lists_of_ints(self):
+        for name, arch in NET_ARCH_PRESETS.items():
+            assert isinstance(arch, list), f"Preset {name} should be a list"
+            assert all(isinstance(x, int) for x in arch), f"Preset {name} should contain ints"
+
+    def test_expected_presets_exist(self):
+        expected = {"small", "medium", "large", "deep", "tapered", "deep_tapered"}
+        assert set(NET_ARCH_PRESETS.keys()) == expected


### PR DESCRIPTION
## Summary
This PR adds extensive unit tests for the hyperparameter sweep tool's pure functions and enhances logging throughout the sweep pipeline with better diagnostics and timing information.

## Key Changes

### Testing (New File)
- Added `environments/shared/tests/test_sweep.py` with 397 lines of comprehensive test coverage
- Tests cover all major pure functions in the sweep module:
  - `_hpt_arg_to_override`: HPT argument name conversion to override notation
  - `_is_per_stage`, `_split_stage_block`, `_search_space_for_stage`, `_settings_for_stage`: Stage configuration parsing
  - `_resolve_search_space`: Search space resolution with defaults and inline JSON
  - `_collect_trial_results`: Trial result collection and pass/fail determination
  - `_best_trial_model_path`: Best trial selection logic
  - `write_results_csv`: CSV output functionality
  - `NET_ARCH_PRESETS`: Network architecture preset validation
- Tests include edge cases, error conditions, and mock Vertex AI trial objects

### Logging Improvements
- **Trial-level diagnostics**: Added per-trial pass/fail logging with specific failure reasons (reward threshold, episode length, forward velocity, success rate)
- **Stage timing**: Added elapsed time tracking and logging for each stage completion
- **Overall sweep timing**: Added total sweep duration to final completion message
- **Verbose output**: Changed trial training verbosity from 1 to 0 to reduce noise in logs

### Implementation Details
- Failure reasons are now collected in a list and logged together for better debugging
- Timing uses `time.monotonic()` for accurate elapsed time measurement
- Logging includes both minutes and seconds for readability
- Trial pass/fail logic refactored to be more explicit about failure conditions while maintaining backward compatibility