### PR TITLE
Retry credential refresh on transient metadata-server errors

### DIFF
--- a/environments/shared/scripts/sweep/__init__.py
+++ b/environments/shared/scripts/sweep/__init__.py
@@ -17,7 +17,7 @@ from .constants import (
     SweepStageError,
     _SweepJobFailed,
 )
-from .orchestration import launch_all_stages, launch_sweep
+from .orchestration import _eager_refresh, launch_all_stages, launch_sweep
 from .results import (
     _best_trial_model_path,
     _best_trial_model_path_any,
@@ -50,6 +50,7 @@ __all__ = [
     "_best_trial_model_path",
     "_best_trial_model_path_any",
     "_collect_trial_results",
+    "_eager_refresh",
     "_evaluate_curriculum_gate",
     "_extract_thresholds",
     "collect_results_from_disk",

--- a/environments/shared/scripts/sweep/__main__.py
+++ b/environments/shared/scripts/sweep/__main__.py
@@ -45,6 +45,12 @@ def _build_parser() -> argparse.ArgumentParser:
     trial.add_argument("--load", type=str, default=None, help="Path to model checkpoint to warm-start from")
     trial.add_argument("--output-dir", type=str, default=None, help="Base output dir (GCS mount path on Vertex AI)")
     trial.add_argument("--wandb", action="store_true", help="Enable W&B logging")
+    trial.add_argument(
+        "--no-tensorboard",
+        action="store_true",
+        default=False,
+        help="Disable TensorBoard logging to reduce disk I/O and storage usage",
+    )
 
     # ── launch mode (single stage) ────────────────────────────────────────────
     launch = subparsers.add_parser(
@@ -111,6 +117,12 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     launch.add_argument("--wandb", action="store_true", help="Enable W&B logging in each trial")
+    launch.add_argument(
+        "--no-tensorboard",
+        action="store_true",
+        default=False,
+        help="Disable TensorBoard logging in each trial to reduce disk I/O and storage usage",
+    )
     launch.add_argument(
         "--load",
         type=str,
@@ -232,6 +244,12 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     launch_all.add_argument("--wandb", action="store_true", help="Enable W&B logging in each trial")
+    launch_all.add_argument(
+        "--no-tensorboard",
+        action="store_true",
+        default=False,
+        help="Disable TensorBoard logging in each trial to reduce disk I/O and storage usage",
+    )
     launch_all.add_argument(
         "--resume",
         action=argparse.BooleanOptionalAction,

--- a/environments/shared/scripts/sweep/orchestration.py
+++ b/environments/shared/scripts/sweep/orchestration.py
@@ -90,8 +90,7 @@ def _eager_refresh(credentials, *, max_retries: int = 4, _request=None):
                 )
                 raise
             logger.warning(
-                "Transient metadata-server error on credential refresh "
-                "(attempt %d/%d), retrying in %ds …",
+                "Transient metadata-server error on credential refresh (attempt %d/%d), retrying in %ds …",
                 attempt,
                 max_retries,
                 delay,

--- a/environments/shared/scripts/sweep/orchestration.py
+++ b/environments/shared/scripts/sweep/orchestration.py
@@ -34,15 +34,27 @@ def _resolve_credentials(project: str | None = None):
     user's ``gcloud auth`` session in Cloud Shell and service-account
     credentials on Vertex AI workers.
 
+    The initial credential refresh is attempted eagerly so that transient
+    metadata-server errors (e.g. the server returning a raw string instead
+    of JSON) are caught and retried here rather than surfacing later as
+    opaque gRPC ``AuthMetadataPlugin`` failures.
+
     Returns:
         A ``(credentials, project)`` tuple suitable for passing to
         ``aiplatform.init()``.
     """
     import google.auth
+    import google.auth.transport.requests
 
     credentials, adc_project = google.auth.default(
         scopes=["https://www.googleapis.com/auth/cloud-platform"],
     )
+
+    # Eagerly refresh credentials so transient metadata-server errors
+    # (TypeError from malformed JSON) are retried here instead of
+    # propagating through the gRPC auth plugin at call time.
+    _eager_refresh(credentials)
+
     resolved_project = project or adc_project
     if resolved_project is None:
         raise RuntimeError(
@@ -50,6 +62,42 @@ def _resolve_credentials(project: str | None = None):
             "set the GOOGLE_CLOUD_PROJECT / GCLOUD_PROJECT environment variable."
         )
     return credentials, resolved_project
+
+
+def _eager_refresh(credentials, *, max_retries: int = 4, _request=None):
+    """Refresh *credentials* with retries for transient metadata errors.
+
+    The GCE metadata server can occasionally return a plain string instead
+    of a JSON object, which causes ``google-auth`` to raise ``TypeError``
+    (``string indices must be integers``).  This helper retries with
+    exponential back-off so the caller gets usable credentials.
+    """
+    if _request is None:
+        import google.auth.transport.requests
+
+        _request = google.auth.transport.requests.Request()
+    delay = 1
+    for attempt in range(1, max_retries + 1):
+        try:
+            credentials.refresh(_request)
+            return
+        except TypeError:
+            if attempt == max_retries:
+                logger.error(
+                    "GCE metadata server returned malformed responses after "
+                    "%d attempts.  Check that the metadata service is healthy.",
+                    max_retries,
+                )
+                raise
+            logger.warning(
+                "Transient metadata-server error on credential refresh "
+                "(attempt %d/%d), retrying in %ds …",
+                attempt,
+                max_retries,
+                delay,
+            )
+            time.sleep(delay)
+            delay *= 2
 
 
 def _dedup_trial_rows(rows: list[dict]) -> list[dict]:

--- a/environments/shared/scripts/sweep/orchestration.py
+++ b/environments/shared/scripts/sweep/orchestration.py
@@ -350,6 +350,7 @@ def launch_sweep(args: argparse.Namespace) -> None:
                 save_freq=getattr(args, "save_freq", None),
                 resume_run=resume_run,
                 restart_job_on_worker_restart=getattr(args, "restart_job_on_worker_restart", False),
+                no_tensorboard=getattr(args, "no_tensorboard", False),
             )
             job_resource_name = getattr(hpt_job, "resource_name", None)
 
@@ -852,6 +853,7 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                     save_freq=getattr(args, "save_freq", None),
                     resume_run=resume_run,
                     restart_job_on_worker_restart=getattr(args, "restart_job_on_worker_restart", False),
+                    no_tensorboard=getattr(args, "no_tensorboard", False),
                 )
                 job_resource_name = getattr(hpt_job, "resource_name", None)
 

--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -224,6 +224,7 @@ def _submit_stage_sweep(
     save_freq: int | None = None,
     resume_run: int = 0,
     restart_job_on_worker_restart: bool = False,
+    no_tensorboard: bool = False,
 ):
     """Build and submit a single-stage HPT job. Returns the job object.
 
@@ -239,6 +240,8 @@ def _submit_stage_sweep(
         restart_job_on_worker_restart: If ``True``, Vertex AI will
             automatically restart the job when a worker is preempted
             (e.g. spot/preemptible VMs).
+        no_tensorboard: If ``True``, disable TensorBoard logging in each
+            trial to reduce disk I/O and storage usage.
     """
     parameter_spec = _build_parameter_spec(search_space, hpt_module)
     if not parameter_spec:
@@ -276,6 +279,8 @@ def _submit_stage_sweep(
         trial_args += fixed_trial_args
     if wandb:
         trial_args.append("--wandb")
+    if no_tensorboard:
+        trial_args.append("--no-tensorboard")
 
     resolved_accelerator = _normalize_accelerator_type(accelerator_type)
     _validate_machine_type(machine_type, resolved_accelerator)

--- a/environments/shared/scripts/sweep/trial.py
+++ b/environments/shared/scripts/sweep/trial.py
@@ -155,6 +155,7 @@ def run_trial(args: argparse.Namespace, extra_args: list[str]) -> None:
         algorithm=args.algorithm,
         use_wandb=args.wandb,
         output_dir=output_dir,
+        use_tensorboard=not args.no_tensorboard,
     )
 
     # Generate stage summary and replay videos (same artifacts the notebook produces)

--- a/environments/shared/tests/test_sweep.py
+++ b/environments/shared/tests/test_sweep.py
@@ -11,6 +11,7 @@ from environments.shared.scripts.sweep import (
     SweepStageError,
     _best_trial_model_path,
     _collect_trial_results,
+    _eager_refresh,
     _hpt_arg_to_override,
     _is_per_stage,
     _is_retryable_gcp_error,
@@ -1681,3 +1682,58 @@ class TestGenerateTrialArtifacts:
             assert (tmp_path / "behavioral_metrics.png").exists()
         except ImportError:
             pass  # graphs are skipped gracefully without matplotlib
+
+
+# ── _eager_refresh ───────────────────────────────────────────────────────────
+
+
+class TestEagerRefresh:
+    """Credential refresh retries on transient metadata-server errors."""
+
+    def _call(self, creds, **kwargs):
+        """Call _eager_refresh with a dummy request to avoid google.auth import."""
+        return _eager_refresh(creds, _request=MagicMock(), **kwargs)
+
+    def test_success_on_first_attempt(self):
+        creds = MagicMock()
+        self._call(creds, max_retries=3)
+        creds.refresh.assert_called_once()
+
+    @patch("time.sleep")
+    def test_retries_on_type_error(self, mock_sleep):
+        creds = MagicMock()
+        creds.refresh.side_effect = [TypeError("string indices"), None]
+        self._call(creds, max_retries=3)
+        assert creds.refresh.call_count == 2
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("time.sleep")
+    def test_raises_after_max_retries(self, mock_sleep):
+        creds = MagicMock()
+        creds.refresh.side_effect = TypeError("string indices")
+        with pytest.raises(TypeError):
+            self._call(creds, max_retries=3)
+        assert creds.refresh.call_count == 3
+
+    @patch("time.sleep")
+    def test_exponential_backoff(self, mock_sleep):
+        creds = MagicMock()
+        creds.refresh.side_effect = [
+            TypeError("string indices"),
+            TypeError("string indices"),
+            TypeError("string indices"),
+            None,
+        ]
+        self._call(creds, max_retries=4)
+        assert mock_sleep.call_args_list == [
+            ((1,),),
+            ((2,),),
+            ((4,),),
+        ]
+
+    def test_non_type_error_propagates_immediately(self):
+        creds = MagicMock()
+        creds.refresh.side_effect = ValueError("unexpected")
+        with pytest.raises(ValueError, match="unexpected"):
+            self._call(creds, max_retries=3)
+        creds.refresh.assert_called_once()

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -238,6 +238,7 @@ def train(
     algorithm: str = "ppo",
     use_wandb: bool = False,
     output_dir: str | None = None,
+    use_tensorboard: bool = True,
 ):
     """Train a single stage of the curriculum."""
     from .config import save_stage_config
@@ -316,14 +317,17 @@ def train(
     alg_kwargs["verbose"] = verbose
     # Buffer TensorBoard writes locally when output is on a GCS FUSE mount
     # to avoid per-event latency from direct GCS writes.
+    local_tb_dir = None
     gcs_tb_path = log_path / "tensorboard"
-    if _is_gcs_path(log_path):
-        local_tb_dir = _make_local_tb_dir(gcs_tb_path)
-        alg_kwargs["tensorboard_log"] = str(local_tb_dir)
-        logger.info("TensorBoard buffering locally at %s (will sync to GCS after training)", local_tb_dir)
+    if use_tensorboard:
+        if _is_gcs_path(log_path):
+            local_tb_dir = _make_local_tb_dir(gcs_tb_path)
+            alg_kwargs["tensorboard_log"] = str(local_tb_dir)
+            logger.info("TensorBoard buffering locally at %s (will sync to GCS after training)", local_tb_dir)
+        else:
+            alg_kwargs["tensorboard_log"] = str(gcs_tb_path)
     else:
-        local_tb_dir = None
-        alg_kwargs["tensorboard_log"] = str(gcs_tb_path)
+        logger.info("TensorBoard logging disabled")
 
     if algorithm == "ppo":
         lr_end = alg_kwargs.pop("learning_rate_end", None)
@@ -637,6 +641,7 @@ def train_curriculum(
     output_dir: str | None = None,
     gcs_bucket: str | None = None,
     gcs_project: str | None = None,
+    use_tensorboard: bool = True,
 ):
     """Run the full 3-stage curriculum with automatic advancement."""
     from .config import (
@@ -720,14 +725,17 @@ def train_curriculum(
         alg_kwargs = config["sac_kwargs"].copy() if algorithm == "sac" else config["ppo_kwargs"].copy()
         alg_kwargs["verbose"] = verbose
         # Buffer TensorBoard writes locally when on GCS FUSE mount
+        local_tb_dir = None
         gcs_tb_path = stage_dir / "tensorboard"
-        if _is_gcs_path(stage_dir):
-            local_tb_dir = _make_local_tb_dir(gcs_tb_path)
-            alg_kwargs["tensorboard_log"] = str(local_tb_dir)
-            logger.info("TensorBoard buffering locally at %s", local_tb_dir)
+        if use_tensorboard:
+            if _is_gcs_path(stage_dir):
+                local_tb_dir = _make_local_tb_dir(gcs_tb_path)
+                alg_kwargs["tensorboard_log"] = str(local_tb_dir)
+                logger.info("TensorBoard buffering locally at %s", local_tb_dir)
+            else:
+                alg_kwargs["tensorboard_log"] = str(gcs_tb_path)
         else:
-            local_tb_dir = None
-            alg_kwargs["tensorboard_log"] = str(gcs_tb_path)
+            logger.info("TensorBoard logging disabled")
 
         if algorithm == "ppo":
             lr_end = alg_kwargs.pop("learning_rate_end", None)


### PR DESCRIPTION
This pull request introduces a new option to disable TensorBoard logging throughout the sweep pipeline, which helps reduce disk I/O and storage usage during hyperparameter tuning and training. It also adds robust credential refresh logic to handle transient errors from the GCE metadata server, improving reliability in cloud environments. The changes are integrated across argument parsing, orchestration, job submission, and training modules, and are covered by new unit tests.

**TensorBoard logging control:**

* Added a `--no-tensorboard` command-line argument to `trial`, `launch`, and `launch-all` modes in `sweep/__main__.py`, allowing users to disable TensorBoard logging for each trial. [[1]](diffhunk://#diff-84ddd430395d11b45c3ae7cb1d237a8f90dcf8b4bacd754a1d9366d36ab3aa2aR48-R53) [[2]](diffhunk://#diff-84ddd430395d11b45c3ae7cb1d237a8f90dcf8b4bacd754a1d9366d36ab3aa2aR120-R125) [[3]](diffhunk://#diff-84ddd430395d11b45c3ae7cb1d237a8f90dcf8b4bacd754a1d9366d36ab3aa2aR247-R252)
* Propagated the `no_tensorboard` option through orchestration (`sweep/orchestration.py`), job submission (`sweep/submit.py`), and training (`sweep/trial.py`, `train_base.py`) to conditionally enable or disable TensorBoard logging in all relevant stages. [[1]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9R353) [[2]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9R856) [[3]](diffhunk://#diff-f7ae977dabc82b92c79dc2ce065efa32b9859ed179e00f29b3676f583de753d0R227) [[4]](diffhunk://#diff-f7ae977dabc82b92c79dc2ce065efa32b9859ed179e00f29b3676f583de753d0R243-R244) [[5]](diffhunk://#diff-f7ae977dabc82b92c79dc2ce065efa32b9859ed179e00f29b3676f583de753d0R282-R283) [[6]](diffhunk://#diff-fee46236ec0dcf80edbecc6ae1be3b906a744450db63056d1df437e47d21b2fcR158) [[7]](diffhunk://#diff-0b3f43c9e217972fc29c8088f802784e0e6f2538db78c81560ca2a1b1907dc76R241) [[8]](diffhunk://#diff-0b3f43c9e217972fc29c8088f802784e0e6f2538db78c81560ca2a1b1907dc76R320-R330) [[9]](diffhunk://#diff-0b3f43c9e217972fc29c8088f802784e0e6f2538db78c81560ca2a1b1907dc76R644) [[10]](diffhunk://#diff-0b3f43c9e217972fc29c8088f802784e0e6f2538db78c81560ca2a1b1907dc76R728-R738)

**Credential refresh reliability:**

* Implemented `_eager_refresh` in `sweep/orchestration.py` to eagerly refresh Google credentials with retries and exponential backoff, handling transient metadata-server errors before they propagate to gRPC calls.
* Integrated `_eager_refresh` into the credential resolution process and exported it in `sweep/__init__.py` for reuse and testing. [[1]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9R37-R57) [[2]](diffhunk://#diff-16dcdd0600719077657ee6b7cdeb42a99bac0e2b08e3a61e37ecc5b182e0b5d9L20-R20) [[3]](diffhunk://#diff-16dcdd0600719077657ee6b7cdeb42a99bac0e2b08e3a61e37ecc5b182e0b5d9R53) [[4]](diffhunk://#diff-0e299a098c6ab95322abfae1341801ed3d54f1acaca02515629328b63010ed3aR14)

**Testing enhancements:**

* Added comprehensive unit tests for `_eager_refresh` in `test_sweep.py`, covering successful refresh, retry logic, exponential backoff, and error propagation.

These changes collectively improve the flexibility and robustness of the sweep pipeline, making it easier to manage resource usage and handle cloud authentication errors.