### PR TITLE
Add height randomization to environment reset for improved robustness

### DIFF
--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -267,6 +267,8 @@ class BaseDinoEnv(gym.Env, ABC):
             noise_scale = 0.01
             self.data.qpos[7:] += self.np_random.uniform(-noise_scale, noise_scale, size=self.data.qpos[7:].shape)
             self.data.qvel[:] += self.np_random.uniform(-noise_scale, noise_scale, size=self.data.qvel.shape)
+            # Slightly vary starting height to improve policy robustness
+            self.data.qpos[2] += self.np_random.normal(0, 0.01)
 
         # Randomize target position (species-specific)
         self._spawn_target()


### PR DESCRIPTION
## Summary
This change enhances the environment reset procedure by adding slight randomization to the agent's starting height, improving policy robustness to initial state variations.

## Key Changes
- Added Gaussian noise (mean=0, std=0.01) to the z-position (qpos[2]) during environment reset
- This complements the existing noise applied to joint positions and velocities
- Helps policies generalize better by training on varied starting heights

## Implementation Details
- Uses `np_random.normal()` with standard deviation of 0.01 to vary the height
- Applied after the existing uniform noise randomization for joint positions and velocities
- Includes a clarifying comment explaining the purpose of this randomization