### PR TITLE
Refine strike training reward shaping and exploration parameters

### DIFF
--- a/configs/velociraptor/stage3_strike.toml
+++ b/configs/velociraptor/stage3_strike.toml
@@ -3,9 +3,9 @@ name = "strike"
 description = "Sprint and strike prey with sickle claw"
 
 [env]
-forward_vel_weight = 1.0
+forward_vel_weight = 0.5               # Halved from 1.0: prevent forward reward from dominating approach/strike signals
 backward_vel_penalty_weight = 0.0
-alive_bonus = 0.5                       # Increase from 0.1: maintain self-preservation during strike training
+alive_bonus = 0.05                     # Drastically reduced from 0.5: survival is learned in stages 1-2; high alive_bonus made striking net-negative (strike terminates episode, costing ~500 in future alive rewards vs 5.0 bonus)
 energy_penalty_weight = 0.001
 tail_stability_weight = 0.02
 posture_weight = 0.1
@@ -14,9 +14,10 @@ gait_symmetry_weight = 0.0             # Disabled: formula rewards asymmetry, no
 smoothness_weight = 0.02
 heading_weight = 0.3                   # Match stage 2: face toward prey for strike
 lateral_penalty_weight = 0.1           # Match stage 2: penalize crab-walking toward prey
-strike_bonus = 5.0                     # Reduced from 10.0: still 10x alive_bonus but limits gradient shock (not ramped by callback)
-strike_approach_weight = 1.0
-prey_distance_range = [3.0, 8.0]
+strike_bonus = 50.0                    # 10x increase from 5.0: must outweigh opportunity cost of episode termination (~50-100 in lost future per-step rewards with reduced alive_bonus)
+strike_approach_weight = 3.0           # 3x increase from 1.0: stronger delta-based gradient toward prey
+strike_proximity_weight = 0.5          # NEW: continuous proximity bonus (1 - dist/max_dist) creates smooth basin of attraction toward prey, complementing noisy delta-based approach
+prey_distance_range = [2.0, 6.0]       # Tightened from [3.0, 8.0]: closer prey makes strike discovery much more likely during exploration
 prey_lateral_range = [-1.5, 1.5]
 max_episode_steps = 1000
 
@@ -28,8 +29,8 @@ batch_size = 256
 n_epochs = 10
 gamma = 0.995
 gae_lambda = 0.95
-clip_range = 0.1
-ent_coef = 0.001
+clip_range = 0.15                      # Widened from 0.1: allow larger policy updates to escape local optimum (survival-only behavior)
+ent_coef = 0.005                       # 5x increase from 0.001: more exploration needed to discover sparse strike reward
 
 [ppo.policy_kwargs]
 net_arch = [256, 256]

--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -32,6 +32,7 @@ Reward components:
     - Tail stability
     - Strike bonus (when claw contacts prey)
     - Approach shaping (distance to prey)
+    - Proximity bonus (continuous reward for being close to prey)
     - Posture (continuous tilt penalty)
     - Nosedive penalty
     - Gait symmetry (alternating foot contacts)
@@ -72,6 +73,7 @@ class RaptorEnv(BaseDinoEnv):
         tail_stability_weight: float = 0.05,
         strike_bonus: float = 10.0,
         strike_approach_weight: float = 1.0,
+        strike_proximity_weight: float = 0.0,
         posture_weight: float = 0.2,
         nosedive_weight: float = 0.0,
         natural_pitch: float = 0.35,
@@ -92,6 +94,7 @@ class RaptorEnv(BaseDinoEnv):
         self.tail_stability_weight = tail_stability_weight
         self.strike_bonus = strike_bonus
         self.strike_approach_weight = strike_approach_weight
+        self.strike_proximity_weight = strike_proximity_weight
         self.posture_weight = posture_weight
         self.nosedive_weight = nosedive_weight
         self.gait_symmetry_weight = gait_symmetry_weight
@@ -319,6 +322,16 @@ class RaptorEnv(BaseDinoEnv):
         info["approach_delta"] = approach_delta
         info["reward_approach"] = reward_approach
 
+        # 6b. Proximity bonus (continuous reward for being close to prey)
+        # Provides a smooth basin of attraction that complements the noisy
+        # delta-based approach reward.  Linearly scales from 0 at max spawn
+        # distance to 1 at the prey location.
+        max_prey_dist = max(self.prey_distance_range[1], 1.0)
+        proximity = max(0.0, 1.0 - prey_distance / max_prey_dist)
+        reward_proximity = self.strike_proximity_weight * proximity
+        info["proximity"] = proximity
+        info["reward_proximity"] = reward_proximity
+
         # 7. Continuous posture reward (quadratic tilt penalty — stronger gradient near upright)
         pelvis_quat = self.data.sensordata[self._sensor_quat_start : self._sensor_quat_start + 4]
         tilt_angle = self._quat_to_tilt(pelvis_quat)
@@ -399,6 +412,7 @@ class RaptorEnv(BaseDinoEnv):
             + reward_tail
             + reward_strike
             + reward_approach
+            + reward_proximity
             + reward_posture
             + reward_nosedive
             + reward_gait

--- a/environments/velociraptor/tests/test_raptor_rewards.py
+++ b/environments/velociraptor/tests/test_raptor_rewards.py
@@ -67,6 +67,7 @@ class TestRewardComponents:
             + info["reward_tail"]
             + info["reward_strike"]
             + info["reward_approach"]
+            + info["reward_proximity"]
             + info["reward_posture"]
             + info["reward_nosedive"]
             + info["reward_gait"]


### PR DESCRIPTION
## Summary
This PR adjusts the reward structure and training hyperparameters for the velociraptor strike stage (stage 3) to better balance the competing objectives of approaching prey and executing strikes. The changes address the issue where the high alive_bonus made striking net-negative by terminating the episode, and introduce a new continuous proximity reward to create a smoother learning signal.

## Key Changes

- **Reward Structure Rebalancing**
  - Reduced `alive_bonus` from 0.5 to 0.05: Survival is already learned in earlier stages; the high bonus was making strikes economically irrational (losing ~500 in future rewards vs 5.0 bonus)
  - Increased `strike_bonus` from 5.0 to 50.0: Must outweigh the opportunity cost of episode termination with reduced alive_bonus
  - Reduced `forward_vel_weight` from 1.0 to 0.5: Prevent forward movement reward from dominating approach/strike signals

- **Approach and Proximity Improvements**
  - Increased `strike_approach_weight` from 1.0 to 3.0: Stronger delta-based gradient toward prey
  - Added new `strike_proximity_weight` parameter (0.5): Continuous proximity bonus that creates a smooth basin of attraction, complementing the noisy delta-based approach reward
  - Tightened `prey_distance_range` from [3.0, 8.0] to [2.0, 6.0]: Closer prey makes strike discovery more likely during exploration

- **Training Hyperparameters**
  - Widened `clip_range` from 0.1 to 0.15: Allow larger policy updates to escape local optima (survival-only behavior)
  - Increased `ent_coef` from 0.001 to 0.005: 5x increase to encourage more exploration for discovering sparse strike reward

- **Implementation**
  - Added `strike_proximity_weight` parameter to environment initialization
  - Implemented proximity bonus calculation in `_get_reward_info()`: linearly scales from 0 at max spawn distance to 1 at prey location
  - Updated reward test to include proximity component in total reward validation

## Notable Details
The proximity bonus provides a continuous, smooth reward signal that helps guide the agent toward prey without relying solely on noisy delta-based approach rewards. This complements the increased strike bonus by creating multiple reinforcement pathways toward the strike behavior.