### PR TITLE
Add cumulative distance_traveled tracking for all dino envs

### DIFF
--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -58,6 +58,10 @@ class BaseDinoEnv(gym.Env, ABC):
         self.max_episode_steps = max_episode_steps
         self._step_count = 0
 
+        # Distance tracking (cumulative XY path length)
+        self._prev_pos_2d: np.ndarray = np.zeros(2)
+        self._distance_traveled: float = 0.0
+
         # Common reward weights
         self.forward_vel_weight = forward_vel_weight
         self.alive_bonus = alive_bonus
@@ -551,6 +555,11 @@ class BaseDinoEnv(gym.Env, ABC):
 
         self._step_count += 1
 
+        # Update cumulative distance traveled (XY path length)
+        current_pos_2d = self.data.qpos[0:2].copy()
+        self._distance_traveled += float(np.linalg.norm(current_pos_2d - self._prev_pos_2d))
+        self._prev_pos_2d = current_pos_2d
+
         # Get observation
         obs = self._get_obs()
 
@@ -569,6 +578,7 @@ class BaseDinoEnv(gym.Env, ABC):
         # Combine info
         info = {**reward_info, **term_info}
         info["step"] = self._step_count
+        info["distance_traveled"] = self._distance_traveled
 
         # Render if needed
         if self.render_mode == "human":
@@ -619,6 +629,8 @@ class BaseDinoEnv(gym.Env, ABC):
         mujoco.mj_forward(self.model, self.data)
 
         self._step_count = 0
+        self._prev_pos_2d = self.data.qpos[0:2].copy()
+        self._distance_traveled = 0.0
 
         obs = self._get_obs()
         info = {"step": 0}

--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -97,6 +97,7 @@ class DiagnosticsCallback(_BaseCallback):
         "pelvis_yaw_vel",
         "drift_distance",
         "spin_instability",
+        "distance_traveled",
     ]
 
     def __init__(self, plateau_window=10, plateau_threshold=1.0, log_dir=None, verbose=0):

