### PR TITLE
Add spin_penalty_weight to RaptorEnv to directly penalize pelvis angular velocity

### DIFF
--- a/configs/velociraptor/stage1_balance.toml
+++ b/configs/velociraptor/stage1_balance.toml
@@ -13,6 +13,7 @@ nosedive_weight = 1.5
 gait_symmetry_weight = 0.0
 smoothness_weight = 0.05
 heading_weight = 0.1                             # Small heading reward to prevent spin-to-balance exploits
+spin_penalty_weight = 0.1                        # Penalize pelvis angular velocity to directly discourage spinning
 strike_bonus = 0.0
 strike_approach_weight = 0.0
 prey_distance_range = [10.0, 15.0]

--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -38,6 +38,7 @@ Reward components:
     - Nosedive penalty
     - Gait symmetry (alternating foot contacts)
     - Action smoothness (penalize jerky action changes)
+    - Spin penalty (penalize pelvis angular velocity)
     - Heading alignment (facing toward prey)
     - Lateral velocity penalty (anti crab-walk)
 """
@@ -84,6 +85,7 @@ class RaptorEnv(BaseDinoEnv):
         heading_weight: float = 0.0,
         lateral_penalty_weight: float = 0.0,
         backward_vel_penalty_weight: float = 0.0,
+        spin_penalty_weight: float = 0.0,
         # Environment settings
         prey_distance_range: Tuple[float, float] = (3.0, 8.0),
         prey_lateral_range: Tuple[float, float] = (-2.0, 2.0),
@@ -106,6 +108,7 @@ class RaptorEnv(BaseDinoEnv):
         self.heading_weight = heading_weight
         self.lateral_penalty_weight = lateral_penalty_weight
         self.backward_vel_penalty_weight = backward_vel_penalty_weight
+        self.spin_penalty_weight = spin_penalty_weight
 
         # Natural forward pitch (~20°). The nosedive penalty and termination
         # are measured relative to this angle so the raptor isn't punished for
@@ -398,6 +401,14 @@ class RaptorEnv(BaseDinoEnv):
         info["pelvis_angular_vel"] = float(np.linalg.norm(pelvis_gyro))
         info["pelvis_yaw_vel"] = float(pelvis_gyro[2])  # Z-axis rotation = yaw = spinning
 
+        # 8d. Spin penalty (penalize pelvis angular velocity, cf. Brachiosaurus gait_stability)
+        pelvis_angvel = self.data.qvel[3:6]
+        spin_instability = float(np.linalg.norm(pelvis_angvel))
+        spin_instability_norm = min(spin_instability / 10.0, 1.0)
+        reward_spin = -self.spin_penalty_weight * spin_instability_norm
+        info["spin_instability"] = spin_instability
+        info["reward_spin"] = reward_spin
+
         # 9. Gait symmetry (reward alternating foot contacts)
         # Track touchdown events (off→on transitions) and reward when
         # consecutive touchdowns alternate feet: L→R→L = 1.0, L→L→R = 0.5.
@@ -477,6 +488,7 @@ class RaptorEnv(BaseDinoEnv):
             + reward_claw_proximity
             + reward_posture
             + reward_nosedive
+            + reward_spin
             + reward_gait
             + reward_smoothness
             + reward_heading

--- a/environments/velociraptor/tests/test_raptor_rewards.py
+++ b/environments/velociraptor/tests/test_raptor_rewards.py
@@ -46,6 +46,7 @@ class TestRaptorRewardComponents:
             + info["reward_claw_proximity"]
             + info["reward_posture"]
             + info["reward_nosedive"]
+            + info["reward_spin"]
             + info["reward_gait"]
             + info["reward_smoothness"]
             + info["reward_heading"]
@@ -151,6 +152,23 @@ class TestRaptorRewardWeightEffects:
         action2 = env.action_space.sample()
         _, _, _, _, info = env.step(action2)
         assert info["reward_smoothness"] == 0.0
+        env.close()
+
+    def test_zero_spin_weight_zeroes_spin_reward(self):
+        env = RaptorEnv(spin_penalty_weight=0.0)
+        env.reset(seed=42)
+        action = env.action_space.sample()
+        _, _, _, _, info = env.step(action)
+        assert info["reward_spin"] == 0.0
+        env.close()
+
+    def test_nonzero_spin_weight_gives_nonpositive_reward(self):
+        env = RaptorEnv(spin_penalty_weight=0.5)
+        env.reset(seed=42)
+        action = env.action_space.sample()
+        _, _, _, _, info = env.step(action)
+        assert info["reward_spin"] <= 0.0
+        assert info["spin_instability"] >= 0.0
         env.close()
 
     def test_zero_backward_vel_weight_zeroes_backward_reward(self):


### PR DESCRIPTION
Adds an explicit pelvis angular velocity penalty (similar to Brachiosaurus's
gait_stability_weight) that penalizes the norm of qvel[3:6]. This complements
the existing heading_weight by directly discouraging spinning behavior rather
than relying solely on the indirect gradient from heading alignment.

Set to 0.1 in stage 1 balance config. Normalized against 10.0 rad/s max.