### PR TITLE
Track heading alignment std to make spinning visible in heading graph

### DIFF
--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -99,6 +99,7 @@ class DiagnosticsCallback(_BaseCallback):
         self._history_timesteps: list[int] = []
         self._history = {k: [] for k in self.INFO_KEYS}
         self._history_rewards = {k: [] for k in self.REWARD_KEYS}
+        self._history_heading_std: list[float] = []
         self._history_terminations: dict[str, list[float]] = {}
         self._history_term_timesteps: list[int] = []
 
@@ -133,6 +134,11 @@ class DiagnosticsCallback(_BaseCallback):
             for key in self.REWARD_KEYS:
                 vals = self._step_infos[key]
                 self._history_rewards[key].append(float(_np.mean(vals)) if vals else float("nan"))
+            # Track heading alignment std to distinguish spinning from stable heading
+            heading_vals = self._step_infos.get("heading_alignment", [])
+            self._history_heading_std.append(
+                float(_np.std(heading_vals)) if len(heading_vals) > 1 else float("nan")
+            )
             self._save_diagnostics()
 
         self._step_infos = {k: [] for k in self.REWARD_KEYS + self.INFO_KEYS}
@@ -190,6 +196,8 @@ class DiagnosticsCallback(_BaseCallback):
             arr = self._history_rewards[key]
             if len(arr) == len(self._history_timesteps):
                 save_dict[key] = _np.array(arr)
+        if len(self._history_heading_std) == len(self._history_timesteps):
+            save_dict["heading_alignment_std"] = _np.array(self._history_heading_std)
         if self._history_term_timesteps:
             save_dict["term_timesteps"] = _np.array(self._history_term_timesteps)
             for reason, fracs in self._history_terminations.items():

--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -136,9 +136,7 @@ class DiagnosticsCallback(_BaseCallback):
                 self._history_rewards[key].append(float(_np.mean(vals)) if vals else float("nan"))
             # Track heading alignment std to distinguish spinning from stable heading
             heading_vals = self._step_infos.get("heading_alignment", [])
-            self._history_heading_std.append(
-                float(_np.std(heading_vals)) if len(heading_vals) > 1 else float("nan")
-            )
+            self._history_heading_std.append(float(_np.std(heading_vals)) if len(heading_vals) > 1 else float("nan"))
             self._save_diagnostics()
 
         self._step_infos = {k: [] for k in self.REWARD_KEYS + self.INFO_KEYS}

--- a/environments/shared/tests/test_diagnostics.py
+++ b/environments/shared/tests/test_diagnostics.py
@@ -250,6 +250,21 @@ class TestSaveDiagnostics:
         cb._on_rollout_end()
         # No error, just no file
 
+    def test_saves_heading_alignment_std(self, callback, tmp_path):
+        callback._step_infos["heading_alignment"] = [1.0, -1.0, 0.5, -0.5]
+        callback._step_infos["forward_vel"] = [1.0]  # needed to trigger history append
+        callback._on_rollout_end()
+        data = np.load(str(tmp_path / "diagnostics.npz"))
+        assert "heading_alignment_std" in data
+        assert data["heading_alignment_std"][0] == pytest.approx(np.std([1.0, -1.0, 0.5, -0.5]))
+
+    def test_heading_alignment_std_nan_when_no_data(self, callback, tmp_path):
+        callback._step_infos["forward_vel"] = [1.0]  # trigger history but no heading data
+        callback._on_rollout_end()
+        data = np.load(str(tmp_path / "diagnostics.npz"))
+        assert "heading_alignment_std" in data
+        assert np.isnan(data["heading_alignment_std"][0])
+
     def test_accumulates_over_multiple_rollouts(self, callback, tmp_path):
         callback._step_infos["forward_vel"] = [1.0]
         callback._on_rollout_end()

--- a/environments/shared/visualization.py
+++ b/environments/shared/visualization.py
@@ -316,9 +316,19 @@ def plot_diagnostics_graphs(
                 alpha=0.7,
             )
 
-        # [0,1] Heading Alignment
+        # [0,1] Heading Alignment (with std band to reveal spinning)
         if "heading_alignment" in diag:
-            axes2[0, 1].plot(ts, diag["heading_alignment"], label=label, color=color)
+            ha = diag["heading_alignment"]
+            axes2[0, 1].plot(ts, ha, label=label, color=color)
+            if "heading_alignment_std" in diag:
+                ha_std = diag["heading_alignment_std"]
+                axes2[0, 1].fill_between(
+                    ts,
+                    ha - ha_std,
+                    ha + ha_std,
+                    alpha=0.2,
+                    color=color,
+                )
 
         # [1,0] Prey / Food Distance
         if "prey_distance" in diag:


### PR DESCRIPTION
The heading graph previously showed only per-rollout mean heading
alignment, which averages to ~0 for a spinning raptor and looks
identical to a raptor stably facing perpendicular to the prey. Now
the DiagnosticsCallback also records per-rollout std of heading
alignment and the visualization plots it as a shaded band, making
spinning behavior clearly distinguishable from stable heading.