### PR TITLE
Fix gait symmetry reward to track foot alternation instead of force

### DIFF
--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -3,11 +3,9 @@ name = "locomotion"
 description = "Learn forward walking/running"
 
 [env]
-forward_vel_weight = 2.0                # Reduced from 4.0: with forward_vel_max=1.5 gives max reward 2.0, avoids sprint-and-fall
-                                        # NOTE: Successful runs used 1.0 with fwd_vel_max=10.0 (weaker gradient).
-                                        # Current combo (2.0/1.5) is ~13x stronger at walking speeds — untested.
-                                        # The 2M-step ramp mitigates initial shock. If stage 2 fails, try 1.0.
-forward_vel_max = 1.5                   # Reduce from 3.0: stronger gradient at low speeds where raptor operates
+forward_vel_weight = 2.0                # With forward_vel_max=3.0 gives max reward 2.0; at 1.3 m/s (current avg) reward = 0.87/step
+                                        # Still provides meaningful gradient without saturating at walking speeds
+forward_vel_max = 3.0                   # Increased from 1.5: agent plateaued at 1.3 m/s (87% of old max), needs headroom to push past waddle
 backward_vel_penalty_weight = 0.5       # Reduced from 2.0: matches successful runs; forward reward provides directional incentive
 alive_bonus = 0.5                       # Reduce from 2.0: was 99% of total reward, drowning forward signal
 fall_penalty = -50.0                    # Reduce from -100: less punitive with lower alive_bonus
@@ -15,7 +13,7 @@ energy_penalty_weight = 0.003
 tail_stability_weight = 0.05
 posture_weight = 0.2                    # Reduced from 0.8: successful runs used 0.0-0.2; high values trap agent in standing posture
 nosedive_weight = 0.3                   # Reduced from 1.0: allows forward lean for gait initiation while preventing face-plants
-gait_symmetry_weight = 0.0             # Disabled: formula rewards instantaneous asymmetry, not alternation
+gait_symmetry_weight = 0.3              # Enabled: fixed formula now tracks touchdown alternation (L→R→L), not instantaneous force
 smoothness_weight = 0.05
 strike_bonus = 0.0
 strike_approach_weight = 0.0

--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -113,6 +113,13 @@ class RaptorEnv(BaseDinoEnv):
         self._prev_prey_distance: float | None = None
         self._prev_action: np.ndarray | None = None
 
+        # Gait symmetry: track foot touchdown events for alternation reward
+        self._contact_threshold = 0.1  # Newtons, matches metrics.py onset detection
+        self._prev_r_in_contact = False
+        self._prev_l_in_contact = False
+        self._touchdown_sequence: list = []  # Recent 'L'/'R' touchdown events
+        self._max_touchdown_history = 20
+
         # Cached initial direction to prey (set in _spawn_target).
         # Used by forward-velocity and heading rewards so the "forward"
         # reference direction stays fixed for the whole episode, preventing
@@ -343,21 +350,42 @@ class RaptorEnv(BaseDinoEnv):
         # 8b. Pelvis height (for LocomotionMetrics tracking)
         info["pelvis_height"] = float(self.data.xpos[self.pelvis_id, 2])
 
-        # 9. Gait symmetry
-        # BUG: This rewards instantaneous contact asymmetry, not foot
-        # alternation. Standing on one leg scores the same as walking,
-        # and normal double-support phases are penalized. To fix, track
-        # foot contact transitions (L→R, R→L switches) over a window
-        # instead of instantaneous force asymmetry. Keep weight at 0.0
-        # until the formula is corrected.
+        # 9. Gait symmetry (reward alternating foot contacts)
+        # Track touchdown events (off→on transitions) and reward when
+        # consecutive touchdowns alternate feet: L→R→L = 1.0, L→L→R = 0.5.
         r_contact = self.data.sensordata[self._sensor_r_foot]
         l_contact = self.data.sensordata[self._sensor_l_foot]
         info["r_foot_contact"] = float(r_contact)
         info["l_foot_contact"] = float(l_contact)
