### PR TITLE
Update training timesteps: stage 1 to 6M, stages 2-3 to 8M

### DIFF
--- a/configs/brachiosaurus/stage1_balance.toml
+++ b/configs/brachiosaurus/stage1_balance.toml
@@ -34,7 +34,7 @@ tau = 0.005
 ent_coef = "auto"
 
 [curriculum]
-timesteps = 4000000
+timesteps = 6000000
 min_avg_reward = 50.0
 min_avg_episode_length = 750
 required_consecutive = 3

--- a/configs/brachiosaurus/stage2_locomotion.toml
+++ b/configs/brachiosaurus/stage2_locomotion.toml
@@ -34,7 +34,7 @@ tau = 0.005
 ent_coef = "auto"
 
 [curriculum]
-timesteps = 5000000
+timesteps = 8000000
 min_avg_reward = 100.0
 min_avg_episode_length = 750
 min_avg_forward_vel = 2.0              # Gate on actual locomotion; without this, a standing-still policy passes on alive_bonus alone. Lower than raptor (0.4) and T-Rex (0.3) — Brachiosaurus is slower.

--- a/configs/brachiosaurus/stage3_food_reach.toml
+++ b/configs/brachiosaurus/stage3_food_reach.toml
@@ -36,7 +36,7 @@ tau = 0.005
 ent_coef = "auto"
 
 [curriculum]
-timesteps = 4000000
+timesteps = 8000000
 min_avg_reward = 50.0                   # Minimum average reward to confirm food-reaching behavior
 min_success_rate = 0.1                  # At least 10% food reach success — confirms behavior emerged
 required_consecutive = 3

--- a/configs/sweep_ppo.json
+++ b/configs/sweep_ppo.json
@@ -1,7 +1,7 @@
 {
   "stage1": {
     "trials": 40,
-    "timesteps": 4000000,
+    "timesteps": 6000000,
     "parallel": 7,
     "n_envs": 4,
     "ppo_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4, "scale": "log"},

--- a/configs/sweep_sac.json
+++ b/configs/sweep_sac.json
@@ -1,7 +1,7 @@
 {
   "stage1": {
     "trials": 10,
-    "timesteps": 500000,
+    "timesteps": 6000000,
     "parallel": 5,
     "n_envs": 4,
     "sac_learning_rate": {"type": "double", "min": 1e-5, "max": 3e-4, "scale": "log"},
@@ -12,7 +12,7 @@
   },
   "stage2": {
     "trials": 20,
-    "timesteps": 1000000,
+    "timesteps": 8000000,
     "parallel": 5,
     "n_envs": 4,
     "sac_learning_rate":           {"type": "double", "min": 1e-5, "max": 3e-4, "scale": "log"},
@@ -24,7 +24,7 @@
   },
   "stage3": {
     "trials": 20,
-    "timesteps": 1500000,
+    "timesteps": 8000000,
     "parallel": 5,
     "n_envs": 4,
     "sac_learning_rate":            {"type": "double", "min": 1e-5, "max": 3e-4, "scale": "log"},

--- a/configs/trex/stage3_bite.toml
+++ b/configs/trex/stage3_bite.toml
@@ -42,7 +42,7 @@ tau = 0.005
 ent_coef = "auto"
 
 [curriculum]
-timesteps = 4000000
+timesteps = 8000000
 min_avg_reward = 50.0
 min_success_rate = 0.1                 # At least 10% bite success — confirms hunting behavior emerged
 required_consecutive = 3

--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -44,7 +44,7 @@ tau = 0.005
 ent_coef = "auto"
 
 [curriculum]
-timesteps = 6000000                    # Reduced from 8M: successful runs passed in 2M; 5M provides margin for warmup/ramp
+timesteps = 8000000
 min_avg_reward = 100.0
 min_avg_episode_length = 750
 min_avg_forward_vel = 2.0

--- a/configs/velociraptor/stage3_strike.toml
+++ b/configs/velociraptor/stage3_strike.toml
@@ -46,7 +46,7 @@ tau = 0.005
 ent_coef = "auto"
 
 [curriculum]
-timesteps = 6000000
+timesteps = 8000000
 min_avg_reward = 50.0
 min_success_rate = 0.1                 # At least 10% strike success — confirms hunting behavior emerged
 required_consecutive = 3

--- a/notebooks/training.ipynb
+++ b/notebooks/training.ipynb
@@ -315,7 +315,7 @@
     "id": "fbQlbP8Uh7I4"
    },
    "outputs": [],
-   "source": "cur1 = STAGE_CONFIGS[1].get(\"curriculum_kwargs\", {})\ntimesteps_1 = 50_000 if QUICK_TEST else cur1.get(\"timesteps\", 1_000_000)\n\nmodel_1, path_1, final_path_1, dir_1, vecnorm_1, results_1 = train_stage(stage=1, timesteps=timesteps_1, run_dir=RUN_DIR)"
+   "source": "cur1 = STAGE_CONFIGS[1].get(\"curriculum_kwargs\", {})\ntimesteps_1 = 50_000 if QUICK_TEST else cur1.get(\"timesteps\", 6_000_000)\n\nmodel_1, path_1, final_path_1, dir_1, vecnorm_1, results_1 = train_stage(stage=1, timesteps=timesteps_1, run_dir=RUN_DIR)"
   },
   {
    "cell_type": "code",
@@ -344,7 +344,7 @@
     "id": "aLi2uw5Rh7I4"
    },
    "outputs": [],
-   "source": "cur2 = STAGE_CONFIGS[2].get(\"curriculum_kwargs\", {})\ntimesteps_2 = 50_000 if QUICK_TEST else cur2.get(\"timesteps\", 2_000_000)\n\nmodel_2, path_2, final_path_2, dir_2, vecnorm_2, results_2 = train_stage(\n    stage=2, timesteps=timesteps_2, load_path=path_1, run_dir=RUN_DIR, vecnorm_path=vecnorm_1\n)"
+   "source": "cur2 = STAGE_CONFIGS[2].get(\"curriculum_kwargs\", {})\ntimesteps_2 = 50_000 if QUICK_TEST else cur2.get(\"timesteps\", 8_000_000)\n\nmodel_2, path_2, final_path_2, dir_2, vecnorm_2, results_2 = train_stage(\n    stage=2, timesteps=timesteps_2, load_path=path_1, run_dir=RUN_DIR, vecnorm_path=vecnorm_1\n)"
   },
   {
    "cell_type": "code",
@@ -369,7 +369,7 @@
     "id": "gk_GwoRBh7I4"
    },
    "outputs": [],
-   "source": "cur3 = STAGE_CONFIGS[3].get(\"curriculum_kwargs\", {})\ntimesteps_3 = 50_000 if QUICK_TEST else cur3.get(\"timesteps\", 3_000_000)\n\nmodel_3, path_3, final_path_3, dir_3, vecnorm_3, results_3 = train_stage(\n    stage=3, timesteps=timesteps_3, load_path=path_2, run_dir=RUN_DIR, vecnorm_path=vecnorm_2\n)"
+   "source": "cur3 = STAGE_CONFIGS[3].get(\"curriculum_kwargs\", {})\ntimesteps_3 = 50_000 if QUICK_TEST else cur3.get(\"timesteps\", 8_000_000)\n\nmodel_3, path_3, final_path_3, dir_3, vecnorm_3, results_3 = train_stage(\n    stage=3, timesteps=timesteps_3, load_path=path_2, run_dir=RUN_DIR, vecnorm_path=vecnorm_2\n)"
   },
   {
    "cell_type": "code",

--- a/notebooks/vertex_ai_sweep.ipynb
+++ b/notebooks/vertex_ai_sweep.ipynb
@@ -371,21 +371,7 @@
     "id": "all-stages-config"
    },
    "outputs": [],
