### PR TITLE
Fix reward sign flipping after prey overshoot in raptor env

### DIFF
--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -113,6 +113,12 @@ class RaptorEnv(BaseDinoEnv):
         self._prev_prey_distance: float | None = None
         self._prev_action: np.ndarray | None = None
 
+        # Cached initial direction to prey (set in _spawn_target).
+        # Used by forward-velocity and heading rewards so the "forward"
+        # reference direction stays fixed for the whole episode, preventing
+        # the reward from flipping sign when the raptor passes the prey.
+        self._initial_prey_dir_2d: np.ndarray = np.array([1.0, 0.0])
+
         super().__init__(
             model_path=model_path,
             render_mode=render_mode,
@@ -226,13 +232,21 @@ class RaptorEnv(BaseDinoEnv):
         # 1. Forward velocity reward (toward prey)
         pelvis_pos = self.data.xpos[self.pelvis_id]
         prey_pos = self.data.mocap_pos[0]
+
+        # Use the cached initial direction so the "forward" reference stays
+        # fixed for the whole episode.  This prevents the reward from flipping
+        # sign when the raptor overshoots and passes the prey.
+        forward_ref_2d = self._initial_prey_dir_2d
+
+        # Keep the live direction available for rewards that genuinely need
+        # the current relative vector (approach shaping, observations).
         prey_dir_2d = prey_pos[:2] - pelvis_pos[:2]
         prey_dist_2d = np.linalg.norm(prey_dir_2d)
         if prey_dist_2d > 1e-6:
             prey_dir_2d = prey_dir_2d / prey_dist_2d
 
         vel_2d = self.data.qvel[0:2]
-        forward_vel = np.dot(vel_2d, prey_dir_2d)
+        forward_vel = np.dot(vel_2d, forward_ref_2d)
         forward_vel_norm = np.clip(forward_vel / self.forward_vel_max, -1.0, 1.0)
         info["forward_vel"] = forward_vel
         reward_forward = self.forward_vel_weight * forward_vel_norm
@@ -361,8 +375,9 @@ class RaptorEnv(BaseDinoEnv):
         body_forward_len = np.linalg.norm(body_forward_2d)
         if body_forward_len > 1e-6:
             body_forward_2d = body_forward_2d / body_forward_len
-        # Dot product: +1 when facing prey, -1 when facing away
-        heading_alignment = float(np.dot(body_forward_2d, prey_dir_2d))
+        # Dot product: +1 when facing the initial prey direction, -1 when facing away.
+        # Uses the cached direction so heading reward doesn't flip after overshoot.
+        heading_alignment = float(np.dot(body_forward_2d, forward_ref_2d))
         reward_heading = self.heading_weight * heading_alignment
         info["heading_alignment"] = heading_alignment
         info["reward_heading"] = reward_heading
@@ -475,6 +490,14 @@ class RaptorEnv(BaseDinoEnv):
         # Prey position (relative to origin, raptor starts at origin)
         prey_pos = np.array([distance, lateral, 0.3])
         self.data.mocap_pos[0] = prey_pos
+
+        # Cache initial 2D direction to prey for stable reward computation.
+        # The raptor starts near the origin, so prey_pos[:2] ≈ the direction.
+        dir_2d = prey_pos[:2].copy()
+        dir_len = np.linalg.norm(dir_2d)
+        if dir_len > 1e-6:
+            dir_2d /= dir_len
+        self._initial_prey_dir_2d = dir_2d
 
         # Reset delta-based tracking (first step will produce zero deltas)
         self._prev_prey_distance = None


### PR DESCRIPTION
## Summary
This PR fixes an issue in the Velociraptor environment where forward velocity and heading rewards would flip sign when the raptor overshoots and passes the prey. The solution caches the initial direction to the prey at spawn time and uses this fixed reference direction for reward computation throughout the episode.

## Key Changes
- **Added `_initial_prey_dir_2d` field**: A new cached attribute that stores the normalized 2D direction to the prey at episode start, initialized in `__init__` and set in `_spawn_target()`
- **Updated forward velocity reward**: Changed from using the live prey direction (`prey_dir_2d`) to the cached initial direction (`forward_ref_2d`) when computing the dot product with velocity
- **Updated heading alignment reward**: Changed from comparing body orientation against live prey direction to comparing against the cached initial direction, preventing reward sign flips after overshoot
- **Preserved live direction tracking**: The current `prey_dir_2d` is still computed and available for other uses (approach shaping, observations) that may need the actual relative vector

## Implementation Details
- The initial direction is computed in `_spawn_target()` after prey position is set, with proper normalization and handling of edge cases (division by zero)
- The cached direction remains constant throughout the episode, providing a stable reference frame for the forward velocity and heading rewards
- This prevents the counterintuitive behavior where the agent would be penalized for moving forward after passing the prey