-        contact_sum = r_contact + l_contact + 1e-6
-        contact_asymmetry = abs(r_contact - l_contact) / contact_sum
-        reward_gait = self.gait_symmetry_weight * contact_asymmetry
-        info["contact_asymmetry"] = contact_asymmetry
+
+        r_in_contact = r_contact > self._contact_threshold
+        l_in_contact = l_contact > self._contact_threshold
+        r_touchdown = r_in_contact and not self._prev_r_in_contact
+        l_touchdown = l_in_contact and not self._prev_l_in_contact
+        self._prev_r_in_contact = r_in_contact
+        self._prev_l_in_contact = l_in_contact
+
+        if r_touchdown:
+            self._touchdown_sequence.append("R")
+        if l_touchdown:
+            self._touchdown_sequence.append("L")
+        if len(self._touchdown_sequence) > self._max_touchdown_history:
+            self._touchdown_sequence = self._touchdown_sequence[-self._max_touchdown_history :]
+
+        n_touchdowns = len(self._touchdown_sequence)
+        if n_touchdowns > 1:
+            alternations = sum(
+                1
+                for i in range(1, n_touchdowns)
+                if self._touchdown_sequence[i] != self._touchdown_sequence[i - 1]
+            )
+            alternation_ratio = alternations / (n_touchdowns - 1)
+        else:
+            alternation_ratio = 0.0
+
+        reward_gait = self.gait_symmetry_weight * alternation_ratio
+        info["alternation_ratio"] = alternation_ratio
+        info["contact_asymmetry"] = alternation_ratio  # backward compat with metrics
         info["reward_gait"] = reward_gait
 
         # 10. Action smoothness (shared helper)
@@ -502,6 +530,11 @@ class RaptorEnv(BaseDinoEnv):
         # Reset delta-based tracking (first step will produce zero deltas)
         self._prev_prey_distance = None
         self._prev_action = None
+
+        # Reset gait symmetry tracking
+        self._prev_r_in_contact = False
+        self._prev_l_in_contact = False
+        self._touchdown_sequence = []
 
 
 # Register with Gymnasium (MesozoicLabs namespace)


### PR DESCRIPTION
## Summary
Fixed the gait symmetry reward function to properly incentivize alternating foot contacts (L→R→L pattern) rather than instantaneous force asymmetry. The previous implementation incorrectly rewarded standing on one leg the same as walking, and penalized normal double-support phases.

## Key Changes

- **Gait symmetry tracking**: Added state variables to track foot contact transitions:
  - `_contact_threshold`: 0.1 N threshold for detecting foot contact (matches metrics.py)
  - `_prev_r_in_contact` / `_prev_l_in_contact`: Previous frame contact state
  - `_touchdown_sequence`: Rolling history of recent 'L'/'R' touchdown events (max 20)

- **Reward calculation**: Changed from instantaneous asymmetry to alternation ratio:
  - Detects off→on transitions (touchdowns) for each foot
  - Counts consecutive alternations in the touchdown sequence
  - Computes `alternation_ratio = alternations / (n_touchdowns - 1)`
  - Rewards perfect alternation (L→R→L) with ratio = 1.0, partial alternation proportionally

- **State reset**: Added gait tracking reset in `_spawn_target()` to clear state between episodes

- **Config updates**: 
  - Re-enabled `gait_symmetry_weight` from 0.0 to 0.3 now that formula is corrected
  - Adjusted `forward_vel_max` from 1.5 to 3.0 to provide headroom for agent improvement
  - Updated comments explaining reward tuning rationale

## Implementation Details

The touchdown detection uses a simple state machine: a touchdown occurs when contact force crosses the threshold from below. This avoids false positives during sustained contact and naturally handles double-support phases (both feet down) without penalty. The rolling history window prevents reward drift from very old gait patterns while maintaining enough context for meaningful alternation metrics.