### PR TITLE
Add support for restart job and async script execution

### DIFF
--- a/environments/shared/scripts/sweep/__init__.py
+++ b/environments/shared/scripts/sweep/__init__.py
@@ -2,7 +2,8 @@
 
 This package provides three modes:
 
-  **launch**      — Submit a Vertex AI Hyperparameter Tuning job for one stage.
+  **launch**      — Submit a Vertex AI Hyperparameter Tuning job for one stage
+                    and poll until completion (supports ``--resume``).
   **launch-all**  — Submit Stage 1, 2, and 3 HPT jobs sequentially.
   **trial**       — Entry point used by each Vertex AI HPT trial worker.
 

--- a/environments/shared/scripts/sweep/__main__.py
+++ b/environments/shared/scripts/sweep/__main__.py
@@ -99,6 +99,32 @@ def _build_parser() -> argparse.ArgumentParser:
             "loaded automatically from <load_path>_vecnorm.pkl if present."
         ),
     )
+    launch.add_argument(
+        "--resume",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Resume from a previous run if a sweep state file exists "
+            "(default: --resume). Use --no-resume to start fresh."
+        ),
+    )
+    launch.add_argument(
+        "--stage-timeout",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Maximum wall-clock seconds to wait for the HPT job to complete. "
+            "If exceeded the job keeps running in the cloud — re-run with "
+            "--resume to reconnect."
+        ),
+    )
+    launch.add_argument(
+        "--poll-interval",
+        type=int,
+        default=120,
+        help="Seconds between job status checks while waiting for completion (default: 120)",
+    )
 
     # ── launch-all mode (all stages, sequential) ──────────────────────────────
     launch_all = subparsers.add_parser(

--- a/environments/shared/scripts/sweep/__main__.py
+++ b/environments/shared/scripts/sweep/__main__.py
@@ -125,6 +125,15 @@ def _build_parser() -> argparse.ArgumentParser:
         default=120,
         help="Seconds between job status checks while waiting for completion (default: 120)",
     )
+    launch.add_argument(
+        "--restart-job-on-worker-restart",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Restart the job if a worker is preempted (e.g. when using spot VMs). "
+            "Maps to Vertex AI's restart_job_on_worker_restart parameter."
+        ),
+    )
 
     # ── launch-all mode (all stages, sequential) ──────────────────────────────
     launch_all = subparsers.add_parser(
@@ -232,6 +241,15 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         default=120,
         help="Seconds between job status checks while waiting for completion (default: 120)",
+    )
+    launch_all.add_argument(
+        "--restart-job-on-worker-restart",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Restart the job if a worker is preempted (e.g. when using spot VMs). "
+            "Maps to Vertex AI's restart_job_on_worker_restart parameter."
+        ),
     )
 
     return parser

--- a/environments/shared/scripts/sweep/orchestration.py
+++ b/environments/shared/scripts/sweep/orchestration.py
@@ -162,8 +162,7 @@ def launch_sweep(args: argparse.Namespace) -> None:
 
                 if status == "completed":
                     logger.info(
-                        "Stage %d already completed (best_reward=%.4f). Nothing to do. "
-                        "Use --no-resume to start fresh.",
+                        "Stage %d already completed (best_reward=%.4f). Nothing to do. Use --no-resume to start fresh.",
                         stage,
                         prev_stage_data.get("best_mean_reward", 0),
                     )
@@ -181,7 +180,9 @@ def launch_sweep(args: argparse.Namespace) -> None:
 
                     try:
                         prev_job = aiplatform.HyperparameterTuningJob.get(prev_resource)
-                        prev_state_name = prev_job.state.name if hasattr(prev_job.state, "name") else str(prev_job.state)
+                        prev_state_name = (
+                            prev_job.state.name if hasattr(prev_job.state, "name") else str(prev_job.state)
+                        )
 
                         if "SUCCEEDED" in prev_state_name:
                             logger.info("Previous job already completed successfully.")

