### PR TITLE
Add job reconnection and polling for multi-stage sweep orchestration

### DIFF
--- a/environments/shared/scripts/sweep/__main__.py
+++ b/environments/shared/scripts/sweep/__main__.py
@@ -190,6 +190,23 @@ def _build_parser() -> argparse.ArgumentParser:
             "status. Useful for running all three stages to completion."
         ),
     )
+    launch_all.add_argument(
+        "--stage-timeout",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Maximum wall-clock seconds to wait for each stage's HPT job to "
+            "complete. If exceeded the job keeps running in the cloud — re-run "
+            "with --resume to reconnect."
+        ),
+    )
+    launch_all.add_argument(
+        "--poll-interval",
+        type=int,
+        default=120,
+        help="Seconds between job status checks while waiting for completion (default: 120)",
+    )
 
     return parser
 

--- a/environments/shared/scripts/sweep/orchestration.py
+++ b/environments/shared/scripts/sweep/orchestration.py
@@ -20,7 +20,7 @@ from .search_space import (
     _settings_for_stage,
 )
 from .state import _load_sweep_state, _save_sweep_state
-from .submit import _is_retryable_gcp_error, _submit_stage_sweep
+from .submit import _is_retryable_gcp_error, _submit_stage_sweep, _wait_for_job
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,6 @@ def launch_sweep(args: argparse.Namespace) -> None:
         search_space=search_space,
         load_path=args.load,
         wandb=args.wandb,
-        sync=False,  # fire-and-forget for single-stage launch
     )
 
 
@@ -132,20 +131,62 @@ def launch_all_stages(args: argparse.Namespace) -> None:
     # Determine the net_arch HPT key for this algorithm (e.g. "ppo_net_arch")
     net_arch_key = f"{args.algorithm}_net_arch"
 
+    # ── CLI args snapshot (persisted in state for reproducibility) ───────────
+    cli_args_snapshot: dict = {
+        "trials": args.trials,
+        "parallel": args.parallel,
+        "n_envs": args.n_envs,
+        "machine_type": args.machine_type,
+        "accelerator_type": args.accelerator_type,
+        "accelerator_count": args.accelerator_count,
+        "timesteps_stage1": args.timesteps_stage1,
+        "timesteps_stage2": args.timesteps_stage2,
+        "timesteps_stage3": args.timesteps_stage3,
+        "trials_stage1": args.trials_stage1,
+        "trials_stage2": args.trials_stage2,
+        "trials_stage3": args.trials_stage3,
+        "parallel_stage1": args.parallel_stage1,
+        "parallel_stage2": args.parallel_stage2,
+        "parallel_stage3": args.parallel_stage3,
+        "image": args.image,
+        "bucket": args.bucket,
+        "project": args.project,
+        "location": args.location,
+        "force_continue": args.force_continue,
+        "stage_timeout": getattr(args, "stage_timeout", None),
+        "poll_interval": getattr(args, "poll_interval", 120),
+    }
+
     # ── Resume: restore state from a previous (possibly interrupted) run ─────
     completed_stages: set[int] = set()
     partial_stages: dict[int, dict] = {}
+    in_progress_stages: dict[int, dict] = {}
     sweep_state: dict = {
         "species": args.species,
         "algorithm": args.algorithm,
         "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "cli_args": cli_args_snapshot,
         "stages": {},
     }
     logger.info("Resume mode: %s", "enabled" if args.resume else "disabled")
     if args.resume:
         prev_state = _load_sweep_state(args.species, args.algorithm, bucket=args.bucket, project=args.project)
         if prev_state and prev_state.get("stages"):
+            # Warn if CLI args differ from the previous run
+            prev_cli = prev_state.get("cli_args", {})
+            if prev_cli:
+                changed = {
+                    k for k in set(prev_cli) | set(cli_args_snapshot) if prev_cli.get(k) != cli_args_snapshot.get(k)
+                }
+                if changed:
+                    logger.warning(
+                        "CLI args differ from previous run on: %s. Current values will be used.",
+                        ", ".join(sorted(changed)),
+                    )
+
             sweep_state = prev_state
+            sweep_state["cli_args"] = cli_args_snapshot  # always store current args
+
             for stg_key, stg_data in prev_state["stages"].items():
                 stg_num = int(stg_key)
                 if stg_data.get("status") == "completed":
