### PR TITLE
Add head proximity reward and validation sweep configs for TRex

### DIFF
--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -23,6 +23,7 @@ bite_bonus = 0.0
 bite_approach_weight = 0.0
 prey_distance_range = [10.0, 15.0]
 max_episode_steps = 1000                  # Match stage 2/3 for consistent episode horizon across curriculum
+reset_noise_scale = 0.05                  # Increased from 0.01 default to improve robustness (matches raptor)
 
 [ppo]
 learning_rate = 3e-4

--- a/configs/trex/stage3_bite.toml
+++ b/configs/trex/stage3_bite.toml
@@ -4,7 +4,7 @@ description = "Sprint and bite prey with jaws"
 
 [env]
 forward_vel_weight = 0.5               # Halved from 1.0: prevent forward reward from dominating approach/bite signals
-alive_bonus = 0.05                     # Drastically reduced from 0.5: survival is learned in stages 1-2; high alive_bonus made biting net-negative (bite terminates episode, costing ~500 in future alive rewards vs 10.0 bonus)
+alive_bonus = 0.0                      # Zeroed: survival is learned in stages 1-2; any per-step alive reward adds opportunity cost that discourages episode-terminating bites
 fall_penalty = -10.0                   # Proportional to reduced alive_bonus (0.05); default -100 is 2000x alive_bonus, making agent overly conservative about approaching prey
 energy_penalty_weight = 0.001
 tail_stability_weight = 0.02
@@ -14,9 +14,10 @@ gait_symmetry_weight = 0.0             # Disabled: formula rewards asymmetry, no
 smoothness_weight = 0.02
 heading_weight = 0.5                   # Match stage 2: face toward prey for bite
 lateral_penalty_weight = 0.3           # Match stage 2: penalize crab-walking toward prey
-bite_bonus = 50.0                      # 5x increase from 10.0: must outweigh opportunity cost of episode termination (~25 in lost future per-step rewards with reduced alive_bonus)
+bite_bonus = 1000.0                    # Must greatly exceed discounted future per-step value; makes biting immediately net-positive (matches raptor strike_bonus)
 bite_approach_weight = 3.0             # 3x increase from 1.0: stronger delta-based gradient toward prey
-prey_distance_range = [3.0, 8.0]
+bite_head_proximity_weight = 1.0       # Head-to-prey proximity shaping: provides final aiming gradient for head positioning near prey
+prey_distance_range = [2.0, 6.0]       # Tightened from [3.0, 8.0]: closer prey makes bite discovery much more likely during exploration
 prey_lateral_range = [-1.5, 1.5]
 max_episode_steps = 1000
 

