### PR TITLE
Centralize GPU detection logic and include GPU info in stage configs

### DIFF
--- a/environments/shared/config.py
+++ b/environments/shared/config.py
@@ -29,6 +29,35 @@ except ImportError:
     import tomli as tomllib
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Known GPU short-names extracted from full device strings.
+_GPU_SHORT_NAMES = ("A100", "H100", "L4", "L40", "T4", "V100", "A10G", "A10", "RTX")
+
+
+def _detect_gpu_info() -> dict[str, Any]:
+    """Return a dict with GPU details, or an empty dict if no GPU is available."""
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return {}
+        full_name = torch.cuda.get_device_name(0)
+        short_name = full_name
+        for short in _GPU_SHORT_NAMES:
+            if short in full_name.upper():
+                short_name = short
+                break
+        props = torch.cuda.get_device_properties(0)
+        return {
+            "gpu_model": short_name,
+            "gpu_full_name": full_name,
+            "gpu_memory_gb": round(props.total_mem / 1e9, 1),
+            "cuda_version": torch.version.cuda or "",
+        }
+    except Exception:
+        return {}
+
+
 _CONFIGS_DIR = _REPO_ROOT / "configs"
 
 # Map stage number -> filename pattern per species (discovered automatically)
@@ -155,6 +184,10 @@ def save_stage_config(
     }
     if extra:
         data["run"] = extra
+
+    gpu_info = _detect_gpu_info()
+    if gpu_info:
+        data["gpu"] = gpu_info
 
     out_path = stage_dir / "stage_config.json"
     out_path.write_text(json.dumps(data, indent=2) + "\n")

--- a/environments/shared/scripts/sweep/ray_search_space.py
+++ b/environments/shared/scripts/sweep/ray_search_space.py
@@ -37,24 +37,13 @@ from .search_space import _load_search_space_file, _search_space_for_stage
 
 logger = logging.getLogger(__name__)
 
-# Known GPU short-names extracted from full device strings.
-_GPU_SHORT_NAMES = ("A100", "H100", "L4", "L40", "T4", "V100", "A10G", "A10", "RTX")
-
 
 def detect_gpu_model() -> str:
     """Return a short GPU model name (e.g. ``"A100"``) or ``""`` if unavailable."""
-    try:
-        import torch
+    from environments.shared.config import _detect_gpu_info
 
-        if not torch.cuda.is_available():
-            return ""
-        full_name = torch.cuda.get_device_name(0)
-        for short in _GPU_SHORT_NAMES:
-            if short in full_name.upper():
-                return short
-        return str(full_name)  # return full name if no known short-name matches
-    except Exception:  # pragma: no cover – torch may not be installed
-        return ""
+    info = _detect_gpu_info()
+    return info.get("gpu_model", "")
 
 
 # Type alias for a single parameter spec dict.

--- a/environments/shared/scripts/sweep/ray_search_space.py
+++ b/environments/shared/scripts/sweep/ray_search_space.py
@@ -43,7 +43,7 @@ def detect_gpu_model() -> str:
     from environments.shared.config import _detect_gpu_info
 
     info = _detect_gpu_info()
-    return info.get("gpu_model", "")
+    return str(info.get("gpu_model", ""))
 
 
 # Type alias for a single parameter spec dict.

--- a/environments/shared/tests/test_config.py
+++ b/environments/shared/tests/test_config.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from environments.shared.config import (
+    _detect_gpu_info,
     _find_stage_file,
     _upload_to_gcs,
     append_stage_result_csv,
@@ -291,6 +292,28 @@ class TestSaveStageConfig:
         stage_config = {"name": "t", "env_kwargs": {}, "ppo_kwargs": {}, "sac_kwargs": {}, "curriculum_kwargs": {}}
         out = save_stage_config(tmp_path / "a" / "b" / "c", 1, stage_config, "PPO")
         assert out.exists()
+
+    def test_includes_gpu_info_when_available(self, tmp_path):
+        stage_config = {"name": "t", "env_kwargs": {}, "ppo_kwargs": {}, "sac_kwargs": {}, "curriculum_kwargs": {}}
+        fake_gpu = {
+            "gpu_model": "A100",
+            "gpu_full_name": "NVIDIA A100-SXM4-40GB",
+            "gpu_memory_gb": 40.0,
+            "cuda_version": "12.1",
+        }
+        with patch("environments.shared.config._detect_gpu_info", return_value=fake_gpu):
+            out = save_stage_config(tmp_path / "gpu_run", 1, stage_config, "PPO")
+        data = json.loads(out.read_text())
+        assert data["gpu"]["gpu_model"] == "A100"
+        assert data["gpu"]["gpu_memory_gb"] == 40.0
+        assert data["gpu"]["cuda_version"] == "12.1"
+
+    def test_omits_gpu_key_when_no_gpu(self, tmp_path):
+        stage_config = {"name": "t", "env_kwargs": {}, "ppo_kwargs": {}, "sac_kwargs": {}, "curriculum_kwargs": {}}
+        with patch("environments.shared.config._detect_gpu_info", return_value={}):
+            out = save_stage_config(tmp_path / "cpu_run", 1, stage_config, "PPO")
+        data = json.loads(out.read_text())
+        assert "gpu" not in data
 
 
 class TestAppendStageResultCsv:

--- a/environments/shared/tests/test_config.py
+++ b/environments/shared/tests/test_config.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 import pytest
 
 from environments.shared.config import (
-    _detect_gpu_info,
     _find_stage_file,
     _upload_to_gcs,
     append_stage_result_csv,


### PR DESCRIPTION
## Summary
This PR refactors GPU detection logic into a centralized utility function and enhances stage configuration saving to include GPU information when available.

## Key Changes
- **Centralized GPU detection**: Moved GPU detection logic from `ray_search_space.py` into a new `_detect_gpu_info()` function in `config.py` that returns comprehensive GPU details (model, full name, memory, CUDA version)
- **Enhanced stage config**: Modified `save_stage_config()` to automatically include GPU information in the saved configuration when a GPU is detected
- **Refactored GPU model detection**: Updated `detect_gpu_model()` in `ray_search_space.py` to use the centralized `_detect_gpu_info()` function, eliminating code duplication
- **Added test coverage**: Included tests to verify GPU info is included when available and omitted when not

## Implementation Details
- The `_detect_gpu_info()` function gracefully handles cases where PyTorch is unavailable or CUDA is not accessible by returning an empty dict
- GPU information is only added to the stage config if `_detect_gpu_info()` returns non-empty data
- The GPU short-name detection logic remains unchanged but is now shared across the codebase
- All GPU detection exceptions are caught and handled silently to prevent failures in CPU-only environments