### PR TITLE
Add heading_weight=0.1 to stage 1 balance configs for velociraptor and trex

### DIFF
--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -10,6 +10,7 @@ tail_stability_weight = 0.15
 posture_weight = 2.0
 nosedive_weight = 3.0
 smoothness_weight = 0.1
+heading_weight = 0.1                  # Small heading reward to prevent spin-to-balance exploits
 gait_symmetry_weight = 0.0     # Disable: default formula rewards single-foot stance, bad for balance
 height_weight = 1.0            # Reward maintaining pelvis height near target (0.90m)
 fall_penalty = -50.0           # Reduce from -100 to lower gradient variance

--- a/configs/velociraptor/stage1_balance.toml
+++ b/configs/velociraptor/stage1_balance.toml
@@ -12,6 +12,7 @@ posture_weight = 1.5
 nosedive_weight = 1.5
 gait_symmetry_weight = 0.0
 smoothness_weight = 0.05
+heading_weight = 0.1                             # Small heading reward to prevent spin-to-balance exploits
 strike_bonus = 0.0
 strike_approach_weight = 0.0
 prey_distance_range = [10.0, 15.0]


### PR DESCRIPTION
Prevents the RL agent from learning spin-to-balance exploits by adding a
small reward for maintaining orientation toward the initial prey direction.