### PR TITLE
Update Notebooks section to match actual notebook files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ mesozoic-labs/
 │       └── tests/             # Shared utility tests
 ├── configs/                   # TOML hyperparameter configs per species/stage
 ├── notebooks/                 # Jupyter notebooks for experiments
-│   ├── velociraptor_training.ipynb
-│   ├── brachiosaurus_training.ipynb
-│   ├── trex_training.ipynb
-│   └── jax_trex_training.ipynb
+│   ├── training.ipynb
+│   ├── jax_trex_training.ipynb
+│   ├── ray_tune_sweep.ipynb
+│   └── google_drive_summary.ipynb
 ├── website/                   # Documentation site (Docusaurus)
 └── results/                   # Training results (GIFs + summary.json per species/algorithm)
 ```
@@ -187,10 +187,10 @@ Hardware: Google Colab T4 GPU
 
 | Notebook | Description |
 |----------|-------------|
-| `notebooks/velociraptor_training.ipynb` | Velociraptor 3-stage curriculum training (Colab-ready) |
-| `notebooks/brachiosaurus_training.ipynb` | Brachiosaurus 3-stage curriculum training (Colab-ready) |
-| `notebooks/trex_training.ipynb` | T-Rex 3-stage curriculum training (Colab-ready) |
-| `notebooks/jax_trex_training.ipynb` | JAX/MJX T-Rex training for TPU acceleration (Colab-ready) |
+| `notebooks/training.ipynb` | Unified 3-stage curriculum training for all species (Colab-ready) |
+| `notebooks/jax_trex_training.ipynb` | JAX/MJX T-Rex training for GPU acceleration (Colab-ready) |
+| `notebooks/ray_tune_sweep.ipynb` | Ray Tune hyperparameter sweep with ASHA early stopping (Colab-ready) |
+| `notebooks/google_drive_summary.ipynb` | Training runs summary and comparison across all species (Colab-ready) |
 
 ## Roadmap
 


### PR DESCRIPTION
Replace outdated per-species notebook references with the actual files: training.ipynb (unified), jax_trex_training.ipynb, ray_tune_sweep.ipynb, and google_drive_summary.ipynb. Also update the repository structure tree.