### PR TITLE
Generate trial artifacts (summaries and videos) after sweep training

### DIFF
--- a/environments/shared/config.py
+++ b/environments/shared/config.py
@@ -256,12 +256,17 @@ def upload_curriculum_artifacts(
     bucket: str | None = None,
     project: str | None = None,
 ) -> None:
-    """Upload curriculum training artifacts (CSV + best models) to GCS.
+    """Upload curriculum training artifacts to GCS.
 
     Uploads:
-    * ``curriculum_results.csv`` → ``training/<species>/curriculum_results_<run>.csv``
+    * ``curriculum_results.csv`` → ``training/<species>/<run>/curriculum_results.csv``
+    * ``training_summary.txt`` → ``training/<species>/<run>/training_summary.txt``
     * Each stage's ``best_model.zip`` and ``stage<N>_final.zip`` →
       ``training/<species>/<run>/stage<N>/models/``
+    * Each stage's ``stage_summary.txt`` →
+      ``training/<species>/<run>/stage<N>/stage_summary.txt``
+    * Each stage's replay videos (``*.mp4``) →
+      ``training/<species>/<run>/stage<N>/``
 
     When *bucket* is ``None`` (no GCP info provided), this function is a
     no-op and all artifacts remain local only.
@@ -285,20 +290,41 @@ def upload_curriculum_artifacts(
         return
 
     run_name = base_dir.name  # e.g. curriculum_20240228_150000
+    gcs_run_prefix = f"training/{species}/{run_name}"
 
     # 1. Upload curriculum_results.csv
     csv_path = base_dir / "curriculum_results.csv"
     if csv_path.exists():
-        gcs_csv = f"training/{species}/{run_name}/curriculum_results.csv"
-        _upload_to_gcs(csv_path, bucket, gcs_csv, project=project)
+        _upload_to_gcs(csv_path, bucket, f"{gcs_run_prefix}/curriculum_results.csv", project=project)
 
-    # 2. Upload best model and final model for each stage
+    # 2. Upload training_summary.txt
+    training_summary = base_dir / "training_summary.txt"
+    if training_summary.exists():
+        _upload_to_gcs(training_summary, bucket, f"{gcs_run_prefix}/training_summary.txt", project=project)
+
+    # 3. Upload per-stage artifacts
     for stage in range(1, 4):
-        stage_model_dir = base_dir / f"stage{stage}" / "models"
+        stage_dir = base_dir / f"stage{stage}"
+        if not stage_dir.is_dir():
+            continue
+
+        gcs_stage_prefix = f"{gcs_run_prefix}/stage{stage}"
+
+        # stage_summary.txt
+        stage_summary = stage_dir / "stage_summary.txt"
+        if stage_summary.exists():
+            _upload_to_gcs(stage_summary, bucket, f"{gcs_stage_prefix}/stage_summary.txt", project=project)
+
+        # Replay videos (*.mp4)
+        for video in stage_dir.glob("*.mp4"):
+            _upload_to_gcs(video, bucket, f"{gcs_stage_prefix}/{video.name}", project=project)
+
+        # Models
+        stage_model_dir = stage_dir / "models"
         if not stage_model_dir.is_dir():
             continue
 
-        gcs_model_prefix = f"training/{species}/{run_name}/stage{stage}/models"
+        gcs_model_prefix = f"{gcs_stage_prefix}/models"
 
         # best_model.zip (from EvalCallback)
         best_model = stage_model_dir / "best_model.zip"

--- a/environments/shared/scripts/sweep/trial.py
+++ b/environments/shared/scripts/sweep/trial.py
@@ -140,7 +140,7 @@ def run_trial(args: argparse.Namespace, extra_args: list[str]) -> None:
             stage_config[algo_key].setdefault("policy_kwargs", {})["net_arch"] = arch
         logger.info("Applied net_arch=%s (%s) to all stages", net_arch_preset, arch)
 
-    train(
+    model = train(
         species_cfg=SPECIES_CONFIG,
         stage_configs=STAGE_CONFIGS,
         stage=args.stage,
@@ -156,6 +156,158 @@ def run_trial(args: argparse.Namespace, extra_args: list[str]) -> None:
         use_wandb=args.wandb,
         output_dir=output_dir,
     )
+
+    # Generate stage summary and replay videos (same artifacts the notebook produces)
+    if output_dir is not None:
+        _generate_trial_artifacts(
+            model=model,
+            species_cfg=SPECIES_CONFIG,
+            stage_configs=STAGE_CONFIGS,
+            stage=args.stage,
+            algorithm=args.algorithm,
+            output_dir=output_dir,
+            timesteps=args.timesteps,
+            seed=args.seed,
+        )
+
+
+def _generate_trial_artifacts(
+    model,
+    species_cfg,
+    stage_configs,
+    stage: int,
+    algorithm: str,
+    output_dir: str,
+    timesteps: int,
+    seed: int,
+) -> None:
+    """Generate stage summary and replay videos for a completed trial.
+
+    Mirrors what the training notebook produces so sweep trials leave the
+    same artifacts: ``stage_summary.txt`` and best/final ``.mp4`` videos.
+    """
+    from pathlib import Path
+
+    import numpy as _np
+
+    from environments.shared.evaluation import record_stage_video
+    from environments.shared.reporting import write_stage_summary
+    from environments.shared.train_base import _ensure_sb3
+
+    sb3 = _ensure_sb3()
+    log_path = Path(output_dir)
+    model_dir = log_path / "models"
+    config = stage_configs[stage]
+    species = species_cfg.species
+
+    # ── Build a results dict from on-disk eval data ─────────────────────
+    eval_npz = log_path / "evaluations.npz"
+    mean_reward = 0.0
+    std_reward = 0.0
+    mean_length = 0.0
+    std_length = 0.0
+    best_eval_reward: float | str = ""
+    best_eval_std: float | str = ""
+    best_eval_length: float | str = ""
+    best_eval_std_length: float | str = ""
+    best_eval_timestep: int | str = ""
+
+    if eval_npz.exists():
+        eval_data = _np.load(str(eval_npz))
+        eval_rewards = eval_data["results"]
+        eval_lengths = eval_data["ep_lengths"]
+        eval_timesteps = eval_data["timesteps"]
+
+        mean_per_eval = eval_rewards.mean(axis=1)
+        best_idx = int(mean_per_eval.argmax())
+
+        best_eval_reward = round(float(mean_per_eval[best_idx]), 2)
+        best_eval_std = round(float(eval_rewards[best_idx].std()), 2)
+        best_eval_length = round(float(eval_lengths[best_idx].mean()), 1)
+        best_eval_std_length = round(float(eval_lengths[best_idx].std()), 1)
+        best_eval_timestep = int(eval_timesteps[best_idx])
+
+        # Use last eval as "final" metrics
+        mean_reward = float(mean_per_eval[-1])
+        std_reward = float(eval_rewards[-1].std())
+        mean_length = float(eval_lengths[-1].mean())
+        std_length = float(eval_lengths[-1].std())
+
+    # Read duration from metrics.json if available
+    metrics_path = log_path / "metrics.json"
+    duration = 0.0
+    if metrics_path.exists():
+        import json as _json
+
+        metrics = _json.loads(metrics_path.read_text())
+        duration = metrics.get("training_duration_seconds", 0.0)
+
+    best_model_path = model_dir / "best_model"
+    final_path = model_dir / f"stage{stage}_final"
+    vecnorm_path = str(model_dir / "best_model_vecnorm.pkl")
+    final_vecnorm_path = str(final_path) + "_vecnorm.pkl"
+
+    sim_dt = config.get("env_kwargs", {}).get("sim_dt", 0.01)
+
+    stage_results = {
+        "stage": stage,
+        "name": config["name"],
+        "description": config["description"],
+        "timesteps": timesteps,
+        "duration_seconds": duration,
+        "mean_reward": mean_reward,
+        "std_reward": std_reward,
+        "mean_episode_length": mean_length,
+        "std_episode_length": std_length,
+        "mean_forward_vel": 0.0,
+        "std_forward_vel": 0.0,
+        "mean_success_rate": 0.0,
+        "best_eval_reward": best_eval_reward,
+        "best_eval_std": best_eval_std,
+        "best_eval_length": best_eval_length,
+        "best_eval_std_length": best_eval_std_length,
+        "best_eval_timestep": best_eval_timestep,
+        "sim_dt": sim_dt,
+        "model_path": str(best_model_path),
+        "vecnorm_path": vecnorm_path,
+    }
+
+    write_stage_summary(log_path, stage_results, species, algorithm)
+    logger.info("Stage summary written to: %s", log_path / "stage_summary.txt")
+
+    # ── Record replay videos for best and final models ──────────────────
+    env_kwargs = config["env_kwargs"].copy()
+    alg_cls = sb3["SAC"] if algorithm == "sac" else sb3["PPO"]
+
+    if (model_dir / "best_model.zip").exists():
+        best_model = alg_cls.load(str(best_model_path))
+        record_stage_video(
+            best_model,
+            env_class=species_cfg.env_class,
+            env_kwargs=env_kwargs,
+            stage=stage,
+            stage_dir=log_path,
+            species=species,
+            algorithm=algorithm,
+            seed=seed,
+            vecnorm_path=vecnorm_path,
+            label="best",
+        )
+
+    if (Path(str(final_path) + ".zip")).exists():
+        final_model = alg_cls.load(str(final_path))
+        record_stage_video(
+            final_model,
+            env_class=species_cfg.env_class,
+            env_kwargs=env_kwargs,
+            stage=stage,
+            stage_dir=log_path,
+            species=species,
+            algorithm=algorithm,
+            seed=seed,
+            vecnorm_path=final_vecnorm_path,
+            label="final",
+        )
 
 
 def _build_parameter_spec(search_space: dict, hpt_module: Any) -> dict:

--- a/environments/shared/tests/test_config.py
+++ b/environments/shared/tests/test_config.py
@@ -387,8 +387,13 @@ class TestUploadCurriculumArtifacts:
         base = tmp_path / "curriculum_20240228_150000"
         base.mkdir()
         (base / "curriculum_results.csv").write_text("stage,reward\n1,10\n")
-        stage1_models = base / "stage1" / "models"
+        (base / "training_summary.txt").write_text("summary")
+        stage1 = base / "stage1"
+        stage1_models = stage1 / "models"
         stage1_models.mkdir(parents=True)
+        (stage1 / "stage_summary.txt").write_text("stage 1 summary")
+        (stage1 / "velociraptor_ppo_stage1_best.mp4").write_bytes(b"vid1")
+        (stage1 / "velociraptor_ppo_stage1_final.mp4").write_bytes(b"vid2")
         (stage1_models / "best_model.zip").write_bytes(b"fake")
         (stage1_models / "stage1_final.zip").write_bytes(b"fake")
         (stage1_models / "stage1_final_vecnorm.pkl").write_bytes(b"fake")
@@ -396,5 +401,13 @@ class TestUploadCurriculumArtifacts:
         with patch("environments.shared.config._upload_to_gcs", return_value=True) as mock_upload:
             upload_curriculum_artifacts(base, "velociraptor", "ppo", bucket="test-bucket", project="test-project")
 
-        # Should have been called for: CSV + best_model + final + vecnorm = 4
-        assert mock_upload.call_count == 4
+        # CSV + training_summary + stage_summary + 2 videos + best_model + final + vecnorm = 8
+        assert mock_upload.call_count == 8
+
+        # Verify the GCS paths for the new artifact types
+        uploaded_paths = [call.args[2] for call in mock_upload.call_args_list]
+        run = "curriculum_20240228_150000"
+        assert f"training/velociraptor/{run}/training_summary.txt" in uploaded_paths
+        assert f"training/velociraptor/{run}/stage1/stage_summary.txt" in uploaded_paths
+        assert f"training/velociraptor/{run}/stage1/velociraptor_ppo_stage1_best.mp4" in uploaded_paths
+        assert f"training/velociraptor/{run}/stage1/velociraptor_ppo_stage1_final.mp4" in uploaded_paths

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -1566,3 +1566,83 @@ class TestCollectResultsFromDiskGCS:
 
         assert len(created_tmpdirs) == 1
         assert not Path(created_tmpdirs[0]).exists()
+
+
+class TestGenerateTrialArtifacts:
+    """Test _generate_trial_artifacts produces stage summary and videos."""
+
+    def test_writes_stage_summary_and_records_videos(self, tmp_path):
+        """After a trial, stage_summary.txt is written and videos are attempted."""
+        import numpy as np
+
+        from environments.shared.scripts.sweep.trial import _generate_trial_artifacts
+
+        # Setup directory structure matching what train() produces
+        model_dir = tmp_path / "models"
+        model_dir.mkdir()
+        (model_dir / "best_model.zip").write_bytes(b"fake")
+        (model_dir / "best_model_vecnorm.pkl").write_bytes(b"fake")
+        (model_dir / "stage1_final.zip").write_bytes(b"fake")
+        (model_dir / "stage1_final_vecnorm.pkl").write_bytes(b"fake")
+
+        # Create evaluations.npz
+        rewards = np.array([[10.0, 12.0], [20.0, 22.0]])
+        lengths = np.array([[100, 110], [200, 210]])
+        timesteps = np.array([50000, 100000])
+        np.savez(
+            str(tmp_path / "evaluations.npz"),
+            results=rewards,
+            ep_lengths=lengths,
+            timesteps=timesteps,
+        )
+
+        mock_species_cfg = MagicMock()
+        mock_species_cfg.species = "velociraptor"
+        mock_species_cfg.env_class = MagicMock
+
+        stage_configs = {
+            1: {
+                "name": "Balance",
+                "description": "Stand up",
+                "env_kwargs": {"sim_dt": 0.01},
+                "ppo_kwargs": {},
+            },
+        }
+
+        mock_sb3 = {
+            "PPO": MagicMock(),
+            "SAC": MagicMock(),
+        }
+
+        with (
+            patch(
+                "environments.shared.train_base._ensure_sb3",
+                return_value=mock_sb3,
+            ),
+            patch(
+                "environments.shared.evaluation.record_stage_video",
+            ) as mock_video,
+        ):
+            _generate_trial_artifacts(
+                model=MagicMock(),
+                species_cfg=mock_species_cfg,
+                stage_configs=stage_configs,
+                stage=1,
+                algorithm="ppo",
+                output_dir=str(tmp_path),
+                timesteps=100_000,
+                seed=42,
+            )
+
+        # stage_summary.txt should exist
+        summary = tmp_path / "stage_summary.txt"
+        assert summary.exists()
+        text = summary.read_text()
+        assert "Balance" in text
+        assert "Velociraptor" in text
+
+        # Videos should be recorded for both best and final models
+        assert mock_video.call_count == 2
+        labels = [call.kwargs["label"] for call in mock_video.call_args_list]
+        assert "best" in labels
+        assert "final" in labels


### PR DESCRIPTION
## Summary
This PR extends the sweep trial runner to generate the same artifacts that the training notebook produces: stage summaries and replay videos. After training completes, the trial now automatically generates `stage_summary.txt` files and records best/final model videos, ensuring sweep trials leave consistent outputs.

## Key Changes

- **Modified `run_trial()` in `trial.py`**: Capture the model returned by `train()` and call a new `_generate_trial_artifacts()` function to post-process results
- **Added `_generate_trial_artifacts()` function**: New helper that:
  - Reads evaluation metrics from `evaluations.npz` to compute best/final reward and episode length statistics
  - Reads training duration from `metrics.json`
  - Generates `stage_summary.txt` with comprehensive stage results using `write_stage_summary()`
  - Records replay videos for both best and final models using `record_stage_video()`
- **Updated `upload_curriculum_artifacts()` in `config.py`**: Extended to upload new artifacts:
  - `training_summary.txt` at the curriculum level
  - Per-stage `stage_summary.txt` files
  - Replay video files (`*.mp4`) for each stage
- **Added comprehensive test coverage** in `test_sweep.py` and `test_config.py`:
  - Tests that `_generate_trial_artifacts()` correctly writes summaries and records videos
  - Tests that upload function handles all new artifact types with correct GCS paths

## Implementation Details

- The new function mirrors the notebook's post-training workflow, ensuring consistency between sweep and interactive training
- Gracefully handles missing evaluation data (e.g., if no evaluations were run)
- Only attempts to record videos if model files exist on disk
- Properly loads best and final models using the appropriate algorithm class (PPO or SAC)
- Maintains backward compatibility—function is only called when `output_dir` is provided