--- a/environments/shared/scripts/sweep/orchestration.py
+++ b/environments/shared/scripts/sweep/orchestration.py
@@ -86,6 +86,10 @@ def launch_sweep(args: argparse.Namespace) -> None:
 
     Each trial runs ``sweep.py trial`` inside the Docker container. The
     HPT service injects the trial's parameter values as additional CLI args.
+
+    The job is submitted and then polled until completion (or ``--stage-timeout``
+    is reached).  State is persisted to a local JSON file and GCS so the job
+    can be reconnected to later by re-running the same command with ``--resume``.
     """
     try:
         from google.cloud import aiplatform
@@ -103,29 +107,339 @@ def launch_sweep(args: argparse.Namespace) -> None:
         credentials=credentials,
     )
 
+    stage = args.stage
+    poll_interval = getattr(args, "poll_interval", 120)
+    stage_timeout = getattr(args, "stage_timeout", None)
+    resume = getattr(args, "resume", True)
+
     # Load search space: inline JSON > file > algorithm default
     resolved = _resolve_search_space(args.search_space, args.search_space_file, args.algorithm)
-    search_space = _search_space_for_stage(resolved, args.stage)
+    search_space = _search_space_for_stage(resolved, stage)
 
-    _submit_stage_sweep(
-        aiplatform=aiplatform,
-        hpt_module=hpt,
-        species=args.species,
-        stage=args.stage,
-        algorithm=args.algorithm,
-        timesteps=args.timesteps,
-        n_envs=args.n_envs,
-        trials=args.trials,
-        parallel=args.parallel,
-        bucket=args.bucket,
-        image=args.image,
-        machine_type=args.machine_type,
-        accelerator_type=args.accelerator_type,
-        accelerator_count=args.accelerator_count,
-        search_space=search_space,
-        load_path=args.load,
-        wandb=args.wandb,
-    )
+    # ── State key used for single-stage launches ──────────────────────────
+    # We store state under a stage-specific key so multiple single-stage
+    # launches for different stages don't overwrite each other.
+    state_stage_key = str(stage)
+
+    # ── CLI args snapshot ─────────────────────────────────────────────────
+    cli_args_snapshot: dict = {
+        "mode": "launch",
+        "stage": stage,
+        "trials": args.trials,
+        "parallel": args.parallel,
+        "timesteps": args.timesteps,
+        "n_envs": args.n_envs,
+        "machine_type": args.machine_type,
+        "accelerator_type": args.accelerator_type,
+        "accelerator_count": args.accelerator_count,
+        "image": args.image,
+        "bucket": args.bucket,
+        "project": args.project,
+        "location": args.location,
+    }
+
+    sweep_state: dict = {
+        "species": args.species,
+        "algorithm": args.algorithm,
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "cli_args": cli_args_snapshot,
+        "stages": {},
+    }
+
+    partial_rows: list[dict] = []
+    resume_run = 0
+    hpt_job = None
+    job_resource_name = None
+    reconnected = False
+
+    # ── Resume: restore state from a previous run ─────────────────────────
+    if resume:
+        prev_state = _load_sweep_state(args.species, args.algorithm, bucket=args.bucket, project=args.project)
+        if prev_state and prev_state.get("stages"):
+            prev_stage_data = prev_state["stages"].get(state_stage_key)
+            if prev_stage_data:
+                status = prev_stage_data.get("status")
+
+                if status == "completed":
+                    logger.info(
+                        "Stage %d already completed (best_reward=%.4f). Nothing to do. "
+                        "Use --no-resume to start fresh.",
+                        stage,
+                        prev_stage_data.get("best_mean_reward", 0),
+                    )
+                    return
+
+                if status == "in_progress" and prev_stage_data.get("job_resource_name"):
+                    prev_resource = prev_stage_data["job_resource_name"]
+                    logger.info("Attempting to reconnect to previous job: %s", prev_resource)
+
+                    # Restore partial rows from earlier runs
+                    prior_partial = prev_stage_data.get("prior_partial_rows", [])
+                    if prior_partial:
+                        partial_rows = list(prior_partial)
+                        logger.info("Restored %d prior partial rows.", len(prior_partial))
+
+                    try:
+                        prev_job = aiplatform.HyperparameterTuningJob.get(prev_resource)
+                        prev_state_name = prev_job.state.name if hasattr(prev_job.state, "name") else str(prev_job.state)
+
+                        if "SUCCEEDED" in prev_state_name:
+                            logger.info("Previous job already completed successfully.")
+                            hpt_job = prev_job
+                            job_resource_name = prev_resource
+                            reconnected = True
+                        elif any(s in prev_state_name for s in ("RUNNING", "QUEUED", "PENDING")):
+                            logger.info("Previous job still running (state=%s) — resuming poll.", prev_state_name)
+                            hpt_job = _wait_for_job(
+                                prev_job,
+                                aiplatform,
+                                poll_interval=poll_interval,
+                                timeout=stage_timeout,
+                            )
+                            job_resource_name = prev_resource
+                            reconnected = True
+                        else:
+                            # Failed/cancelled — collect partial results
+                            logger.warning(
+                                "Previous job in state %s — collecting partial results.",
+                                prev_state_name,
+                            )
+                            try:
+                                from environments.shared.config import load_stage_config as _lsc_ip
+
+                                _sc_ip = _lsc_ip(args.species, stage)
+                                _ip_rows = _collect_trial_results(prev_job, stage, _sc_ip)
+                                _ip_rows = [r for r in _ip_rows if r.get("best_mean_reward") is not None]
+                                if _ip_rows:
+                                    _ip_out = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
+                                    ip_resume = prev_stage_data.get("resume_run", 0)
+                                    if ip_resume:
+                                        _ip_out = f"{_ip_out}_r{ip_resume}"
+                                    for row in _ip_rows:
+                                        row["model_path"] = f"{_ip_out}/{row['trial_id']}/models/best_model.zip"
+                                    partial_rows = _dedup_trial_rows(partial_rows + _ip_rows)
+                                    resume_run = ip_resume + 1
+                                    logger.info(
+                                        "Recovered %d trials from previous job (%d total partial).",
+                                        len(_ip_rows),
+                                        len(partial_rows),
+                                    )
+                            except Exception as ip_collect_exc:
+                                logger.warning(
+                                    "Could not collect partial results from previous job: %s",
+                                    ip_collect_exc,
+                                )
+                    except Exception as reconnect_exc:
+                        logger.warning(
+                            "Could not reconnect to previous job %s: %s. Will submit a new job.",
+                            prev_resource,
+                            reconnect_exc,
+                        )
+
+                elif status == "partial":
+                    partial_rows = [
+                        r for r in prev_stage_data.get("trial_rows", []) if r.get("best_mean_reward") is not None
+                    ]
+                    if partial_rows:
+                        resume_run = prev_stage_data.get("resume_run", 0) + 1
+                        logger.info(
+                            "Resuming stage %d: %d partial trials recovered from previous run.",
+                            stage,
+                            len(partial_rows),
+                        )
+
+            # Preserve state for other stages so we don't clobber them
+            sweep_state = prev_state
+            sweep_state["cli_args"] = cli_args_snapshot
+
+    remaining_trials = args.trials - len(partial_rows)
+
+    # ── Submit new job if needed ──────────────────────────────────────────
+    try:
+        if not reconnected and remaining_trials > 0:
+            if partial_rows:
+                logger.info(
+                    "Stage %d: %d trials recovered, %d remaining.",
+                    stage,
+                    len(partial_rows),
+                    remaining_trials,
+                )
+
+            hpt_job = _submit_stage_sweep(
+                aiplatform=aiplatform,
+                hpt_module=hpt,
+                species=args.species,
+                stage=stage,
+                algorithm=args.algorithm,
+                timesteps=args.timesteps,
+                n_envs=args.n_envs,
+                trials=remaining_trials,
+                parallel=args.parallel,
+                bucket=args.bucket,
+                image=args.image,
+                machine_type=args.machine_type,
+                accelerator_type=args.accelerator_type,
+                accelerator_count=args.accelerator_count,
+                search_space=search_space,
+                load_path=args.load,
+                wandb=args.wandb,
+                resume_run=resume_run,
+            )
+            job_resource_name = getattr(hpt_job, "resource_name", None)
+
+            # Save in-progress state immediately so the job can be
+            # reconnected if the process is interrupted.
+            sweep_state["stages"][state_stage_key] = {
+                "status": "in_progress",
+                "job_resource_name": job_resource_name,
+                "load_path": args.load,
+                "resume_run": resume_run,
+                "prior_partial_rows": partial_rows,
+                "submitted_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            }
+            _save_sweep_state(
+                sweep_state,
+                args.species,
+                args.algorithm,
+                bucket=args.bucket,
+                project=args.project,
+            )
+
+            # Poll until the job completes
+            hpt_job = _wait_for_job(
+                hpt_job,
+                aiplatform,
+                poll_interval=poll_interval,
+                timeout=stage_timeout,
+            )
+
+        # ── Collect results ───────────────────────────────────────────────
+        if hpt_job is not None:
+            from environments.shared.config import load_stage_config as _load_stage_config
+
+            stage_config = _load_stage_config(args.species, stage)
+            new_rows = _collect_trial_results(hpt_job, stage, stage_config)
+
+            output_base = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
+            if resume_run:
+                output_base = f"{output_base}_r{resume_run}"
+            for row in new_rows:
+                row["model_path"] = f"{output_base}/{row['trial_id']}/models/best_model.zip"
+
+            stage_rows = _dedup_trial_rows(partial_rows + new_rows)
+        elif remaining_trials <= 0:
+            logger.info(
+                "Stage %d: all %d trials already completed in previous run.",
+                stage,
+                len(partial_rows),
+            )
+            stage_rows = list(partial_rows)
+        else:
+            stage_rows = list(partial_rows)
+
+        # Identify the best trial
+        best_row: dict | None = None
+        best_model_path: str | None = None
+        try:
+            best_model_path, best_row = _best_trial_model_path(stage_rows, args.bucket, args.species, stage)
+        except SweepStageError:
+            # Fall back to best trial regardless of gate status
+            try:
+                best_model_path, best_row = _best_trial_model_path_any(stage_rows, args.bucket, args.species, stage)
+            except SweepStageError:
+                logger.warning("No trials reported a valid reward for stage %d.", stage)
+
+        if best_row is not None:
+            logger.info(
+                "Stage %d best trial: id=%s  reward=%.4f  passed=%s",
+                stage,
+                best_row["trial_id"],
+                best_row.get("best_mean_reward", 0),
+                best_row.get("stage_passed", False),
+            )
+
+        # Save completed state
+        sweep_state["stages"][state_stage_key] = {
+            "status": "completed",
+            "job_resource_name": job_resource_name,
+            "best_trial_id": best_row["trial_id"] if best_row else None,
+            "best_mean_reward": best_row.get("best_mean_reward") if best_row else None,
+            "best_model_path": best_model_path,
+            "completed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "trial_rows": stage_rows,
+        }
+        _save_sweep_state(
+            sweep_state,
+            args.species,
+            args.algorithm,
+            bucket=args.bucket,
+            project=args.project,
+        )
+
+        # Write results CSV
+        csv_path = Path(f"sweep_results_{args.species}_{args.algorithm}_stage{stage}.csv")
+        write_results_csv(stage_rows, csv_path)
+
+        # Upload CSV to GCS
+        try:
+            from google.cloud import storage as _gcs
+
+            _gcs_client = _gcs.Client(project=args.project)
+            _gcs_bucket = _gcs_client.bucket(args.bucket)
+            gcs_csv_path = f"sweeps/{args.species}/{csv_path.name}"
+            _gcs_bucket.blob(gcs_csv_path).upload_from_filename(str(csv_path))
+            logger.info("Sweep CSV uploaded to: gs://%s/%s", args.bucket, gcs_csv_path)
+        except Exception as exc:
+            logger.warning("Failed to upload sweep CSV to GCS: %s. Local copy at: %s", exc, csv_path)
+
+        logger.info("Stage %d sweep complete.", stage)
+
+    except Exception as exc:
+        if isinstance(exc, (SweepStageError, TimeoutError)) or _is_retryable_gcp_error(exc):
+            # Partial trial recovery
+            if isinstance(exc, _SweepJobFailed) and exc.hpt_job is not None:
+                try:
+                    from environments.shared.config import load_stage_config as _lsc
+
+                    _sc = _lsc(args.species, stage)
+                    _new_partial = _collect_trial_results(exc.hpt_job, stage, _sc)
+                    _new_partial = [r for r in _new_partial if r.get("best_mean_reward") is not None]
+                    if _new_partial:
+                        _out = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
+                        if resume_run:
+                            _out = f"{_out}_r{resume_run}"
+                        for row in _new_partial:
+                            row["model_path"] = f"{_out}/{row['trial_id']}/models/best_model.zip"
+
+                        all_partial = _dedup_trial_rows(partial_rows + _new_partial)
+                        sweep_state["stages"][state_stage_key] = {
+                            "status": "partial",
+                            "job_resource_name": getattr(exc.hpt_job, "resource_name", None),
+                            "trial_rows": all_partial,
+                            "resume_run": resume_run,
+                        }
+                        logger.info(
+                            "Recovered %d completed trials from failed job (total partial: %d).",
+                            len(_new_partial),
+                            len(all_partial),
+                        )
+                except Exception as collect_exc:
+                    logger.warning("Could not collect partial trial results: %s", collect_exc)
+
+            logger.error(
+                "Stage %d failed: %s. Saving progress — re-run the same command to resume.",
+                stage,
+                exc,
+            )
+            _save_sweep_state(
+                sweep_state,
+                args.species,
+                args.algorithm,
+                bucket=args.bucket,
+                project=args.project,
+            )
+            sys.exit(1)
+        raise
 
 
 def launch_all_stages(args: argparse.Namespace) -> None:

--- a/environments/shared/scripts/sweep/orchestration.py
+++ b/environments/shared/scripts/sweep/orchestration.py
@@ -285,6 +285,7 @@ def launch_sweep(args: argparse.Namespace) -> None:
                 load_path=args.load,
                 wandb=args.wandb,
                 resume_run=resume_run,
+                restart_job_on_worker_restart=getattr(args, "restart_job_on_worker_restart", False),
             )
             job_resource_name = getattr(hpt_job, "resource_name", None)
 
@@ -766,6 +767,7 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                     fixed_trial_args=fixed_trial_args,
                     wandb=args.wandb,
                     resume_run=resume_run,
+                    restart_job_on_worker_restart=getattr(args, "restart_job_on_worker_restart", False),
                 )
                 job_resource_name = getattr(hpt_job, "resource_name", None)
 

--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -179,6 +179,7 @@ def _submit_stage_sweep(
     fixed_trial_args: list[str] | None = None,
     wandb: bool = False,
     resume_run: int = 0,
+    restart_job_on_worker_restart: bool = False,
 ):
     """Build and submit a single-stage HPT job. Returns the job object.
 
