### PR TITLE
Prefer best model over final model for curriculum training stages

### DIFF
--- a/environments/brachiosaurus/scripts/train_sb3.py
+++ b/environments/brachiosaurus/scripts/train_sb3.py
@@ -10,8 +10,8 @@ Supports curriculum learning with three stages:
 Usage:
     # Single-stage training
     python train_sb3.py train --stage 1 --timesteps 1000000
-    python train_sb3.py train --stage 2 --timesteps 2000000 --load models/stage1_final.zip
-    python train_sb3.py train --stage 3 --timesteps 3000000 --load models/stage2_final.zip
+    python train_sb3.py train --stage 2 --timesteps 2000000 --load models/best_model.zip
+    python train_sb3.py train --stage 3 --timesteps 3000000 --load models/best_model.zip
 
     # Automated end-to-end curriculum (all 3 stages)
     python train_sb3.py curriculum --n-envs 4

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -631,10 +631,24 @@ def train_curriculum(
         final_path = model_dir / f"stage{stage}_final"
         model.save(str(final_path))
         train_env.save(str(final_path) + "_vecnorm.pkl")
-        load_path = str(final_path)
         prev_vecnorm_path = str(final_path) + "_vecnorm.pkl"
 
-        logger.info("Stage %d complete. Model saved to %s", stage, final_path)
+        # Prefer the best model (saved by EvalCallback) for the next stage,
+        # as it represents peak evaluated performance and protects against
+        # late-stage training instability.
+        best_model_path = model_dir / "best_model.zip"
+        if best_model_path.exists():
+            load_path = str(model_dir / "best_model")
+            logger.info(
+                "Stage %d complete. Using best model for next stage: %s",
+                stage, best_model_path,
+            )
+        else:
+            load_path = str(final_path)
+            logger.info(
+                "Stage %d complete. No best model found; using final model: %s",
+                stage, final_path,
+            )
 
         train_env.close()
         eval_env.close()

--- a/environments/trex/scripts/train_sb3.py
+++ b/environments/trex/scripts/train_sb3.py
@@ -10,8 +10,8 @@ Supports curriculum learning with three stages:
 Usage:
     # Single-stage training
     python train_sb3.py train --stage 1 --timesteps 1000000
-    python train_sb3.py train --stage 2 --timesteps 2000000 --load models/stage1_final.zip
-    python train_sb3.py train --stage 3 --timesteps 3000000 --load models/stage2_final.zip
+    python train_sb3.py train --stage 2 --timesteps 2000000 --load models/best_model.zip
+    python train_sb3.py train --stage 3 --timesteps 3000000 --load models/best_model.zip
 
     # Automated end-to-end curriculum (all 3 stages)
     python train_sb3.py curriculum --n-envs 4

--- a/environments/velociraptor/scripts/train_sb3.py
+++ b/environments/velociraptor/scripts/train_sb3.py
@@ -10,8 +10,8 @@ Supports curriculum learning with three stages:
 Usage:
     # Single-stage training
     python train_sb3.py train --stage 1 --timesteps 1000000
-    python train_sb3.py train --stage 2 --timesteps 2000000 --load models/stage1_final.zip
-    python train_sb3.py train --stage 3 --timesteps 3000000 --load models/stage2_final.zip
+    python train_sb3.py train --stage 2 --timesteps 2000000 --load models/best_model.zip
+    python train_sb3.py train --stage 3 --timesteps 3000000 --load models/best_model.zip
 
     # Automated end-to-end curriculum (all 3 stages)
     python train_sb3.py curriculum --n-envs 4


### PR DESCRIPTION
## Summary
Updated curriculum training to prioritize the best evaluated model (saved by EvalCallback) over the final model when transitioning between stages. This prevents late-stage training instability from degrading performance in subsequent stages.

## Key Changes
- **train_base.py**: Modified `train_curriculum()` to check for and prefer `best_model.zip` when loading the model for the next stage, with fallback to the final model if best model doesn't exist
- **train_sb3.py scripts**: Updated usage documentation in brachiosaurus, trex, and velociraptor environments to reflect loading `best_model.zip` instead of stage-specific final models for multi-stage training

## Implementation Details
- The best model path is checked using `best_model_path.exists()` before attempting to load
- Appropriate logging messages distinguish between using the best model vs. the final model
- The change is backward compatible—if no best model exists, the training falls back to using the final model as before
- This improvement applies to both automated curriculum training and manual multi-stage training workflows

https://claude.ai/code/session_01VDzDoaUxTPBJWF3oGsuXTo