### PR TITLE
Add bite_success diagnostic tracking and visualization

### DIFF
--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -91,6 +91,7 @@ class DiagnosticsCallback(_BaseCallback):
         "forward_z",
         "approach_delta",
         "strike_success",
+        "bite_success",
         "r_foot_contact",
         "l_foot_contact",
         "pelvis_angular_vel",

--- a/environments/shared/visualization.py
+++ b/environments/shared/visualization.py
@@ -376,6 +376,8 @@ def plot_diagnostics_graphs(
         # [1,1] Strike / Bite / Food Success Rate
         if "strike_success" in diag:
             axes2[1, 1].plot(ts, diag["strike_success"], label=label, color=color)
+        if "bite_success" in diag:
+            axes2[1, 1].plot(ts, diag["bite_success"], label=label, color=color)
 
         # [2,0] Distance Traveled (cumulative XY path length)
         if "distance_traveled" in diag:


### PR DESCRIPTION
## Summary
This PR adds support for tracking and visualizing bite success metrics in the diagnostics system, complementing the existing strike success tracking.

## Key Changes
- **diagnostics.py**: Added `"bite_success"` to the list of tracked diagnostic metrics
- **visualization.py**: Added plotting logic to display `bite_success` data on the same chart as `strike_success` (axes2[1, 1])

## Implementation Details
The bite success metric is now captured alongside strike success in the diagnostics callback and will be visualized in the same subplot, allowing for easy comparison between strike and bite success rates during training and evaluation.