### PR TITLE
Add GCS support to sweep results collection and visualization

### DIFF
--- a/environments/shared/scripts/sweep/__main__.py
+++ b/environments/shared/scripts/sweep/__main__.py
@@ -354,13 +354,23 @@ def main() -> None:
         if not rows:
             logger.error("No results found — nothing to write.")
             sys.exit(1)
-        csv_path = args.csv or str(Path(args.output_dir) / "collected_results.csv")
+        if args.csv:
+            csv_path = args.csv
+        elif args.output_dir.startswith("gs://"):
+            csv_path = args.output_dir.rstrip("/") + "/collected_results.csv"
+        else:
+            csv_path = str(Path(args.output_dir) / "collected_results.csv")
         write_results_csv(rows, csv_path)
         logger.info("Combined CSV written to: %s  (%d rows)", csv_path, len(rows))
         if args.plot:
             from .results import plot_sweep_results
 
-            species = args.species or Path(args.output_dir).name
+            if args.species:
+                species = args.species
+            elif args.output_dir.startswith("gs://"):
+                species = args.output_dir.rstrip("/").rsplit("/", 1)[-1]
+            else:
+                species = Path(args.output_dir).name
             algorithm = args.algorithm or "unknown"
             plot_sweep_results(csv_path, species, algorithm)
     else:

--- a/environments/shared/scripts/sweep/results.py
+++ b/environments/shared/scripts/sweep/results.py
@@ -230,7 +230,7 @@ def write_results_csv(rows: list[dict], path: str | Path) -> Path:
 
         if not path_str.startswith("gs://"):
             raise ValueError(f"Not a gs:// URI: {path_str}")
-        without_scheme = path_str[len("gs://"):]
+        without_scheme = path_str[len("gs://") :]
         bucket_name, _, blob_name = without_scheme.partition("/")
         client = storage.Client()
         bucket = client.bucket(bucket_name)