-   "source": [
-    "# ── Per-stage timestep budgets ────────────────────────────────────────────────\n",
-    "TIMESTEPS_STAGE1 = 500_000    # @param {type:\"integer\"}\n",
-    "TIMESTEPS_STAGE2 = 1_000_000  # @param {type:\"integer\"}\n",
-    "TIMESTEPS_STAGE3 = 1_500_000  # @param {type:\"integer\"}\n",
-    "\n",
-    "# ── Per-stage trial budgets (set to None to use the defaults above) ──────────\n",
-    "TRIALS_STAGE1 = None   # @param {type:\"raw\"} — defaults to MAX_TRIALS\n",
-    "TRIALS_STAGE2 = None   # @param {type:\"raw\"} — defaults to MAX_TRIALS\n",
-    "TRIALS_STAGE3 = None   # @param {type:\"raw\"} — defaults to MAX_TRIALS\n",
-    "\n",
-    "PARALLEL_STAGE1 = None  # @param {type:\"raw\"} — defaults to PARALLEL_TRIALS\n",
-    "PARALLEL_STAGE2 = None  # @param {type:\"raw\"} — defaults to PARALLEL_TRIALS\n",
-    "PARALLEL_STAGE3 = None  # @param {type:\"raw\"} — defaults to PARALLEL_TRIALS"
-   ]
+   "source": "# ── Per-stage timestep budgets ────────────────────────────────────────────────\nTIMESTEPS_STAGE1 = 6_000_000    # @param {type:\"integer\"}\nTIMESTEPS_STAGE2 = 8_000_000  # @param {type:\"integer\"}\nTIMESTEPS_STAGE3 = 8_000_000  # @param {type:\"integer\"}\n\n# ── Per-stage trial budgets (set to None to use the defaults above) ──────────\nTRIALS_STAGE1 = None   # @param {type:\"raw\"} — defaults to MAX_TRIALS\nTRIALS_STAGE2 = None   # @param {type:\"raw\"} — defaults to MAX_TRIALS\nTRIALS_STAGE3 = None   # @param {type:\"raw\"} — defaults to MAX_TRIALS\n\nPARALLEL_STAGE1 = None  # @param {type:\"raw\"} — defaults to PARALLEL_TRIALS\nPARALLEL_STAGE2 = None  # @param {type:\"raw\"} — defaults to PARALLEL_TRIALS\nPARALLEL_STAGE3 = None  # @param {type:\"raw\"} — defaults to PARALLEL_TRIALS"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Standardize training timesteps across all species TOML configs,
JSON sweep configs, and notebook defaults.

https://claude.ai/code/session_012dJGMx1mratU5D95xbhpzQ