### PR TITLE
Fix gait_symmetry scoring and rebalance Stage 2/3 quality metrics

### DIFF
--- a/configs/quality_scoring.toml
+++ b/configs/quality_scoring.toml
@@ -61,7 +61,7 @@ weight = 0.15
 direction = "maximize"
 
 [stage_2."fwd_vel_m/s"]
-weight = 0.30
+weight = 0.25
 direction = "maximize"
 
 [stage_2.distance_m]
@@ -69,7 +69,7 @@ weight = 0.20
 direction = "maximize"
 
 [stage_2.ep_length]
-weight = 0.10
+weight = 0.15
 direction = "maximize"
 
 [stage_2.vel_consistency]

--- a/configs/quality_scoring.toml
+++ b/configs/quality_scoring.toml
@@ -48,6 +48,12 @@ direction = "minimize"
 # ── Stage 2: Locomotion ──────────────────────────────────────────────
 # Goal: walk/run forward with good gait quality.
 # Forward velocity and distance are the primary signals.
+#
+# TODO: Re-add gait_symmetry once the training reward is fixed.
+# Currently gait_symmetry_weight=0.0 in all training configs (the
+# formula rewards asymmetry/single-foot stance, not alternation), so
+# scoring on a metric the agent was never trained on adds noise.
+# See: base_env.py _compute_gait_symmetry() and stage config comments.
 [stage_2]
 
 [stage_2.best_mean_reward]
@@ -55,7 +61,7 @@ weight = 0.15
 direction = "maximize"
 
 [stage_2."fwd_vel_m/s"]
-weight = 0.25
+weight = 0.30
 direction = "maximize"
 
 [stage_2.distance_m]
@@ -63,10 +69,6 @@ weight = 0.20
 direction = "maximize"
 
 [stage_2.ep_length]
-weight = 0.10
-direction = "maximize"
-
-[stage_2.gait_symmetry]
 weight = 0.10
 direction = "maximize"
 
@@ -79,7 +81,7 @@ weight = 0.10
 direction = "minimize"
 
 [stage_2.tilt_rad]
-weight = 0.05
+weight = 0.10
 direction = "minimize"
 
 
@@ -88,6 +90,9 @@ direction = "minimize"
 # Shorter episodes with high success rate = efficient prey engagement.
 # A dino that finds and contacts the target quickly is better than one
 # that wanders for the full episode before getting lucky.
+#
+# TODO: Re-add gait_symmetry once the training reward is fixed.
+# Same issue as Stage 2 — see comment above.
 [stage_3]
 
 [stage_3.best_mean_reward]
@@ -110,16 +115,12 @@ direction = "maximize"
 weight = 0.15
 direction = "minimize"
 
-[stage_3.gait_symmetry]
-weight = 0.10
-direction = "maximize"
-
 [stage_3.cost_of_transport]
 weight = 0.10
 direction = "minimize"
 
 [stage_3.tilt_rad]
-weight = 0.05
+weight = 0.10
 direction = "minimize"
 
 [stage_3.pelvis_height_m]
@@ -127,5 +128,5 @@ weight = 0.05
 direction = "maximize"
 
 [stage_3.mean_success_rate]
-weight = 0.15
+weight = 0.20
 direction = "maximize"


### PR DESCRIPTION
## Summary
This PR removes `gait_symmetry` from the quality scoring configuration for Stages 2 and 3, and rebalances the weights of other metrics to compensate. The gait symmetry metric is being temporarily disabled because the training reward formula has a bug that actually rewards asymmetry rather than proper gait alternation, making it an unreliable scoring signal.

## Key Changes
- **Removed `gait_symmetry` metric** from both Stage 2 and Stage 3 scoring (weight was 0.10 in each)
  - Added TODO comments explaining the issue and referencing the problematic `_compute_gait_symmetry()` implementation in base_env.py
  - This prevents scoring agents on a metric they were never properly trained to optimize

- **Rebalanced Stage 2 weights:**
  - Increased `fwd_vel_m/s` from 0.25 to 0.30 (primary locomotion signal)
  - Increased `tilt_rad` from 0.05 to 0.10 (body stability penalty)

- **Rebalanced Stage 3 weights:**
  - Increased `tilt_rad` from 0.05 to 0.10 (body stability penalty)
  - Increased `mean_success_rate` from 0.15 to 0.20 (prey engagement efficiency)

## Implementation Details
The weight redistribution maintains the overall scoring philosophy while emphasizing more reliable metrics:
- Stage 2 now prioritizes forward velocity and penalizes excessive tilting
- Stage 3 now emphasizes successful prey engagement while maintaining stability constraints
- Total weights remain normalized across each stage