--- a/environments/shared/scripts/sweep/results.py
+++ b/environments/shared/scripts/sweep/results.py
@@ -189,13 +189,20 @@ def write_results_csv(rows: list[dict], path: str | Path) -> Path:
         Path to the written CSV file.
     """
     import csv
+    import tempfile
 
-    path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path_str = str(path)
+    is_gcs = path_str.startswith("gs://")
+
+    if is_gcs:
+        local_path = Path(tempfile.mktemp(suffix=".csv"))
+    else:
+        local_path = Path(path_str)
+        local_path.parent.mkdir(parents=True, exist_ok=True)
 
     if not rows:
         logger.warning("No trial rows to write — skipping CSV")
-        return path
+        return local_path if not is_gcs else Path(path_str)
 
     fixed_cols = ["trial_id", "stage"]
     metric_cols = [
@@ -213,13 +220,25 @@ def write_results_csv(rows: list[dict], path: str | Path) -> Path:
     hparam_cols: list[str] = sorted({k for row in rows for k in row if k not in fixed_cols + metric_cols})
     fieldnames = fixed_cols + hparam_cols + metric_cols
 
-    with open(path, "w", newline="") as f:
+    with open(local_path, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
         writer.writeheader()
         writer.writerows(rows)
 
-    logger.info("Sweep results written to: %s", path)
-    return path
+    if is_gcs:
+        from google.cloud import storage
+
+        if not path_str.startswith("gs://"):
+            raise ValueError(f"Not a gs:// URI: {path_str}")
+        without_scheme = path_str[len("gs://"):]
+        bucket_name, _, blob_name = without_scheme.partition("/")
+        client = storage.Client()
+        bucket = client.bucket(bucket_name)
+        bucket.blob(blob_name).upload_from_filename(str(local_path))
+        local_path.unlink(missing_ok=True)
+
+    logger.info("Sweep results written to: %s", path_str)
+    return Path(path_str)
 
 
 def plot_sweep_results(csv_path: str | Path, species: str, algorithm: str, save_dir: str | Path | None = None) -> None:

--- a/website/docs/training/sweeps.md
+++ b/website/docs/training/sweeps.md
@@ -468,6 +468,69 @@ python -m environments.shared.scripts.sweep launch-all \
     --trials 20 --parallel 5 --no-resume
 ```
 
+## Collecting Results
+
+After a sweep completes, use `collect-results` to scan all trial directories and produce a combined CSV:
+
+```bash
+python -m environments.shared.scripts.sweep collect-results \
+  gs://YOUR_BUCKET/sweeps/velociraptor
+```
+
+This downloads every `metrics.json` and `stage_config.json` from the GCS prefix, evaluates pass/fail against curriculum thresholds, and writes a CSV to the same directory (`collected_results.csv` by default).
+
+### Options
+
+| Flag | Description | Default |
+|---|---|---|
+| `--csv PATH` | Output CSV path | `<output_dir>/collected_results.csv` |
+| `--species NAME` | Species name (log messages & plot titles) | directory name |
+| `--algorithm NAME` | Algorithm name (plot titles) | `unknown` |
+| `--stages N [N ...]` | Only collect these stage numbers | all stages found |
+| `--plot` | Generate PNG visualisation graphs | off |
+
+### Example with plots
+
+```bash
+python -m environments.shared.scripts.sweep collect-results \
+  gs://YOUR_BUCKET/sweeps/velociraptor \
+  --species velociraptor \
+  --algorithm ppo \
+  --plot
+```
+
+This produces:
+
+- **collected_results.csv** — one row per trial with hyperparameters, metrics (`best_mean_reward`, `best_mean_episode_length`, etc.), curriculum thresholds, and a `stage_passed` flag.
+- **sweep_trial_metrics.png** — 2x2 grid: reward per trial, episode length per trial, training stability scatter, and pass/fail summary.
+- **sweep_hyperparameter_analysis.png** — scatter plots of each hyperparameter vs `best_mean_reward`, colour-coded by stage.
+
+### Expected directory structure
+
+The command looks for `stage<N>/` sub-directories under the path you provide:
+
+```
+gs://YOUR_BUCKET/sweeps/velociraptor/     ← pass this path
+  stage1/
+    1/metrics.json
+    2/metrics.json
+    ...
+  stage2/
+    1/metrics.json
+    ...
+```
+
+Single-trial (curriculum) layouts where `metrics.json` sits directly in each `stage<N>/` directory are also supported.
+
+### Filtering by stage
+
+```bash
+# Only collect results for stages 1 and 2
+python -m environments.shared.scripts.sweep collect-results \
+  gs://YOUR_BUCKET/sweeps/velociraptor \
+  --stages 1 2
+```
+
 ## Resource Errors and Retries
 
 When submitting a job to Vertex AI, transient errors (quota exhaustion, service unavailability) are automatically retried up to 3 times with increasing delays (60 s, 180 s, 300 s). If all retries fail:


### PR DESCRIPTION
## Summary
This PR adds support for collecting and visualizing sweep results directly from Google Cloud Storage (GCS) paths, eliminating the need to download results locally before analysis.

## Key Changes

- **Documentation**: Added comprehensive "Collecting Results" section to `sweeps.md` with usage examples, options table, directory structure guidance, and filtering examples
- **GCS CSV Writing**: Modified `write_results_csv()` to detect GCS paths (`gs://`) and write CSV files to a temporary local file before uploading to GCS
- **GCS Path Handling**: Updated `collect-results` command to properly construct GCS paths for the output CSV and extract species name from GCS URIs when not explicitly provided

## Implementation Details

- CSV files are written to a temporary local file first, then uploaded to GCS using the Google Cloud Storage client library
- The function returns the original GCS path even though the file is written locally first
- Species name extraction from GCS paths uses `rsplit("/", 1)[-1]` to get the last path component
- CSV path defaults are now GCS-aware: `gs://bucket/path/collected_results.csv` instead of trying to use `Path()` operations on GCS URIs
- Temporary files are cleaned up after successful upload to GCS