@@ -191,6 +192,9 @@ def _submit_stage_sweep(
             positive integer so the new job writes to a separate GCS
             sub-directory (``stage{N}_r{resume_run}``) to avoid overwriting
             checkpoints from previous runs.
+        restart_job_on_worker_restart: If ``True``, Vertex AI will
+            automatically restart the job when a worker is preempted
+            (e.g. spot/preemptible VMs).
     """
     parameter_spec = _build_parameter_spec(search_space, hpt_module)
     if not parameter_spec:
@@ -253,6 +257,8 @@ def _submit_stage_sweep(
         logger.info("    %-30s %s", k, v)
     if load_path:
         logger.info("  Warm-start model: %s", load_path)
+    if restart_job_on_worker_restart:
+        logger.info("  restart_job_on_worker_restart: enabled")
 
     custom_job = aiplatform.CustomJob(
         display_name=f"{display_name}-trial",
@@ -286,7 +292,10 @@ def _submit_stage_sweep(
         try:
             _CREATION_TIMEOUT = 300
             _executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            _future = _executor.submit(hpt_job.run, sync=True)
+            _run_kwargs: dict = {"sync": True}
+            if restart_job_on_worker_restart:
+                _run_kwargs["restart_job_on_worker_restart"] = True
+            _future = _executor.submit(lambda: hpt_job.run(**_run_kwargs))
 
             # Poll until the job resource is created (resource_name becomes
             # available) or the future raises an error.

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -935,6 +935,155 @@ class TestResolveSearchSpaceLogging:
 # ── _best_trial_model_path for stage 3 (no chain-forward needed) ──
 
 
+# ── restart_job_on_worker_restart ──────────────────────────────────
+
+
+class TestRestartJobOnWorkerRestart:
+    def test_restart_passed_to_run(self):
+        """restart_job_on_worker_restart=True is forwarded to hpt_job.run()."""
+        from environments.shared.scripts.sweep import _submit_stage_sweep
+
+        mock_aiplatform = MagicMock()
+        mock_hpt = MagicMock()
+
+        mock_job = MagicMock()
+        mock_aiplatform.HyperparameterTuningJob.return_value = mock_job
+        mock_aiplatform.CustomJob.return_value = MagicMock()
+
+        search_space = {"ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4, "scale": "log"}}
+
+        _submit_stage_sweep(
+            aiplatform=mock_aiplatform,
+            hpt_module=mock_hpt,
+            species="velociraptor",
+            stage=1,
+            algorithm="ppo",
+            timesteps=100000,
+            n_envs=4,
+            trials=5,
+            parallel=2,
+            bucket="test-bucket",
+            image="test-image",
+            machine_type="n1-standard-8",
+            accelerator_type="NVIDIA_TESLA_T4",
+            accelerator_count=1,
+            search_space=search_space,
+            restart_job_on_worker_restart=True,
+        )
+
+        mock_job.run.assert_called_once_with(sync=True, restart_job_on_worker_restart=True)
+
+    def test_restart_not_passed_when_false(self):
+        """restart_job_on_worker_restart=False (default) does not add the kwarg."""
+        from environments.shared.scripts.sweep import _submit_stage_sweep
+
+        mock_aiplatform = MagicMock()
+        mock_hpt = MagicMock()
+
+        mock_job = MagicMock()
+        mock_aiplatform.HyperparameterTuningJob.return_value = mock_job
+        mock_aiplatform.CustomJob.return_value = MagicMock()
+
+        search_space = {"ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4, "scale": "log"}}
+
+        _submit_stage_sweep(
+            aiplatform=mock_aiplatform,
+            hpt_module=mock_hpt,
+            species="velociraptor",
+            stage=1,
+            algorithm="ppo",
+            timesteps=100000,
+            n_envs=4,
+            trials=5,
+            parallel=2,
+            bucket="test-bucket",
+            image="test-image",
+            machine_type="n1-standard-8",
+            accelerator_type="NVIDIA_TESLA_T4",
+            accelerator_count=1,
+            search_space=search_space,
+        )
+
+        mock_job.run.assert_called_once_with(sync=True)
+
+    def test_cli_arg_parsed(self):
+        """--restart-job-on-worker-restart is parsed correctly."""
+        from environments.shared.scripts.sweep.__main__ import _build_parser
+
+        parser = _build_parser()
+
+        # launch mode
+        args = parser.parse_args(
+            [
+                "launch",
+                "--species",
+                "velociraptor",
+                "--project",
+                "test",
+                "--bucket",
+                "b",
+                "--image",
+                "img",
+                "--restart-job-on-worker-restart",
+            ]
+        )
+        assert args.restart_job_on_worker_restart is True
+
+        # launch mode with --no- prefix
+        args = parser.parse_args(
+            [
+                "launch",
+                "--species",
+                "velociraptor",
+                "--project",
+                "test",
+                "--bucket",
+                "b",
+                "--image",
+                "img",
+                "--no-restart-job-on-worker-restart",
+            ]
+        )
+        assert args.restart_job_on_worker_restart is False
+
+        # launch-all mode
+        args = parser.parse_args(
+            [
+                "launch-all",
+                "--species",
+                "velociraptor",
+                "--project",
+                "test",
+                "--bucket",
+                "b",
+                "--image",
+                "img",
+                "--restart-job-on-worker-restart",
+            ]
+        )
+        assert args.restart_job_on_worker_restart is True
+
+    def test_cli_default_is_false(self):
+        """Default value for --restart-job-on-worker-restart is False."""
+        from environments.shared.scripts.sweep.__main__ import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "launch",
+                "--species",
+                "velociraptor",
+                "--project",
+                "test",
+                "--bucket",
+                "b",
+                "--image",
+                "img",
+            ]
+        )
+        assert args.restart_job_on_worker_restart is False
+
+
 class TestBestTrialModelPathStage3:
     def test_stage3_best_trial_identified(self):
         rows = [


### PR DESCRIPTION
This pull request adds robust resume and recovery support to the single-stage sweep launch workflow, making it easier to reconnect to and recover from interrupted or failed Vertex AI Hyperparameter Tuning jobs. The changes introduce new CLI options for resuming runs, controlling polling intervals, and setting stage timeouts, and overhaul the orchestration logic to persist and restore sweep state, reconnect to existing jobs, and recover partial results.

**Resume and recovery workflow enhancements:**

* Added support for resuming single-stage sweep jobs via the new `--resume` flag, including logic to restore state, reconnect to running jobs, and recover partial trial results from previous runs. (`environments/shared/scripts/sweep/orchestration.py`, `environments/shared/scripts/sweep/__main__.py`) [[1]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9R110-R277) [[2]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9R287-R444) [[3]](diffhunk://#diff-84ddd430395d11b45c3ae7cb1d237a8f90dcf8b4bacd754a1d9366d36ab3aa2aR102-R127)

* Persisted detailed sweep state (including job resource name, partial/completed trial rows, resume run count, and CLI args snapshot) to local and GCS storage, enabling robust recovery and state tracking across runs. (`environments/shared/scripts/sweep/orchestration.py`)

**CLI improvements:**

* Added new CLI arguments to the `launch` mode: `--resume` (default true), `--stage-timeout`, and `--poll-interval`, giving users control over job resumption, polling frequency, and maximum wait time. (`environments/shared/scripts/sweep/__main__.py`)

**Documentation updates:**

* Updated the package docstring in `__init__.py` to clarify that `launch` now supports polling and resuming via `--resume`. (`environments/shared/scripts/sweep/__init__.py`)

**Result handling and output:**

* Improved result collection: deduplicates recovered and new trial rows, identifies best trial/model, writes results to CSV, and uploads the CSV to GCS. Handles partial recovery and error cases gracefully. (`environments/shared/scripts/sweep/orchestration.py`)

These changes significantly improve reliability and usability for long-running or interrupted sweep jobs, making it easier for users to resume, monitor, and recover their work.