### PR TITLE
Fix accelerator type enum error by normalizing short aliases like "T4"

### DIFF
--- a/environments/shared/scripts/sweep/__init__.py
+++ b/environments/shared/scripts/sweep/__init__.py
@@ -36,7 +36,7 @@ from .state import (
     _save_sweep_state,
     _sweep_state_local_path,
 )
-from .submit import _is_retryable_gcp_error, _submit_stage_sweep
+from .submit import _is_retryable_gcp_error, _normalize_accelerator_type, _submit_stage_sweep
 from .trial import _hpt_arg_to_override, run_trial
 
 __all__ = [

--- a/environments/shared/scripts/sweep/__init__.py
+++ b/environments/shared/scripts/sweep/__init__.py
@@ -50,6 +50,7 @@ __all__ = [
     "_is_per_stage",
     "_is_retryable_gcp_error",
     "_load_sweep_state",
+    "_normalize_accelerator_type",
     "_resolve_search_space",
     "_save_sweep_state",
     "_search_space_for_stage",

--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -300,7 +300,11 @@ def _submit_stage_sweep(
             hpt_job=hpt_job,
         ) from last_exc
 
-    logger.info("Job submitted: %s", hpt_job.resource_name)
+    try:
+        job_name = hpt_job.resource_name
+    except RuntimeError:
+        job_name = hpt_job.display_name
+    logger.info("Job submitted: %s", job_name)
     logger.info("Monitor at: https://console.cloud.google.com/vertex-ai/training/hyperparameter-tuning-jobs")
     logger.info("Results will be written to: gs://%s/sweeps/%s/stage%d/", bucket, species, stage)
     return hpt_job

--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -9,6 +9,23 @@ from .trial import _build_parameter_spec
 
 logger = logging.getLogger(__name__)
 
+# Common short names → full Vertex AI accelerator enum labels.
+_ACCELERATOR_ALIASES: dict[str, str] = {
+    "T4": "NVIDIA_TESLA_T4",
+    "V100": "NVIDIA_TESLA_V100",
+    "P100": "NVIDIA_TESLA_P100",
+    "A100": "NVIDIA_TESLA_A100",
+    "L4": "NVIDIA_L4",
+}
+
+
+def _normalize_accelerator_type(raw: str) -> str | None:
+    """Return the canonical Vertex AI enum label, or *None* for CPU-only."""
+    if raw.lower() == "none":
+        return None
+    upper = raw.upper()
+    return _ACCELERATOR_ALIASES.get(upper, raw)
+
 
 def _is_retryable_gcp_error(exc: Exception) -> bool:
     """Return ``True`` if *exc* is a transient GCP error worth retrying.
@@ -208,13 +225,16 @@ def _submit_stage_sweep(
     if wandb:
         trial_args.append("--wandb")
 
+    resolved_accelerator = _normalize_accelerator_type(accelerator_type)
+
+    machine_spec: dict = {"machine_type": machine_type}
+    if resolved_accelerator is not None:
+        machine_spec["accelerator_type"] = resolved_accelerator
+        machine_spec["accelerator_count"] = accelerator_count
+
     worker_pool_specs = [
         {
-            "machine_spec": {
-                "machine_type": machine_type,
-                "accelerator_type": accelerator_type,
-                "accelerator_count": accelerator_count,
-            },
+            "machine_spec": machine_spec,
             "replica_count": 1,
             "container_spec": {
                 "image_uri": image,

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -14,6 +14,7 @@ from environments.shared.scripts.sweep import (
     _is_per_stage,
     _is_retryable_gcp_error,
     _load_sweep_state,
+    _normalize_accelerator_type,
     _resolve_search_space,
     _save_sweep_state,
     _search_space_for_stage,
@@ -23,6 +24,37 @@ from environments.shared.scripts.sweep import (
     _SweepJobFailed,
     write_results_csv,
 )
+
+# ── _normalize_accelerator_type ──────────────────────────────────────────────
+
+
+class TestNormalizeAcceleratorType:
+    """Short aliases like 'T4' are expanded to full Vertex AI enum labels."""
+
+    def test_short_alias_t4(self):
+        assert _normalize_accelerator_type("T4") == "NVIDIA_TESLA_T4"
+
+    def test_short_alias_case_insensitive(self):
+        assert _normalize_accelerator_type("t4") == "NVIDIA_TESLA_T4"
+        assert _normalize_accelerator_type("v100") == "NVIDIA_TESLA_V100"
+
+    def test_full_name_passthrough(self):
+        assert _normalize_accelerator_type("NVIDIA_TESLA_T4") == "NVIDIA_TESLA_T4"
+
+    def test_none_string_returns_none(self):
+        assert _normalize_accelerator_type("None") is None
+        assert _normalize_accelerator_type("none") is None
+        assert _normalize_accelerator_type("NONE") is None
+
+    def test_unknown_type_passthrough(self):
+        assert _normalize_accelerator_type("TPU_V3") == "TPU_V3"
+
+    def test_l4_alias(self):
+        assert _normalize_accelerator_type("L4") == "NVIDIA_L4"
+
+    def test_a100_alias(self):
+        assert _normalize_accelerator_type("A100") == "NVIDIA_TESLA_A100"
+
 
 # ── _hpt_arg_to_override ────────────────────────────────────────────────────
 

--- a/website/docs/training/sweeps.md
+++ b/website/docs/training/sweeps.md
@@ -166,6 +166,8 @@ python -m environments.shared.scripts.sweep launch \
   --accelerator-type None
 ```
 
+Short accelerator aliases are accepted: `T4` → `NVIDIA_TESLA_T4`, `V100` → `NVIDIA_TESLA_V100`, `A100` → `NVIDIA_TESLA_A100`, `L4` → `NVIDIA_L4`. Use `None` for CPU-only.
+
 This runs 5 trials (3 in parallel) at 100K steps each. Stage 1 (balance) is CPU-bound and doesn't need a GPU. Once you're confident the pipeline works, scale up to 20 trials at 500K steps with `--search-space-file configs/sweep_ppo.json`.
 
 ### Full Stage 1 sweep


### PR DESCRIPTION
Vertex AI requires full enum labels (e.g. NVIDIA_TESLA_T4) but users commonly pass short names like "T4". Added _normalize_accelerator_type() to map short aliases to full labels and properly handle "None" for CPU-only runs by omitting accelerator fields from machine_spec entirely.