### PR TITLE
Make TensorBoard sync best-effort and fix GCS FUSE compatibility

### DIFF
--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -149,7 +149,12 @@ def _make_local_tb_dir(gcs_tb_path: str | Path) -> Path:
 
 
 def _sync_tb_to_gcs(local_tb_dir: Path, gcs_tb_path: str | Path) -> None:
-    """Copy locally-buffered TensorBoard events to the GCS FUSE mount."""
+    """Copy locally-buffered TensorBoard events to the GCS FUSE mount.
+
+    Uses :func:`shutil.copy` (not ``copy2``) because GCS FUSE does not
+    support the ``os.utime`` / ``os.chmod`` calls that ``copy2`` makes
+    to preserve file metadata, which causes ``OSError`` on FUSE mounts.
+    """
     gcs_dest = Path(gcs_tb_path)
     if not local_tb_dir.exists():
         return
@@ -160,7 +165,7 @@ def _sync_tb_to_gcs(local_tb_dir: Path, gcs_tb_path: str | Path) -> None:
             rel = src_file.relative_to(local_tb_dir)
             dest = gcs_dest / rel
             dest.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(src_file, dest)
+            shutil.copy(src_file, dest)
             n_copied += 1
     logger.info("Synced %d TensorBoard files to %s", n_copied, gcs_dest)
     # Clean up temp dir
@@ -461,14 +466,18 @@ def train(
         stage_config=config,
     )
 
-    # Sync locally-buffered TensorBoard events to GCS before saving the model
-    if local_tb_dir is not None:
-        _sync_tb_to_gcs(local_tb_dir, gcs_tb_path)
-
     # Save final model
     final_path = model_dir / f"stage{stage}_final"
     model.save(str(final_path))
     train_env.save(str(final_path) + "_vecnorm.pkl")
+
+    # Sync locally-buffered TensorBoard events to GCS (best-effort, after
+    # model save so a sync failure never prevents checkpoint writes).
+    if local_tb_dir is not None:
+        try:
+            _sync_tb_to_gcs(local_tb_dir, gcs_tb_path)
+        except Exception:
+            logger.warning("TensorBoard sync to GCS failed.", exc_info=True)
 
     train_env.close()
     eval_env.close()
@@ -844,14 +853,17 @@ def train_curriculum(
         if wandb_run is not None:
             wandb_run.finish()
 
-        # Sync locally-buffered TensorBoard events to GCS
-        if local_tb_dir is not None:
-            _sync_tb_to_gcs(local_tb_dir, gcs_tb_path)
-
-        # Save stage checkpoint
+        # Save stage checkpoint (before TB sync so checkpoint is never lost)
         final_path = model_dir / f"stage{stage}_final"
         model.save(str(final_path))
         train_env.save(str(final_path) + "_vecnorm.pkl")
+
+        # Sync locally-buffered TensorBoard events to GCS (best-effort)
+        if local_tb_dir is not None:
+            try:
+                _sync_tb_to_gcs(local_tb_dir, gcs_tb_path)
+            except Exception:
+                logger.warning("TensorBoard sync to GCS failed.", exc_info=True)
 
         # Prefer loading the best model + its matched VecNormalize for the
         # next stage.  SaveVecNormalizeCallback (wired to EvalCallback's


### PR DESCRIPTION
## Summary
This PR improves the robustness of TensorBoard event syncing to GCS by making it a best-effort operation that won't block model checkpointing, and fixes a compatibility issue with GCS FUSE mounts.

## Key Changes
- **Fixed GCS FUSE compatibility**: Changed `shutil.copy2()` to `shutil.copy()` in `_sync_tb_to_gcs()` because GCS FUSE doesn't support the `os.utime()` and `os.chmod()` calls that `copy2` makes to preserve file metadata, which causes `OSError` on FUSE mounts
- **Made TB sync best-effort**: Moved TensorBoard syncing to occur *after* model checkpoint saving in both `train()` and `train_curriculum()` functions, ensuring that sync failures never prevent checkpoint writes
- **Added error handling**: Wrapped `_sync_tb_to_gcs()` calls in try-except blocks that log warnings instead of raising exceptions, allowing training to continue even if sync fails
- **Updated docstring**: Enhanced the `_sync_tb_to_gcs()` docstring to explain why `copy` is used instead of `copy2`

## Implementation Details
The sync operation is now positioned as a cleanup/logging step that happens after critical model saving operations. This ensures that even if GCS connectivity issues or FUSE mount problems occur during sync, the training checkpoints are already safely persisted locally.