@@ -157,6 +198,10 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                         fixed_trial_args = stg_data["fixed_trial_args"]
                     if stg_data.get("trial_rows"):
                         all_rows.extend(stg_data["trial_rows"])
+                elif stg_data.get("status") == "in_progress":
+                    in_progress_stages[stg_num] = stg_data
+                    if stg_data.get("fixed_trial_args"):
+                        fixed_trial_args = stg_data["fixed_trial_args"]
                 elif stg_data.get("status") == "partial":
                     partial_stages[stg_num] = stg_data
                     if stg_data.get("fixed_trial_args"):
@@ -167,6 +212,13 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                     sorted(completed_stages),
                     load_path,
                 )
+            if in_progress_stages:
+                for ips, ipd in sorted(in_progress_stages.items()):
+                    logger.info(
+                        "Resuming sweep: stage %d has an in-progress job: %s",
+                        ips,
+                        ipd.get("job_resource_name", "unknown"),
+                    )
             if partial_stages:
                 for ps, pd in sorted(partial_stages.items()):
                     logger.info(
@@ -223,11 +275,80 @@ def launch_all_stages(args: argparse.Namespace) -> None:
         )
         logger.info("=" * 60)
 
+        poll_interval = getattr(args, "poll_interval", 120)
+        stage_timeout = getattr(args, "stage_timeout", None)
+
         try:
             remaining_trials = trials - len(partial_rows)
             job_resource_name = None
+            hpt_job = None
+            reconnected = False
 
-            if remaining_trials > 0:
+            # ── Reconnect to an in-progress job from a previous run ───────
+            in_progress_data = in_progress_stages.get(stage)
+            if in_progress_data and in_progress_data.get("job_resource_name"):
+                prev_resource = in_progress_data["job_resource_name"]
+                logger.info("Attempting to reconnect to previous job: %s", prev_resource)
+                try:
+                    prev_job = aiplatform.HyperparameterTuningJob.get(prev_resource)
+                    prev_state_name = prev_job.state.name if hasattr(prev_job.state, "name") else str(prev_job.state)
+
+                    if "SUCCEEDED" in prev_state_name:
+                        logger.info("Previous job already completed successfully.")
+                        hpt_job = prev_job
+                        job_resource_name = prev_resource
+                        reconnected = True
+                    elif any(s in prev_state_name for s in ("RUNNING", "QUEUED", "PENDING")):
+                        logger.info("Previous job still running (state=%s) — resuming poll.", prev_state_name)
+                        hpt_job = _wait_for_job(
+                            prev_job,
+                            aiplatform,
+                            poll_interval=poll_interval,
+                            timeout=stage_timeout,
+                        )
+                        job_resource_name = prev_resource
+                        reconnected = True
+                    else:
+                        # Failed/cancelled — collect partial results
+                        logger.warning(
+                            "Previous job in state %s — collecting partial results.",
+                            prev_state_name,
+                        )
+                        try:
+                            from environments.shared.config import load_stage_config as _lsc_ip
+
+                            _sc_ip = _lsc_ip(args.species, stage)
+                            _ip_rows = _collect_trial_results(prev_job, stage, _sc_ip)
+                            _ip_rows = [r for r in _ip_rows if r.get("best_mean_reward") is not None]
+                            if _ip_rows:
+                                _ip_out = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
+                                ip_resume = in_progress_data.get("resume_run", 0)
+                                if ip_resume:
+                                    _ip_out = f"{_ip_out}_r{ip_resume}"
+                                for row in _ip_rows:
+                                    row["model_path"] = f"{_ip_out}/{row['trial_id']}/models/best_model.zip"
+                                partial_rows = partial_rows + _ip_rows
+                                remaining_trials = trials - len(partial_rows)
+                                resume_run = ip_resume + 1
+                                logger.info(
+                                    "Recovered %d trials from previous in-progress job (%d total partial).",
+                                    len(_ip_rows),
+                                    len(partial_rows),
+                                )
+                        except Exception as ip_collect_exc:
+                            logger.warning(
+                                "Could not collect partial results from previous job: %s",
+                                ip_collect_exc,
+                            )
+                except Exception as reconnect_exc:
+                    logger.warning(
+                        "Could not reconnect to previous job %s: %s. Will submit a new job.",
+                        prev_resource,
+                        reconnect_exc,
+                    )
+
+            # ── Submit new job if needed ───────────────────────────────────
+            if not reconnected and remaining_trials > 0:
                 if partial_rows:
                     logger.info(
                         "Resuming stage %d: %d trials recovered from previous run, %d remaining.",
@@ -255,12 +376,38 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                     load_path=load_path,
                     fixed_trial_args=fixed_trial_args,
                     wandb=args.wandb,
-                    sync=True,  # block until this stage's sweep is done
                     resume_run=resume_run,
                 )
                 job_resource_name = getattr(hpt_job, "resource_name", None)
 
