### PR TITLE
Configure logging early and fix GRACE_PERIOD comment

### DIFF
--- a/notebooks/ray_tune_sweep.ipynb
+++ b/notebooks/ray_tune_sweep.ipynb
@@ -119,32 +119,7 @@
     "id": "cell-4"
    },
    "outputs": [],
-   "source": [
-    "import json\n",
-    "import sys\n",
-    "import time\n",
-    "from datetime import datetime\n",
-    "from pathlib import Path\n",
-    "\n",
-    "import numpy as np\n",
-    "\n",
-    "if IN_COLAB:\n",
-    "    repo_root = Path(\"/content/mesozoic-labs\")\n",
-    "else:\n",
-    "    repo_root = Path(\"..\").resolve()\n",
-    "\n",
-    "if str(repo_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(repo_root))\n",
-    "\n",
-    "import mujoco\n",
-    "\n",
-    "from environments.shared.config import load_all_stages\n",
-    "from environments.shared.scripts.sweep.constants import NET_ARCH_PRESETS\n",
-    "from environments.shared.train_base import SpeciesConfig\n",
-    "\n",
-    "print(f\"MuJoCo version: {mujoco.__version__}\")\n",
-    "print(f\"Repo root: {repo_root}\")"
-   ]
+   "source": "import json\nimport logging\nimport sys\nimport time\nfrom datetime import datetime\nfrom pathlib import Path\n\nimport numpy as np\n\n# Configure logging early \u2014 must run before any getLogger() calls so the\n# root handler is in place for both the driver process and notebook cells.\nlogging.basicConfig(\n    level=logging.INFO,\n    format=\"%(asctime)s [%(levelname)s] %(name)s: %(message)s\",\n    datefmt=\"%Y-%m-%d %H:%M:%S\",\n)\n\nif IN_COLAB:\n    repo_root = Path(\"/content/mesozoic-labs\")\nelse:\n    repo_root = Path(\"..\").resolve()\n\nif str(repo_root) not in sys.path:\n    sys.path.insert(0, str(repo_root))\n\nimport mujoco\n\nfrom environments.shared.config import load_all_stages\nfrom environments.shared.scripts.sweep.constants import NET_ARCH_PRESETS\nfrom environments.shared.train_base import SpeciesConfig\n\nprint(f\"MuJoCo version: {mujoco.__version__}\")\nprint(f\"Repo root: {repo_root}\")"
   },
   {
    "cell_type": "markdown",
@@ -794,7 +769,7 @@
     "\n",
     "# ASHA scheduler for early stopping\n",
     "max_reports = TIMESTEPS_PER_TRIAL // EVAL_FREQ\n",
-    "GRACE_PERIOD = 20            # Don't stop before 8 eval reports (~1M steps)\n",
+    "GRACE_PERIOD = 20            # Don't stop before 20 eval reports (~1M steps)\n",
     "REDUCTION_FACTOR = 3        # Keep top ~33% of trials at each rung\n",
     "scheduler = ASHAScheduler(\n",
     "    metric=\"best_mean_reward\",\n",
@@ -1209,7 +1184,6 @@
   {
    "cell_type": "code",
    "source": [
-    "import logging\n",
     "import pandas as pd\n",
     "from stable_baselines3 import PPO, SAC\n",
     "\n",
@@ -1218,8 +1192,7 @@
     "from environments.shared.reporting import generate_stage_artifacts\n",
     "from environments.shared.train_base import create_vec_env, _ensure_sb3\n",
     "\n",
-    "logging.basicConfig(level=logging.INFO)\n",
-    "_logger = logging.getLogger(\"post_sweep_analysis\")\n",
+    "_logger = logging.getLogger(__name__)\n",
     "\n",
     "sb3 = _ensure_sb3()\n",
     "stage_config = STAGE_CONFIGS[STAGE]\n",


### PR DESCRIPTION
## Summary
This PR improves logging configuration in the Ray Tune sweep notebook by moving `logging.basicConfig()` to the initial imports cell and consolidates logging setup across the notebook.

## Key Changes
- **Moved logging configuration to cell 4**: Added `logging.basicConfig()` call with INFO level and standardized format to the initial imports cell, ensuring the root handler is in place before any `getLogger()` calls in both the driver process and notebook cells
- **Removed duplicate logging import and setup**: Eliminated redundant `import logging` and `logging.basicConfig()` call from the post-sweep analysis cell
- **Simplified logger initialization**: Changed from `logging.getLogger("post_sweep_analysis")` to `logging.getLogger(__name__)` for better modularity
- **Fixed GRACE_PERIOD comment**: Corrected the comment from "Don't stop before 8 eval reports" to "Don't stop before 20 eval reports" to match the actual GRACE_PERIOD value of 20

## Implementation Details
The logging configuration is now centralized in the first code cell with a clear comment explaining why it must run early. This ensures consistent logging behavior across all notebook cells and prevents issues with logging handlers not being properly initialized when Ray Tune spawns worker processes.