### PR TITLE
Add sweep resumption and retry logic for multi-stage HPT

### DIFF
--- a/environments/shared/scripts/sweep.py
+++ b/environments/shared/scripts/sweep.py
@@ -93,6 +93,7 @@ logger = logging.getLogger(__name__)
 class SweepStageError(Exception):
     """Raised when a sweep stage fails and cannot proceed."""
 
+
 # ── Default search spaces ────────────────────────────────────────────────────
 # Each entry: parameter_id -> {"type": ..., ...}
 # parameter_id uses underscore notation to match Vertex AI HPT arg injection.
@@ -789,8 +790,7 @@ def _best_trial_model_path(stage_rows: list[dict], bucket: str, species: str, st
 
     if best_row is None:
         raise SweepStageError(
-            f"No trials passed stage {stage} criteria. "
-            "Re-run with adjusted thresholds or more trials."
+            f"No trials passed stage {stage} criteria. Re-run with adjusted thresholds or more trials."
         )
 
     best_trial_id = best_row["trial_id"]
@@ -1157,9 +1157,7 @@ def launch_all_stages(args: argparse.Namespace) -> None:
         "stages": {},
     }
     if args.resume:
-        prev_state = _load_sweep_state(
-            args.species, args.algorithm, bucket=args.bucket, project=args.project
-        )
+        prev_state = _load_sweep_state(args.species, args.algorithm, bucket=args.bucket, project=args.project)
         if prev_state and prev_state.get("stages"):
             sweep_state = prev_state
             for stg_key, stg_data in prev_state["stages"].items():
@@ -1281,8 +1279,11 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                 "trial_rows": stage_rows,
             }
             _save_sweep_state(
-                sweep_state, args.species, args.algorithm,
-                bucket=args.bucket, project=args.project,
+                sweep_state,
+                args.species,
+                args.algorithm,
+                bucket=args.bucket,
+                project=args.project,
             )
 
         except (SweepStageError, Exception) as exc:
@@ -1295,8 +1296,11 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                     sorted(int(k) for k, v in sweep_state["stages"].items() if v.get("status") == "completed"),
                 )
                 _save_sweep_state(
-                    sweep_state, args.species, args.algorithm,
-                    bucket=args.bucket, project=args.project,
+                    sweep_state,
+                    args.species,
+                    args.algorithm,
+                    bucket=args.bucket,
+                    project=args.project,
                 )
                 sys.exit(1)
             raise

--- a/environments/shared/scripts/sweep.py
+++ b/environments/shared/scripts/sweep.py
@@ -89,6 +89,10 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+
+class SweepStageError(Exception):
+    """Raised when a sweep stage fails and cannot proceed."""
+
 # ── Default search spaces ────────────────────────────────────────────────────
 # Each entry: parameter_id -> {"type": ..., ...}
 # parameter_id uses underscore notation to match Vertex AI HPT arg injection.
