### PR TITLE
Add early stopping on eval collapse and improve PPO training stability

### DIFF
--- a/configs/velociraptor/stage1_balance.toml
+++ b/configs/velociraptor/stage1_balance.toml
@@ -16,16 +16,19 @@ strike_bonus = 0.0
 strike_approach_weight = 0.0
 prey_distance_range = [10.0, 15.0]
 max_episode_steps = 1000                  # Match stage 2/3 for consistent episode horizon across curriculum
+reset_noise_scale = 0.05                  # Increased from 0.01 default to improve robustness and reduce eval variance
 
 [ppo]
 learning_rate = 3e-4
 learning_rate_end = 1e-5
+lr_schedule = "cosine"                       # "linear" or "cosine" — cosine decays faster mid-training, protecting converged policies
 n_steps = 2048
 batch_size = 256
-n_epochs = 10
-gamma = 0.995
+n_epochs = 6                                 # Reduced from 10 to limit per-rollout over-updating
+gamma = 0.99                                 # Reduced from 0.995 to stabilise value estimation for balance
 gae_lambda = 0.95
 clip_range = 0.2
+clip_range_end = 0.1                         # Anneal clip_range to constrain late-training policy updates
 ent_coef = 0.005
 
 [ppo.policy_kwargs]

--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -44,6 +44,7 @@ class BaseDinoEnv(gym.Env, ABC):
         fall_penalty: float = -100.0,
         healthy_z_range: Tuple[float, float] = (0.25, 1.0),
         max_tilt_angle: float = 1.047,
+        reset_noise_scale: float = 0.01,
     ):
         super().__init__()
 
@@ -66,6 +67,7 @@ class BaseDinoEnv(gym.Env, ABC):
         # Environment settings
         self.healthy_z_range = healthy_z_range
         self.max_tilt_angle = max_tilt_angle
+        self.reset_noise_scale = reset_noise_scale
 
         # Cache body/geom/site IDs (species-specific)
         self._cache_ids()
@@ -264,11 +266,11 @@ class BaseDinoEnv(gym.Env, ABC):
 
         # Add small random perturbation to initial pose
         if self.np_random is not None:
-            noise_scale = 0.01
+            noise_scale = self.reset_noise_scale
             self.data.qpos[7:] += self.np_random.uniform(-noise_scale, noise_scale, size=self.data.qpos[7:].shape)
             self.data.qvel[:] += self.np_random.uniform(-noise_scale, noise_scale, size=self.data.qvel.shape)
             # Slightly vary starting height to improve policy robustness
-            self.data.qpos[2] += self.np_random.normal(0, 0.01)
+            self.data.qpos[2] += self.np_random.normal(0, noise_scale)
 
         # Randomize target position (species-specific)
         self._spawn_target()

--- a/environments/shared/curriculum.py
+++ b/environments/shared/curriculum.py
@@ -761,6 +761,101 @@ class RewardRampCallback(BaseCallback):  # type: ignore[misc]
         return True
 
 