--- a/environments/shared/evaluation.py
+++ b/environments/shared/evaluation.py
@@ -140,6 +140,10 @@ def eval_policy_quality(
             clean_key = key.replace("mean_mean_", "mean_")
             result[f"eval_{clean_key}"] = round(agg[key], 4)
 
+    # Distance traveled
+    if "mean_distance_traveled" in agg:
+        result["eval_distance_traveled"] = round(agg["mean_distance_traveled"], 4)
+
     # Reward component breakdown (cumulative per episode, averaged across episodes)
     for key, value in agg.items():
         if key.startswith("mean_reward_component_"):
@@ -354,6 +358,12 @@ def _log_eval_results(
         agg.get("mean_total_distance", 0),
         agg.get("std_total_distance", 0),
     )
+    if "mean_distance_traveled" in agg:
+        logger.info(
+            "  Path length:  %.3f +/- %.3f m",
+            agg.get("mean_distance_traveled", 0),
+            agg.get("std_distance_traveled", 0),
+        )
 
     logger.info("--- Gait Quality ---")
     logger.info("  Symmetry:     %.3f", agg.get("mean_gait_symmetry", 0))

--- a/environments/shared/metrics.py
+++ b/environments/shared/metrics.py
@@ -49,6 +49,7 @@ class LocomotionMetrics:
     _contact_asymmetries: List[float] = field(default_factory=list)
     _pelvis_angular_velocities: List[float] = field(default_factory=list)
     _pelvis_yaw_velocities: List[float] = field(default_factory=list)
+    _distances_traveled: List[float] = field(default_factory=list)
     _reward_components: Dict[str, List[float]] = field(default_factory=dict)
     _dt: float = 0.02  # default timestep * frame_skip
     _termination_reason: Optional[str] = None
@@ -68,6 +69,7 @@ class LocomotionMetrics:
         self._contact_asymmetries.clear()
         self._pelvis_angular_velocities.clear()
         self._pelvis_yaw_velocities.clear()
+        self._distances_traveled.clear()
         self._reward_components.clear()
         self._termination_reason = None
 
@@ -119,6 +121,9 @@ class LocomotionMetrics:
 
         if "pelvis_yaw_vel" in info:
             self._pelvis_yaw_velocities.append(float(info["pelvis_yaw_vel"]))
+
+        if "distance_traveled" in info:
+            self._distances_traveled.append(float(info["distance_traveled"]))
 
         # Track individual reward components for post-training breakdown.
         # Uses the canonical list from DiagnosticsCallback to stay in sync.
@@ -251,6 +256,10 @@ class LocomotionMetrics:
             yaw = np.array(self._pelvis_yaw_velocities)
             result["mean_pelvis_yaw_velocity"] = float(np.mean(np.abs(yaw)))
             result["max_pelvis_yaw_velocity"] = float(np.max(np.abs(yaw)))
+
+        # --- Distance traveled (cumulative XY path length) ---
+        if self._distances_traveled:
+            result["distance_traveled"] = float(self._distances_traveled[-1])
 
         # --- Reward component breakdown ---
         for key, values in self._reward_components.items():

--- a/environments/shared/reporting.py
+++ b/environments/shared/reporting.py
@@ -25,6 +25,7 @@ CSV_METRIC_COLUMNS: List[str] = [
     "last_mean_episode_length",
     "mean_forward_vel",
     "std_forward_vel",
+    "mean_distance_traveled",
     "mean_success_rate",
     "training_duration_seconds",
     "reward_threshold",
@@ -335,6 +336,7 @@ def save_results_csv(
         row["last_mean_episode_length"] = round(r.get("mean_episode_length", 0.0), 1)
         row["mean_forward_vel"] = round(r.get("mean_forward_vel", 0.0), 2)
         row["std_forward_vel"] = round(r.get("std_forward_vel", 0.0), 2)
+        row["mean_distance_traveled"] = round(r.get("mean_distance_traveled", 0.0), 2)
         row["mean_success_rate"] = round(r.get("mean_success_rate", 0.0), 4)
         row["training_duration_seconds"] = round(r.get("duration_seconds", 0.0), 1)
 

--- a/environments/shared/scripts/sweep/results.py
+++ b/environments/shared/scripts/sweep/results.py
@@ -190,6 +190,7 @@ def _collect_trial_results(hpt_job: Any, stage: int, stage_config: dict, output_
         row["last_mean_episode_length"] = aux.get("last_mean_episode_length")
         row["mean_forward_vel"] = aux.get("mean_forward_vel")
         row["std_forward_vel"] = aux.get("std_forward_vel")
+        row["mean_distance_traveled"] = aux.get("mean_distance_traveled")
         row["mean_success_rate"] = aux.get("mean_success_rate")
         row["training_duration_seconds"] = aux.get("training_duration_seconds")
 
@@ -824,6 +825,7 @@ def _collect_results_local(
                     "last_mean_episode_length": metrics.get("last_mean_episode_length"),
                     "mean_forward_vel": metrics.get("mean_forward_vel"),
                     "std_forward_vel": metrics.get("std_forward_vel"),
+                    "mean_distance_traveled": metrics.get("mean_distance_traveled"),
                     "mean_success_rate": metrics.get("mean_success_rate"),
                     "training_duration_seconds": metrics.get("training_duration_seconds"),
                     "reward_threshold": trial_reward_th,

--- a/environments/shared/tests/test_base_env.py
+++ b/environments/shared/tests/test_base_env.py
@@ -191,3 +191,57 @@ class TestActionScaling:
         scaled = env._scale_action(action)
         ctrl_min = env.model.actuator_ctrlrange[:, 0]
         np.testing.assert_allclose(scaled, ctrl_min, atol=1e-6)
+
+
+# ── distance tracking ────────────────────────────────────────────────────
+
+
+class TestDistanceTracking:
+    """Test cumulative XY distance traveled tracking."""
+
+    @pytest.fixture
+    def env(self):
+        e = RaptorEnv(max_episode_steps=100)
+        yield e
+        e.close()
+
+    def test_distance_starts_at_zero(self, env):
+        env.reset(seed=42)
+        action = np.zeros(env.action_space.shape, dtype=np.float32)
+        _, _, _, _, info = env.step(action)
+        # First step distance should be very small (near zero with zero action)
+        assert "distance_traveled" in info
+        assert info["distance_traveled"] >= 0.0
+
+    def test_distance_is_non_negative(self, env):
+        env.reset(seed=42)
+        action = env.action_space.sample()
+        for _ in range(10):
+            _, _, terminated, _, info = env.step(action)
+            assert info["distance_traveled"] >= 0.0
+            if terminated:
+                break
+
+    def test_distance_is_monotonically_increasing(self, env):
+        env.reset(seed=42)
+        action = env.action_space.sample()
+        prev_dist = 0.0
+        for _ in range(10):
+            _, _, terminated, _, info = env.step(action)
+            assert info["distance_traveled"] >= prev_dist
+            prev_dist = info["distance_traveled"]
+            if terminated:
+                break
+
+    def test_distance_resets_on_reset(self, env):
+        env.reset(seed=42)
+        action = env.action_space.sample()
+        for _ in range(5):
+            _, _, terminated, _, _ = env.step(action)
+            if terminated:
+                break
+        env.reset(seed=42)
+        action = np.zeros(env.action_space.shape, dtype=np.float32)
+        _, _, _, _, info = env.step(action)
+        # After reset, distance should be near zero again
+        assert info["distance_traveled"] < 0.1

--- a/environments/shared/tests/test_metrics.py
+++ b/environments/shared/tests/test_metrics.py
@@ -113,6 +113,26 @@ class TestLocomotionMetrics:
         result = metrics.compute()
         assert result["velocity_consistency"] < 1.0
 
+    def test_distance_traveled(self, metrics):
+        """distance_traveled uses the last recorded value (cumulative from env)."""
+        distances = [0.0, 0.5, 1.2, 2.0, 3.5]
+        for d in distances:
+            metrics.record_step({"forward_vel": 1.0, "distance_traveled": d})
+        result = metrics.compute()
+        assert result["distance_traveled"] == pytest.approx(3.5)
+
+    def test_distance_traveled_missing(self, metrics):
+        """When distance_traveled is not in info, it should not appear in result."""
+        metrics.record_step({"forward_vel": 1.0})
+        result = metrics.compute()
+        assert "distance_traveled" not in result
+
+    def test_distance_traveled_reset(self, metrics):
+        metrics.record_step({"forward_vel": 1.0, "distance_traveled": 5.0})
+        metrics.reset()
+        result = metrics.compute()
+        assert "distance_traveled" not in result
+
 
 class TestGaitSymmetry:
     """Test gait symmetry computation."""

--- a/environments/shared/tests/test_reporting.py
+++ b/environments/shared/tests/test_reporting.py
@@ -3,6 +3,7 @@
 import json
 
 from environments.shared.reporting import (
+    CSV_METRIC_COLUMNS,
     build_stage_results_from_eval_data,
     format_duration,
     format_duration_hms,
@@ -10,6 +11,19 @@ from environments.shared.reporting import (
     write_stage_summary,
     write_training_summary,
 )
+
+# ── CSV_METRIC_COLUMNS ──────────────────────────────────────────────────
+
+
+class TestCsvMetricColumns:
+    """Tests for CSV_METRIC_COLUMNS schema."""
+
+    def test_contains_distance_traveled(self):
+        assert "mean_distance_traveled" in CSV_METRIC_COLUMNS
+
+    def test_contains_forward_vel(self):
+        assert "mean_forward_vel" in CSV_METRIC_COLUMNS
+
 
 # ── format_duration ──────────────────────────────────────────────────────
 

--- a/environments/shared/tests/test_visualization.py
+++ b/environments/shared/tests/test_visualization.py
@@ -98,6 +98,39 @@ class TestPlotDiagnosticsGraphs:
         assert (tmp_path / "locomotion_health.png").exists()
         assert (tmp_path / "behavioral_metrics.png").exists()
 
+    def test_plots_distance_traveled_and_drift(self, tmp_path):
+        matplotlib.use("Agg")
+
+        from environments.shared.visualization import plot_diagnostics_graphs
+
+        ts = np.array([50000, 100000])
+        np.savez(
+            str(tmp_path / "diagnostics.npz"),
+            timesteps=ts,
+            tilt_angle=np.array([0.1, 0.05]),
+            forward_vel=np.array([0.5, 1.0]),
+            pelvis_height=np.array([0.8, 0.85]),
+            reward_energy=np.array([-0.1, -0.2]),
+            distance_traveled=np.array([0.5, 2.3]),
+            drift_distance=np.array([0.1, 0.3]),
+        )
+
+        stage_configs = {1: {"name": "Balance"}}
+
+        fig1, fig2 = plot_diagnostics_graphs(
+            [(1, tmp_path)],
+            stage_configs,
+            species="velociraptor",
+            algorithm="ppo",
+            save_dir=tmp_path,
+            show=False,
+        )
+
+        assert (tmp_path / "behavioral_metrics.png").exists()
+        # Verify the figure has 3 rows (3x2 grid)
+        assert fig2.axes[0] is not None  # Should have at least 6 axes
+        assert len(fig2.axes) == 6
+
     def test_handles_empty_diagnostics(self, tmp_path):
         matplotlib.use("Agg")
 

--- a/environments/shared/visualization.py
+++ b/environments/shared/visualization.py
@@ -142,15 +142,17 @@ def plot_diagnostics_graphs(
     save_dir: "str | Path | None" = None,
     show: bool = True,
 ) -> "tuple":
-    """Create two 2x2 diagnostic figures tracking advanced training metrics.
+    """Create two diagnostic figures tracking advanced training metrics.
 
-    Figure 1 -- Locomotion Health (``locomotion_health.png``):
+    Figure 1 -- Locomotion Health (``locomotion_health.png``, 2x2):
       - Termination Breakdown, Cost of Transport,
         Pelvis Height, Reward Decomposition
 
-    Figure 2 -- Behavioral Metrics (``behavioral_metrics.png``):
+    Figure 2 -- Behavioral Metrics (``behavioral_metrics.png``, 3x2):
       - Gait Symmetry + Stride Frequency, Heading Alignment,
-        Prey Distance, Strike Success Rate
+        Prey Distance, Strike Success Rate,
+        Distance Traveled (cumulative path length),
+        Drift Distance (displacement from spawn)
 
     Returns ``(fig1, fig2)``.  When *show* is ``False``, figures are
     closed after saving (headless / sweep usage).
@@ -309,7 +311,7 @@ def plot_diagnostics_graphs(
     # -----------------------------------------------------------
     # Figure 2: Behavioral Metrics
     # -----------------------------------------------------------
-    fig2, axes2 = plt.subplots(2, 2, figsize=(14, 10))
+    fig2, axes2 = plt.subplots(3, 2, figsize=(14, 15))
     fig2.suptitle(
         f"{species_title} {algorithm} \u2013 Behavioral Metrics",
         fontsize=14,
@@ -372,6 +374,14 @@ def plot_diagnostics_graphs(
         if "strike_success" in diag:
             axes2[1, 1].plot(ts, diag["strike_success"], label=label, color=color)
 
+        # [2,0] Distance Traveled (cumulative XY path length)
+        if "distance_traveled" in diag:
+            axes2[2, 0].plot(ts, diag["distance_traveled"], label=label, color=color)
+
+        # [2,1] Drift Distance (displacement from spawn)
+        if "drift_distance" in diag:
+            axes2[2, 1].plot(ts, diag["drift_distance"], label=label, color=color)
+
     axes2[0, 0].set_xlabel("Timesteps")
     axes2[0, 0].set_ylabel("Gait Symmetry (\u2013) / Stride Freq proxy (--)")
     axes2[0, 0].set_title(f"{species_title} {algorithm} \u2013 Gait Symmetry + Stride Frequency")
@@ -395,6 +405,18 @@ def plot_diagnostics_graphs(
     axes2[1, 1].set_title(f"{species_title} {algorithm} \u2013 Strike Success Rate")
     axes2[1, 1].legend()
     axes2[1, 1].grid(True, alpha=0.3)
+
+    axes2[2, 0].set_xlabel("Timesteps")
+    axes2[2, 0].set_ylabel("Distance Traveled (m)")
+    axes2[2, 0].set_title(f"{species_title} {algorithm} \u2013 Distance Traveled (path length)")
+    axes2[2, 0].legend()
+    axes2[2, 0].grid(True, alpha=0.3)
+
+    axes2[2, 1].set_xlabel("Timesteps")
+    axes2[2, 1].set_ylabel("Drift Distance (m)")
+    axes2[2, 1].set_title(f"{species_title} {algorithm} \u2013 Drift Distance (displacement from spawn)")
+    axes2[2, 1].legend()
+    axes2[2, 1].grid(True, alpha=0.3)
 
     fig2.tight_layout()
     if save_dir is not None:


### PR DESCRIPTION
Track total XY path length (odometer) in BaseDinoEnv, useful for
monitoring drift in stage 1 (balance) and running distance in stage 2
(locomotion). Logged to TensorBoard via DiagnosticsCallback and
available in LocomotionMetrics episode reports.

https://claude.ai/code/session_01TCigpFxDRz52gE99ocyh5K