### PR TITLE
Add nvidia-smi fallback for GPU detection when torch unavailable

### DIFF
--- a/environments/shared/config.py
+++ b/environments/shared/config.py
@@ -36,23 +36,63 @@ _GPU_SHORT_NAMES = ("A100", "H100", "L4", "L40", "T4", "V100", "A10G", "A10", "R
 
 def _detect_gpu_info() -> dict[str, Any]:
     """Return a dict with GPU details, or an empty dict if no GPU is available."""
+    # Try torch first (most accurate when available).
     try:
         import torch
 
-        if not torch.cuda.is_available():
+        if torch.cuda.is_available():
+            full_name = torch.cuda.get_device_name(0)
+            short_name = full_name
+            for short in _GPU_SHORT_NAMES:
+                if short in full_name.upper():
+                    short_name = short
+                    break
+            props = torch.cuda.get_device_properties(0)
+            return {
+                "gpu_model": short_name,
+                "gpu_full_name": full_name,
+                "gpu_memory_gb": round(props.total_mem / 1e9, 1),
+                "cuda_version": torch.version.cuda or "",
+            }
+    except Exception:
+        pass
+
+    # Fallback: query nvidia-smi directly (works without torch).
+    return _detect_gpu_info_nvidia_smi()
+
+
+def _detect_gpu_info_nvidia_smi() -> dict[str, Any]:
+    """Detect GPU info via nvidia-smi. Returns empty dict on failure."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,memory.total,driver_version",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
             return {}
-        full_name = torch.cuda.get_device_name(0)
+        line = result.stdout.strip().split("\n")[0]
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) < 3:
+            return {}
+        full_name, memory_mb, driver_version = parts[0], parts[1], parts[2]
         short_name = full_name
         for short in _GPU_SHORT_NAMES:
             if short in full_name.upper():
                 short_name = short
                 break
-        props = torch.cuda.get_device_properties(0)
         return {
             "gpu_model": short_name,
             "gpu_full_name": full_name,
-            "gpu_memory_gb": round(props.total_mem / 1e9, 1),
-            "cuda_version": torch.version.cuda or "",
+            "gpu_memory_gb": round(float(memory_mb) / 1024, 1),
+            "driver_version": driver_version,
         }
     except Exception:
         return {}

--- a/environments/shared/tests/test_config.py
+++ b/environments/shared/tests/test_config.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 import pytest
 
 from environments.shared.config import (
+    _detect_gpu_info,
+    _detect_gpu_info_nvidia_smi,
     _find_stage_file,
     _upload_to_gcs,
     append_stage_result_csv,
@@ -313,6 +315,51 @@ class TestSaveStageConfig:
             out = save_stage_config(tmp_path / "cpu_run", 1, stage_config, "PPO")
         data = json.loads(out.read_text())
         assert "gpu" not in data
+
+
+class TestDetectGpuInfo:
+    """Tests for GPU detection with torch and nvidia-smi fallback."""
+
+    def test_falls_back_to_nvidia_smi_when_torch_unavailable(self):
+        fake_smi = {
+            "gpu_model": "T4",
+            "gpu_full_name": "Tesla T4",
+            "gpu_memory_gb": 15.0,
+            "driver_version": "535.104.05",
+        }
+        with (
+            patch.dict("sys.modules", {"torch": None}),
+            patch("environments.shared.config._detect_gpu_info_nvidia_smi", return_value=fake_smi),
+        ):
+            result = _detect_gpu_info()
+        assert result["gpu_model"] == "T4"
+        assert result["gpu_memory_gb"] == 15.0
+
+    def test_nvidia_smi_parses_output(self):
+        import subprocess
+
+        fake_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Tesla T4, 15360, 535.104.05\n", stderr=""
+        )
+        with patch("subprocess.run", return_value=fake_result):
+            result = _detect_gpu_info_nvidia_smi()
+        assert result["gpu_model"] == "T4"
+        assert result["gpu_full_name"] == "Tesla T4"
+        assert result["gpu_memory_gb"] == 15.0
+        assert result["driver_version"] == "535.104.05"
+
+    def test_nvidia_smi_returns_empty_on_failure(self):
+        import subprocess
+
+        fake_result = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="not found")
+        with patch("subprocess.run", return_value=fake_result):
+            result = _detect_gpu_info_nvidia_smi()
+        assert result == {}
+
+    def test_nvidia_smi_returns_empty_when_not_installed(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = _detect_gpu_info_nvidia_smi()
+        assert result == {}
 
 
 class TestAppendStageResultCsv:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ Issues = "https://github.com/kuds/mesozoic-labs/issues"
 
 [project.optional-dependencies]
 train = [
+    "torch>=2.0.0",
     "stable-baselines3[extra]>=2.2.0",
     "wandb>=0.16.0",
     "cloudml-hypertune>=0.1.0.dev0",


### PR DESCRIPTION
## Summary
Refactored GPU detection to support both PyTorch and nvidia-smi backends, with nvidia-smi as a fallback when PyTorch is unavailable or CUDA is not detected.

## Key Changes
- **Refactored `_detect_gpu_info()`**: Now attempts PyTorch detection first, then falls back to nvidia-smi if torch is unavailable or CUDA is not available
- **New `_detect_gpu_info_nvidia_smi()` function**: Extracts GPU information directly from nvidia-smi command output, parsing GPU name, memory, and driver version
- **Improved robustness**: GPU detection now works in environments where PyTorch is not installed, as long as nvidia-smi is available
- **Added comprehensive tests**: New `TestDetectGpuInfo` class with tests covering torch fallback, nvidia-smi parsing, and error handling scenarios
- **Updated dependencies**: Added `torch>=2.0.0` to optional train dependencies

## Implementation Details
- The nvidia-smi fallback queries GPU name, memory (in MB), and driver version using `--format=csv,noheader,nounits`
- Memory conversion: nvidia-smi returns memory in MB, converted to GB by dividing by 1024
- Error handling: Returns empty dict on subprocess failures, timeouts, or malformed output
- GPU model shortening logic is preserved and applied to both detection methods