--- a/configs/trex/sweep_validation.toml
+++ b/configs/trex/sweep_validation.toml
@@ -1,0 +1,122 @@
+# Validation configurations for Stage 1 (balance) — candidates for
+# hyperparameter sweep validation.
+#
+# Select one by setting VALIDATION_SETTING = 1..3 in the training notebook.
+# Set to None to skip the override and use the default stage1_balance.toml.
+#
+# | Setting | Source             | Best Reward | Ep Length | Key Traits                          |
+# |---------|--------------------|-------------|-----------|-------------------------------------|
+# | 1       | Baseline (TOML)    | TBD         | TBD       | Default stage1_balance.toml values  |
+# | 2       | Anti-rotation      | TBD         | TBD       | Stronger heading/spin penalties     |
+# | 3       | High alive bonus   | TBD         | TBD       | Boosted alive bonus, tuned posture  |
+
+# --- Setting 1: Baseline — default stage1_balance.toml with reset_noise_scale=0.05 ---
+
+[setting_1.env]
+alive_bonus = 2.0
+backward_vel_penalty_weight = 0.0
+drift_penalty_weight = 0.3
+spin_penalty_weight = 0.1
+energy_penalty_weight = 0.05
+forward_vel_weight = 0.0
+gait_symmetry_weight = 0.0
+heading_weight = 0.1
+nosedive_weight = 3.0
+posture_weight = 2.0
+smoothness_weight = 0.1
+height_weight = 1.0
+speed_penalty_weight = 0.3
+speed_penalty_threshold = 0.10
+bite_bonus = 0.0
+bite_approach_weight = 0.0
+bite_head_proximity_weight = 0.0
+prey_distance_range = [10.0, 15.0]
+max_episode_steps = 1000
+reset_noise_scale = 0.05
+
+[setting_1.ppo]
+learning_rate = 3e-4
+n_steps = 4096
+batch_size = 128
+n_epochs = 10
+gamma = 0.998
+gae_lambda = 0.95
+clip_range = 0.2
+ent_coef = 0.005
+
+[setting_1.ppo.policy_kwargs]
+net_arch = [256, 256]
+
+# --- Setting 2: Anti-rotation — Stronger heading/spin to prevent rotation exploits ---
+
+[setting_2.env]
+alive_bonus = 1.75
+backward_vel_penalty_weight = 0.0
+drift_penalty_weight = 0.5
+spin_penalty_weight = 0.3
+energy_penalty_weight = 0.075
+forward_vel_weight = 0.0
+gait_symmetry_weight = 0.0
+heading_weight = 0.3
+nosedive_weight = 1.5
+posture_weight = 1.5
+smoothness_weight = 0.05
+height_weight = 1.0
+speed_penalty_weight = 0.3
+speed_penalty_threshold = 0.10
+bite_bonus = 0.0
+bite_approach_weight = 0.0
+bite_head_proximity_weight = 0.0
+prey_distance_range = [10.0, 15.0]
+max_episode_steps = 1000
+reset_noise_scale = 0.05
+
+[setting_2.ppo]
+learning_rate = 3e-5
+n_steps = 2048
+batch_size = 128
+n_epochs = 6
+gamma = 0.98
+gae_lambda = 0.95
+clip_range = 0.2
+ent_coef = 0.001
+
+[setting_2.ppo.policy_kwargs]
+net_arch = [512, 256]
+
+# --- Setting 3: High alive bonus — Boosted survival signal, tuned posture ---
+
+[setting_3.env]
+alive_bonus = 4.5
+backward_vel_penalty_weight = 0.5
+drift_penalty_weight = 0.0
+spin_penalty_weight = 0.0
+energy_penalty_weight = 0.02
+forward_vel_weight = 0.0
+gait_symmetry_weight = 0.0
+heading_weight = 0.1
+nosedive_weight = 2.1
+posture_weight = 1.3
+smoothness_weight = 0.05
+height_weight = 0.5
+speed_penalty_weight = 0.0
+speed_penalty_threshold = 0.10
+bite_bonus = 0.0
+bite_approach_weight = 0.0
+bite_head_proximity_weight = 0.0
+prey_distance_range = [10.0, 15.0]
+max_episode_steps = 1000
+reset_noise_scale = 0.05
+
+[setting_3.ppo]
+learning_rate = 5e-5
+n_steps = 1024
+batch_size = 128
+n_epochs = 10
+gamma = 0.988
+gae_lambda = 0.95
+clip_range = 0.2
+ent_coef = 0.0015
+
+[setting_3.ppo.policy_kwargs]
+net_arch = [512, 256]

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -32,6 +32,7 @@ Reward components:
     - Tail stability
     - Bite bonus (head contacts prey)
     - Approach shaping (distance to prey)
+    - Head proximity shaping (reward for positioning head near prey)
     - Posture (continuous tilt penalty)
     - Nosedive penalty
     - Height maintenance
@@ -76,6 +77,7 @@ class TRexEnv(BaseDinoEnv):
         tail_stability_weight: float = 0.05,
         bite_bonus: float = 10.0,
         bite_approach_weight: float = 1.0,
+        bite_head_proximity_weight: float = 0.0,
         posture_weight: float = 0.2,
         nosedive_weight: float = 0.0,
         natural_pitch: float = 0.17,
@@ -102,6 +104,7 @@ class TRexEnv(BaseDinoEnv):
         self.tail_stability_weight = tail_stability_weight
         self.bite_bonus = bite_bonus
         self.bite_approach_weight = bite_approach_weight
+        self.bite_head_proximity_weight = bite_head_proximity_weight
         self.posture_weight = posture_weight
         self.nosedive_weight = nosedive_weight
         self.height_weight = height_weight
@@ -194,6 +197,9 @@ class TRexEnv(BaseDinoEnv):
         self.l_foot_site_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_SITE, "l_foot")
         self.tail_tip_site_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_SITE, "tail_tip")
         self.head_tip_site_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_SITE, "head_tip")
