### PR TITLE
Fix random seed initialization in environment factory

### DIFF
--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -139,13 +139,13 @@ def make_env(
     sb3 = _ensure_sb3()
 
     def _init():
+        sb3["set_random_seed"](seed + rank)
         env_kwargs = stage_configs[stage]["env_kwargs"].copy()
         env = species_cfg.env_class(**env_kwargs)
         env = sb3["Monitor"](env)
         env.reset(seed=seed + rank)
         return env
 
-    sb3["set_random_seed"](seed)
     return _init
 
 


### PR DESCRIPTION
## Summary
Moved the random seed initialization to occur inside the environment initialization function rather than at the factory level, ensuring each environment instance gets a properly seeded random state based on its rank.

## Key Changes
- Moved `sb3["set_random_seed"](seed + rank)` call from outside the `_init()` function to inside it
- This ensures the random seed is set with the rank offset when each environment is actually instantiated, rather than once when the factory is created

## Implementation Details
The seed initialization now happens at the correct time in the environment lifecycle:
- Previously: seed was set once when `make_env()` was called (using base `seed` only)
- Now: seed is set each time `_init()` is called (using `seed + rank` for proper per-environment seeding)

This fix ensures that in multi-environment setups (e.g., parallel training), each environment gets a unique, deterministic random seed based on its rank, preventing unintended correlation between parallel environments.