### PR TITLE
Introduces a new "collect-results" command

### DIFF
--- a/environments/shared/scripts/sweep/__init__.py
+++ b/environments/shared/scripts/sweep/__init__.py
@@ -22,6 +22,7 @@ from .results import (
     _best_trial_model_path,
     _best_trial_model_path_any,
     _collect_trial_results,
+    collect_results_from_disk,
     plot_sweep_results,
     write_results_csv,
 )
@@ -47,6 +48,7 @@ __all__ = [
     "_best_trial_model_path",
     "_best_trial_model_path_any",
     "_collect_trial_results",
+    "collect_results_from_disk",
     "_hpt_arg_to_override",
     "_is_per_stage",
     "_is_retryable_gcp_error",

--- a/environments/shared/scripts/sweep/__main__.py
+++ b/environments/shared/scripts/sweep/__main__.py
@@ -11,6 +11,7 @@ if _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
 
 from .orchestration import launch_all_stages, launch_sweep
+from .results import collect_results_from_disk, write_results_csv
 from .trial import run_trial
 
 logging.basicConfig(
@@ -277,6 +278,53 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # ── collect-results mode ────────────────────────────────────────────────
+    collect = subparsers.add_parser(
+        "collect-results",
+        help="Scan trial directories for metrics.json and produce a combined CSV",
+    )
+    collect.add_argument(
+        "output_dir",
+        type=str,
+        help=(
+            "Root directory containing stage sub-directories with trial results. "
+            "For sweeps: .../sweeps/<species>  For curriculum: .../curriculum_<timestamp>"
+        ),
+    )
+    collect.add_argument(
+        "--csv",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Output CSV path (default: <output_dir>/collected_results.csv)",
+    )
+    collect.add_argument(
+        "--species",
+        type=str,
+        default=None,
+        help="Species name (used in log messages and plot titles)",
+    )
+    collect.add_argument(
+        "--algorithm",
+        type=str,
+        default=None,
+        help="Algorithm name (used in plot titles when --plot is set)",
+    )
+    collect.add_argument(
+        "--stages",
+        type=int,
+        nargs="+",
+        default=None,
+        metavar="N",
+        help="Only collect results for these stage numbers (default: all)",
+    )
+    collect.add_argument(
+        "--plot",
+        action="store_true",
+        default=False,
+        help="Generate visualisation graphs alongside the CSV",
+    )
+
     return parser
 
 
@@ -295,6 +343,26 @@ def main() -> None:
         if extra_args:
             logger.warning("Ignoring unexpected args in launch-all mode: %s", extra_args)
         launch_all_stages(args)
+    elif args.mode == "collect-results":
+        if extra_args:
+            logger.warning("Ignoring unexpected args in collect-results mode: %s", extra_args)
+        rows = collect_results_from_disk(
+            args.output_dir,
+            species=args.species,
+            stages=args.stages,
+        )
+        if not rows:
+            logger.error("No results found — nothing to write.")
+            sys.exit(1)
+        csv_path = args.csv or str(Path(args.output_dir) / "collected_results.csv")
+        write_results_csv(rows, csv_path)
+        logger.info("Combined CSV written to: %s  (%d rows)", csv_path, len(rows))
+        if args.plot:
+            from .results import plot_sweep_results
+
+            species = args.species or Path(args.output_dir).name
+            algorithm = args.algorithm or "unknown"
+            plot_sweep_results(csv_path, species, algorithm)
     else:
         parser.print_help()
         sys.exit(1)

--- a/environments/shared/scripts/sweep/orchestration.py
+++ b/environments/shared/scripts/sweep/orchestration.py
@@ -224,13 +224,13 @@ def launch_sweep(args: argparse.Namespace) -> None:
                                 from environments.shared.config import load_stage_config as _lsc_ip
 
                                 _sc_ip = _lsc_ip(args.species, stage)
-                                _ip_rows = _collect_trial_results(prev_job, stage, _sc_ip)
+                                _ip_out = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
+                                ip_resume = prev_stage_data.get("resume_run", 0)
+                                if ip_resume:
+                                    _ip_out = f"{_ip_out}_r{ip_resume}"
+                                _ip_rows = _collect_trial_results(prev_job, stage, _sc_ip, output_base=_ip_out)
                                 _ip_rows = [r for r in _ip_rows if r.get("best_mean_reward") is not None]
                                 if _ip_rows:
-                                    _ip_out = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
-                                    ip_resume = prev_stage_data.get("resume_run", 0)
-                                    if ip_resume:
-                                        _ip_out = f"{_ip_out}_r{ip_resume}"
                                     for row in _ip_rows:
                                         row["model_path"] = f"{_ip_out}/{row['trial_id']}/models/best_model.zip"
                                     partial_rows = _dedup_trial_rows(partial_rows + _ip_rows)
@@ -337,11 +337,11 @@ def launch_sweep(args: argparse.Namespace) -> None:
             from environments.shared.config import load_stage_config as _load_stage_config
 
             stage_config = _load_stage_config(args.species, stage)
-            new_rows = _collect_trial_results(hpt_job, stage, stage_config)
 
             output_base = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
             if resume_run:
                 output_base = f"{output_base}_r{resume_run}"
+            new_rows = _collect_trial_results(hpt_job, stage, stage_config, output_base=output_base)
             for row in new_rows:
                 row["model_path"] = f"{output_base}/{row['trial_id']}/models/best_model.zip"
 
@@ -431,12 +431,12 @@ def launch_sweep(args: argparse.Namespace) -> None:
                     from environments.shared.config import load_stage_config as _lsc
 
                     _sc = _lsc(args.species, stage)
-                    _new_partial = _collect_trial_results(exc.hpt_job, stage, _sc)
+                    _out = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
+                    if resume_run:
+                        _out = f"{_out}_r{resume_run}"
+                    _new_partial = _collect_trial_results(exc.hpt_job, stage, _sc, output_base=_out)
                     _new_partial = [r for r in _new_partial if r.get("best_mean_reward") is not None]
                     if _new_partial:
-                        _out = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
-                        if resume_run:
-                            _out = f"{_out}_r{resume_run}"
                         for row in _new_partial:
                             row["model_path"] = f"{_out}/{row['trial_id']}/models/best_model.zip"
 
@@ -735,13 +735,13 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                             from environments.shared.config import load_stage_config as _lsc_ip
 
                             _sc_ip = _lsc_ip(args.species, stage)
-                            _ip_rows = _collect_trial_results(prev_job, stage, _sc_ip)
+                            _ip_out = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
+                            ip_resume = in_progress_data.get("resume_run", 0)
+                            if ip_resume:
+                                _ip_out = f"{_ip_out}_r{ip_resume}"
+                            _ip_rows = _collect_trial_results(prev_job, stage, _sc_ip, output_base=_ip_out)
                             _ip_rows = [r for r in _ip_rows if r.get("best_mean_reward") is not None]
                             if _ip_rows:
-                                _ip_out = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
-                                ip_resume = in_progress_data.get("resume_run", 0)
-                                if ip_resume:
-                                    _ip_out = f"{_ip_out}_r{ip_resume}"
                                 for row in _ip_rows:
                                     row["model_path"] = f"{_ip_out}/{row['trial_id']}/models/best_model.zip"
                                 partial_rows = _dedup_trial_rows(partial_rows + _ip_rows)
@@ -834,7 +834,6 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                 from environments.shared.config import load_stage_config as _load_stage_config
 
                 stage_config = _load_stage_config(args.species, stage)
-                new_rows = _collect_trial_results(hpt_job, stage, stage_config)
 
                 # Tag new rows with model_path so _best_trial_model_path can
                 # locate the correct checkpoint even when trials span multiple
@@ -842,6 +841,7 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                 output_base = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
                 if resume_run:
                     output_base = f"{output_base}_r{resume_run}"
+                new_rows = _collect_trial_results(hpt_job, stage, stage_config, output_base=output_base)
                 for row in new_rows:
                     row["model_path"] = f"{output_base}/{row['trial_id']}/models/best_model.zip"
 
@@ -947,15 +947,15 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                         from environments.shared.config import load_stage_config as _lsc
 
                         _sc = _lsc(args.species, stage)
-                        _new_partial = _collect_trial_results(exc.hpt_job, stage, _sc)
+                        # Tag each row with its model_path for correct
+                        # checkpoint resolution on resume.
+                        _out = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
+                        if resume_run:
+                            _out = f"{_out}_r{resume_run}"
+                        _new_partial = _collect_trial_results(exc.hpt_job, stage, _sc, output_base=_out)
                         # Keep only trials that actually reported metrics
                         _new_partial = [r for r in _new_partial if r.get("best_mean_reward") is not None]
                         if _new_partial:
-                            # Tag each row with its model_path for correct
-                            # checkpoint resolution on resume.
-                            _out = f"/gcs/{args.bucket}/sweeps/{args.species}/stage{stage}"
-                            if resume_run:
-                                _out = f"{_out}_r{resume_run}"
                             for row in _new_partial:
                                 row["model_path"] = f"{_out}/{row['trial_id']}/models/best_model.zip"
 

--- a/environments/shared/scripts/sweep/results.py
+++ b/environments/shared/scripts/sweep/results.py
@@ -410,6 +410,160 @@ def plot_sweep_results(csv_path: str | Path, species: str, algorithm: str, save_
         logger.info("No varying numeric hyperparameters found — skipping hyperparameter analysis graph")
 
 
+def collect_results_from_disk(
+    output_dir: str | Path,
+    species: str | None = None,
+    stages: list[int] | None = None,
+) -> list[dict]:
+    """Scan trial directories on disk and collect results into row dicts.
+
+    This is the offline equivalent of :func:`_collect_trial_results` — it
+    reads ``metrics.json`` sidecars directly from the filesystem without
+    needing a Vertex AI HPT job object.
+
+    Expected directory layout (one of)::
+
+        # Sweep layout: output_dir = .../sweeps/<species>
+        output_dir/stage1/<trial_id>/metrics.json
+        output_dir/stage2/<trial_id>/metrics.json
+
+        # Curriculum layout: output_dir = .../curriculum_<timestamp>
+        output_dir/stage1/metrics.json
+        output_dir/stage2/metrics.json
+
+    Each trial's ``stage_config.json`` (if present) is used to populate
+    curriculum thresholds and evaluate pass/fail status.
+
+    Args:
+        output_dir: Root directory containing stage sub-directories.
+        species: Species name (for logging only; optional).
+        stages: Restrict collection to these stage numbers.  Defaults to
+            all ``stage*`` sub-directories found.
+
+    Returns:
+        List of result dicts compatible with :func:`write_results_csv`.
+    """
+    output_dir = Path(output_dir)
+    if not output_dir.is_dir():
+        logger.error("Output directory does not exist: %s", output_dir)
+        return []
+
+    # Discover stage directories
+    stage_dirs: list[tuple[int, Path]] = []
+    for child in sorted(output_dir.iterdir()):
+        if child.is_dir() and child.name.startswith("stage"):
+            try:
+                stage_num = int(child.name.replace("stage", "").split("_")[0])
+            except ValueError:
+                continue
+            if stages and stage_num not in stages:
+                continue
+            stage_dirs.append((stage_num, child))
+
+    if not stage_dirs:
+        logger.warning("No stage directories found under %s", output_dir)
+        return []
+
+    rows: list[dict] = []
+    for stage_num, stage_path in stage_dirs:
+        # Load stage_config.json for thresholds (may be at the stage level
+        # or inside each trial directory — check the stage level first).
+        stage_config_path = stage_path / "stage_config.json"
+        stage_cfg: dict = {}
+        if stage_config_path.exists():
+            try:
+                with open(stage_config_path) as f:
+                    stage_cfg = json.load(f)
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Failed to read %s: %s", stage_config_path, exc)
+
+        cur = stage_cfg.get("curriculum", {})
+        reward_threshold = cur.get("min_avg_reward")
+        ep_length_threshold = cur.get("min_avg_episode_length")
+        forward_vel_threshold = cur.get("min_avg_forward_vel")
+        success_rate_threshold = cur.get("min_success_rate")
+
+        # Check if this is a single-trial (curriculum) layout where
+        # metrics.json sits directly in the stage directory.
+        direct_metrics = stage_path / "metrics.json"
+        if direct_metrics.exists():
+            trial_dirs = [(stage_path.name, stage_path)]
+        else:
+            # Sweep layout: each child is a trial directory.
+            trial_dirs = []
+            for td in sorted(stage_path.iterdir()):
+                if td.is_dir() and (td / "metrics.json").exists():
+                    trial_dirs.append((td.name, td))
+
+        for trial_id, trial_path in trial_dirs:
+            metrics = _load_trial_metrics(str(trial_path.parent), trial_path.name)
+            if not metrics:
+                logger.warning("Stage %d trial %s: no valid metrics.json", stage_num, trial_id)
+                continue
+
+            # Load per-trial stage_config.json if the stage-level one wasn't found.
+            if not stage_cfg:
+                per_trial_cfg_path = trial_path / "stage_config.json"
+                if per_trial_cfg_path.exists():
+                    try:
+                        with open(per_trial_cfg_path) as f:
+                            trial_cfg = json.load(f)
+                        cur = trial_cfg.get("curriculum", {})
+                        reward_threshold = cur.get("min_avg_reward")
+                        ep_length_threshold = cur.get("min_avg_episode_length")
+                        forward_vel_threshold = cur.get("min_avg_forward_vel")
+                        success_rate_threshold = cur.get("min_success_rate")
+                    except (json.JSONDecodeError, OSError):
+                        pass
+
+            best_reward = metrics.get("best_mean_reward")
+            row: dict = {
+                "trial_id": trial_id,
+                "stage": stage_num,
+                "best_mean_reward": best_reward,
+                "best_mean_episode_length": metrics.get("best_mean_episode_length"),
+                "last_mean_reward": metrics.get("last_mean_reward"),
+                "last_mean_episode_length": metrics.get("last_mean_episode_length"),
+                "reward_threshold": reward_threshold,
+                "ep_length_threshold": ep_length_threshold,
+                "forward_vel_threshold": forward_vel_threshold,
+                "success_rate_threshold": success_rate_threshold,
+            }
+
+            # Evaluate pass/fail using the same logic as _collect_trial_results.
+            passed = best_reward is not None
+            if best_reward is None:
+                passed = False
+            if reward_threshold is not None and (best_reward is None or best_reward < reward_threshold):
+                passed = False
+            if passed and ep_length_threshold is not None:
+                best_ep = metrics.get("best_mean_episode_length")
+                if best_ep is None or best_ep < ep_length_threshold:
+                    passed = False
+            if passed and forward_vel_threshold is not None:
+                fwd_vel = metrics.get("best_mean_forward_vel")
+                if fwd_vel is None or fwd_vel < forward_vel_threshold:
+                    passed = False
+            if passed and success_rate_threshold is not None:
+                sr = metrics.get("best_mean_success_rate")
+                if sr is None or sr < success_rate_threshold:
+                    passed = False
+            row["stage_passed"] = passed
+
+            rows.append(row)
+
+        logger.info(
+            "Stage %d: collected %d trial(s) from %s",
+            stage_num,
+            len([r for r in rows if r["stage"] == stage_num]),
+            stage_path,
+        )
+
+    species_label = species or output_dir.name
+    logger.info("Collected %d total rows for %s", len(rows), species_label)
+    return rows
+
+
 def _best_trial_model_path(stage_rows: list[dict], bucket: str, species: str, stage: int) -> tuple[str, dict]:
     """Return the GCS path of the best trial's best model and its result row.
 

--- a/environments/shared/scripts/sweep/results.py
+++ b/environments/shared/scripts/sweep/results.py
@@ -435,14 +435,14 @@ def _download_gcs_results(gcs_uri: str, local_dir: Path) -> Path:
         raise ValueError(f"Not a gs:// URI: {gcs_uri}")
 
     # Parse gs://bucket/prefix
-    without_scheme = gcs_uri[len("gs://"):]
+    without_scheme = gcs_uri[len("gs://") :]
     slash_idx = without_scheme.find("/")
     if slash_idx == -1:
         bucket_name = without_scheme
         prefix = ""
     else:
         bucket_name = without_scheme[:slash_idx]
-        prefix = without_scheme[slash_idx + 1:].rstrip("/")
+        prefix = without_scheme[slash_idx + 1 :].rstrip("/")
 
     client = _gcs.Client()
     bucket = client.bucket(bucket_name)
@@ -458,7 +458,7 @@ def _download_gcs_results(gcs_uri: str, local_dir: Path) -> Path:
             continue
 
         # Compute the relative path under the prefix.
-        rel_path = blob.name[len(blob_prefix):] if blob_prefix else blob.name
+        rel_path = blob.name[len(blob_prefix) :] if blob_prefix else blob.name
         local_path = local_dir / rel_path
         local_path.parent.mkdir(parents=True, exist_ok=True)
         blob.download_to_filename(str(local_path))

--- a/environments/shared/scripts/sweep/results.py
+++ b/environments/shared/scripts/sweep/results.py
@@ -1,5 +1,6 @@
 """Trial result collection, CSV export, and visualisation."""
 
+import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -9,16 +10,45 @@ from .constants import SweepStageError
 logger = logging.getLogger(__name__)
 
 
-def _collect_trial_results(hpt_job: Any, stage: int, stage_config: dict) -> list[dict]:
+def _load_trial_metrics(output_base: str, trial_id: str) -> dict[str, float]:
+    """Load auxiliary metrics from a trial's ``metrics.json`` sidecar on GCS.
+
+    The training code writes all computed metrics (episode lengths,
+    forward velocity, success rate, etc.) to ``<trial_dir>/metrics.json``
+    so they can be collected without being declared in the HPT
+    ``metric_spec``.
+
+    Returns an empty dict if the file is missing (e.g. trial crashed).
+    """
+    metrics_path = Path(f"{output_base}/{trial_id}/metrics.json")
+    if not metrics_path.exists():
+        logger.warning("  Trial %s: metrics.json not found at %s", trial_id, metrics_path)
+        return {}
+    try:
+        with open(metrics_path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("  Trial %s: failed to read metrics.json: %s", trial_id, exc)
+        return {}
+
+
+def _collect_trial_results(hpt_job: Any, stage: int, stage_config: dict, output_base: str) -> list[dict]:
     """Extract per-trial hyperparameters and outcomes from a completed HPT job.
+
+    The primary optimisation metric (``best_mean_reward``) is read from
+    the HPT trial's ``final_measurement``.  All auxiliary metrics are
+    read from the ``metrics.json`` sidecar written by the training code
+    to each trial's GCS output directory.
 
     Each returned dict contains:
 
     * ``trial_id`` — Vertex AI trial identifier
     * ``stage`` — curriculum stage number
     * one key per hyperparameter (e.g. ``ppo_learning_rate``)
-    * ``best_mean_reward`` — final metric reported by the trial
-    * ``best_mean_episode_length`` — episode length from the best eval
+    * ``best_mean_reward`` — primary HPT metric
+    * ``best_mean_episode_length`` — from ``metrics.json``
+    * ``last_mean_reward`` — from ``metrics.json``
+    * ``last_mean_episode_length`` — from ``metrics.json``
     * ``reward_threshold`` — ``min_avg_reward`` from the stage TOML config
     * ``ep_length_threshold`` — ``min_avg_episode_length`` from config
     * ``forward_vel_threshold`` — ``min_avg_forward_vel`` from config
@@ -38,16 +68,23 @@ def _collect_trial_results(hpt_job: Any, stage: int, stage_config: dict) -> list
             for param in trial.parameters:
                 row[param.parameter_id] = param.value
 
-        # Extract all reported metrics from the trial
-        metrics: dict[str, float | None] = {}
+        # Primary metric from HPT final_measurement
+        best_reward: float | None = None
         if trial.final_measurement and trial.final_measurement.metrics:
             for metric in trial.final_measurement.metrics:
-                metrics[metric.metric_id] = metric.value
+                if metric.metric_id == "best_mean_reward":
+                    best_reward = metric.value
 
-        best_reward = metrics.get("best_mean_reward")
-        best_ep_length = metrics.get("best_mean_episode_length")
-        last_reward = metrics.get("last_mean_reward")
-        last_ep_length = metrics.get("last_mean_episode_length")
+        # Auxiliary metrics from the JSON sidecar
+        aux = _load_trial_metrics(output_base, trial.id)
+        # Prefer HPT value for best_mean_reward (authoritative), fall
+        # back to sidecar if HPT somehow didn't capture it.
+        if best_reward is None:
+            best_reward = aux.get("best_mean_reward")
+
+        best_ep_length = aux.get("best_mean_episode_length")
+        last_reward = aux.get("last_mean_reward")
+        last_ep_length = aux.get("last_mean_episode_length")
 
         row["best_mean_reward"] = best_reward
         row["best_mean_episode_length"] = best_ep_length
@@ -73,12 +110,12 @@ def _collect_trial_results(hpt_job: Any, stage: int, stage_config: dict) -> list
                 passed = False
                 fail_reasons.append(f"ep_length {best_ep_length} < threshold {ep_length_threshold}")
         if passed and forward_vel_threshold is not None:
-            trial_fwd_vel = metrics.get("best_mean_forward_vel")
+            trial_fwd_vel = aux.get("best_mean_forward_vel")
             if trial_fwd_vel is None or trial_fwd_vel < forward_vel_threshold:
                 passed = False
                 fail_reasons.append(f"forward_vel {trial_fwd_vel} < threshold {forward_vel_threshold}")
         if passed and success_rate_threshold is not None:
-            trial_success_rate = metrics.get("best_mean_success_rate")
+            trial_success_rate = aux.get("best_mean_success_rate")
             if trial_success_rate is None or trial_success_rate < success_rate_threshold:
                 passed = False
                 fail_reasons.append(f"success_rate {trial_success_rate} < threshold {success_rate_threshold}")

--- a/environments/shared/scripts/sweep/results.py
+++ b/environments/shared/scripts/sweep/results.py
@@ -26,7 +26,7 @@ def _load_trial_metrics(output_base: str, trial_id: str) -> dict[str, float]:
         return {}
     try:
         with open(metrics_path) as f:
-            return json.load(f)
+            return dict(json.load(f))
     except (json.JSONDecodeError, OSError) as exc:
         logger.warning("  Trial %s: failed to read metrics.json: %s", trial_id, exc)
         return {}

--- a/environments/shared/scripts/sweep/results.py
+++ b/environments/shared/scripts/sweep/results.py
@@ -410,6 +410,70 @@ def plot_sweep_results(csv_path: str | Path, species: str, algorithm: str, save_
         logger.info("No varying numeric hyperparameters found — skipping hyperparameter analysis graph")
 
 
+def _download_gcs_results(gcs_uri: str, local_dir: Path) -> Path:
+    """Download ``metrics.json`` and ``stage_config.json`` from a GCS URI.
+
+    Mirrors the remote directory structure into *local_dir* so the
+    local-path logic in :func:`collect_results_from_disk` can process
+    the files without modification.
+
+    Args:
+        gcs_uri: A ``gs://bucket/prefix`` URI pointing at the root
+            directory containing ``stage*`` sub-directories.
+        local_dir: Local directory to download files into.
+
+    Returns:
+        Path to the local mirror root (same as *local_dir*).
+
+    Raises:
+        ImportError: If ``google-cloud-storage`` is not installed.
+        ValueError: If *gcs_uri* is not a valid ``gs://`` URI.
+    """
+    from google.cloud import storage as _gcs
+
+    if not gcs_uri.startswith("gs://"):
+        raise ValueError(f"Not a gs:// URI: {gcs_uri}")
+
+    # Parse gs://bucket/prefix
+    without_scheme = gcs_uri[len("gs://"):]
+    slash_idx = without_scheme.find("/")
+    if slash_idx == -1:
+        bucket_name = without_scheme
+        prefix = ""
+    else:
+        bucket_name = without_scheme[:slash_idx]
+        prefix = without_scheme[slash_idx + 1:].rstrip("/")
+
+    client = _gcs.Client()
+    bucket = client.bucket(bucket_name)
+
+    blob_prefix = f"{prefix}/" if prefix else ""
+    target_filenames = {"metrics.json", "stage_config.json"}
+    downloaded = 0
+
+    for blob in bucket.list_blobs(prefix=blob_prefix):
+        # Only download the JSON files we care about.
+        basename = blob.name.rsplit("/", 1)[-1] if "/" in blob.name else blob.name
+        if basename not in target_filenames:
+            continue
+
+        # Compute the relative path under the prefix.
+        rel_path = blob.name[len(blob_prefix):] if blob_prefix else blob.name
+        local_path = local_dir / rel_path
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        blob.download_to_filename(str(local_path))
+        downloaded += 1
+
+    logger.info(
+        "Downloaded %d file(s) from gs://%s/%s to %s",
+        downloaded,
+        bucket_name,
+        prefix,
+        local_dir,
+    )
+    return local_dir
+
+
 def collect_results_from_disk(
     output_dir: str | Path,
     species: str | None = None,
@@ -420,6 +484,10 @@ def collect_results_from_disk(
     This is the offline equivalent of :func:`_collect_trial_results` — it
     reads ``metrics.json`` sidecars directly from the filesystem without
     needing a Vertex AI HPT job object.
+
+    Supports both local paths and ``gs://`` URIs.  When a ``gs://`` URI
+    is provided, the relevant JSON files are downloaded to a temporary
+    directory which is cleaned up automatically.
 
     Expected directory layout (one of)::
 
@@ -435,7 +503,8 @@ def collect_results_from_disk(
     curriculum thresholds and evaluate pass/fail status.
 
     Args:
-        output_dir: Root directory containing stage sub-directories.
+        output_dir: Root directory containing stage sub-directories, or a
+            ``gs://bucket/prefix`` URI.
         species: Species name (for logging only; optional).
         stages: Restrict collection to these stage numbers.  Defaults to
             all ``stage*`` sub-directories found.
@@ -443,7 +512,43 @@ def collect_results_from_disk(
     Returns:
         List of result dicts compatible with :func:`write_results_csv`.
     """
-    output_dir = Path(output_dir)
+    import tempfile
+
+    # Handle gs:// URIs by downloading to a temp directory.
+    cleanup_tempdir = None
+    output_dir_str = str(output_dir)
+    if output_dir_str.startswith("gs://"):
+        tmpdir = tempfile.mkdtemp(prefix="sweep_collect_")
+        cleanup_tempdir = tmpdir
+        try:
+            output_dir = _download_gcs_results(output_dir_str, Path(tmpdir))
+        except Exception:
+            import shutil
+
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            raise
+    else:
+        output_dir = Path(output_dir)
+
+    try:
+        return _collect_results_local(output_dir, species, stages)
+    finally:
+        if cleanup_tempdir is not None:
+            import shutil
+
+            shutil.rmtree(cleanup_tempdir, ignore_errors=True)
+
+
+def _collect_results_local(
+    output_dir: Path,
+    species: str | None = None,
+    stages: list[int] | None = None,
+) -> list[dict]:
+    """Collect results from a local directory tree.
+
+    This is the internal implementation used by :func:`collect_results_from_disk`
+    after any GCS download has been completed.
+    """
     if not output_dir.is_dir():
         logger.error("Output directory does not exist: %s", output_dir)
         return []

--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -275,14 +275,7 @@ def _submit_stage_sweep(
     hpt_job = aiplatform.HyperparameterTuningJob(
         display_name=display_name,
         custom_job=custom_job,
-        metric_spec={
-            "best_mean_reward": "maximize",
-            "best_mean_episode_length": "maximize",
-            "last_mean_reward": "maximize",
-            "last_mean_episode_length": "maximize",
-            "best_mean_forward_vel": "maximize",
-            "best_mean_success_rate": "maximize",
-        },
+        metric_spec={"best_mean_reward": "maximize"},
         parameter_spec=parameter_spec,
         max_trial_count=trials,
         parallel_trial_count=parallel,
@@ -367,14 +360,7 @@ def _submit_stage_sweep(
             hpt_job = aiplatform.HyperparameterTuningJob(
                 display_name=display_name,
                 custom_job=custom_job,
-                metric_spec={
-                    "best_mean_reward": "maximize",
-                    "best_mean_episode_length": "maximize",
-                    "last_mean_reward": "maximize",
-                    "last_mean_episode_length": "maximize",
-                    "best_mean_forward_vel": "maximize",
-                    "best_mean_success_rate": "maximize",
-                },
+                metric_spec={"best_mean_reward": "maximize"},
                 parameter_spec=parameter_spec,
                 max_trial_count=trials,
                 parallel_trial_count=parallel,

--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -275,7 +275,14 @@ def _submit_stage_sweep(
     hpt_job = aiplatform.HyperparameterTuningJob(
         display_name=display_name,
         custom_job=custom_job,
-        metric_spec={"best_mean_reward": "maximize"},
+        metric_spec={
+            "best_mean_reward": "maximize",
+            "best_mean_episode_length": "maximize",
+            "last_mean_reward": "maximize",
+            "last_mean_episode_length": "maximize",
+            "best_mean_forward_vel": "maximize",
+            "best_mean_success_rate": "maximize",
+        },
         parameter_spec=parameter_spec,
         max_trial_count=trials,
         parallel_trial_count=parallel,
@@ -360,7 +367,14 @@ def _submit_stage_sweep(
             hpt_job = aiplatform.HyperparameterTuningJob(
                 display_name=display_name,
                 custom_job=custom_job,
-                metric_spec={"best_mean_reward": "maximize"},
+                metric_spec={
+                    "best_mean_reward": "maximize",
+                    "best_mean_episode_length": "maximize",
+                    "last_mean_reward": "maximize",
+                    "last_mean_episode_length": "maximize",
+                    "best_mean_forward_vel": "maximize",
+                    "best_mean_success_rate": "maximize",
+                },
                 parameter_spec=parameter_spec,
                 max_trial_count=trials,
                 parallel_trial_count=parallel,

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -1,6 +1,7 @@
 """Tests for the hyperparameter sweep tool's pure functions."""
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -258,58 +259,79 @@ def _make_mock_trial(trial_id, params=None, metrics=None):
     return trial
 
 
+def _write_trial_metrics(output_base, trial_id, metrics_dict):
+    """Write a metrics.json sidecar for a mock trial."""
+    import json
+
+    trial_dir = Path(output_base) / str(trial_id)
+    trial_dir.mkdir(parents=True, exist_ok=True)
+    with open(trial_dir / "metrics.json", "w") as f:
+        json.dump(metrics_dict, f)
+
+
 class TestCollectTrialResults:
-    def test_passing_trial(self):
+    def test_passing_trial(self, tmp_path):
         trial = _make_mock_trial(
             "1",
             params={"ppo_learning_rate": 0.0003},
-            metrics={"best_mean_reward": 150.0, "best_mean_episode_length": 500.0},
+            metrics={"best_mean_reward": 150.0},
         )
+        _write_trial_metrics(tmp_path, "1", {
+            "best_mean_reward": 150.0,
+            "best_mean_episode_length": 500.0,
+        })
         job = MagicMock()
         job.trials = [trial]
         stage_config = {"curriculum_kwargs": {"min_avg_reward": 100.0}}
 
-        rows = _collect_trial_results(job, 1, stage_config)
+        rows = _collect_trial_results(job, 1, stage_config, output_base=str(tmp_path))
         assert len(rows) == 1
         assert rows[0]["stage_passed"] is True
         assert rows[0]["best_mean_reward"] == 150.0
+        assert rows[0]["best_mean_episode_length"] == 500.0
 
-    def test_failing_trial_below_threshold(self):
+    def test_failing_trial_below_threshold(self, tmp_path):
         trial = _make_mock_trial(
             "2",
             metrics={"best_mean_reward": 50.0},
         )
+        _write_trial_metrics(tmp_path, "2", {"best_mean_reward": 50.0})
         job = MagicMock()
         job.trials = [trial]
         stage_config = {"curriculum_kwargs": {"min_avg_reward": 100.0}}
 
-        rows = _collect_trial_results(job, 1, stage_config)
+        rows = _collect_trial_results(job, 1, stage_config, output_base=str(tmp_path))
         assert rows[0]["stage_passed"] is False
 
-    def test_crashed_trial_no_metrics(self):
+    def test_crashed_trial_no_metrics(self, tmp_path):
         trial = _make_mock_trial("3")
         job = MagicMock()
         job.trials = [trial]
         stage_config = {"curriculum_kwargs": {}}
 
-        rows = _collect_trial_results(job, 1, stage_config)
+        rows = _collect_trial_results(job, 1, stage_config, output_base=str(tmp_path))
         assert rows[0]["stage_passed"] is False
         assert rows[0]["best_mean_reward"] is None
 
-    def test_no_thresholds_passes_with_valid_reward(self):
+    def test_no_thresholds_passes_with_valid_reward(self, tmp_path):
         trial = _make_mock_trial("4", metrics={"best_mean_reward": 10.0})
+        _write_trial_metrics(tmp_path, "4", {"best_mean_reward": 10.0})
         job = MagicMock()
         job.trials = [trial]
         stage_config = {"curriculum_kwargs": {}}
 
-        rows = _collect_trial_results(job, 3, stage_config)
+        rows = _collect_trial_results(job, 3, stage_config, output_base=str(tmp_path))
         assert rows[0]["stage_passed"] is True
 
-    def test_ep_length_threshold_checked(self):
+    def test_ep_length_threshold_checked(self, tmp_path):
         trial = _make_mock_trial(
             "5",
-            metrics={"best_mean_reward": 200.0, "best_mean_episode_length": 100.0},
+            metrics={"best_mean_reward": 200.0},
         )
+        _write_trial_metrics(tmp_path, "5", {
+            "best_mean_reward": 200.0,
+            "best_mean_episode_length": 100.0,
+        })
         job = MagicMock()
         job.trials = [trial]
         stage_config = {
@@ -319,17 +341,18 @@ class TestCollectTrialResults:
             }
         }
 
-        rows = _collect_trial_results(job, 1, stage_config)
+        rows = _collect_trial_results(job, 1, stage_config, output_base=str(tmp_path))
         assert rows[0]["stage_passed"] is False
 
-    def test_forward_vel_threshold_checked(self):
+    def test_forward_vel_threshold_checked(self, tmp_path):
         trial = _make_mock_trial(
             "6",
-            metrics={
-                "best_mean_reward": 200.0,
-                "best_mean_forward_vel": 0.5,
-            },
+            metrics={"best_mean_reward": 200.0},
         )
+        _write_trial_metrics(tmp_path, "6", {
+            "best_mean_reward": 200.0,
+            "best_mean_forward_vel": 0.5,
+        })
         job = MagicMock()
         job.trials = [trial]
         stage_config = {
@@ -339,7 +362,7 @@ class TestCollectTrialResults:
             }
         }
 
-        rows = _collect_trial_results(job, 2, stage_config)
+        rows = _collect_trial_results(job, 2, stage_config, output_base=str(tmp_path))
         assert rows[0]["stage_passed"] is False
 
 

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -1227,3 +1227,129 @@ class TestCollectResultsFromDisk:
         assert stages.count(1) == 2
         assert stages.count(2) == 1
         assert stages.count(3) == 1
+
+
+# ── collect_results_from_disk with gs:// URIs ──────────────────────────
+
+
+def _make_mock_gcs_blobs(file_map):
+    """Build mock GCS blobs from a dict of {blob_name: content_bytes}.
+
+    Returns a list of mock blob objects whose ``download_to_filename``
+    writes the content to the requested local path.
+    """
+    blobs = []
+    for name, content in file_map.items():
+        blob = MagicMock()
+        blob.name = name
+
+        def _download(local_path, _content=content):
+            Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(local_path).write_bytes(_content)
+
+        blob.download_to_filename = _download
+        blobs.append(blob)
+    return blobs
+
+
+class TestCollectResultsFromDiskGCS:
+    def _gcs_modules(self, mock_storage):
+        """Build sys.modules dict for mocking google.cloud.storage."""
+        mock_gc = MagicMock()
+        mock_gc.storage = mock_storage
+        return {
+            "google": MagicMock(),
+            "google.cloud": mock_gc,
+            "google.cloud.storage": mock_storage,
+        }
+
+    def test_gs_uri_downloads_and_collects(self):
+        """gs:// URI triggers GCS download and produces correct rows."""
+        metrics_1 = json.dumps({"best_mean_reward": 150.0}).encode()
+        metrics_2 = json.dumps({"best_mean_reward": 200.0}).encode()
+        stage_cfg = json.dumps({"curriculum": {"min_avg_reward": 100.0}}).encode()
+
+        file_map = {
+            "sweeps/velociraptor/stage1/1/metrics.json": metrics_1,
+            "sweeps/velociraptor/stage1/stage_config.json": stage_cfg,
+            "sweeps/velociraptor/stage2/1/metrics.json": metrics_2,
+            # Also include a non-JSON file that should be skipped
+            "sweeps/velociraptor/stage1/1/best_model.zip": b"fake_model",
+        }
+        mock_blobs = _make_mock_gcs_blobs(file_map)
+
+        mock_storage = MagicMock()
+        mock_client = MagicMock()
+        mock_bucket = MagicMock()
+        mock_storage.Client.return_value = mock_client
+        mock_client.bucket.return_value = mock_bucket
+        mock_bucket.list_blobs.return_value = mock_blobs
+
+        with patch.dict("sys.modules", self._gcs_modules(mock_storage)):
+            rows = collect_results_from_disk(
+                "gs://my-bucket/sweeps/velociraptor",
+                species="velociraptor",
+            )
+
+        assert len(rows) == 2
+        stage_nums = {r["stage"] for r in rows}
+        assert stage_nums == {1, 2}
+        # Stage 1 has a stage_config.json with threshold
+        s1_row = [r for r in rows if r["stage"] == 1][0]
+        assert s1_row["reward_threshold"] == 100.0
+        assert s1_row["stage_passed"] is True
+
+    def test_gs_uri_cleans_up_tempdir_on_success(self):
+        """Temp directory is cleaned up after successful collection."""
+        metrics = json.dumps({"best_mean_reward": 100.0}).encode()
+        file_map = {"prefix/stage1/1/metrics.json": metrics}
+        mock_blobs = _make_mock_gcs_blobs(file_map)
+
+        mock_storage = MagicMock()
+        mock_client = MagicMock()
+        mock_bucket = MagicMock()
+        mock_storage.Client.return_value = mock_client
+        mock_client.bucket.return_value = mock_bucket
+        mock_bucket.list_blobs.return_value = mock_blobs
+
+        created_tmpdirs = []
+        original_mkdtemp = __import__("tempfile").mkdtemp
+
+        def tracking_mkdtemp(**kwargs):
+            d = original_mkdtemp(**kwargs)
+            created_tmpdirs.append(d)
+            return d
+
+        with (
+            patch.dict("sys.modules", self._gcs_modules(mock_storage)),
+            patch("tempfile.mkdtemp", side_effect=tracking_mkdtemp),
+        ):
+            rows = collect_results_from_disk("gs://bucket/prefix")
+
+        assert len(rows) == 1
+        # Temp dir should have been cleaned up
+        assert len(created_tmpdirs) == 1
+        assert not Path(created_tmpdirs[0]).exists()
+
+    def test_gs_uri_cleans_up_tempdir_on_error(self):
+        """Temp directory is cleaned up even if GCS download fails."""
+        mock_storage = MagicMock()
+        mock_storage.Client.side_effect = Exception("auth failed")
+
+        created_tmpdirs = []
+        original_mkdtemp = __import__("tempfile").mkdtemp
+
+        def tracking_mkdtemp(**kwargs):
+            d = original_mkdtemp(**kwargs)
+            created_tmpdirs.append(d)
+            return d
+
+        with (
+            patch.dict("sys.modules", self._gcs_modules(mock_storage)),
+            patch("tempfile.mkdtemp", side_effect=tracking_mkdtemp),
+        ):
+            with pytest.raises(Exception, match="auth failed"):
+                collect_results_from_disk("gs://bucket/prefix")
+
+        assert len(created_tmpdirs) == 1
+        assert not Path(created_tmpdirs[0]).exists()

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -23,6 +23,7 @@ from environments.shared.scripts.sweep import (
     _split_stage_block,
     _sweep_state_local_path,
     _SweepJobFailed,
+    collect_results_from_disk,
     write_results_csv,
 )
 
@@ -1116,3 +1117,113 @@ class TestBestTrialModelPathStage3:
         path, best_row = _best_trial_model_path(rows, "bucket", "velociraptor", 3)
         assert best_row["trial_id"] == "2"
         assert "stage3" in path
+
+
+# ── collect_results_from_disk ───────────────────────────────────────────
+
+
+def _setup_sweep_dir(base, stage, trials):
+    """Create a sweep-style directory with metrics.json per trial.
+
+    Args:
+        base: Root path (tmp_path).
+        stage: Stage number.
+        trials: Dict mapping trial_id -> metrics dict.
+
+    Returns:
+        The stage directory path.
+    """
+    stage_dir = base / f"stage{stage}"
+    for trial_id, metrics in trials.items():
+        trial_dir = stage_dir / str(trial_id)
+        trial_dir.mkdir(parents=True, exist_ok=True)
+        with open(trial_dir / "metrics.json", "w") as f:
+            json.dump(metrics, f)
+    return stage_dir
+
+
+class TestCollectResultsFromDisk:
+    def test_sweep_layout(self, tmp_path):
+        """Collects results from sweep-style trial directories."""
+        _setup_sweep_dir(tmp_path, 1, {
+            "1": {"best_mean_reward": 150.0, "best_mean_episode_length": 500.0},
+            "2": {"best_mean_reward": 80.0, "best_mean_episode_length": 300.0},
+        })
+        rows = collect_results_from_disk(tmp_path)
+        assert len(rows) == 2
+        rewards = {r["trial_id"]: r["best_mean_reward"] for r in rows}
+        assert rewards["1"] == 150.0
+        assert rewards["2"] == 80.0
+
+    def test_curriculum_layout(self, tmp_path):
+        """Collects results from curriculum-style single-trial directories."""
+        for stage in (1, 2):
+            stage_dir = tmp_path / f"stage{stage}"
+            stage_dir.mkdir(parents=True)
+            with open(stage_dir / "metrics.json", "w") as f:
+                json.dump({"best_mean_reward": 100.0 * stage}, f)
+        rows = collect_results_from_disk(tmp_path)
+        assert len(rows) == 2
+        assert rows[0]["stage"] == 1
+        assert rows[1]["stage"] == 2
+
+    def test_stage_filter(self, tmp_path):
+        """Only collects from specified stages."""
+        _setup_sweep_dir(tmp_path, 1, {"1": {"best_mean_reward": 100.0}})
+        _setup_sweep_dir(tmp_path, 2, {"1": {"best_mean_reward": 200.0}})
+        rows = collect_results_from_disk(tmp_path, stages=[2])
+        assert len(rows) == 1
+        assert rows[0]["stage"] == 2
+
+    def test_thresholds_from_stage_config(self, tmp_path):
+        """Loads curriculum thresholds from stage_config.json."""
+        stage_dir = _setup_sweep_dir(tmp_path, 1, {
+            "1": {"best_mean_reward": 50.0},
+        })
+        cfg = {"curriculum": {"min_avg_reward": 100.0}}
+        with open(stage_dir / "stage_config.json", "w") as f:
+            json.dump(cfg, f)
+        rows = collect_results_from_disk(tmp_path)
+        assert len(rows) == 1
+        assert rows[0]["stage_passed"] is False
+        assert rows[0]["reward_threshold"] == 100.0
+
+    def test_passing_trial_with_threshold(self, tmp_path):
+        """Trial passes when reward exceeds threshold."""
+        stage_dir = _setup_sweep_dir(tmp_path, 1, {
+            "1": {"best_mean_reward": 150.0},
+        })
+        cfg = {"curriculum": {"min_avg_reward": 100.0}}
+        with open(stage_dir / "stage_config.json", "w") as f:
+            json.dump(cfg, f)
+        rows = collect_results_from_disk(tmp_path)
+        assert rows[0]["stage_passed"] is True
+
+    def test_empty_directory(self, tmp_path):
+        """Returns empty list for directory with no stage sub-dirs."""
+        rows = collect_results_from_disk(tmp_path)
+        assert rows == []
+
+    def test_nonexistent_directory(self, tmp_path):
+        """Returns empty list for nonexistent directory."""
+        rows = collect_results_from_disk(tmp_path / "does_not_exist")
+        assert rows == []
+
+    def test_multi_stage_collection(self, tmp_path):
+        """Collects across multiple stages into a single list."""
+        _setup_sweep_dir(tmp_path, 1, {
+            "1": {"best_mean_reward": 100.0},
+            "2": {"best_mean_reward": 120.0},
+        })
+        _setup_sweep_dir(tmp_path, 2, {
+            "1": {"best_mean_reward": 200.0},
+        })
+        _setup_sweep_dir(tmp_path, 3, {
+            "1": {"best_mean_reward": 300.0},
+        })
+        rows = collect_results_from_disk(tmp_path)
+        assert len(rows) == 4
+        stages = [r["stage"] for r in rows]
+        assert stages.count(1) == 2
+        assert stages.count(2) == 1
+        assert stages.count(3) == 1

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -277,10 +277,14 @@ class TestCollectTrialResults:
             params={"ppo_learning_rate": 0.0003},
             metrics={"best_mean_reward": 150.0},
         )
-        _write_trial_metrics(tmp_path, "1", {
-            "best_mean_reward": 150.0,
-            "best_mean_episode_length": 500.0,
-        })
+        _write_trial_metrics(
+            tmp_path,
+            "1",
+            {
+                "best_mean_reward": 150.0,
+                "best_mean_episode_length": 500.0,
+            },
+        )
         job = MagicMock()
         job.trials = [trial]
         stage_config = {"curriculum_kwargs": {"min_avg_reward": 100.0}}
@@ -329,10 +333,14 @@ class TestCollectTrialResults:
             "5",
             metrics={"best_mean_reward": 200.0},
         )
-        _write_trial_metrics(tmp_path, "5", {
-            "best_mean_reward": 200.0,
-            "best_mean_episode_length": 100.0,
-        })
+        _write_trial_metrics(
+            tmp_path,
+            "5",
+            {
+                "best_mean_reward": 200.0,
+                "best_mean_episode_length": 100.0,
+            },
+        )
         job = MagicMock()
         job.trials = [trial]
         stage_config = {
@@ -350,10 +358,14 @@ class TestCollectTrialResults:
             "6",
             metrics={"best_mean_reward": 200.0},
         )
-        _write_trial_metrics(tmp_path, "6", {
-            "best_mean_reward": 200.0,
-            "best_mean_forward_vel": 0.5,
-        })
+        _write_trial_metrics(
+            tmp_path,
+            "6",
+            {
+                "best_mean_reward": 200.0,
+                "best_mean_forward_vel": 0.5,
+            },
+        )
         job = MagicMock()
         job.trials = [trial]
         stage_config = {
@@ -1145,10 +1157,14 @@ def _setup_sweep_dir(base, stage, trials):
 class TestCollectResultsFromDisk:
     def test_sweep_layout(self, tmp_path):
         """Collects results from sweep-style trial directories."""
-        _setup_sweep_dir(tmp_path, 1, {
-            "1": {"best_mean_reward": 150.0, "best_mean_episode_length": 500.0},
-            "2": {"best_mean_reward": 80.0, "best_mean_episode_length": 300.0},
-        })
+        _setup_sweep_dir(
+            tmp_path,
+            1,
+            {
+                "1": {"best_mean_reward": 150.0, "best_mean_episode_length": 500.0},
+                "2": {"best_mean_reward": 80.0, "best_mean_episode_length": 300.0},
+            },
+        )
         rows = collect_results_from_disk(tmp_path)
         assert len(rows) == 2
         rewards = {r["trial_id"]: r["best_mean_reward"] for r in rows}
@@ -1177,9 +1193,13 @@ class TestCollectResultsFromDisk:
 
     def test_thresholds_from_stage_config(self, tmp_path):
         """Loads curriculum thresholds from stage_config.json."""
-        stage_dir = _setup_sweep_dir(tmp_path, 1, {
-            "1": {"best_mean_reward": 50.0},
-        })
+        stage_dir = _setup_sweep_dir(
+            tmp_path,
+            1,
+            {
+                "1": {"best_mean_reward": 50.0},
+            },
+        )
         cfg = {"curriculum": {"min_avg_reward": 100.0}}
         with open(stage_dir / "stage_config.json", "w") as f:
             json.dump(cfg, f)
@@ -1190,9 +1210,13 @@ class TestCollectResultsFromDisk:
 
     def test_passing_trial_with_threshold(self, tmp_path):
         """Trial passes when reward exceeds threshold."""
-        stage_dir = _setup_sweep_dir(tmp_path, 1, {
-            "1": {"best_mean_reward": 150.0},
-        })
+        stage_dir = _setup_sweep_dir(
+            tmp_path,
+            1,
+            {
+                "1": {"best_mean_reward": 150.0},
+            },
+        )
         cfg = {"curriculum": {"min_avg_reward": 100.0}}
         with open(stage_dir / "stage_config.json", "w") as f:
             json.dump(cfg, f)
@@ -1211,16 +1235,28 @@ class TestCollectResultsFromDisk:
 
     def test_multi_stage_collection(self, tmp_path):
         """Collects across multiple stages into a single list."""
-        _setup_sweep_dir(tmp_path, 1, {
-            "1": {"best_mean_reward": 100.0},
-            "2": {"best_mean_reward": 120.0},
-        })
-        _setup_sweep_dir(tmp_path, 2, {
-            "1": {"best_mean_reward": 200.0},
-        })
-        _setup_sweep_dir(tmp_path, 3, {
-            "1": {"best_mean_reward": 300.0},
-        })
+        _setup_sweep_dir(
+            tmp_path,
+            1,
+            {
+                "1": {"best_mean_reward": 100.0},
+                "2": {"best_mean_reward": 120.0},
+            },
+        )
+        _setup_sweep_dir(
+            tmp_path,
+            2,
+            {
+                "1": {"best_mean_reward": 200.0},
+            },
+        )
+        _setup_sweep_dir(
+            tmp_path,
+            3,
+            {
+                "1": {"best_mean_reward": 300.0},
+            },
+        )
         rows = collect_results_from_disk(tmp_path)
         assert len(rows) == 4
         stages = [r["stage"] for r in rows]

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -432,28 +432,41 @@ def _report_hpt_metrics(
     total_timesteps: int,
     algorithm: str,
 ):
-    """Report metrics to Vertex AI Hypertune (no-op when not installed).
+    """Report metrics to Vertex AI Hypertune and write a local JSON sidecar.
+
+    Only ``best_mean_reward`` is declared in the HPT ``metric_spec`` (it
+    is the sole optimisation target).  All auxiliary metrics are written
+    to ``<log_path>/metrics.json`` so they can be collected from GCS
+    after the sweep completes — without polluting the HPT objective.
 
     For forward velocity and success rate (stages 2+), the **best model**
     checkpoint is loaded with its matched VecNormalize stats so the
     reported metrics reflect the checkpoint that will be handed off to
     the next stage — not the final model which may have regressed.
     """
-    try:
-        import hypertune as _hypertune
-    except ImportError:
-        return
+    import json as _json
 
     import numpy as _np
 
     sb3 = _ensure_sb3()
 
-    _hpt = _hypertune.HyperTune()
-    _hpt.report_hyperparameter_tuning_metric(
-        hyperparameter_metric_tag="best_mean_reward",
-        metric_value=eval_callback.best_mean_reward,
-        global_step=total_timesteps,
-    )
+    # Accumulate all metrics for the JSON sidecar.
+    aux_metrics: dict[str, float] = {
+        "best_mean_reward": float(eval_callback.best_mean_reward),
+    }
+
+    # Report the primary optimisation metric to HPT (if available).
+    try:
+        import hypertune as _hypertune
+
+        _hpt = _hypertune.HyperTune()
+        _hpt.report_hyperparameter_tuning_metric(
+            hyperparameter_metric_tag="best_mean_reward",
+            metric_value=eval_callback.best_mean_reward,
+            global_step=total_timesteps,
+        )
+    except ImportError:
+        _hpt = None
     logger.info(
         "HPT metric reported: best_mean_reward=%.4f",
         eval_callback.best_mean_reward,
@@ -468,11 +481,7 @@ def _report_hpt_metrics(
 
         best_eval_idx = int(mean_rewards_per_eval.argmax())
         best_mean_ep_length = float(eval_lengths[best_eval_idx].mean())
-        _hpt.report_hyperparameter_tuning_metric(
-            hyperparameter_metric_tag="best_mean_episode_length",
-            metric_value=best_mean_ep_length,
-            global_step=total_timesteps,
-        )
+        aux_metrics["best_mean_episode_length"] = best_mean_ep_length
         logger.info(
             "HPT metric reported: best_mean_episode_length=%.1f",
             best_mean_ep_length,
@@ -480,16 +489,8 @@ def _report_hpt_metrics(
 
         last_mean_reward = float(mean_rewards_per_eval[-1])
         last_mean_ep_length = float(eval_lengths[-1].mean())
-        _hpt.report_hyperparameter_tuning_metric(
-            hyperparameter_metric_tag="last_mean_reward",
-            metric_value=last_mean_reward,
-            global_step=total_timesteps,
-        )
-        _hpt.report_hyperparameter_tuning_metric(
-            hyperparameter_metric_tag="last_mean_episode_length",
-            metric_value=last_mean_ep_length,
-            global_step=total_timesteps,
-        )
+        aux_metrics["last_mean_reward"] = last_mean_reward
+        aux_metrics["last_mean_episode_length"] = last_mean_ep_length
         logger.info(
             "HPT metric reported: last_mean_reward=%.4f, last_mean_episode_length=%.1f",
             last_mean_reward,
@@ -522,23 +523,22 @@ def _report_hpt_metrics(
         _, _, fwd_vels, success_flags = eval_policy(eval_model, eval_env, species_cfg.success_keys, n_episodes=30)
         if fwd_vels:
             best_fwd = float(_np.mean(fwd_vels))
-            _hpt.report_hyperparameter_tuning_metric(
-                hyperparameter_metric_tag="best_mean_forward_vel",
-                metric_value=best_fwd,
-                global_step=total_timesteps,
-            )
+            aux_metrics["best_mean_forward_vel"] = best_fwd
             logger.info("HPT metric reported: best_mean_forward_vel=%.4f", best_fwd)
         if stage >= 3 and success_flags:
             best_success = float(_np.mean(success_flags))
-            _hpt.report_hyperparameter_tuning_metric(
-                hyperparameter_metric_tag="best_mean_success_rate",
-                metric_value=best_success,
-                global_step=total_timesteps,
-            )
+            aux_metrics["best_mean_success_rate"] = best_success
             logger.info(
                 "HPT metric reported: best_mean_success_rate=%.4f",
                 best_success,
             )
+
+    # Write all metrics to a JSON sidecar so they can be collected from
+    # GCS without relying on the HPT metric_spec.
+    metrics_path = Path(log_path) / "metrics.json"
+    with open(metrics_path, "w") as f:
+        _json.dump(aux_metrics, f, indent=2)
+    logger.info("Metrics sidecar written to: %s", metrics_path)
 
 
 # ── Curriculum training ──────────────────────────────────────────────────


### PR DESCRIPTION
This pull request introduces a new "collect-results" command to the sweep script, enabling users to aggregate trial metrics from disk into a combined CSV, with optional visualisation. It also refactors the results collection logic to read auxiliary metrics from a `metrics.json` sidecar file for each trial, ensuring more complete and robust metric extraction. Several internal APIs are updated to support this functionality, and related orchestration code is modified to pass output directory information as needed.

**New features:**

* Added a `collect-results` CLI subcommand to `sweep/__main__.py`, allowing users to scan trial directories for `metrics.json` files and produce a combined CSV, with options for filtering, plotting, and specifying output paths. [[1]](diffhunk://#diff-84ddd430395d11b45c3ae7cb1d237a8f90dcf8b4bacd754a1d9366d36ab3aa2aR281-R327) [[2]](diffhunk://#diff-84ddd430395d11b45c3ae7cb1d237a8f90dcf8b4bacd754a1d9366d36ab3aa2aR346-R365)

**Results collection improvements:**

* Implemented `_load_trial_metrics` in `results.py` to read auxiliary metrics from each trial's `metrics.json` file, improving the completeness of collected metrics and handling missing or malformed files gracefully.
* Refactored `_collect_trial_results` to use the new sidecar metrics, preferring the HPT-reported value for `best_mean_reward` but falling back to the sidecar if needed, and extracting additional metrics directly from disk. [[1]](diffhunk://#diff-f435c5eb500996fd25ffee846d03656a9dd7ae2f836b761d7c0938275b4c404eL41-R87) [[2]](diffhunk://#diff-f435c5eb500996fd25ffee846d03656a9dd7ae2f836b761d7c0938275b4c404eL76-R118)

**API and orchestration changes:**

* Updated all calls to `_collect_trial_results` in orchestration code (`orchestration.py`) to pass the new `output_base` argument, ensuring correct resolution of metrics files for each trial. [[1]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9L227-R233) [[2]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9L340-R344) [[3]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9L434-R439) [[4]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9L738-R744) [[5]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9L837-R844) [[6]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9L950-R958)
* Exposed `collect_results_from_disk` and related functions in `sweep/__init__.py` for use in the new CLI and other modules. [[1]](diffhunk://#diff-16dcdd0600719077657ee6b7cdeb42a99bac0e2b08e3a61e37ecc5b182e0b5d9R25) [[2]](diffhunk://#diff-16dcdd0600719077657ee6b7cdeb42a99bac0e2b08e3a61e37ecc5b182e0b5d9R51)
* Imported new results collection functions in `sweep/__main__.py` for CLI integration.