+
+        # Prey mocap body
+        self.prey_mocap_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, "prey")
 
         # Sensor indices (order matches MJCF sensor definition)
         # pelvis_gyro(3), pelvis_accel(3), pelvis_orientation(4),
@@ -323,6 +329,19 @@ class TRexEnv(BaseDinoEnv):
         info["approach_delta"] = approach_delta
         info["reward_approach"] = reward_approach
 
+        # 6b. Head-to-prey proximity shaping
+        # Uses the head tip position (not the pelvis) to give the agent a
+        # gradient for aiming its head toward the prey.  Analogous to the
+        # raptor's claw proximity reward.
+        head_tip_pos = self.data.site_xpos[self.head_tip_site_id]
+        head_prey_dist = float(np.linalg.norm(prey_pos - head_tip_pos))
+        head_proximity_max_dist = 3.0
+        head_proximity = max(0.0, 1.0 - head_prey_dist / head_proximity_max_dist)
+        reward_head_proximity = self.bite_head_proximity_weight * head_proximity
+        info["head_prey_distance"] = head_prey_dist
+        info["head_proximity"] = head_proximity
+        info["reward_head_proximity"] = reward_head_proximity
+
         # 7. Continuous posture reward
         pelvis_quat = self.data.sensordata[self._sensor_quat_start : self._sensor_quat_start + 4]
         reward_posture, tilt_angle = self._compute_posture_reward(pelvis_quat, self.posture_weight)
@@ -407,6 +426,7 @@ class TRexEnv(BaseDinoEnv):
             + reward_tail
             + reward_bite
             + reward_approach
+            + reward_head_proximity
             + reward_posture
             + reward_nosedive
             + reward_height

