### PR TITLE
Increase stage 1/2 episode length to 750 and stage 2 speed to 2.0

### DIFF
--- a/configs/brachiosaurus/stage1_balance.toml
+++ b/configs/brachiosaurus/stage1_balance.toml
@@ -36,5 +36,5 @@ ent_coef = "auto"
 [curriculum]
 timesteps = 4000000
 min_avg_reward = 50.0
-min_avg_episode_length = 400
+min_avg_episode_length = 750
 required_consecutive = 3

--- a/configs/brachiosaurus/stage2_locomotion.toml
+++ b/configs/brachiosaurus/stage2_locomotion.toml
@@ -36,8 +36,8 @@ ent_coef = "auto"
 [curriculum]
 timesteps = 5000000
 min_avg_reward = 100.0
-min_avg_episode_length = 800
-min_avg_forward_vel = 0.2              # Gate on actual locomotion; without this, a standing-still policy passes on alive_bonus alone. Lower than raptor (0.4) and T-Rex (0.3) — Brachiosaurus is slower.
+min_avg_episode_length = 750
+min_avg_forward_vel = 2.0              # Gate on actual locomotion; without this, a standing-still policy passes on alive_bonus alone. Lower than raptor (0.4) and T-Rex (0.3) — Brachiosaurus is slower.
 required_consecutive = 3
 warmup_timesteps = 100000               # Timesteps to constrain policy updates while critic adapts (PPO only)
 warmup_clip_range = 0.02                # Small clip range during warm-up to limit policy change

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -46,5 +46,5 @@ ent_coef = "auto"
 [curriculum]
 timesteps = 6000000
 min_avg_reward = 100.0
-min_avg_episode_length = 300
+min_avg_episode_length = 750
 required_consecutive = 3

--- a/configs/trex/stage2_locomotion.toml
+++ b/configs/trex/stage2_locomotion.toml
@@ -45,8 +45,8 @@ ent_coef = "auto"
 [curriculum]
 timesteps = 8000000                     # Increase from 5M: your best T-Rex stage2 was only at 2M steps and still improving
 min_avg_reward = 100.0
-min_avg_episode_length = 600            # Reduce from 800: T-Rex best run reached 682, 800 is too strict
-min_avg_forward_vel = 0.3               # Reduce from 0.4: T-Rex is slower/heavier than velociraptor
+min_avg_episode_length = 750            # Reduce from 800: T-Rex best run reached 682, 800 is too strict
+min_avg_forward_vel = 2.0               # Reduce from 0.4: T-Rex is slower/heavier than velociraptor
 required_consecutive = 3
 warmup_timesteps = 300000               # Increased from 100k: give critic more time to adapt to new reward landscape (matches raptor stage 2 proportional warmup)
 warmup_clip_range = 0.02                # Small clip range during warm-up to limit policy change

--- a/configs/velociraptor/stage1_balance.toml
+++ b/configs/velociraptor/stage1_balance.toml
@@ -47,5 +47,5 @@ ent_coef = "auto"
 [curriculum]
 timesteps = 6000000
 min_avg_reward = 100.0
-min_avg_episode_length = 300
+min_avg_episode_length = 750
 required_consecutive = 3

--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -46,8 +46,8 @@ ent_coef = "auto"
 [curriculum]
 timesteps = 6000000                    # Reduced from 8M: successful runs passed in 2M; 5M provides margin for warmup/ramp
 min_avg_reward = 100.0
-min_avg_episode_length = 600
-min_avg_forward_vel = 0.4
+min_avg_episode_length = 750
+min_avg_forward_vel = 2.0
 required_consecutive = 3
 warmup_timesteps = 300000               # Increase from 100k: give critic more time to adapt to new reward landscape
 warmup_clip_range = 0.02


### PR DESCRIPTION
Raise min_avg_episode_length to 750 for all species in both stage 1
and stage 2 curriculum criteria. Increase min_avg_forward_vel to 2.0
in all stage 2 configs to require faster locomotion before advancing.

https://claude.ai/code/session_01XHc5HWNf3ge4RtP6ESTyP2