### PR TITLE
Fix job_name fallback to use local variable instead of attribute

### DIFF
--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -303,7 +303,7 @@ def _submit_stage_sweep(
     try:
         job_name = hpt_job.resource_name
     except RuntimeError:
-        job_name = hpt_job.display_name
+        job_name = display_name
     logger.info("Job submitted: %s", job_name)
     logger.info("Monitor at: https://console.cloud.google.com/vertex-ai/training/hyperparameter-tuning-jobs")
     logger.info("Results will be written to: gs://%s/sweeps/%s/stage%d/", bucket, species, stage)


### PR DESCRIPTION
## Summary
Fixed a bug in the hyperparameter tuning job submission logic where the fallback job name assignment was incorrectly referencing a non-existent attribute instead of the local variable.

## Changes
- Changed `job_name = hpt_job.display_name` to `job_name = display_name` in the exception handler of `_submit_stage_sweep()`
- This ensures the function uses the `display_name` parameter passed to the function rather than attempting to access an attribute that may not exist on the `hpt_job` object

## Details
When a `RuntimeError` is raised while accessing `hpt_job.resource_name`, the code falls back to assigning a job name. The fix corrects this fallback to use the `display_name` variable that is already available in the function scope, which is the intended behavior for this error case.