### PR TITLE
Set default value for --n-envs argument to 4

### DIFF
--- a/environments/shared/scripts/sweep/__main__.py
+++ b/environments/shared/scripts/sweep/__main__.py
@@ -69,7 +69,7 @@ def _build_parser() -> argparse.ArgumentParser:
     launch.add_argument(
         "--n-envs",
         type=int,
-        default=None,
+        default=4,
         help="Parallel environments per trial (default: 4, or from search-space file)",
     )
     launch.add_argument("--project", required=True, help="GCP project ID")


### PR DESCRIPTION
## Summary
Updated the default value for the `--n-envs` command-line argument from `None` to `4` in the sweep launcher script.

## Changes
- Changed the `--n-envs` argument default from `None` to `4`
- This aligns the code default with the documented behavior in the help text, which already indicated "default: 4, or from search-space file"

## Details
This change ensures that when users don't explicitly specify the `--n-envs` parameter, the script will use 4 parallel environments per trial by default, rather than requiring the value to be sourced from the search-space file. This makes the default behavior more explicit and consistent with the documented help message.