@@ -784,13 +788,121 @@ def _best_trial_model_path(stage_rows: list[dict], bucket: str, species: str, st
                 best_row = row
 
     if best_row is None:
-        logger.error("No trials passed stage %d criteria. Aborting multi-stage sweep.", stage)
-        sys.exit(1)
+        raise SweepStageError(
+            f"No trials passed stage {stage} criteria. "
+            "Re-run with adjusted thresholds or more trials."
+        )
 
     best_trial_id = best_row["trial_id"]
     logger.info("Best passing trial for stage %d: id=%s  best_mean_reward=%.4f", stage, best_trial_id, best_value)
     path = f"/gcs/{bucket}/sweeps/{species}/stage{stage}/{best_trial_id}/models/stage{stage}_final.zip"
     return path, best_row
+
+
+def _sweep_state_local_path(species: str, algorithm: str) -> Path:
+    """Return the local path for a sweep state file."""
+    return Path(f"sweep_state_{species}_{algorithm}.json")
+
+
+def _save_sweep_state(
+    state: dict,
+    species: str,
+    algorithm: str,
+    bucket: str | None = None,
+    project: str | None = None,
+) -> None:
+    """Persist sweep progress to local disk and (best-effort) GCS.
+
+    The state dict is written as JSON to a local file and, if *bucket* is
+    provided, also uploaded to
+    ``gs://<bucket>/sweeps/<species>/_sweep_state.json``.
+    """
+    local_path = _sweep_state_local_path(species, algorithm)
+    local_path.write_text(json.dumps(state, indent=2))
+    logger.info("Sweep state saved locally: %s", local_path)
+
+    if bucket:
+        gcs_key = f"sweeps/{species}/_sweep_state.json"
+        try:
+            from google.cloud import storage as _gcs
+
+            _client = _gcs.Client(project=project)
+            _bkt = _client.bucket(bucket)
+            _bkt.blob(gcs_key).upload_from_string(json.dumps(state, indent=2))
+            logger.info("Sweep state uploaded to: gs://%s/%s", bucket, gcs_key)
+        except Exception as exc:
+            logger.warning("Failed to upload sweep state to GCS: %s", exc)
+
+
+def _load_sweep_state(
+    species: str,
+    algorithm: str,
+    bucket: str | None = None,
+    project: str | None = None,
+) -> dict | None:
+    """Load a previously saved sweep state file.
+
+    Checks GCS first (if *bucket* is provided), then falls back to the
+    local file.  Returns ``None`` if no state exists or if the state does
+    not match *species* and *algorithm*.
+    """
+    state: dict | None = None
+
+    # Try GCS first
+    if bucket:
+        gcs_key = f"sweeps/{species}/_sweep_state.json"
+        try:
+            from google.cloud import storage as _gcs
+
+            _client = _gcs.Client(project=project)
+            _bkt = _client.bucket(bucket)
+            blob = _bkt.blob(gcs_key)
+            if blob.exists():
+                state = json.loads(blob.download_as_text())
+                logger.info("Loaded sweep state from: gs://%s/%s", bucket, gcs_key)
+        except Exception as exc:
+            logger.warning("Could not read sweep state from GCS: %s", exc)
+
+    # Fall back to local file
+    if state is None:
+        local_path = _sweep_state_local_path(species, algorithm)
+        if local_path.exists():
+            try:
+                state = json.loads(local_path.read_text())
+                logger.info("Loaded sweep state from: %s", local_path)
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Could not read local sweep state: %s", exc)
+
+    # Validate species + algorithm match
+    if state is not None:
+        if state.get("species") != species or state.get("algorithm") != algorithm:
+            logger.warning(
+                "Sweep state species/algorithm (%s/%s) does not match current (%s/%s) — ignoring",
+                state.get("species"),
+                state.get("algorithm"),
+                species,
+                algorithm,
+            )
+            return None
+
+    return state
+
+
+def _is_retryable_gcp_error(exc: Exception) -> bool:
+    """Return ``True`` if *exc* is a transient GCP error worth retrying.
+
+    Matches by class name so we don't need ``google-cloud-aiplatform``
+    installed at import time (the exceptions live in ``google.api_core``).
+    """
+    retryable_names = {
+        "ResourceExhausted",
+        "ServiceUnavailable",
+        "GoogleAPICallError",
+        "TooManyRequests",
+        "InternalServerError",
+        "GatewayTimeout",
+    }
+    return type(exc).__name__ in retryable_names
 
 
 def _submit_stage_sweep(
@@ -894,7 +1006,35 @@ def _submit_stage_sweep(
         parallel_trial_count=parallel,
     )
 
-    hpt_job.run(sync=sync)
+    # Retry loop for transient Vertex AI / quota errors.
+    _RETRY_DELAYS = [60, 180, 300]  # seconds between retries
+    last_exc: Exception | None = None
+    for attempt in range(len(_RETRY_DELAYS) + 1):
+        try:
+            hpt_job.run(sync=sync)
+            break  # success
+        except Exception as exc:
+            # Only retry on transient / quota errors from the Google API.
+            _retryable = _is_retryable_gcp_error(exc)
+            if not _retryable or attempt >= len(_RETRY_DELAYS):
+                raise
+            last_exc = exc
+            delay = _RETRY_DELAYS[attempt]
+            logger.warning(
+                "Vertex AI error on attempt %d/%d for stage %d: %s. Retrying in %ds …",
+                attempt + 1,
+                len(_RETRY_DELAYS) + 1,
+                stage,
+                exc,
+                delay,
+            )
+            time.sleep(delay)
+    else:
+        # All retries exhausted — should not reach here because we re-raise
+        # above, but guard defensively.
+        raise SweepStageError(
+            f"Job submission for stage {stage} failed after {len(_RETRY_DELAYS) + 1} attempts"
+        ) from last_exc
 
     logger.info("Job submitted: %s", hpt_job.resource_name)
     logger.info("Monitor at: https://console.cloud.google.com/vertex-ai/training/hyperparameter-tuning-jobs")
@@ -1008,7 +1148,47 @@ def launch_all_stages(args: argparse.Namespace) -> None:
     # Determine the net_arch HPT key for this algorithm (e.g. "ppo_net_arch")
     net_arch_key = f"{args.algorithm}_net_arch"
 
+    # ── Resume: restore state from a previous (possibly interrupted) run ─────
+    completed_stages: set[int] = set()
+    sweep_state: dict = {
+        "species": args.species,
+        "algorithm": args.algorithm,
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "stages": {},
+    }
+    if args.resume:
+        prev_state = _load_sweep_state(
+            args.species, args.algorithm, bucket=args.bucket, project=args.project
+        )
+        if prev_state and prev_state.get("stages"):
+            sweep_state = prev_state
+            for stg_key, stg_data in prev_state["stages"].items():
+                if stg_data.get("status") == "completed":
+                    stg_num = int(stg_key)
+                    completed_stages.add(stg_num)
+                    # Restore load_path and fixed_trial_args from the last completed stage
+                    if stg_data.get("best_model_path"):
+                        load_path = stg_data["best_model_path"]
+                    if stg_data.get("fixed_trial_args"):
+                        fixed_trial_args = stg_data["fixed_trial_args"]
+                    if stg_data.get("trial_rows"):
+                        all_rows.extend(stg_data["trial_rows"])
+            if completed_stages:
+                logger.info(
+                    "Resuming sweep: stages %s already completed. load_path=%s",
+                    sorted(completed_stages),
+                    load_path,
+                )
+    # ── End resume ───────────────────────────────────────────────────────────
+
     for stage in range(1, 4):
+        # Skip stages that were already completed in a previous run
+        if stage in completed_stages:
+            logger.info("=" * 60)
+            logger.info("ALL-STAGES SWEEP  —  Stage %d / 3  (SKIPPED — already completed)", stage)
+            logger.info("=" * 60)
+            continue
+
         stage_start_time = time.monotonic()
         search_space = _search_space_for_stage(resolved, stage)
         file_settings = _settings_for_stage(resolved, stage)
@@ -1035,58 +1215,91 @@ def launch_all_stages(args: argparse.Namespace) -> None:
         logger.info("ALL-STAGES SWEEP  —  Stage %d / 3", stage)
         logger.info("=" * 60)
 
-        hpt_job = _submit_stage_sweep(
-            aiplatform=aiplatform,
-            hpt_module=hpt,
-            species=args.species,
-            stage=stage,
-            algorithm=args.algorithm,
-            timesteps=timesteps,
-            n_envs=n_envs,
-            trials=trials,
-            parallel=parallel,
-            bucket=args.bucket,
-            image=args.image,
-            machine_type=args.machine_type,
-            accelerator_type=args.accelerator_type,
-            accelerator_count=args.accelerator_count,
-            search_space=search_space,
-            load_path=load_path,
-            fixed_trial_args=fixed_trial_args,
-            wandb=args.wandb,
-            sync=True,  # block until this stage's sweep is done
-        )
+        try:
+            hpt_job = _submit_stage_sweep(
+                aiplatform=aiplatform,
+                hpt_module=hpt,
+                species=args.species,
+                stage=stage,
+                algorithm=args.algorithm,
+                timesteps=timesteps,
+                n_envs=n_envs,
+                trials=trials,
+                parallel=parallel,
+                bucket=args.bucket,
+                image=args.image,
+                machine_type=args.machine_type,
+                accelerator_type=args.accelerator_type,
+                accelerator_count=args.accelerator_count,
+                search_space=search_space,
+                load_path=load_path,
+                fixed_trial_args=fixed_trial_args,
+                wandb=args.wandb,
+                sync=True,  # block until this stage's sweep is done
+            )
 
-        # Collect per-trial results and append to the running list
-        from environments.shared.config import load_stage_config as _load_stage_config
+            # Collect per-trial results and append to the running list
+            from environments.shared.config import load_stage_config as _load_stage_config
 
-        stage_config = _load_stage_config(args.species, stage)
-        stage_rows = _collect_trial_results(hpt_job, stage, stage_config)
-        all_rows.extend(stage_rows)
+            stage_config = _load_stage_config(args.species, stage)
+            stage_rows = _collect_trial_results(hpt_job, stage, stage_config)
+            all_rows.extend(stage_rows)
 
-        stage_elapsed = time.monotonic() - stage_start_time
-        stage_mins = stage_elapsed / 60
-        logger.info(
-            "Stage %d finished in %.1f min (%.0f s). Trials: %d total, %d passed.",
-            stage,
-            stage_mins,
-            stage_elapsed,
-            len(stage_rows),
-            sum(1 for r in stage_rows if r.get("stage_passed")),
-        )
+            stage_elapsed = time.monotonic() - stage_start_time
+            stage_mins = stage_elapsed / 60
+            logger.info(
+                "Stage %d finished in %.1f min (%.0f s). Trials: %d total, %d passed.",
+                stage,
+                stage_mins,
+                stage_elapsed,
+                len(stage_rows),
+                sum(1 for r in stage_rows if r.get("stage_passed")),
+            )
 
-        if stage < 3:
-            # Find the best trial and chain its checkpoint into the next stage
-            load_path, best_row = _best_trial_model_path(stage_rows, args.bucket, args.species, stage)
-            logger.info("Stage %d complete. Best passing model: %s", stage, load_path)
+            if stage < 3:
+                # Find the best trial and chain its checkpoint into the next stage
+                load_path, best_row = _best_trial_model_path(stage_rows, args.bucket, args.species, stage)
+                logger.info("Stage %d complete. Best passing model: %s", stage, load_path)
 
-            # Propagate the winning trial's net_arch to subsequent stages so
-            # every trial loads the checkpoint with a matching architecture.
-            # net_arch is only searched in stage 1; stages 2+ inherit it.
-            best_net_arch = best_row.get(net_arch_key)
-            if best_net_arch is not None:
-                fixed_trial_args = [f"--{net_arch_key}", str(best_net_arch)]
-                logger.info("Propagating %s=%s from best trial to stage %d", net_arch_key, best_net_arch, stage + 1)
+                # Propagate the winning trial's net_arch to subsequent stages so
+                # every trial loads the checkpoint with a matching architecture.
+                # net_arch is only searched in stage 1; stages 2+ inherit it.
+                best_net_arch = best_row.get(net_arch_key)
+                if best_net_arch is not None:
+                    fixed_trial_args = [f"--{net_arch_key}", str(best_net_arch)]
+                    logger.info("Propagating %s=%s from best trial to stage %d", net_arch_key, best_net_arch, stage + 1)
+
+            # Save state after each stage completes successfully
+            sweep_state["stages"][str(stage)] = {
+                "status": "completed",
+                "job_resource_name": getattr(hpt_job, "resource_name", None),
+                "best_trial_id": best_row["trial_id"] if stage < 3 else None,
+                "best_mean_reward": best_row.get("best_mean_reward") if stage < 3 else None,
+                "best_model_path": load_path if stage < 3 else None,
+                "fixed_trial_args": fixed_trial_args,
+                "completed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "trial_rows": stage_rows,
+            }
+            _save_sweep_state(
+                sweep_state, args.species, args.algorithm,
+                bucket=args.bucket, project=args.project,
+            )
+
+        except (SweepStageError, Exception) as exc:
+            if isinstance(exc, SweepStageError) or _is_retryable_gcp_error(exc):
+                logger.error(
+                    "Stage %d failed: %s. Saving progress — completed stages: %s. "
+                    "Re-run the same command to resume from where you left off.",
+                    stage,
+                    exc,
+                    sorted(int(k) for k, v in sweep_state["stages"].items() if v.get("status") == "completed"),
+                )
+                _save_sweep_state(
+                    sweep_state, args.species, args.algorithm,
+                    bucket=args.bucket, project=args.project,
+                )
+                sys.exit(1)
+            raise
 
     # Write a combined CSV of every trial across all three stages
     csv_path = Path(f"sweep_results_{args.species}_{args.algorithm}.csv")
@@ -1272,6 +1485,15 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     launch_all.add_argument("--wandb", action="store_true", help="Enable W&B logging in each trial")
+    launch_all.add_argument(
+        "--resume",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Resume from the last completed stage if a sweep state file exists "
+            "(default: --resume). Use --no-resume to start fresh."
+        ),
+    )
 
     return parser
 

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -470,7 +470,9 @@ class TestSaveLoadSweepState:
         # Mock google.cloud.storage to raise on Client() so the GCS upload fails
         mock_storage = MagicMock()
         mock_storage.Client.side_effect = Exception("connection refused")
-        with patch.dict("sys.modules", {"google.cloud.storage": mock_storage, "google.cloud": MagicMock(), "google": MagicMock()}):
+        with patch.dict(
+            "sys.modules", {"google.cloud.storage": mock_storage, "google.cloud": MagicMock(), "google": MagicMock()}
+        ):
             # Should not raise even if GCS upload fails
             _save_sweep_state(state, "velociraptor", "ppo", bucket="my-bucket")
         # Local file should still be written

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -1,6 +1,5 @@
 """Tests for the hyperparameter sweep tool's pure functions."""
 
-import json
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -1,19 +1,25 @@
 """Tests for the hyperparameter sweep tool's pure functions."""
 
-from unittest.mock import MagicMock
+import json
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from environments.shared.scripts.sweep import (
     NET_ARCH_PRESETS,
+    SweepStageError,
     _best_trial_model_path,
     _collect_trial_results,
     _hpt_arg_to_override,
     _is_per_stage,
+    _is_retryable_gcp_error,
+    _load_sweep_state,
     _resolve_search_space,
+    _save_sweep_state,
     _search_space_for_stage,
     _settings_for_stage,
     _split_stage_block,
+    _sweep_state_local_path,
     write_results_csv,
 )
 
@@ -320,11 +326,11 @@ class TestBestTrialModelPath:
         assert "stage1" in path
         assert "/2/" in path
 
-    def test_exits_when_no_trials_pass(self):
+    def test_raises_when_no_trials_pass(self):
         rows = [
             {"trial_id": "1", "stage_passed": False, "best_mean_reward": 50.0},
         ]
-        with pytest.raises(SystemExit):
+        with pytest.raises(SweepStageError):
             _best_trial_model_path(rows, "bucket", "trex", 2)
 
     def test_gcs_path_format(self):
@@ -386,3 +392,206 @@ class TestNetArchPresets:
     def test_expected_presets_exist(self):
         expected = {"small", "medium", "large", "deep", "tapered", "deep_tapered"}
         assert set(NET_ARCH_PRESETS.keys()) == expected
+
+
+# ── SweepStageError ─────────────────────────────────────────────────────
+
+
+class TestSweepStageError:
+    def test_is_exception(self):
+        assert issubclass(SweepStageError, Exception)
+
+    def test_message(self):
+        err = SweepStageError("stage 2 failed")
+        assert "stage 2 failed" in str(err)
+
+
+# ── _is_retryable_gcp_error ────────────────────────────────────────────
+
+
+class TestIsRetryableGcpError:
+    def test_retryable_by_name(self):
+        for name in ("ResourceExhausted", "ServiceUnavailable", "GoogleAPICallError", "TooManyRequests"):
+            # Create a dynamically-named exception class
+            exc_cls = type(name, (Exception,), {})
+            assert _is_retryable_gcp_error(exc_cls("quota exceeded")) is True
+
+    def test_non_retryable(self):
+        assert _is_retryable_gcp_error(ValueError("bad")) is False
+        assert _is_retryable_gcp_error(RuntimeError("crash")) is False
+
+
+# ── _save_sweep_state / _load_sweep_state ───────────────────────────────
+
+
+class TestSaveLoadSweepState:
+    def test_round_trip_local(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        state = {
+            "species": "velociraptor",
+            "algorithm": "ppo",
+            "started_at": "2026-01-01T00:00:00Z",
+            "stages": {
+                "1": {"status": "completed", "best_model_path": "/gcs/bucket/path.zip"},
+            },
+        }
+        _save_sweep_state(state, "velociraptor", "ppo")
+        loaded = _load_sweep_state("velociraptor", "ppo")
+        assert loaded is not None
+        assert loaded["species"] == "velociraptor"
+        assert loaded["stages"]["1"]["status"] == "completed"
+
+    def test_load_returns_none_when_no_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert _load_sweep_state("velociraptor", "ppo") is None
+
+    def test_load_returns_none_on_species_mismatch(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        state = {"species": "trex", "algorithm": "ppo", "stages": {}}
+        _save_sweep_state(state, "trex", "ppo")
+        # Try to load with different species
+        loaded = _load_sweep_state("velociraptor", "ppo")
+        assert loaded is None
+
+    def test_load_returns_none_on_algorithm_mismatch(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        state = {"species": "velociraptor", "algorithm": "ppo", "stages": {}}
+        _save_sweep_state(state, "velociraptor", "ppo")
+        loaded = _load_sweep_state("velociraptor", "sac")
+        assert loaded is None
+
+    def test_local_path_format(self):
+        path = _sweep_state_local_path("velociraptor", "ppo")
+        assert path.name == "sweep_state_velociraptor_ppo.json"
+
+    def test_gcs_upload_failure_is_non_fatal(self, tmp_path, monkeypatch):
+        """GCS failures should log a warning but not raise."""
+        monkeypatch.chdir(tmp_path)
+        state = {"species": "velociraptor", "algorithm": "ppo", "stages": {}}
+        # Mock google.cloud.storage to raise on Client() so the GCS upload fails
+        mock_storage = MagicMock()
+        mock_storage.Client.side_effect = Exception("connection refused")
+        with patch.dict("sys.modules", {"google.cloud.storage": mock_storage, "google.cloud": MagicMock(), "google": MagicMock()}):
+            # Should not raise even if GCS upload fails
+            _save_sweep_state(state, "velociraptor", "ppo", bucket="my-bucket")
+        # Local file should still be written
+        assert _sweep_state_local_path("velociraptor", "ppo").exists()
+
+
+# ── Retry logic in _submit_stage_sweep ──────────────────────────────────
+
+
+class TestSubmitStageRetry:
+    def test_retries_on_resource_exhausted(self):
+        """hpt_job.run() is retried on retryable errors."""
+        from environments.shared.scripts.sweep import _submit_stage_sweep
+
+        mock_aiplatform = MagicMock()
+        mock_hpt = MagicMock()
+
+        # Make the HPT job's run method fail twice then succeed
+        ResourceExhausted = type("ResourceExhausted", (Exception,), {})
+        mock_job = MagicMock()
+        mock_job.run.side_effect = [
+            ResourceExhausted("quota"),
+            ResourceExhausted("quota"),
+            None,  # success on 3rd attempt
+        ]
+        mock_aiplatform.HyperparameterTuningJob.return_value = mock_job
+        mock_aiplatform.CustomJob.return_value = MagicMock()
+
+        search_space = {"ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4, "scale": "log"}}
+
+        with patch("time.sleep"):
+            result = _submit_stage_sweep(
+                aiplatform=mock_aiplatform,
+                hpt_module=mock_hpt,
+                species="velociraptor",
+                stage=1,
+                algorithm="ppo",
+                timesteps=100000,
+                n_envs=4,
+                trials=5,
+                parallel=2,
+                bucket="test-bucket",
+                image="test-image",
+                machine_type="n1-standard-8",
+                accelerator_type="NVIDIA_TESLA_T4",
+                accelerator_count=1,
+                search_space=search_space,
+            )
+
+        assert mock_job.run.call_count == 3
+        assert result is mock_job
+
+    def test_raises_after_all_retries_exhausted(self):
+        """After all retry attempts are exhausted, the exception is raised."""
+        from environments.shared.scripts.sweep import _submit_stage_sweep
+
+        mock_aiplatform = MagicMock()
+        mock_hpt = MagicMock()
+
+        ResourceExhausted = type("ResourceExhausted", (Exception,), {})
+        mock_job = MagicMock()
+        mock_job.run.side_effect = ResourceExhausted("quota")
+        mock_aiplatform.HyperparameterTuningJob.return_value = mock_job
+        mock_aiplatform.CustomJob.return_value = MagicMock()
+
+        search_space = {"ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4, "scale": "log"}}
+
+        with patch("time.sleep"), pytest.raises(ResourceExhausted):
+            _submit_stage_sweep(
+                aiplatform=mock_aiplatform,
+                hpt_module=mock_hpt,
+                species="velociraptor",
+                stage=1,
+                algorithm="ppo",
+                timesteps=100000,
+                n_envs=4,
+                trials=5,
+                parallel=2,
+                bucket="test-bucket",
+                image="test-image",
+                machine_type="n1-standard-8",
+                accelerator_type="NVIDIA_TESLA_T4",
+                accelerator_count=1,
+                search_space=search_space,
+            )
+
+        # 1 initial + 3 retries = 4 total attempts
+        assert mock_job.run.call_count == 4
+
+    def test_non_retryable_error_raised_immediately(self):
+        """Non-retryable errors are raised without retry."""
+        from environments.shared.scripts.sweep import _submit_stage_sweep
+
+        mock_aiplatform = MagicMock()
+        mock_hpt = MagicMock()
+
+        mock_job = MagicMock()
+        mock_job.run.side_effect = ValueError("bad parameter")
+        mock_aiplatform.HyperparameterTuningJob.return_value = mock_job
+        mock_aiplatform.CustomJob.return_value = MagicMock()
+
+        search_space = {"ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4, "scale": "log"}}
+
+        with patch("time.sleep"), pytest.raises(ValueError, match="bad parameter"):
+            _submit_stage_sweep(
+                aiplatform=mock_aiplatform,
+                hpt_module=mock_hpt,
+                species="velociraptor",
+                stage=1,
+                algorithm="ppo",
+                timesteps=100000,
+                n_envs=4,
+                trials=5,
+                parallel=2,
+                bucket="test-bucket",
+                image="test-image",
+                machine_type="n1-standard-8",
+                accelerator_type="NVIDIA_TESLA_T4",
+                accelerator_count=1,
+                search_space=search_space,
+            )
+
+        assert mock_job.run.call_count == 1

--- a/website/docs/training/sweeps.md
+++ b/website/docs/training/sweeps.md
@@ -335,3 +335,42 @@ For a full `launch-all` (3 stages at 500k/1M/1.5M steps per trial, 20 trials eac
 
 **Tip:** Start with 100 000–200 000 timesteps per trial to get a rough ranking, then run longer trials for the top 3–5 configurations.
 
+## Resuming a Sweep
+
+`launch-all` automatically saves progress after each stage completes. If the process is interrupted (network failure, quota exhaustion, machine crash), re-run the **exact same command** and the completed stages will be skipped:
+
+```bash
+# First run — gets interrupted during Stage 2
+python environments/shared/scripts/sweep.py launch-all \
+    --species velociraptor --algorithm ppo \
+    --project MY_PROJECT --bucket MY_BUCKET --image IMAGE_URI \
+    --trials 20 --parallel 5
+
+# Re-run — Stage 1 is skipped, resumes from Stage 2
+python environments/shared/scripts/sweep.py launch-all \
+    --species velociraptor --algorithm ppo \
+    --project MY_PROJECT --bucket MY_BUCKET --image IMAGE_URI \
+    --trials 20 --parallel 5
+```
+
+State is saved to both a local file (`sweep_state_<species>_<algorithm>.json`) and GCS (`gs://<bucket>/sweeps/<species>/_sweep_state.json`). On resume, GCS is checked first, then the local file.
+
+To **start fresh** and ignore any saved state, pass `--no-resume`:
+
+```bash
+python environments/shared/scripts/sweep.py launch-all \
+    --species velociraptor --algorithm ppo \
+    --project MY_PROJECT --bucket MY_BUCKET --image IMAGE_URI \
+    --trials 20 --parallel 5 --no-resume
+```
+
+## Resource Errors and Retries
+
+When submitting a job to Vertex AI, transient errors (quota exhaustion, service unavailability) are automatically retried up to 3 times with increasing delays (60 s, 180 s, 300 s). If all retries fail:
+
+1. Progress for already-completed stages is saved.
+2. The script exits with a clear error message.
+3. Re-running the same command resumes from where it left off.
+
+Non-transient errors (invalid parameters, authentication failures) are **not** retried and fail immediately.
+


### PR DESCRIPTION
## Summary

This PR adds robust resumption and error-handling capabilities to the multi-stage hyperparameter tuning sweep tool. The changes enable interrupted sweeps to be resumed from the last completed stage and add automatic retry logic for transient GCP/Vertex AI errors.

## Key Changes

- **New `SweepStageError` exception**: Custom exception for sweep-specific failures, replacing `sys.exit()` calls for better error handling and testability.

- **Sweep state persistence**: 
  - Added `_save_sweep_state()` to persist progress to both local disk and GCS after each stage completes
  - Added `_load_sweep_state()` to restore state from GCS (preferred) or local file with validation
  - Added `_sweep_state_local_path()` helper for consistent state file naming

- **Resume functionality**:
  - New `--resume` / `--no-resume` CLI flag (enabled by default) to control resumption behavior
  - `launch_all_stages()` now checks for saved state and skips already-completed stages
  - Restores `load_path` and `fixed_trial_args` from the last completed stage to maintain the training chain

- **Automatic retry logic**:
  - Added `_is_retryable_gcp_error()` to identify transient GCP errors by exception class name
  - `_submit_stage_sweep()` now retries job submission up to 3 times with exponential backoff (60s, 180s, 300s) for quota/service errors
  - Non-transient errors fail immediately without retry

- **Improved error handling**:
  - Stage failures now save progress before exiting, allowing resume on re-run
  - Clear logging of which stages were completed and which failed
  - GCS upload failures are non-fatal (logged as warnings)

- **Documentation**: Added "Resuming a Sweep" and "Resource Errors and Retries" sections to `sweeps.md` with examples.

## Implementation Details

- State is stored as JSON with species/algorithm validation to prevent cross-run contamination
- GCS operations use best-effort pattern: failures don't block local persistence
- Retry delays are hardcoded as `[60, 180, 300]` seconds for predictable backoff
- Exception matching uses class name strings to avoid import-time dependency on `google-cloud-aiplatform`
- All new functions are thoroughly tested with unit tests covering happy paths, error cases, and edge conditions