### PR TITLE
Validate GPU compatibility with machine types in sweep submission

### DIFF
--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -52,9 +52,7 @@ def _validate_machine_type(machine_type: str, accelerator_type: str | None = Non
             f"Supported families: {', '.join(p.rstrip('-') for p in _SUPPORTED_MACHINE_PREFIXES)}. "
             f'The default is "n1-standard-8".'
         )
-    if accelerator_type is not None and not any(
-        machine_type.startswith(p) for p in _GPU_COMPATIBLE_PREFIXES
-    ):
+    if accelerator_type is not None and not any(machine_type.startswith(p) for p in _GPU_COMPATIBLE_PREFIXES):
         raise ValueError(
             f'Accelerator "{accelerator_type}" is not supported for machine type '
             f'"{machine_type}". Use a GPU-compatible machine family '

--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -31,14 +31,35 @@ _SUPPORTED_MACHINE_PREFIXES = (
     "g2-",
 )
 
+# Machine-type families that support attaching GPU accelerators.
+_GPU_COMPATIBLE_PREFIXES = (
+    "n1-",
+    "a2-",
+    "a3-",
+    "g2-",
+)
 
-def _validate_machine_type(machine_type: str) -> None:
-    """Raise ``ValueError`` early if the machine type is unsupported."""
+
+def _validate_machine_type(machine_type: str, accelerator_type: str | None = None) -> None:
+    """Raise ``ValueError`` early if the machine type is unsupported.
+
+    When *accelerator_type* is not ``None``, also checks that the machine
+    family supports GPU attachment (e.g. ``c2-`` and ``e2-`` do not).
+    """
     if not any(machine_type.startswith(p) for p in _SUPPORTED_MACHINE_PREFIXES):
         raise ValueError(
             f'Machine type "{machine_type}" is not supported by Vertex AI custom training. '
             f"Supported families: {', '.join(p.rstrip('-') for p in _SUPPORTED_MACHINE_PREFIXES)}. "
             f'The default is "n1-standard-8".'
+        )
+    if accelerator_type is not None and not any(
+        machine_type.startswith(p) for p in _GPU_COMPATIBLE_PREFIXES
+    ):
+        raise ValueError(
+            f'Accelerator "{accelerator_type}" is not supported for machine type '
+            f'"{machine_type}". Use a GPU-compatible machine family '
+            f"({', '.join(p.rstrip('-') for p in _GPU_COMPATIBLE_PREFIXES)}) "
+            f'or set --accelerator-type=None for CPU-only. The default is "n1-standard-8".'
         )
 
 
@@ -258,8 +279,8 @@ def _submit_stage_sweep(
     if wandb:
         trial_args.append("--wandb")
 
-    _validate_machine_type(machine_type)
     resolved_accelerator = _normalize_accelerator_type(accelerator_type)
+    _validate_machine_type(machine_type, resolved_accelerator)
 
     machine_spec: dict = {"machine_type": machine_type}
     if resolved_accelerator is not None:

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -85,6 +85,26 @@ class TestValidateMachineType:
         with pytest.raises(ValueError, match="not supported by Vertex AI"):
             _validate_machine_type(mt)
 
+    @pytest.mark.parametrize(
+        "mt",
+        ["n1-standard-8", "a2-highgpu-1g", "g2-standard-4"],
+    )
+    def test_gpu_compatible_types_with_accelerator(self, mt):
+        _validate_machine_type(mt, "NVIDIA_TESLA_T4")  # should not raise
+
+    @pytest.mark.parametrize(
+        "mt",
+        ["c2-standard-8", "e2-standard-16", "n2-standard-4", "m1-ultramem-40"],
+    )
+    def test_gpu_incompatible_types_with_accelerator_raise(self, mt):
+        with pytest.raises(ValueError, match="not supported for machine type"):
+            _validate_machine_type(mt, "NVIDIA_TESLA_T4")
+
+    def test_cpu_only_allows_any_supported_machine(self):
+        # accelerator_type=None means CPU-only — no GPU check needed
+        _validate_machine_type("c2-standard-8", None)
+        _validate_machine_type("e2-standard-16", None)
+
 
 # ── _hpt_arg_to_override ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Add validation to ensure that when a GPU accelerator is requested, the selected machine type supports GPU attachment. This prevents submission of invalid configurations to Vertex AI.

## Key Changes
- Added `_GPU_COMPATIBLE_PREFIXES` constant defining machine families that support GPU accelerators (n1-, a2-, a3-, g2-)
- Enhanced `_validate_machine_type()` function to accept an optional `accelerator_type` parameter and validate GPU compatibility when an accelerator is specified
- Updated validation logic in `_submit_stage_sweep()` to check GPU compatibility after normalizing the accelerator type
- Added comprehensive test coverage for GPU-compatible and GPU-incompatible machine types with accelerators
- Added test to verify CPU-only mode (accelerator_type=None) allows any supported machine type

## Implementation Details
- The GPU compatibility check only runs when `accelerator_type` is not `None`, allowing CPU-only configurations on any supported machine family
- Error messages clearly indicate which machine families support GPUs and suggest using CPU-only mode as an alternative
- Validation order was adjusted to normalize the accelerator type before validation, ensuring consistent behavior