-                # Collect per-trial results and append to the running list
+                # Save in-progress state immediately so the job can be
+                # reconnected if the orchestrator is interrupted.
+                sweep_state["stages"][str(stage)] = {
+                    "status": "in_progress",
+                    "job_resource_name": job_resource_name,
+                    "load_path": load_path,
+                    "fixed_trial_args": fixed_trial_args,
+                    "resume_run": resume_run,
+                    "submitted_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                }
+                _save_sweep_state(
+                    sweep_state,
+                    args.species,
+                    args.algorithm,
+                    bucket=args.bucket,
+                    project=args.project,
+                )
+
+                # Poll until the job completes
+                hpt_job = _wait_for_job(
+                    hpt_job,
+                    aiplatform,
+                    poll_interval=poll_interval,
+                    timeout=stage_timeout,
+                )
+
+            # ── Collect results ────────────────────────────────────────────
+            if hpt_job is not None:
                 from environments.shared.config import load_stage_config as _load_stage_config
 
                 stage_config = _load_stage_config(args.species, stage)
@@ -276,7 +423,7 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                     row["model_path"] = f"{output_base}/{row['trial_id']}/models/best_model.zip"
 
                 stage_rows = partial_rows + new_rows
-            else:
+            elif remaining_trials <= 0:
                 # All requested trials were already completed in a previous
                 # partial run — no need to submit a new job.
                 logger.info(
@@ -284,6 +431,8 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                     stage,
                     len(partial_rows),
                 )
+                stage_rows = list(partial_rows)
+            else:
                 stage_rows = list(partial_rows)
 
             all_rows.extend(stage_rows)
@@ -366,7 +515,7 @@ def launch_all_stages(args: argparse.Namespace) -> None:
             )
 
         except Exception as exc:
-            if isinstance(exc, SweepStageError) or _is_retryable_gcp_error(exc):
+            if isinstance(exc, (SweepStageError, TimeoutError)) or _is_retryable_gcp_error(exc):
                 # ── Partial trial recovery ────────────────────────────────
                 # Try to salvage completed trials from the failed job so they
                 # can be reused on the next ``--resume`` run.

--- a/environments/shared/scripts/sweep/orchestration.py
+++ b/environments/shared/scripts/sweep/orchestration.py
@@ -25,6 +25,35 @@ from .submit import _is_retryable_gcp_error, _submit_stage_sweep, _wait_for_job
 logger = logging.getLogger(__name__)
 
 
