### PR TITLE
Improve early stopping and HPT metrics reporting

### DIFF
--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -382,7 +382,7 @@ def _build_core_callbacks(
 
     callbacks.append(_DiagCB(log_dir=str(log_path), verbose=verbose))
 
-    callbacks.append(EvalCollapseEarlyStopCallback(eval_callback=eval_callback, verbose=verbose))
+    callbacks.append(EvalCollapseEarlyStopCallback(eval_callback=eval_callback, min_evals=8, patience=5, verbose=verbose))
 
     if use_wandb:
         callbacks.append(WandbCallback())
@@ -728,21 +728,22 @@ def _report_hpt_metrics(
     )
     if fwd_vels:
         mean_fwd = float(_np.mean(fwd_vels))
+        std_fwd = float(_np.std(fwd_vels))
         aux_metrics["mean_forward_vel"] = mean_fwd
+        aux_metrics["std_forward_vel"] = std_fwd
         # Keep backward-compat alias used by existing sweep analysis.
         aux_metrics["best_mean_forward_vel"] = mean_fwd
-        logger.info("HPT metric reported: mean_forward_vel=%.4f", mean_fwd)
+        logger.info("HPT metric reported: mean_forward_vel=%.4f (std=%.4f)", mean_fwd, std_fwd)
     if distances:
         mean_dist = float(_np.mean(distances))
         aux_metrics["mean_distance_traveled"] = mean_dist
         logger.info("HPT metric reported: mean_distance_traveled=%.4f", mean_dist)
-    if stage >= 3 and success_flags:
-        best_success = float(_np.mean(success_flags))
-        aux_metrics["best_mean_success_rate"] = best_success
-        logger.info(
-            "HPT metric reported: best_mean_success_rate=%.4f",
-            best_success,
-        )
+    if success_flags:
+        mean_success = float(_np.mean(success_flags))
+        aux_metrics["mean_success_rate"] = mean_success
+        # Keep backward-compat alias used by existing sweep analysis.
+        aux_metrics["best_mean_success_rate"] = mean_success
+        logger.info("HPT metric reported: mean_success_rate=%.4f", mean_success)
 
     # Include key hyperparameters in the sidecar so offline result
     # collection works even when stage_config.json is missing.

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -382,7 +382,9 @@ def _build_core_callbacks(
 
     callbacks.append(_DiagCB(log_dir=str(log_path), verbose=verbose))
 
-    callbacks.append(EvalCollapseEarlyStopCallback(eval_callback=eval_callback, min_evals=8, patience=5, verbose=verbose))
+    callbacks.append(
+        EvalCollapseEarlyStopCallback(eval_callback=eval_callback, min_evals=8, patience=5, verbose=verbose)
+    )
 
     if use_wandb:
         callbacks.append(WandbCallback())


### PR DESCRIPTION
## Summary
This PR enhances the training pipeline by improving early stopping configuration and expanding hyperparameter tuning (HPT) metrics reporting with additional statistical measures.

## Key Changes

- **Early Stopping Configuration**: Added explicit parameters to `EvalCollapseEarlyStopCallback` with `min_evals=8` and `patience=5` to make the early stopping behavior more transparent and configurable.

- **Forward Velocity Metrics**: Extended forward velocity reporting to include standard deviation (`std_forward_vel`) alongside the mean, providing better insight into velocity consistency across evaluation episodes.

- **Success Rate Metrics**: 
  - Removed the `stage >= 3` condition, making success rate metrics available for all training stages (previously only reported in stage 3+)
  - Renamed the primary metric from `best_mean_success_rate` to `mean_success_rate` for consistency with other metrics
  - Maintained backward-compatibility alias `best_mean_success_rate` for existing sweep analysis tools

- **Logging Improvements**: Updated log messages to include standard deviation for forward velocity and clarified metric naming in logs.

## Implementation Details
These changes improve observability during hyperparameter tuning by providing more comprehensive metrics and making success rate tracking available throughout training, not just in later stages.