### PR TITLE
Uncap drift distance penalty so it grows indefinitely with displacement

### DIFF
--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -280,8 +280,8 @@ class TRexEnv(BaseDinoEnv):
         #     quadratic so small wobbles are cheap but sustained drift is costly)
         drift_2d = pelvis_pos[:2] - self._initial_pos_2d
         drift_dist = float(np.linalg.norm(drift_2d))
-        # Normalize: 1.0 at 2m drift, capped at 1.0
-        drift_norm = min(drift_dist / 2.0, 1.0)
+        # Normalize: 1.0 at 2m drift, uncapped so penalty grows with distance
+        drift_norm = drift_dist / 2.0
         reward_drift = -self.drift_penalty_weight * (drift_norm**2)
         info["drift_distance"] = drift_dist
         info["reward_drift"] = reward_drift

--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -294,8 +294,8 @@ class RaptorEnv(BaseDinoEnv):
         #     quadratic so small wobbles are cheap but sustained drift is costly)
         drift_2d = pelvis_pos[:2] - self._initial_pos_2d
         drift_dist = float(np.linalg.norm(drift_2d))
-        # Normalize: 1.0 at 2m drift, capped at 1.0
-        drift_norm = min(drift_dist / 2.0, 1.0)
+        # Normalize: 1.0 at 2m drift, uncapped so penalty grows with distance
+        drift_norm = drift_dist / 2.0
         reward_drift = -self.drift_penalty_weight * (drift_norm**2)
         info["drift_distance"] = drift_dist
         info["reward_drift"] = reward_drift


### PR DESCRIPTION
The previous cap at 2m meant the agent could learn to drift forward
since the bounded penalty was outweighed by forward reward. Removing
the cap ensures the quadratic penalty keeps increasing, providing
continuous pressure to stay near the spawn point.

https://claude.ai/code/session_01W8vE7PWpS336Ayu52aZp4S