+def _dedup_trial_rows(rows: list[dict]) -> list[dict]:
+    """Deduplicate trial rows by ``trial_id``, keeping the last occurrence.
+
+    When merging partial rows from multiple resume cycles, the same
+    ``trial_id`` can appear more than once (e.g. if Vertex AI re-uses an
+    ID across separate HPT jobs, or if rows are accidentally appended
+    twice).  Later entries are assumed to have more complete data, so
+    the last occurrence wins.
+    """
+    seen: dict[str, dict] = {}
+    for row in rows:
+        tid = row.get("trial_id")
+        if tid is not None:
+            seen[tid] = row
+        else:
+            # Rows without a trial_id are kept unconditionally (shouldn't
+            # happen in practice, but don't silently drop data).
+            seen[id(row)] = row
+    deduped = list(seen.values())
+    if len(deduped) < len(rows):
+        logger.info(
+            "Deduplicated trial rows: %d → %d (removed %d duplicates)",
+            len(rows),
+            len(deduped),
+            len(rows) - len(deduped),
+        )
+    return deduped
+
+
 def launch_sweep(args: argparse.Namespace) -> None:
     """Submit a Vertex AI Hyperparameter Tuning job for a single stage.
 
@@ -294,7 +323,7 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                 # job so they aren't lost across multiple resume cycles.
                 prior_partial = in_progress_data.get("prior_partial_rows", [])
                 if prior_partial:
-                    partial_rows = partial_rows + prior_partial
+                    partial_rows = _dedup_trial_rows(partial_rows + prior_partial)
                     remaining_trials = trials - len(partial_rows)
                     logger.info(
                         "Restored %d prior partial rows from earlier runs.",
@@ -339,7 +368,7 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                                     _ip_out = f"{_ip_out}_r{ip_resume}"
                                 for row in _ip_rows:
                                     row["model_path"] = f"{_ip_out}/{row['trial_id']}/models/best_model.zip"
-                                partial_rows = partial_rows + _ip_rows
+                                partial_rows = _dedup_trial_rows(partial_rows + _ip_rows)
                                 remaining_trials = trials - len(partial_rows)
                                 resume_run = ip_resume + 1
                                 logger.info(
@@ -437,7 +466,7 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                 for row in new_rows:
                     row["model_path"] = f"{output_base}/{row['trial_id']}/models/best_model.zip"
 
-                stage_rows = partial_rows + new_rows
+                stage_rows = _dedup_trial_rows(partial_rows + new_rows)
             elif remaining_trials <= 0:
                 # All requested trials were already completed in a previous
                 # partial run — no need to submit a new job.
@@ -551,7 +580,7 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                             for row in _new_partial:
                                 row["model_path"] = f"{_out}/{row['trial_id']}/models/best_model.zip"
 
-                            all_partial = partial_rows + _new_partial
+                            all_partial = _dedup_trial_rows(partial_rows + _new_partial)
                             sweep_state["stages"][str(stage)] = {
                                 "status": "partial",
                                 "job_resource_name": getattr(exc.hpt_job, "resource_name", None),

--- a/environments/shared/scripts/sweep/orchestration.py
+++ b/environments/shared/scripts/sweep/orchestration.py
@@ -38,11 +38,11 @@ def _dedup_trial_rows(rows: list[dict]) -> list[dict]:
     for row in rows:
         tid = row.get("trial_id")
         if tid is not None:
-            seen[tid] = row
+            seen[str(tid)] = row
         else:
             # Rows without a trial_id are kept unconditionally (shouldn't
             # happen in practice, but don't silently drop data).
-            seen[id(row)] = row
+            seen[f"_no_id_{id(row)}"] = row
     deduped = list(seen.values())
     if len(deduped) < len(rows):
         logger.info(

--- a/environments/shared/scripts/sweep/orchestration.py
+++ b/environments/shared/scripts/sweep/orchestration.py
@@ -289,6 +289,18 @@ def launch_all_stages(args: argparse.Namespace) -> None:
             if in_progress_data and in_progress_data.get("job_resource_name"):
                 prev_resource = in_progress_data["job_resource_name"]
                 logger.info("Attempting to reconnect to previous job: %s", prev_resource)
+
+                # Restore partial rows from runs that preceded the in-progress
+                # job so they aren't lost across multiple resume cycles.
+                prior_partial = in_progress_data.get("prior_partial_rows", [])
+                if prior_partial:
+                    partial_rows = partial_rows + prior_partial
+                    remaining_trials = trials - len(partial_rows)
+                    logger.info(
+                        "Restored %d prior partial rows from earlier runs.",
+                        len(prior_partial),
+                    )
+
                 try:
                     prev_job = aiplatform.HyperparameterTuningJob.get(prev_resource)
                     prev_state_name = prev_job.state.name if hasattr(prev_job.state, "name") else str(prev_job.state)
@@ -382,12 +394,15 @@ def launch_all_stages(args: argparse.Namespace) -> None:
 
                 # Save in-progress state immediately so the job can be
                 # reconnected if the orchestrator is interrupted.
+                # Include any partial_rows recovered from earlier runs so
+                # they survive across multiple resume cycles.
                 sweep_state["stages"][str(stage)] = {
                     "status": "in_progress",
                     "job_resource_name": job_resource_name,
                     "load_path": load_path,
                     "fixed_trial_args": fixed_trial_args,
                     "resume_run": resume_run,
+                    "prior_partial_rows": partial_rows,
                     "submitted_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                 }
                 _save_sweep_state(

--- a/environments/shared/scripts/sweep/state.py
+++ b/environments/shared/scripts/sweep/state.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+import os
+import tempfile
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -26,7 +28,21 @@ def _save_sweep_state(
     ``gs://<bucket>/sweeps/<species>/_sweep_state.json``.
     """
     local_path = _sweep_state_local_path(species, algorithm)