--- a/environments/trex/scripts/test_actuators.py
+++ b/environments/trex/scripts/test_actuators.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Test actuators by applying sinusoidal control signals.
+Useful for verifying joint ranges and actuator gains.
+
+Usage:
+    python test_actuators.py
+"""
+
+import time
+from pathlib import Path
+
+import mujoco
+import mujoco.viewer
+import numpy as np
+
+
+def main():
+    # Load model
+    model_path = Path(__file__).parent.parent / "assets" / "trex.xml"
+    model = mujoco.MjModel.from_xml_path(str(model_path))
+    data = mujoco.MjData(model)
+
+    print(f"Testing {model.nu} actuators...")
+    print("Each actuator will move through its range.\n")
+
+    # Map actuator index to name
+    act_names = []
+    for i in range(model.nu):
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i)
+        act_names.append(name)
+        print(f"  [{i:2d}] {name}: range [{model.actuator_ctrlrange[i, 0]:.1f}, {model.actuator_ctrlrange[i, 1]:.1f}]")
+
+    print("\nStarting viewer with sinusoidal actuation...")
+    print("Watch the joints move through their ranges.")
+
+    start_time = time.time()
+
+    with mujoco.viewer.launch_passive(model, data) as viewer:
+        viewer.cam.distance = 3.0
+        viewer.cam.azimuth = 135
+        viewer.cam.elevation = -15
+
+        while viewer.is_running():
+            t = time.time() - start_time
+
+            # Apply sinusoidal control to each actuator
+            for i in range(model.nu):
+                # Different frequency for each actuator to see them move independently
+                freq = 0.5 + 0.1 * i
+                phase = i * 0.5
+
+                # Get control range
+                ctrl_min = model.actuator_ctrlrange[i, 0]
+                ctrl_max = model.actuator_ctrlrange[i, 1]
+
+                # Position: oscillate through joint range
+                mid = (ctrl_min + ctrl_max) / 2
+                amp = (ctrl_max - ctrl_min) / 2 * 0.8  # 80% of range
+                data.ctrl[i] = mid + amp * np.sin(2 * np.pi * freq * t + phase)
+
+            # Step simulation
+            mujoco.mj_step(model, data)
+            viewer.sync()
+
+
+if __name__ == "__main__":
+    main()

--- a/environments/trex/tests/test_trex_rewards.py
+++ b/environments/trex/tests/test_trex_rewards.py
@@ -27,11 +27,14 @@ class TestTRexRewardComponents:
         _, _, terminated, _, info = env.step(action)
         expected = (
             info["reward_forward"]
+            + info["reward_backward"]
+            + info["reward_drift"]
             + info["reward_alive"]
             + info["reward_energy"]
             + info["reward_tail"]
             + info["reward_bite"]
             + info["reward_approach"]
+            + info["reward_head_proximity"]
             + info["reward_posture"]
             + info["reward_nosedive"]
             + info["reward_height"]
@@ -39,6 +42,8 @@ class TestTRexRewardComponents:
             + info["reward_smoothness"]
             + info["reward_heading"]
             + info["reward_lateral"]
+            + info["reward_spin"]
+            + info["reward_speed"]
         )
         if terminated:
             expected += env.fall_penalty
@@ -128,6 +133,25 @@ class TestTRexRewardWeightEffects:
         action2 = env.action_space.sample()
         _, _, _, _, info = env.step(action2)
         assert info["reward_smoothness"] == 0.0
+        env.close()
+
+    def test_zero_head_proximity_weight_zeroes_head_proximity_reward(self):
+        env = TRexEnv(bite_head_proximity_weight=0.0)
+        env.reset(seed=42)
+        action = env.action_space.sample()
+        _, _, _, _, info = env.step(action)
+        assert info["reward_head_proximity"] == 0.0
+        env.close()
+
+    def test_positive_head_proximity_weight_gives_reward(self):
+        env = TRexEnv(bite_head_proximity_weight=1.0)
+        env.reset(seed=42)
+        action = np.zeros(env.action_space.shape, dtype=np.float32)
+        _, _, _, _, info = env.step(action)
+        # Head proximity should be non-negative
+        assert info["reward_head_proximity"] >= 0.0
+        assert info["head_proximity"] >= 0.0
+        assert info["head_prey_distance"] >= 0.0
         env.close()
 
     def test_zero_height_weight_zeroes_height_reward(self):


### PR DESCRIPTION
## Summary
This PR adds a head-proximity shaping reward to the TRex environment and introduces three validation configurations for hyperparameter sweep testing. The head proximity reward helps the agent learn to position its head near prey, complementing the existing approach-based shaping. Three distinct training configurations are provided to explore different reward balances and learning strategies.

## Key Changes

**Environment Enhancements:**
- Added `bite_head_proximity_weight` parameter to TRexEnv for head-to-prey distance shaping
- Implemented head proximity reward calculation using head tip position (not pelvis) to give the agent a gradient for aiming toward prey
- Added prey mocap body ID caching for efficient position lookups
- Updated reward info dict to include `head_prey_distance`, `head_proximity`, and `reward_head_proximity` metrics

**Test Coverage:**
- Added tests for head proximity reward functionality:
  - `test_zero_head_proximity_weight_zeroes_head_proximity_reward`: Verifies zero weight disables the reward
  - `test_positive_head_proximity_weight_gives_reward`: Validates reward computation with positive weight
- Updated `test_total_reward_is_sum_of_components` to include all reward components in the expected sum

**Validation Configurations:**
- Created `sweep_validation.toml` with three distinct settings for hyperparameter sweep validation:
  - **Setting 1 (Baseline)**: Default stage1_balance.toml values with reset_noise_scale=0.05
  - **Setting 2 (Anti-rotation)**: Stronger heading/spin penalties (0.3/0.3) to prevent rotation exploits, larger network (512x256)
  - **Setting 3 (High alive bonus)**: Boosted alive bonus (4.5) with tuned posture and reduced penalties, emphasizing survival

**Configuration Updates:**
- Updated `stage1_balance.toml` to include `reset_noise_scale = 0.05` for consistency
- Updated `stage3_bite.toml` with revised alive_bonus (0.0) and bite_bonus (1000.0) to properly balance episode termination incentives

**Utility Script:**
- Added `test_actuators.py` for verifying joint ranges and actuator gains through sinusoidal control signals

## Implementation Details
- Head proximity uses a maximum distance threshold of 3.0 units and computes normalized proximity as `max(0.0, 1.0 - distance / 3.0)`
- The three validation settings explore different trade-offs: baseline stability, rotation prevention, and survival-focused learning
- All validation settings maintain consistent episode length (1000 steps) and prey distance range for fair comparison