### PR TITLE
Add library version tracking to config and search space

### DIFF
--- a/environments/shared/config.py
+++ b/environments/shared/config.py
@@ -53,6 +53,7 @@ def get_library_version() -> str:
 
     return "unknown"
 
+
 # Known GPU short-names extracted from full device strings.
 _GPU_SHORT_NAMES = ("A100", "H100", "L4", "L40", "T4", "V100", "A10G", "A10", "RTX")
 

--- a/environments/shared/config.py
+++ b/environments/shared/config.py
@@ -31,6 +31,28 @@ except ImportError:
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
+
+def get_library_version() -> str:
+    """Return the mesozoic-labs package version string.
+
+    Tries ``importlib.metadata`` first (works when the package is installed),
+    then falls back to parsing ``pyproject.toml`` at the repository root.
+    """
+    try:
+        from importlib.metadata import version
+
+        return version("mesozoic-labs")
+    except Exception:
+        pass
+
+    pyproject = _REPO_ROOT / "pyproject.toml"
+    if pyproject.exists():
+        with open(pyproject, "rb") as f:
+            data = tomllib.load(f)
+        return data.get("project", {}).get("version", "unknown")
+
+    return "unknown"
+
 # Known GPU short-names extracted from full device strings.
 _GPU_SHORT_NAMES = ("A100", "H100", "L4", "L40", "T4", "V100", "A10G", "A10", "RTX")
 
@@ -246,6 +268,7 @@ def save_stage_config(
         "name": stage_config.get("name", ""),
         "description": stage_config.get("description", ""),
         "algorithm": algorithm.upper(),
+        "library_version": get_library_version(),
         "reward_weights": env_kwargs,
         "hyperparameters": stage_config.get(algo_key, {}),
         "curriculum": stage_config.get("curriculum_kwargs", {}),

--- a/environments/shared/config.py
+++ b/environments/shared/config.py
@@ -49,7 +49,7 @@ def get_library_version() -> str:
     if pyproject.exists():
         with open(pyproject, "rb") as f:
             data = tomllib.load(f)
-        return data.get("project", {}).get("version", "unknown")
+        return str(data.get("project", {}).get("version", "unknown"))
 
     return "unknown"
 

--- a/environments/shared/scripts/sweep/ray_search_space.py
+++ b/environments/shared/scripts/sweep/ray_search_space.py
@@ -168,10 +168,13 @@ def save_search_space(
     filename = f"search_space_stage{stage}_{algorithm}.json" if stage and algorithm else "search_space.json"
     filepath = dest / filename
 
+    from environments.shared.config import get_library_version
+
     payload: dict[str, Any] = {
         "species": species,
         "stage": stage,
         "algorithm": algorithm,
+        "library_version": get_library_version(),
         "num_parameters": len(search_space),
     }
 


### PR DESCRIPTION
## Summary
This PR adds automatic library version tracking to configuration and search space artifacts by introducing a `get_library_version()` utility function and integrating it into the config and search space saving workflows.

## Key Changes
- **New `get_library_version()` function** in `environments/shared/config.py`:
  - Attempts to retrieve the package version using `importlib.metadata` (for installed packages)
  - Falls back to parsing `pyproject.toml` at the repository root if metadata is unavailable
  - Returns "unknown" if neither method succeeds
  - Includes comprehensive docstring explaining the fallback behavior

- **Config integration**: Added `library_version` field to saved stage configurations via `save_stage_config()`

- **Search space integration**: Added `library_version` field to saved search space payloads via `save_search_space()`

## Implementation Details
- The function uses a try-except pattern to gracefully handle cases where the package isn't installed
- Uses `tomllib` (already imported in the module) to parse `pyproject.toml` when needed
- The version information is now persisted alongside other metadata in both config and search space artifacts, enabling better reproducibility and debugging