-    local_path.write_text(json.dumps(state, indent=2))
+    # Write to a temp file then atomically rename to avoid corruption
+    # if the process is killed mid-write (e.g. Ctrl+C, OOM, SIGKILL).
+    try:
+        fd, tmp_path = tempfile.mkstemp(
+            dir=local_path.parent,
+            prefix=f".{local_path.name}.",
+            suffix=".tmp",
+        )
+        with os.fdopen(fd, "w") as f:
+            json.dump(state, f, indent=2)
+        os.replace(tmp_path, local_path)
+    except OSError:
+        # Fallback: direct write (e.g. if the filesystem doesn't
+        # support atomic rename from the temp directory).
+        local_path.write_text(json.dumps(state, indent=2))
     logger.info("Sweep state saved locally: %s", local_path)
 
     if bucket:

--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -237,7 +237,7 @@ def _submit_stage_sweep(
     custom_job = aiplatform.CustomJob(
         display_name=f"{display_name}-trial",
         worker_pool_specs=worker_pool_specs,
-        base_output_dir=f"gs://{bucket}/sweeps/{species}/stage{stage}",
+        base_output_dir=f"gs://{bucket}/sweeps/{species}/stage{stage}{'_r' + str(resume_run) if resume_run else ''}",
     )
 
     hpt_job = aiplatform.HyperparameterTuningJob(

--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -27,6 +27,120 @@ def _is_retryable_gcp_error(exc: Exception) -> bool:
     return type(exc).__name__ in retryable_names
 
 
+def _state_name(state) -> str:
+    """Return the string name of a Vertex AI job state enum value."""
+    return state.name if hasattr(state, "name") else str(state)
+
+
+def _wait_for_job(
+    hpt_job,
+    aiplatform,
+    *,
+    poll_interval: int = 120,
+    timeout: float | None = None,
+):
+    """Poll a running HPT job until completion with progress logging.
+
+    Periodically refreshes the job state and logs trial progress, providing
+    visibility into multi-hour sweeps.  When *timeout* is set, raises
+    ``TimeoutError`` if the job hasn't finished within the given number of
+    seconds — the job continues running in the cloud and can be resumed.
+
+    Args:
+        hpt_job: A submitted ``HyperparameterTuningJob`` with a valid
+            ``resource_name``.
+        aiplatform: The ``google.cloud.aiplatform`` module, used to refresh
+            the job via ``HyperparameterTuningJob.get()``.
+        poll_interval: Seconds between status checks (default 120).
+        timeout: Maximum wall-clock seconds to wait.  ``None`` means wait
+            indefinitely.
+
+    Returns:
+        The refreshed job object with final trial data.
+
+    Raises:
+        _SweepJobFailed: If the job ends in a failed or cancelled state.
+        TimeoutError: If *timeout* is exceeded while the job is still running.
+    """
+    resource_name = hpt_job.resource_name
+    start = time.monotonic()
+
+    logger.info(
+        "Waiting for job %s (poll every %ds, timeout %s) …",
+        resource_name,
+        poll_interval,
+        f"{timeout / 3600:.1f}h" if timeout else "none",
+    )
+
+    # Check initial state — important for reconnection where the job may
+    # already be finished.
+    initial_state = _state_name(hpt_job.state)
+    if "SUCCEEDED" in initial_state:
+        logger.info("Job already completed successfully.")
+        return hpt_job
+    if "FAILED" in initial_state or "CANCELLED" in initial_state:
+        raise _SweepJobFailed(
+            f"Job {resource_name} already in terminal state {initial_state}",
+            hpt_job=hpt_job,
+        )
+
+    while True:
+        time.sleep(poll_interval)
+        elapsed = time.monotonic() - start
+        elapsed_min = elapsed / 60
+
+        # Refresh job state from Vertex AI
+        try:
+            refreshed = aiplatform.HyperparameterTuningJob.get(resource_name)
+        except Exception as exc:
+            logger.warning("Failed to refresh job state (will retry): %s", exc)
+            continue
+
+        state = _state_name(refreshed.state)
+
+        # Count trial progress
+        trials = getattr(refreshed, "trials", None) or []
+        n_total = len(trials)
+        n_completed = sum(1 for t in trials if t.final_measurement)
+
+        # Find best reward so far
+        best_so_far: float | None = None
+        for t in trials:
+            if t.final_measurement and t.final_measurement.metrics:
+                for m in t.final_measurement.metrics:
+                    if m.metric_id == "best_mean_reward":
+                        if best_so_far is None or m.value > best_so_far:
+                            best_so_far = m.value
+
+        reward_str = f"  best_reward={best_so_far:.4f}" if best_so_far is not None else ""
+        logger.info(
+            "  [%.0f min] state=%s | trials: %d/%d completed%s",
+            elapsed_min,
+            state,
+            n_completed,
+            n_total,
+            reward_str,
+        )
+
+        # Check terminal state
+        if "SUCCEEDED" in state:
+            logger.info("Job completed successfully after %.1f min.", elapsed_min)
+            return refreshed
+        if "FAILED" in state or "CANCELLED" in state:
+            raise _SweepJobFailed(
+                f"Job {resource_name} ended with state {state} after {elapsed_min:.1f} min",
+                hpt_job=refreshed,
+            )
+
+        # Check timeout
+        if timeout is not None and elapsed > timeout:
+            raise TimeoutError(
+                f"Job {resource_name} timed out after {elapsed_min:.1f} min "
+                f"(limit: {timeout / 60:.1f} min). The job is still running in "
+                f"the cloud — re-run with --resume to reconnect."
+            )
+
+
 def _submit_stage_sweep(
     *,
     aiplatform,
@@ -47,7 +161,6 @@ def _submit_stage_sweep(
     load_path: str | None = None,
     fixed_trial_args: list[str] | None = None,
     wandb: bool = False,
-    sync: bool = False,
     resume_run: int = 0,
 ):
     """Build and submit a single-stage HPT job. Returns the job object.
@@ -141,7 +254,7 @@ def _submit_stage_sweep(
     last_exc: Exception | None = None
     for attempt in range(len(_RETRY_DELAYS) + 1):
         try:
-            hpt_job.run(sync=sync)
+            hpt_job.run(sync=False)
             break  # success
         except Exception as exc:
             # Only retry on transient / quota errors from the Google API.


### PR DESCRIPTION
## Summary
This PR enhances the sweep orchestration system to support resuming interrupted hyperparameter tuning jobs and adds explicit polling with timeout support. Previously, the system would fire-and-forget jobs without waiting for completion or handling reconnection to in-progress jobs from previous runs.

## Key Changes

- **Job Reconnection**: When resuming a sweep with `--resume`, the orchestrator now attempts to reconnect to in-progress jobs from the previous run instead of always submitting new jobs. This prevents duplicate work and allows recovery from orchestrator interruptions.

- **Explicit Job Polling**: Introduced `_wait_for_job()` function that polls a running HPT job with configurable intervals and logs progress (trial counts, best reward, elapsed time). This replaces the implicit `sync=True` behavior and provides visibility into long-running sweeps.

- **Timeout Support**: Added `--stage-timeout` and `--poll-interval` CLI arguments to control maximum wait time per stage and polling frequency. Jobs that exceed the timeout continue running in the cloud and can be resumed later.

- **CLI Args Snapshot**: The orchestrator now persists CLI arguments in the sweep state file for reproducibility. On resume, it warns if any arguments differ from the previous run and always uses current values.

- **Partial Row Recovery**: Enhanced recovery logic to preserve partial trial results across multiple resume cycles, including results from jobs that were in-progress when the orchestrator was interrupted.

- **State Tracking**: Added "in_progress" status to the sweep state to distinguish between completed stages, partial stages, and currently-running stages. This enables proper reconnection logic.

## Implementation Details

- The `_submit_stage_sweep()` function no longer accepts a `sync` parameter; all jobs are submitted with `sync=False` and polling is handled separately.
- Job state is saved immediately after submission (before polling) so reconnection is possible even if the orchestrator crashes during the wait.
- Prior partial rows from earlier runs are stored in the in-progress state and restored when reconnecting, preventing data loss across resume cycles.
- The reconnection logic handles various job terminal states: successfully completed jobs are collected immediately, running jobs are polled, and failed/cancelled jobs attempt partial result recovery.
- `TimeoutError` is now treated as a retryable error alongside `SweepStageError` and transient GCP errors.