### PR TITLE
Add CPU-optimized machine type recommendation for Vertex AI training

### DIFF
--- a/website/docs/training/vertex-ai.md
+++ b/website/docs/training/vertex-ai.md
@@ -235,6 +235,8 @@ Choose your machine type based on budget and training needs:
 - **Full curriculum runs:** `n1-standard-16` + T4 to support `--subproc` with more parallel environments.
 - **Future JAX/MJX training:** A100 GPUs become essential for batch simulation.
 
+> **Tip:** For CPU-bound training (no GPU), consider using [`c2-standard-*` machine types](https://cloud.google.com/compute/docs/compute-optimized-machines#c2_machine_types) instead of `n1-standard-*`. C2 machines offer higher per-core performance (3.1 GHz sustained all-core turbo), which benefits MuJoCo's single-threaded simulation stepping and SB3's CPU-side rollout collection. For example, `c2-standard-8` typically completes Stage 1 faster than `n1-standard-8` at a comparable price point.
+
 ## 4. Saving Checkpoints to GCS
 
 Use `--output-dir` (the preferred flag for cloud training) to point the script at a GCS-mounted path. Vertex AI mounts the job's `base_output_dir` bucket at `/gcs/<bucket>/` inside the container, so all outputs — models, VecNormalize stats, TensorBoard logs — land in cloud storage automatically.


### PR DESCRIPTION
## Summary
Added guidance for users running CPU-bound training on Vertex AI by recommending Google Cloud's `c2-standard-*` compute-optimized machine types as an alternative to `n1-standard-*` instances.

## Changes
- Added a tip section in the machine type selection documentation explaining when and why to use C2 machines for CPU-bound training
- Highlighted that C2 machines offer superior per-core performance (3.1 GHz sustained all-core turbo) compared to N1 machines
- Explained the specific benefits for MuJoCo's single-threaded simulation stepping and SB3's CPU-side rollout collection
- Provided a concrete example (`c2-standard-8` vs `n1-standard-8`) showing performance/cost parity

## Details
This addition helps users optimize their training infrastructure by providing an evidence-based recommendation for CPU-only workloads. The tip is positioned in the machine type selection section where users are already making infrastructure decisions, making it immediately actionable.