### PR TITLE
Improve job creation timeout handling and error reporting

### DIFF
--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -289,9 +289,7 @@ def _submit_stage_sweep(
             for _tick in range(_CREATION_TIMEOUT):
                 # Check if the background thread raised an exception.
                 # Try multiple attribute names across SDK versions.
-                _future = getattr(hpt_job, "_latest_future", None) or getattr(
-                    hpt_job, "_blocking_future", None
-                )
+                _future = getattr(hpt_job, "_latest_future", None) or getattr(hpt_job, "_blocking_future", None)
                 if _future is not None and _future.done():
                     # .result() re-raises any exception from the thread.
                     _future.result()
@@ -305,9 +303,7 @@ def _submit_stage_sweep(
                 # Do a final check on the SDK future — if the background
                 # thread failed, surface the real error instead of a
                 # generic timeout message.
-                _future = getattr(hpt_job, "_latest_future", None) or getattr(
-                    hpt_job, "_blocking_future", None
-                )
+                _future = getattr(hpt_job, "_latest_future", None) or getattr(hpt_job, "_blocking_future", None)
                 if _future is not None:
                     try:
                         _future.result(timeout=5)

--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -285,10 +285,13 @@ def _submit_stage_sweep(
             # create the job resource.  Poll resource_name and also check
             # the SDK future for errors so we surface the real exception
             # (e.g. permission denied) instead of timing out silently.
-            _CREATION_TIMEOUT = 120
+            _CREATION_TIMEOUT = 300
             for _tick in range(_CREATION_TIMEOUT):
                 # Check if the background thread raised an exception.
-                _future = getattr(hpt_job, "_latest_future", None)
+                # Try multiple attribute names across SDK versions.
+                _future = getattr(hpt_job, "_latest_future", None) or getattr(
+                    hpt_job, "_blocking_future", None
+                )
                 if _future is not None and _future.done():
                     # .result() re-raises any exception from the thread.
                     _future.result()
@@ -299,10 +302,23 @@ def _submit_stage_sweep(
                 except RuntimeError:
                     time.sleep(1)
             else:
+                # Do a final check on the SDK future — if the background
+                # thread failed, surface the real error instead of a
+                # generic timeout message.
+                _future = getattr(hpt_job, "_latest_future", None) or getattr(
+                    hpt_job, "_blocking_future", None
+                )
+                if _future is not None:
+                    try:
+                        _future.result(timeout=5)
+                    except Exception as _real_exc:
+                        raise _real_exc
                 raise RuntimeError(
                     f"Job '{display_name}' resource was not created within "
-                    f"{_CREATION_TIMEOUT}s — check Vertex AI permissions and "
-                    f"project configuration."
+                    f"{_CREATION_TIMEOUT}s. The SDK background thread did not "
+                    f"surface an error (future={'found' if _future is not None else 'not found'}). "
+                    f"Check Vertex AI permissions, project configuration, and "
+                    f"that the service account has roles/aiplatform.user."
                 )
 
             break  # success — exit retry loop


### PR DESCRIPTION
## Summary
Enhanced the job creation timeout logic in the sweep submission script to better handle SDK version differences and surface underlying errors instead of generic timeout messages.

## Key Changes
- **Increased creation timeout** from 120s to 300s to allow more time for job resource creation
- **Added SDK version compatibility** by checking both `_latest_future` and `_blocking_future` attributes, as different SDK versions use different attribute names
- **Improved error reporting** by performing a final check on the SDK future before raising a timeout error, allowing real exceptions from the background thread to be surfaced instead of a generic timeout message
- **Enhanced error message** to include:
  - Whether a future was found or not
  - Explicit mention of the `roles/aiplatform.user` role requirement
  - Clarification that the timeout occurred because the SDK background thread didn't surface an error

## Implementation Details
The changes ensure that if a background thread in the SDK encounters an actual error (e.g., permission denied), that error is re-raised to the user rather than being masked by a generic "resource was not created within Xs" timeout message. This makes debugging permission and configuration issues significantly easier.