### PR TITLE
Increase curriculum thresholds for behavior emergence validation

### DIFF
--- a/configs/brachiosaurus/stage1_balance.toml
+++ b/configs/brachiosaurus/stage1_balance.toml
@@ -35,6 +35,6 @@ ent_coef = "auto"
 
 [curriculum]
 timesteps = 6000000
-min_avg_reward = 50.0
+min_avg_reward = 100.0
 min_avg_episode_length = 750
 required_consecutive = 3

--- a/configs/brachiosaurus/stage3_food_reach.toml
+++ b/configs/brachiosaurus/stage3_food_reach.toml
@@ -37,8 +37,8 @@ ent_coef = "auto"
 
 [curriculum]
 timesteps = 8000000
-min_avg_reward = 50.0                   # Minimum average reward to confirm food-reaching behavior
-min_success_rate = 0.1                  # At least 10% food reach success — confirms behavior emerged
+min_avg_reward = 100.0                  # Minimum average reward to confirm food-reaching behavior
+min_success_rate = 0.25                 # At least 25% food reach success — confirms behavior emerged
 required_consecutive = 3
 warmup_timesteps = 100000               # Timesteps to constrain policy updates while critic adapts (PPO only)
 warmup_clip_range = 0.02                # Small clip range during warm-up to limit policy change

--- a/configs/trex/stage3_bite.toml
+++ b/configs/trex/stage3_bite.toml
@@ -43,8 +43,8 @@ ent_coef = "auto"
 
 [curriculum]
 timesteps = 8000000
-min_avg_reward = 50.0
-min_success_rate = 0.1                 # At least 10% bite success — confirms hunting behavior emerged
+min_avg_reward = 100.0
+min_success_rate = 0.25                # At least 25% bite success — confirms hunting behavior emerged
 required_consecutive = 3
 warmup_timesteps = 100000               # Timesteps to constrain policy updates while critic adapts (PPO only)
 warmup_clip_range = 0.02                # Small clip range during warm-up to limit policy change

--- a/configs/velociraptor/stage3_strike.toml
+++ b/configs/velociraptor/stage3_strike.toml
@@ -47,8 +47,8 @@ ent_coef = "auto"
 
 [curriculum]
 timesteps = 8000000
-min_avg_reward = 50.0
-min_success_rate = 0.1                 # At least 10% strike success — confirms hunting behavior emerged
+min_avg_reward = 100.0
+min_success_rate = 0.25                # At least 25% strike success — confirms hunting behavior emerged
 required_consecutive = 3
 warmup_timesteps = 300000               # Increased from 100k: Stage 3 introduces new reward components, critic needs more adaptation time
 warmup_clip_range = 0.02                # Small clip range during warm-up to limit policy change


### PR DESCRIPTION
## Summary
This PR increases the curriculum learning thresholds across multiple training stages to enforce stricter validation criteria for behavior emergence. The changes raise both minimum average reward and success rate requirements, ensuring that agents demonstrate more robust learning before progressing to subsequent stages.

## Key Changes
- **Minimum average reward**: Increased from 50.0 to 100.0 across all affected stages
  - Brachiosaurus stage1_balance
  - Brachiosaurus stage3_food_reach
  - T-Rex stage3_bite
  - Velociraptor stage3_strike

- **Minimum success rate**: Increased from 0.1 (10%) to 0.25 (25%) for stage 3 behaviors
  - Brachiosaurus food-reaching behavior
  - T-Rex hunting/bite behavior
  - Velociraptor hunting/strike behavior

## Implementation Details
These threshold increases apply to the curriculum learning validation logic, which determines when an agent has sufficiently mastered a stage before advancing. The stricter requirements (2x reward threshold and 2.5x success rate threshold) ensure that:
- Agents achieve more stable and consistent performance
- Behaviors are more reliably emergent before progression
- Training quality is improved across all dinosaur species and behavioral stages