### PR TITLE
Remove unsupported machine types from Vertex AI validation

### DIFF
--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -19,17 +19,13 @@ _ACCELERATOR_ALIASES: dict[str, str] = {
 }
 
 # Machine-type families supported by Vertex AI custom training jobs.
+# See https://docs.cloud.google.com/vertex-ai/docs/training/configure-compute
 _SUPPORTED_MACHINE_PREFIXES = (
     "n1-",
     "n2-",
-    "n2d-",
     "e2-",
     "c2-",
-    "c2d-",
-    "c3-",
     "m1-",
-    "m2-",
-    "m3-",
     "a2-",
     "a3-",
     "g2-",

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -73,7 +73,6 @@ class TestValidateMachineType:
             "n2-standard-4",
             "e2-standard-16",
             "c2-standard-8",
-            "c3-standard-4",
             "a2-highgpu-1g",
             "g2-standard-4",
         ],
@@ -81,7 +80,7 @@ class TestValidateMachineType:
     def test_supported_types_pass(self, mt):
         _validate_machine_type(mt)  # should not raise
 
-    @pytest.mark.parametrize("mt", ["c4-standard-8", "c4-highcpu-16", "z1-standard-4"])
+    @pytest.mark.parametrize("mt", ["c3-standard-4", "c4-standard-8", "c4-highcpu-16", "z1-standard-4"])
     def test_unsupported_types_raise(self, mt):
         with pytest.raises(ValueError, match="not supported by Vertex AI"):
             _validate_machine_type(mt)


### PR DESCRIPTION
c3, c2d, n2d, m2, m3 are not supported by Vertex AI custom training. Removed them from _SUPPORTED_MACHINE_PREFIXES and updated tests accordingly so invalid machine types are caught before job submission.