### PR TITLE
Validate machine types before Vertex AI job submission

### DIFF
--- a/environments/shared/scripts/sweep/__init__.py
+++ b/environments/shared/scripts/sweep/__init__.py
@@ -40,7 +40,7 @@ from .state import (
     _save_sweep_state,
     _sweep_state_local_path,
 )
-from .submit import _is_retryable_gcp_error, _normalize_accelerator_type, _submit_stage_sweep
+from .submit import _is_retryable_gcp_error, _normalize_accelerator_type, _submit_stage_sweep, _validate_machine_type
 from .trial import _hpt_arg_to_override, _parse_hpt_extra_args, run_trial
 
 __all__ = [
@@ -66,6 +66,7 @@ __all__ = [
     "_split_stage_block",
     "_submit_stage_sweep",
     "_sweep_state_local_path",
+    "_validate_machine_type",
     "launch_all_stages",
     "launch_sweep",
     "plot_sweep_results",

--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -20,11 +20,18 @@ _ACCELERATOR_ALIASES: dict[str, str] = {
 
 # Machine-type families supported by Vertex AI custom training jobs.
 _SUPPORTED_MACHINE_PREFIXES = (
-    "n1-", "n2-", "n2d-",
+    "n1-",
+    "n2-",
+    "n2d-",
     "e2-",
-    "c2-", "c2d-", "c3-",
-    "m1-", "m2-", "m3-",
-    "a2-", "a3-",
+    "c2-",
+    "c2d-",
+    "c3-",
+    "m1-",
+    "m2-",
+    "m3-",
+    "a2-",
+    "a3-",
     "g2-",
 )
 

--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -18,6 +18,26 @@ _ACCELERATOR_ALIASES: dict[str, str] = {
     "L4": "NVIDIA_L4",
 }
 
+# Machine-type families supported by Vertex AI custom training jobs.
+_SUPPORTED_MACHINE_PREFIXES = (
+    "n1-", "n2-", "n2d-",
+    "e2-",
+    "c2-", "c2d-", "c3-",
+    "m1-", "m2-", "m3-",
+    "a2-", "a3-",
+    "g2-",
+)
+
+
+def _validate_machine_type(machine_type: str) -> None:
+    """Raise ``ValueError`` early if the machine type is unsupported."""
+    if not any(machine_type.startswith(p) for p in _SUPPORTED_MACHINE_PREFIXES):
+        raise ValueError(
+            f'Machine type "{machine_type}" is not supported by Vertex AI custom training. '
+            f"Supported families: {', '.join(p.rstrip('-') for p in _SUPPORTED_MACHINE_PREFIXES)}. "
+            f'The default is "n1-standard-8".'
+        )
+
 
 def _normalize_accelerator_type(raw: str) -> str | None:
     """Return the canonical Vertex AI enum label, or *None* for CPU-only."""
@@ -235,6 +255,7 @@ def _submit_stage_sweep(
     if wandb:
         trial_args.append("--wandb")
 
+    _validate_machine_type(machine_type)
     resolved_accelerator = _normalize_accelerator_type(accelerator_type)
 
     machine_spec: dict = {"machine_type": machine_type}

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -24,6 +24,7 @@ from environments.shared.scripts.sweep import (
     _split_stage_block,
     _sweep_state_local_path,
     _SweepJobFailed,
+    _validate_machine_type,
     collect_results_from_disk,
     write_results_csv,
 )
@@ -57,6 +58,22 @@ class TestNormalizeAcceleratorType:
 
     def test_a100_alias(self):
         assert _normalize_accelerator_type("A100") == "NVIDIA_TESLA_A100"
+
+
+# ── _validate_machine_type ───────────────────────────────────────────────────
+
+
+class TestValidateMachineType:
+    """Unsupported machine families are rejected before job submission."""
+
+    @pytest.mark.parametrize("mt", ["n1-standard-8", "n2-standard-4", "e2-standard-16", "c2-standard-8", "c3-standard-4", "a2-highgpu-1g", "g2-standard-4"])
+    def test_supported_types_pass(self, mt):
+        _validate_machine_type(mt)  # should not raise
+
+    @pytest.mark.parametrize("mt", ["c4-standard-8", "c4-highcpu-16", "z1-standard-4"])
+    def test_unsupported_types_raise(self, mt):
+        with pytest.raises(ValueError, match="not supported by Vertex AI"):
+            _validate_machine_type(mt)
 
 
 # ── _hpt_arg_to_override ────────────────────────────────────────────────────

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -66,7 +66,18 @@ class TestNormalizeAcceleratorType:
 class TestValidateMachineType:
     """Unsupported machine families are rejected before job submission."""
 
-    @pytest.mark.parametrize("mt", ["n1-standard-8", "n2-standard-4", "e2-standard-16", "c2-standard-8", "c3-standard-4", "a2-highgpu-1g", "g2-standard-4"])
+    @pytest.mark.parametrize(
+        "mt",
+        [
+            "n1-standard-8",
+            "n2-standard-4",
+            "e2-standard-16",
+            "c2-standard-8",
+            "c3-standard-4",
+            "a2-highgpu-1g",
+            "g2-standard-4",
+        ],
+    )
     def test_supported_types_pass(self, mt):
         _validate_machine_type(mt)  # should not raise
 


### PR DESCRIPTION
## Summary
Add early validation of machine types to prevent submission of unsupported configurations to Vertex AI custom training jobs. This catches configuration errors before job submission, providing clear feedback to users about supported machine families.

## Key Changes
- Added `_SUPPORTED_MACHINE_PREFIXES` constant defining all machine-type families supported by Vertex AI custom training (n1, n2, n2d, e2, c2, c2d, c3, m1, m2, m3, a2, a3, g2)
- Implemented `_validate_machine_type()` function that raises `ValueError` with a helpful error message if an unsupported machine type is provided
- Integrated validation into `_submit_stage_sweep()` to check machine type before job submission
- Added comprehensive test coverage with parametrized tests for both supported and unsupported machine types
- Exported `_validate_machine_type` from the sweep module's public API

## Implementation Details
- Validation uses prefix matching to support all machine sizes within each family (e.g., "n1-standard-8", "n1-highmem-16")
- Error message includes the list of supported families and mentions the default machine type for user reference
- Validation occurs early in the submission pipeline, before any Vertex AI API calls