+class EvalCollapseEarlyStopCallback(BaseCallback):  # type: ignore[misc]
+    """Stop training if eval reward drops significantly from the peak.
+
+    Monitors evaluation results and stops training when the mean reward
+    drops below ``(1 - drop_fraction) * peak_reward`` for
+    ``patience`` consecutive evaluations.  This prevents wasting compute
+    on a policy that has already collapsed past recovery.
+
+    Args:
+        eval_callback: The ``EvalCallback`` whose ``evaluations.npz``
+            to monitor.
+        drop_fraction: Fractional drop from peak that triggers early
+            stopping (default 0.3 = 30% drop).
+        patience: Number of consecutive below-threshold evaluations
+            before stopping (default 3).
+        min_evals: Minimum number of evaluations before early stopping
+            can activate (default 5).
+        verbose: Verbosity level.
+    """
+
+    def __init__(
+        self,
+        eval_callback: Any,
+        drop_fraction: float = 0.3,
+        patience: int = 3,
+        min_evals: int = 5,
+        verbose: int = 0,
+    ):
+        if not _SB3_AVAILABLE:
+            raise ImportError("stable-baselines3 is required for EvalCollapseEarlyStopCallback.")
+        super().__init__(verbose)
+        self.eval_callback = eval_callback
+        self.drop_fraction = drop_fraction
+        self.patience = patience
+        self.min_evals = min_evals
+        self._peak_reward = -np.inf
+        self._consecutive_drops = 0
+        self._last_seen_n_evals = 0
+
+    def _on_step(self) -> bool:
+        log_path = getattr(self.eval_callback, "log_path", None)
+        if log_path is None:
+            return True
+
+        from pathlib import Path
+
+        npz_path = Path(log_path) / "evaluations.npz"
+        if not npz_path.exists():
+            return True
+
+        data = np.load(str(npz_path))
+        eval_rewards = data["results"]  # (n_evals, n_episodes)
+        n_evals = eval_rewards.shape[0]
+
+        if n_evals <= self._last_seen_n_evals:
+            return True  # No new eval yet
+        self._last_seen_n_evals = n_evals
+
+        if n_evals < self.min_evals:
+            return True
+
+        mean_rewards = eval_rewards.mean(axis=1)
+        current_peak = float(mean_rewards.max())
+        self._peak_reward = max(self._peak_reward, current_peak)
+
+        latest_mean = float(mean_rewards[-1])
+        threshold = (1.0 - self.drop_fraction) * self._peak_reward
+
+        if self._peak_reward > 0 and latest_mean < threshold:
+            self._consecutive_drops += 1
+            logger.warning(
+                "EvalCollapseEarlyStop: reward %.1f < %.1f (%.0f%% of peak %.1f), "
+                "consecutive drops: %d/%d",
+                latest_mean,
+                threshold,
+                100 * (1 - self.drop_fraction),
+                self._peak_reward,
+                self._consecutive_drops,
+                self.patience,
+            )
+            if self._consecutive_drops >= self.patience:
+                logger.warning(
+                    "EvalCollapseEarlyStop: stopping training at step %d — "
+                    "reward collapsed from peak %.1f to %.1f",
+                    self.num_timesteps,
+                    self._peak_reward,
+                    latest_mean,
+                )
+                return False
+        else:
+            self._consecutive_drops = 0
+
+        return True
+
+
 class SaveVecNormalizeCallback(BaseCallback):  # type: ignore[misc]
     """Save VecNormalize stats whenever triggered.
 

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -108,6 +108,22 @@ def linear_schedule(initial_lr: float, final_lr: float):
     return schedule
 
 
+def cosine_schedule(initial_lr: float, final_lr: float):
+    """Return a callable that decays learning rate on a cosine curve.
+
+    Decays faster in mid-training than linear, then flattens near the end.
+    This better protects converged policies from late-training destabilisation.
+    """
+    import math
+
+    def schedule(progress_remaining: float) -> float:
+        # progress_remaining goes from 1.0 → 0.0
+        cosine_decay = 0.5 * (1.0 + math.cos(math.pi * (1.0 - progress_remaining)))
+        return final_lr + cosine_decay * (initial_lr - final_lr)
+
+    return schedule
+
+
 # ── Environment creation ─────────────────────────────────────────────────
 
 
@@ -183,6 +199,7 @@ def train(
     """Train a single stage of the curriculum."""
     from .config import save_stage_config
     from .curriculum import (
+        EvalCollapseEarlyStopCallback,
         RewardRampCallback,
         SaveVecNormalizeCallback,
         StageWarmupCallback,
@@ -258,10 +275,21 @@ def train(
 
     if algorithm == "ppo":
         lr_end = alg_kwargs.pop("learning_rate_end", None)
+        lr_schedule_type = alg_kwargs.pop("lr_schedule", "linear")
         if lr_end is not None:
             lr_start = alg_kwargs["learning_rate"]
-            alg_kwargs["learning_rate"] = linear_schedule(lr_start, lr_end)
-            logger.info("Using linear LR schedule: %s -> %s", lr_start, lr_end)
+            if lr_schedule_type == "cosine":
+                alg_kwargs["learning_rate"] = cosine_schedule(lr_start, lr_end)
+            else:
+                alg_kwargs["learning_rate"] = linear_schedule(lr_start, lr_end)
+            logger.info("Using %s LR schedule: %s -> %s", lr_schedule_type, lr_start, lr_end)
+
+        # Clip range annealing
+        clip_range_end = alg_kwargs.pop("clip_range_end", None)
+        if clip_range_end is not None:
+            clip_start = alg_kwargs["clip_range"]
+            alg_kwargs["clip_range"] = linear_schedule(clip_start, clip_range_end)
+            logger.info("Using clip_range schedule: %s -> %s", clip_start, clip_range_end)
 
     wandb_run = None
     if use_wandb:
@@ -315,6 +343,9 @@ def train(
     callbacks.append(checkpoint_callback)
 
     callbacks.append(DiagnosticsCallback(log_dir=str(log_path), verbose=verbose))
+
+    # Early stopping on eval reward collapse
+    callbacks.append(EvalCollapseEarlyStopCallback(eval_callback=eval_callback, verbose=verbose))
 
     if use_wandb:
         callbacks.append(WandbCallback())
@@ -537,6 +568,7 @@ def train_curriculum(
     from .curriculum import (
         CurriculumCallback,
         CurriculumManager,
+        EvalCollapseEarlyStopCallback,
         RewardRampCallback,
         SaveVecNormalizeCallback,
         StageWarmupCallback,
@@ -613,10 +645,21 @@ def train_curriculum(
 
         if algorithm == "ppo":
             lr_end = alg_kwargs.pop("learning_rate_end", None)
+            lr_schedule_type = alg_kwargs.pop("lr_schedule", "linear")
             if lr_end is not None:
                 lr_start = alg_kwargs["learning_rate"]
-                alg_kwargs["learning_rate"] = linear_schedule(lr_start, lr_end)
-                logger.info("Using linear LR schedule: %s -> %s", lr_start, lr_end)
+                if lr_schedule_type == "cosine":
+                    alg_kwargs["learning_rate"] = cosine_schedule(lr_start, lr_end)
+                else:
+                    alg_kwargs["learning_rate"] = linear_schedule(lr_start, lr_end)
+                logger.info("Using %s LR schedule: %s -> %s", lr_schedule_type, lr_start, lr_end)
+
+            # Clip range annealing
+            clip_range_end = alg_kwargs.pop("clip_range_end", None)
+            if clip_range_end is not None:
+                clip_start = alg_kwargs["clip_range"]
+                alg_kwargs["clip_range"] = linear_schedule(clip_start, clip_range_end)
+                logger.info("Using clip_range schedule: %s -> %s", clip_start, clip_range_end)
 
         wandb_run = None
         if use_wandb:
@@ -658,6 +701,9 @@ def train_curriculum(
         callbacks.append(checkpoint_callback)
 
         callbacks.append(DiagnosticsCallback(log_dir=str(stage_dir), verbose=verbose))
+
+        # Early stopping on eval reward collapse
+        callbacks.append(EvalCollapseEarlyStopCallback(eval_callback=eval_callback, verbose=verbose))
 
         if use_wandb:
             callbacks.append(WandbCallback())

--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -86,6 +86,7 @@ class RaptorEnv(BaseDinoEnv):
         prey_distance_range: Tuple[float, float] = (3.0, 8.0),
         prey_lateral_range: Tuple[float, float] = (-2.0, 2.0),
         healthy_z_range: Tuple[float, float] = (0.3, 1.0),
+        reset_noise_scale: float = 0.01,
     ):
         model_path = str(Path(__file__).parent.parent / "assets" / "raptor.xml")
 
@@ -139,6 +140,7 @@ class RaptorEnv(BaseDinoEnv):
             energy_penalty_weight=energy_penalty_weight,
             fall_penalty=fall_penalty,
             healthy_z_range=healthy_z_range,
+            reset_noise_scale=reset_noise_scale,
         )
 
     def _cache_ids(self):


### PR DESCRIPTION
## Summary
This PR enhances training stability and efficiency by adding early stopping when evaluation rewards collapse, introducing cosine learning rate scheduling, and implementing clip range annealing for PPO. These changes help prevent wasted compute on policies that have degraded and better protect converged policies from late-training destabilization.

## Key Changes

- **EvalCollapseEarlyStopCallback**: New callback that monitors evaluation results and stops training when mean reward drops below `(1 - drop_fraction) * peak_reward` for `patience` consecutive evaluations. This prevents wasting compute on policies that have already collapsed past recovery.

- **Cosine Learning Rate Schedule**: Added `cosine_schedule()` function that decays learning rate on a cosine curve, decaying faster mid-training than linear schedules while flattening near the end. This better protects converged policies from late-training destabilization.

- **Clip Range Annealing**: Implemented linear annealing of PPO's `clip_range` parameter via new `clip_range_end` config option, constraining policy updates in later training stages.

- **Learning Rate Schedule Selection**: Added `lr_schedule` config option ("linear" or "cosine") to allow flexible choice of learning rate decay strategy.

- **Reset Noise Scale Parameterization**: Made `reset_noise_scale` configurable in environment initialization (default 0.01) to improve policy robustness and reduce evaluation variance.

- **Velociraptor Stage 1 Config Updates**:
  - Increased `reset_noise_scale` from 0.01 to 0.05 for improved robustness
  - Switched to cosine learning rate schedule
  - Reduced `n_epochs` from 10 to 6 to limit per-rollout over-updating
  - Reduced `gamma` from 0.995 to 0.99 for more stable value estimation
  - Added `clip_range_end = 0.1` for clip range annealing

## Implementation Details

- Early stopping callback loads evaluation results from `evaluations.npz` and tracks peak reward across all evaluations, only triggering after minimum evaluation threshold is met
- Cosine schedule uses `0.5 * (1 + cos(π * (1 - progress)))` for smooth decay
- Both `train()` and `train_curriculum()` functions updated to support new features
- Reset noise scale now consistently applied to both position and velocity perturbations