### PR TITLE
Add post-training quality evaluation and spinning detection metrics

### DIFF
--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -77,6 +77,8 @@ class DiagnosticsCallback(_BaseCallback):
         "strike_success",
         "r_foot_contact",
         "l_foot_contact",
+        "pelvis_angular_vel",
+        "pelvis_yaw_vel",
     ]
 
     def __init__(self, plateau_window=10, plateau_threshold=1.0, log_dir=None, verbose=0):

--- a/environments/shared/evaluation.py
+++ b/environments/shared/evaluation.py
@@ -62,6 +62,102 @@ def eval_policy(
     return rewards, lengths, fwd_vels, successes
 
 
+def eval_policy_quality(
+    model,
+    eval_env,
+    success_keys: list[str],
+    n_episodes: int = 50,
+) -> dict:
+    """Evaluate a trained policy collecting quality metrics for post-training selection.
+
+    Runs *n_episodes* deterministic rollouts using :class:`LocomotionMetrics`
+    and returns aggregated quality metrics including spinning detection
+    signals, reward component breakdowns, and heading stability.
+
+    This is designed to be called after training to populate the
+    ``metrics.json`` sidecar with columns that enable model selection
+    beyond raw reward.
+
+    Returns:
+        Dict of aggregated eval metrics (prefixed with ``eval_``).
+    """
+    from .metrics import LocomotionMetrics
+
+    import numpy as _np
+
+    episode_reports = []
+
+    for _ in range(n_episodes):
+        obs = eval_env.reset()
+        metrics = LocomotionMetrics()
+        done = False
+        while not done:
+            action, _ = model.predict(obs, deterministic=True)
+            obs, reward, dones, infos = eval_env.step(action)
+            metrics.record_step(infos[0], float(reward[0]))
+            done = bool(dones[0])
+        episode_reports.append(metrics.compute())
+
+    agg = LocomotionMetrics.aggregate_episodes(episode_reports)
+
+    # Extract the key quality metrics with eval_ prefix
+    result: dict = {}
+
+    # Core performance
+    for key in (
+        "mean_episode_length",
+        "mean_total_reward",
+    ):
+        if key in agg:
+            result[f"eval_{key}"] = round(agg[key], 4)
+
+    # Spinning detection
+    for key in (
+        "mean_mean_pelvis_angular_velocity",
+        "mean_max_pelvis_angular_velocity",
+        "mean_mean_pelvis_yaw_velocity",
+        "mean_max_pelvis_yaw_velocity",
+    ):
+        if key in agg:
+            # Simplify key: mean_mean_pelvis_angular_velocity → eval_mean_pelvis_angular_velocity
+            clean_key = key.replace("mean_mean_", "mean_").replace("mean_max_", "max_")
+            result[f"eval_{clean_key}"] = round(agg[key], 4)
+
+    # Heading stability
+    for key in (
+        "mean_mean_heading_alignment",
+        "std_mean_heading_alignment",
+        "mean_std_heading_alignment",
+    ):
+        if key in agg:
+            clean_key = key.replace("mean_mean_", "mean_").replace("mean_std_", "std_")
+            result[f"eval_{clean_key}"] = round(agg[key], 4)
+
+    # Posture quality
+    for key in (
+        "mean_mean_tilt_angle",
+        "mean_mean_pelvis_height",
+    ):
+        if key in agg:
+            clean_key = key.replace("mean_mean_", "mean_")
+            result[f"eval_{clean_key}"] = round(agg[key], 4)
+
+    # Reward component breakdown (cumulative per episode, averaged across episodes)
+    for key, value in agg.items():
+        if key.startswith("mean_reward_component_"):
+            component = key.replace("mean_reward_component_", "")
+            result[f"eval_reward_{component}"] = round(value, 4)
+
+    # Termination reason distribution
+    term_counts = agg.get("termination_counts")
+    if term_counts:
+        total = sum(term_counts.values())
+        for reason, count in term_counts.items():
+            result[f"eval_term_{reason}_pct"] = round(count / total, 4)
+
+    return result
+
+
 def record_stage_video(
     model,
     env_class: type,

--- a/environments/shared/evaluation.py
+++ b/environments/shared/evaluation.py
@@ -83,8 +83,6 @@ def eval_policy_quality(
     """
     from .metrics import LocomotionMetrics
 
-    import numpy as _np
-
     episode_reports = []
 
     for _ in range(n_episodes):

--- a/environments/shared/metrics.py
+++ b/environments/shared/metrics.py
@@ -45,6 +45,9 @@ class LocomotionMetrics:
     _heading_alignments: List[float] = field(default_factory=list)
     _success_events: List[float] = field(default_factory=list)
     _contact_asymmetries: List[float] = field(default_factory=list)
+    _pelvis_angular_velocities: List[float] = field(default_factory=list)
+    _pelvis_yaw_velocities: List[float] = field(default_factory=list)
+    _reward_components: Dict[str, List[float]] = field(default_factory=dict)
     _dt: float = 0.02  # default timestep * frame_skip
     _termination_reason: Optional[str] = None
 
@@ -61,6 +64,9 @@ class LocomotionMetrics:
         self._heading_alignments.clear()
         self._success_events.clear()
         self._contact_asymmetries.clear()
+        self._pelvis_angular_velocities.clear()
+        self._pelvis_yaw_velocities.clear()
+        self._reward_components.clear()
         self._termination_reason = None
 
     def record_step(self, info: Dict[str, Any], reward: float = 0.0):
@@ -105,6 +111,23 @@ class LocomotionMetrics:
 
         if "contact_asymmetry" in info:
             self._contact_asymmetries.append(float(info["contact_asymmetry"]))
+
+        if "pelvis_angular_vel" in info:
+            self._pelvis_angular_velocities.append(float(info["pelvis_angular_vel"]))
+
+        if "pelvis_yaw_vel" in info:
+            self._pelvis_yaw_velocities.append(float(info["pelvis_yaw_vel"]))
+
+        # Track individual reward components for post-training breakdown
+        for key in (
+            "reward_forward", "reward_alive", "reward_energy", "reward_tail",
+            "reward_posture", "reward_nosedive", "reward_smoothness",
+            "reward_strike", "reward_approach", "reward_gait",
+            "reward_heading", "reward_lateral", "reward_backward",
+            "reward_proximity", "reward_claw_proximity",
+        ):
+            if key in info:
+                self._reward_components.setdefault(key, []).append(float(info[key]))
 
         # Capture termination reason from the final step
         if "termination_reason" in info:
@@ -208,6 +231,25 @@ class LocomotionMetrics:
         # --- Contact asymmetry ---
         if self._contact_asymmetries:
             result["mean_contact_asymmetry"] = float(np.mean(self._contact_asymmetries))
+
+        # --- Pelvis angular velocity (spinning detection) ---
+        if self._pelvis_angular_velocities:
+            angvel = np.array(self._pelvis_angular_velocities)
+            result["mean_pelvis_angular_velocity"] = float(np.mean(angvel))
+            result["max_pelvis_angular_velocity"] = float(np.max(angvel))
+            result["std_pelvis_angular_velocity"] = float(np.std(angvel))
+
+        if self._pelvis_yaw_velocities:
+            yaw = np.array(self._pelvis_yaw_velocities)
+            result["mean_pelvis_yaw_velocity"] = float(np.mean(np.abs(yaw)))
+            result["max_pelvis_yaw_velocity"] = float(np.max(np.abs(yaw)))
+
+        # --- Reward component breakdown ---
+        for key, values in self._reward_components.items():
+            if values:
+                # Strip "reward_" prefix for cleaner metric names
+                component = key.replace("reward_", "")
+                result[f"reward_component_{component}"] = float(np.sum(values))
 
         # --- Termination reason ---
         if self._termination_reason is not None:

--- a/environments/shared/metrics.py
+++ b/environments/shared/metrics.py
@@ -120,11 +120,21 @@ class LocomotionMetrics:
 
         # Track individual reward components for post-training breakdown
         for key in (
-            "reward_forward", "reward_alive", "reward_energy", "reward_tail",
-            "reward_posture", "reward_nosedive", "reward_smoothness",
-            "reward_strike", "reward_approach", "reward_gait",
-            "reward_heading", "reward_lateral", "reward_backward",
-            "reward_proximity", "reward_claw_proximity",
+            "reward_forward",
+            "reward_alive",
+            "reward_energy",
+            "reward_tail",
+            "reward_posture",
+            "reward_nosedive",
+            "reward_smoothness",
+            "reward_strike",
+            "reward_approach",
+            "reward_gait",
+            "reward_heading",
+            "reward_lateral",
+            "reward_backward",
+            "reward_proximity",
+            "reward_claw_proximity",
         ):
             if key in info:
                 self._reward_components.setdefault(key, []).append(float(info[key]))

--- a/environments/shared/scripts/sweep/results.py
+++ b/environments/shared/scripts/sweep/results.py
@@ -187,6 +187,12 @@ def _collect_trial_results(hpt_job: Any, stage: int, stage_config: dict, output_
         row["last_mean_reward"] = aux.get("last_mean_reward")
         row["last_mean_episode_length"] = aux.get("last_mean_episode_length")
         row["training_duration_seconds"] = aux.get("training_duration_seconds")
+
+        # Quality evaluation metrics (spinning detection, heading, reward breakdown)
+        for key, value in aux.items():
+            if key.startswith("eval_"):
+                row[key] = value
+
         row["reward_threshold"] = reward_threshold
         row["ep_length_threshold"] = ep_length_threshold
         row["forward_vel_threshold"] = forward_vel_threshold
@@ -260,9 +266,12 @@ def write_results_csv(rows: list[dict], path: str | Path) -> Path:
         "success_rate_threshold",
         "stage_passed",
     ]
+    # Collect eval_* quality metric columns across all rows (union, sorted)
+    eval_cols: list[str] = sorted({k for row in rows for k in row if k.startswith("eval_")})
     # Collect all hyperparameter column names across all rows (union, sorted)
-    hparam_cols: list[str] = sorted({k for row in rows for k in row if k not in fixed_cols + metric_cols})
-    fieldnames = fixed_cols + hparam_cols + metric_cols
+    all_known = set(fixed_cols + metric_cols + eval_cols)
+    hparam_cols: list[str] = sorted({k for row in rows for k in row if k not in all_known})
+    fieldnames = fixed_cols + hparam_cols + metric_cols + eval_cols
 
     with open(local_path, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
@@ -511,13 +520,15 @@ def plot_sweep_results(csv_path: str | Path, species: str, algorithm: str, save_
         "best_mean_episode_length",
         "last_mean_reward",
         "last_mean_episode_length",
+        "training_duration_seconds",
         "reward_threshold",
         "ep_length_threshold",
         "forward_vel_threshold",
         "success_rate_threshold",
         "stage_passed",
     }
-    hparam_cols = [k for k in rows[0].keys() if k not in fixed_cols]
+    # Exclude eval_* quality metrics from hyperparameter analysis
+    hparam_cols = [k for k in rows[0].keys() if k not in fixed_cols and not k.startswith("eval_")]
     # Filter to columns with numeric, varying values
     numeric_hparams = []
     for col in hparam_cols:

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -576,29 +576,49 @@ def _report_hpt_metrics(
             last_mean_ep_length,
         )
 
+    # ── Post-training quality evaluation (all stages) ──────────────────
+    # Run evaluation rollouts with LocomotionMetrics to collect spinning
+    # detection signals, heading stability, and reward component breakdown.
+    # These metrics enable model selection beyond raw reward.
+    from .curriculum import load_vecnorm_stats
+
+    best_model_zip = model_dir / "best_model.zip"
+    best_vecnorm_path = model_dir / "best_model_vecnorm.pkl"
+    alg_cls = sb3["SAC"] if algorithm == "sac" else sb3["PPO"]
+
+    if best_model_zip.exists():
+        eval_model = alg_cls.load(str(model_dir / "best_model"), env=eval_env)
+        if best_vecnorm_path.exists():
+            load_vecnorm_stats(str(best_vecnorm_path), eval_env)
+        eval_env.training = False
+        eval_env.norm_reward = False
+        logger.info("HPT eval: using best model + matched VecNormalize")
+    else:
+        eval_model = model
+        eval_env.training = False
+        eval_env.norm_reward = False
+        logger.warning("HPT eval: best_model.zip not found, falling back to final model")
+
+    # Quality evaluation with full LocomotionMetrics (spinning detection,
+    # heading alignment, reward breakdown, etc.)
+    from .evaluation import eval_policy_quality
+
+    try:
+        quality_metrics = eval_policy_quality(
+            eval_model, eval_env, species_cfg.success_keys, n_episodes=50
+        )
+        aux_metrics.update(quality_metrics)
+        logger.info(
+            "Quality eval complete: %d metrics collected (angular_vel=%.3f, heading_align=%.3f)",
+            len(quality_metrics),
+            quality_metrics.get("eval_mean_pelvis_angular_velocity", float("nan")),
+            quality_metrics.get("eval_mean_heading_alignment", float("nan")),
+        )
+    except Exception:
+        logger.warning("Quality evaluation failed — skipping quality metrics.", exc_info=True)
+
     if stage >= 2:
-        # Use the best model + its matched VecNormalize for forward_vel
-        # and success_rate evaluation so the metrics reflect the checkpoint
-        # that will actually be handed off to the next stage.
-        from .curriculum import load_vecnorm_stats
-
-        best_model_zip = model_dir / "best_model.zip"
-        best_vecnorm_path = model_dir / "best_model_vecnorm.pkl"
-        alg_cls = sb3["SAC"] if algorithm == "sac" else sb3["PPO"]
-
-        if best_model_zip.exists():
-            eval_model = alg_cls.load(str(model_dir / "best_model"), env=eval_env)
-            if best_vecnorm_path.exists():
-                load_vecnorm_stats(str(best_vecnorm_path), eval_env)
-            eval_env.training = False
-            eval_env.norm_reward = False
-            logger.info("HPT eval: using best model + matched VecNormalize")
-        else:
-            eval_model = model
-            eval_env.training = False
-            eval_env.norm_reward = False
-            logger.warning("HPT eval: best_model.zip not found, falling back to final model")
-
+        # Forward velocity and success rate evaluation for stage advancement.
         _, _, fwd_vels, success_flags = eval_policy(eval_model, eval_env, species_cfg.success_keys, n_episodes=30)
         if fwd_vels:
             best_fwd = float(_np.mean(fwd_vels))

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -604,9 +604,7 @@ def _report_hpt_metrics(
     from .evaluation import eval_policy_quality
 
     try:
-        quality_metrics = eval_policy_quality(
-            eval_model, eval_env, species_cfg.success_keys, n_episodes=50
-        )
+        quality_metrics = eval_policy_quality(eval_model, eval_env, species_cfg.success_keys, n_episodes=50)
         aux_metrics.update(quality_metrics)
         logger.info(
             "Quality eval complete: %d metrics collected (angular_vel=%.3f, heading_align=%.3f)",

--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -393,6 +393,11 @@ class RaptorEnv(BaseDinoEnv):
         # 8b. Pelvis height (for LocomotionMetrics tracking)
         info["pelvis_height"] = float(self.data.xpos[self.pelvis_id, 2])
 
+        # 8c. Pelvis angular velocity (for spinning detection in eval metrics)
+        pelvis_gyro = self.data.sensordata[self._sensor_gyro_start : self._sensor_gyro_start + 3]
+        info["pelvis_angular_vel"] = float(np.linalg.norm(pelvis_gyro))
+        info["pelvis_yaw_vel"] = float(pelvis_gyro[2])  # Z-axis rotation = yaw = spinning
+
         # 9. Gait symmetry (reward alternating foot contacts)
         # Track touchdown events (off→on transitions) and reward when
         # consecutive touchdowns alternate feet: L→R→L = 1.0, L→L→R = 0.5.


### PR DESCRIPTION
Run 50-episode eval with LocomotionMetrics after training to collect
spinning detection signals (pelvis angular velocity, yaw velocity),
heading stability, posture quality, and reward component breakdown.

These metrics flow into metrics.json and collected_results.csv as
eval_* columns, enabling model selection beyond raw reward — which
was dominated by alive_bonus * episode_length (spinning).

Changes:
- raptor_env: emit pelvis_angular_vel and pelvis_yaw_vel in info dict
- metrics: track angular velocity, yaw velocity, reward components
- evaluation: add eval_policy_quality() for post-training selection
- train_base: call quality eval in _report_hpt_metrics for all stages
- results: include eval_* columns in CSV, exclude from hparam analysis
- diagnostics: log pelvis_angular_vel and pelvis_yaw_vel to TensorBoard