### PR TITLE
Add --stage-timeout 0 fire-and-forget mode

### DIFF
--- a/environments/shared/scripts/sweep/__main__.py
+++ b/environments/shared/scripts/sweep/__main__.py
@@ -149,8 +149,9 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="SECONDS",
         help=(
             "Maximum wall-clock seconds to wait for the HPT job to complete. "
-            "If exceeded the job keeps running in the cloud — re-run with "
-            "--resume to reconnect."
+            "Use 0 to submit and exit immediately without polling "
+            "(fire-and-forget). If exceeded the job keeps running in the "
+            "cloud — re-run with --resume to reconnect."
         ),
     )
     launch.add_argument(
@@ -276,8 +277,9 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="SECONDS",
         help=(
             "Maximum wall-clock seconds to wait for each stage's HPT job to "
-            "complete. If exceeded the job keeps running in the cloud — re-run "
-            "with --resume to reconnect."
+            "complete. Use 0 to submit and exit immediately without polling "
+            "(fire-and-forget). If exceeded the job keeps running in the "
+            "cloud — re-run with --resume to reconnect."
         ),
     )
     launch_all.add_argument(

--- a/environments/shared/scripts/sweep/orchestration.py
+++ b/environments/shared/scripts/sweep/orchestration.py
@@ -376,8 +376,7 @@ def launch_sweep(args: argparse.Namespace) -> None:
             # Poll until the job completes (--stage-timeout 0 means fire-and-forget)
             if stage_timeout == 0:
                 logger.info(
-                    "Job submitted (--stage-timeout 0). Re-run with --resume to check results.\n"
-                    "  Resource: %s",
+                    "Job submitted (--stage-timeout 0). Re-run with --resume to check results.\n  Resource: %s",
                     job_resource_name,
                 )
                 os._exit(0)

--- a/environments/shared/scripts/sweep/orchestration.py
+++ b/environments/shared/scripts/sweep/orchestration.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import os
 import sys
 import time
 from pathlib import Path
@@ -372,7 +373,15 @@ def launch_sweep(args: argparse.Namespace) -> None:
                 project=args.project,
             )
 
-            # Poll until the job completes
+            # Poll until the job completes (--stage-timeout 0 means fire-and-forget)
+            if stage_timeout == 0:
+                logger.info(
+                    "Job submitted (--stage-timeout 0). Re-run with --resume to check results.\n"
+                    "  Resource: %s",
+                    job_resource_name,
+                )
+                os._exit(0)
+
             hpt_job = _wait_for_job(
                 hpt_job,
                 aiplatform,
@@ -515,7 +524,8 @@ def launch_sweep(args: argparse.Namespace) -> None:
                 bucket=args.bucket,
                 project=args.project,
             )
-            sys.exit(1)
+            # Use os._exit to avoid hanging on non-daemon SDK threads (e.g. gRPC).
+            os._exit(1)
         # Save state for unexpected errors too, so progress isn't lost.
         _save_sweep_state(
             sweep_state,
@@ -878,7 +888,16 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                     project=args.project,
                 )
 
-                # Poll until the job completes
+                # Poll until the job completes (--stage-timeout 0 means fire-and-forget)
+                if stage_timeout == 0:
+                    logger.info(
+                        "Stage %d job submitted (--stage-timeout 0). Re-run with --resume to check results.\n"
+                        "  Resource: %s",
+                        stage,
+                        job_resource_name,
+                    )
+                    os._exit(0)
+
                 hpt_job = _wait_for_job(
                     hpt_job,
                     aiplatform,
@@ -1048,7 +1067,8 @@ def launch_all_stages(args: argparse.Namespace) -> None:
                     bucket=args.bucket,
                     project=args.project,
                 )
-                sys.exit(1)
+                # Use os._exit to avoid hanging on non-daemon SDK threads (e.g. gRPC).
+                os._exit(1)
             # Save state for unexpected errors too, so progress isn't lost.
             _save_sweep_state(
                 sweep_state,

--- a/environments/shared/scripts/sweep/submit.py
+++ b/environments/shared/scripts/sweep/submit.py
@@ -124,6 +124,13 @@ def _wait_for_job(
     resource_name = hpt_job.resource_name
     start = time.monotonic()
 
+    # timeout=0 means fire-and-forget — skip polling entirely.
+    if timeout == 0:
+        raise TimeoutError(
+            f"Job {resource_name} submitted (--stage-timeout 0). "
+            f"The job is running in the cloud — re-run with --resume to reconnect."
+        )
+
     logger.info(
         "Waiting for job %s (poll every %ds, timeout %s) …",
         resource_name,


### PR DESCRIPTION
This pull request introduces support for a "fire-and-forget" mode in the sweep orchestration scripts, allowing jobs to be submitted without waiting for completion when a timeout of 0 is specified. This improves usability for users who want to submit jobs and exit immediately, and addresses issues with process termination by switching from `sys.exit` to `os._exit`.

**Fire-and-forget mode enhancements:**

* Updated help text for `--timeout` and `--stage-timeout` arguments to document the new fire-and-forget behavior when set to 0. [[1]](diffhunk://#diff-84ddd430395d11b45c3ae7cb1d237a8f90dcf8b4bacd754a1d9366d36ab3aa2aL152-R154) [[2]](diffhunk://#diff-84ddd430395d11b45c3ae7cb1d237a8f90dcf8b4bacd754a1d9366d36ab3aa2aL279-R282)
* Added logic in `launch_sweep` and `launch_all_stages` to exit immediately after job submission when timeout is 0, logging a clear message to the user. [[1]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9L375-R384) [[2]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9L881-R900)

**Process termination improvements:**

* Replaced `sys.exit` with `os._exit` to ensure immediate process termination and avoid hanging on non-daemon SDK threads (such as gRPC). [[1]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9L518-R528) [[2]](diffhunk://#diff-9a018ace9ce9d0d7c2a8605ee9e434dbd656893976606b35bd9b88fd755bd2c9L1051-R1071)
* Added `os` import to support the new exit method.

**Polling logic adjustment:**

* Modified `_wait_for_job` in `submit.py` to raise a `TimeoutError` immediately when timeout is 0, skipping polling and informing the user that the job can be resumed later.