### PR TITLE
Fix ruff formatting in 5 files

### DIFF
--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -142,7 +142,7 @@ class DiagnosticsCallback(_BaseCallback):
         if ep_rewards:
             self._rollout_ep_rewards.append(_np.mean(ep_rewards))
             if len(self._rollout_ep_rewards) >= self.plateau_window:
-                recent = self._rollout_ep_rewards[-self.plateau_window:]
+                recent = self._rollout_ep_rewards[-self.plateau_window :]
                 variation = max(recent) - min(recent)
                 self.logger.record("diagnostics/reward_variation", variation)
                 if variation < self.plateau_threshold:

--- a/environments/shared/reporting.py
+++ b/environments/shared/reporting.py
@@ -94,11 +94,13 @@ def write_stage_summary(
             lines.append(f"  Fwd vel:      {bm_vel} +/- {bm_vel_s} m/s")
         if bm_sr != "":
             lines.append(f"  Success rate: {bm_sr:.0%}")
-    lines.extend([
-        f"Best model:     {results_dict['model_path']}.zip",
-        f"VecNormalize:   {results_dict['vecnorm_path']}",
-        "",
-    ])
+    lines.extend(
+        [
+            f"Best model:     {results_dict['model_path']}.zip",
+            f"VecNormalize:   {results_dict['vecnorm_path']}",
+            "",
+        ]
+    )
     summary_text = "\n".join(lines) + "\n"
     summary_path.write_text(summary_text)
     return summary_path
@@ -157,7 +159,8 @@ def write_training_summary(
             best_ts = r.get("best_eval_timestep", "")
             ts_label = f"  (at {best_ts:,} steps)" if isinstance(best_ts, int) else ""
             lines.append(f"  Best eval:      {best_r} +/- {best_s}{ts_label}")
-        lines.extend([
+        lines.extend(
+            [
                 f"  Best model:     {r['model_path']}.zip",
                 "",
             ]

--- a/environments/shared/scripts/sweep.py
+++ b/environments/shared/scripts/sweep.py
@@ -451,29 +451,21 @@ def _collect_trial_results(hpt_job: Any, stage: int, stage_config: dict) -> list
             fail_reasons.append("no reward reported (trial may have crashed)")
         if reward_threshold is not None and (best_reward is None or best_reward < reward_threshold):
             passed = False
-            fail_reasons.append(
-                f"reward {best_reward} < threshold {reward_threshold}"
-            )
+            fail_reasons.append(f"reward {best_reward} < threshold {reward_threshold}")
         if passed and ep_length_threshold is not None:
             if best_ep_length is None or best_ep_length < ep_length_threshold:
                 passed = False
-                fail_reasons.append(
-                    f"ep_length {best_ep_length} < threshold {ep_length_threshold}"
-                )
+                fail_reasons.append(f"ep_length {best_ep_length} < threshold {ep_length_threshold}")
         if passed and forward_vel_threshold is not None:
             trial_fwd_vel = metrics.get("best_mean_forward_vel")
             if trial_fwd_vel is None or trial_fwd_vel < forward_vel_threshold:
                 passed = False
-                fail_reasons.append(
-                    f"forward_vel {trial_fwd_vel} < threshold {forward_vel_threshold}"
-                )
+                fail_reasons.append(f"forward_vel {trial_fwd_vel} < threshold {forward_vel_threshold}")
         if passed and success_rate_threshold is not None:
             trial_success_rate = metrics.get("best_mean_success_rate")
             if trial_success_rate is None or trial_success_rate < success_rate_threshold:
                 passed = False
-                fail_reasons.append(
-                    f"success_rate {trial_success_rate} < threshold {success_rate_threshold}"
-                )
+                fail_reasons.append(f"success_rate {trial_success_rate} < threshold {success_rate_threshold}")
         row["stage_passed"] = passed
 
         # Log per-trial diagnostic summary

--- a/environments/shared/tests/test_reporting.py
+++ b/environments/shared/tests/test_reporting.py
@@ -233,9 +233,7 @@ class TestWriteTrainingSummary:
 
     def test_contains_quick_test_flag(self, tmp_path):
         results = [_make_stage_result(1)]
-        path = write_training_summary(
-            tmp_path, results, "velociraptor", "PPO", seed=42, n_envs=4, quick_test=True
-        )
+        path = write_training_summary(tmp_path, results, "velociraptor", "PPO", seed=42, n_envs=4, quick_test=True)
         text = path.read_text()
         assert "True" in text
 

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -33,10 +33,7 @@ class TestHptArgToOverride:
         assert _hpt_arg_to_override("env_alive_bonus", "2.0") == "env.alive_bonus=2.0"
 
     def test_curriculum_prefix(self):
-        assert (
-            _hpt_arg_to_override("curriculum_warmup_timesteps", "50000")
-            == "curriculum.warmup_timesteps=50000"
-        )
+        assert _hpt_arg_to_override("curriculum_warmup_timesteps", "50000") == "curriculum.warmup_timesteps=50000"
 
     def test_unknown_prefix_passthrough(self):
         assert _hpt_arg_to_override("unknown_param", "42") == "unknown_param=42"
@@ -49,10 +46,7 @@ class TestHptArgToOverride:
         assert _hpt_arg_to_override("ppo_clip_range", "0.2") == "ppo.clip_range=0.2"
 
     def test_env_multi_word_param(self):
-        assert (
-            _hpt_arg_to_override("env_forward_vel_weight", "1.5")
-            == "env.forward_vel_weight=1.5"
-        )
+        assert _hpt_arg_to_override("env_forward_vel_weight", "1.5") == "env.forward_vel_weight=1.5"
 
 
 # ── _is_per_stage / _split_stage_block / _search_space_for_stage ─────────


### PR DESCRIPTION
Apply ruff format to diagnostics.py, reporting.py, sweep.py, test_reporting.py, and test_sweep.py to pass format checks.