### PR TITLE
Fix brachiosaurus static-crouch exploit with idle penalty

### DIFF
--- a/configs/brachiosaurus/stage2_locomotion.toml
+++ b/configs/brachiosaurus/stage2_locomotion.toml
@@ -3,21 +3,23 @@ name = "locomotion"
 description = "Learn coordinated quadrupedal walking"
 
 [env]
-forward_vel_weight = 3.0               # Increased from 2.0: stronger forward signal to prevent standing-still exploit. Agent was earning ~2000 reward without walking.
-forward_vel_max = 1.0                  # Raised from 0.5: previous cap saturated reward at 0.5 m/s, removing gradient toward 0.75 m/s graduation target.
-alive_bonus = 0.75                     # Raised from 0.25: episodes averaged only 457/1000 steps with 80% fall rate. Stronger survival incentive to extend episodes.
+forward_vel_weight = 8.0               # Increased from 3.0: must dominate passive rewards (alive+posture+heading~0.45/step). At 0.75 m/s this gives 6.0/step, making walking clearly optimal.
+forward_vel_max = 1.0                  # Keep at 1.0: allows gradient up to graduation target of 0.75 m/s.
+alive_bonus = 0.1                      # Reduced from 0.75: previous value gave 750/episode for standing still, enabling static-crouch exploit. Minimal survival signal only.
 fall_penalty = -50.0                   # Match T-Rex stage 2
-energy_penalty_weight = 0.002          # Increase from 0.001: provide some efficiency signal (matches T-Rex stage 2)
+energy_penalty_weight = 0.002          # Keep: provides efficiency signal
 tail_stability_weight = 0.05           # Penalize tail thrashing during locomotion
 gait_stability_weight = 0.05
-gait_symmetry_weight = 0.15           # Enabled: encourage diagonal-pair alternation for proper quadrupedal walk/trot. Was 0.0, agent showed collapsed gait symmetry and shuffling.
+gait_symmetry_weight = 0.15            # Keep: encourage diagonal-pair alternation for proper quadrupedal gait.
 smoothness_weight = 0.05               # Penalize jerky actions for smoother movement
-posture_weight = 0.6                   # Raised from 0.2: agent reached 7.8° tilt causing chronic nosedives. Stronger upright signal provides earlier correction than nosedive penalty.
-nosedive_weight = 0.4                  # Reduced from 0.8: nosedive fires too late (after agent is already leaning). Shifted budget to posture_weight for proactive correction.
-natural_pitch = -0.15                  # Slight upward neck angle target (radians). Was 0.0 which allowed flat neck as optimal.
-height_weight = 0.3                    # Reduced from 1.5: high value rewarded crouching for stability over walking. Minimal signal sufficient.
-heading_weight = 0.3                   # Reward facing toward food
+posture_weight = 0.15                  # Reduced from 0.6: high value rewarded static upright stance over walking. Minimal signal to prevent extreme tilt.
+nosedive_weight = 0.4                  # Keep: penalizes excessive forward pitch.
+natural_pitch = -0.15                  # Slight upward neck angle target (radians).
+height_weight = 0.1                    # Reduced from 0.3: further reduce passive standing reward.
+heading_weight = 0.1                   # Reduced from 0.3: was contributing to static-crouch exploit. Minimal directional signal.
 lateral_penalty_weight = 0.1           # Mild anti-crab-walk penalty
+idle_penalty_weight = 0.5              # NEW: mild penalty for standing still. Insurance against static-crouch exploit on this stable quadruped. Bipeds (T-Rex, raptor) don't need this because standing is inherently unstable.
+idle_velocity_threshold = 0.1          # NEW: speed (m/s) at which idle penalty reaches zero. Below this, agent is penalised for inaction.
 food_reach_bonus = 0.0
 food_approach_weight = 0.0
 food_head_proximity_weight = 0.0
@@ -34,7 +36,7 @@ n_epochs = 10
 gamma = 0.995                           # Increase from 0.99: longer horizon values sustained locomotion (matches T-Rex)
 gae_lambda = 0.95
 clip_range = 0.2
-ent_coef = 0.005
+ent_coef = 0.01                           # Increased from 0.005: previous run collapsed at ~9M steps, likely entropy collapse. Higher value maintains exploration over 12M steps.
 
 [ppo.policy_kwargs]
 net_arch = [512, 256]                  # Larger first layer to match Stage 1 setting 4 architecture

--- a/environments/brachiosaurus/envs/brachio_env.py
+++ b/environments/brachiosaurus/envs/brachio_env.py
@@ -85,6 +85,8 @@ class BrachioEnv(BaseDinoEnv):
         tail_stability_weight: float = 0.0,
         speed_penalty_weight: float = 0.0,
         speed_penalty_threshold: float = 0.10,
+        idle_penalty_weight: float = 0.0,
+        idle_velocity_threshold: float = 0.05,
         forward_vel_max: float = 1.0,
         food_reach_bonus: float = 10.0,
         food_reach_threshold: float = 0.5,
@@ -114,6 +116,8 @@ class BrachioEnv(BaseDinoEnv):
         self.tail_stability_weight = tail_stability_weight
         self.speed_penalty_weight = speed_penalty_weight
         self.speed_penalty_threshold = speed_penalty_threshold
+        self.idle_penalty_weight = idle_penalty_weight
+        self.idle_velocity_threshold = idle_velocity_threshold
         self.forward_vel_max = forward_vel_max
         self.food_reach_bonus = food_reach_bonus
         self.food_reach_threshold = food_reach_threshold
@@ -403,6 +407,12 @@ class BrachioEnv(BaseDinoEnv):
         info["abs_speed"] = abs_speed
         info["reward_speed"] = reward_speed
 
+        # 14b. Idle penalty (penalise standing still / barely moving)
+        reward_idle, idle_speed = self._compute_idle_penalty(
+            vel_2d, self.idle_penalty_weight, self.idle_velocity_threshold
+        )
+        info["reward_idle"] = reward_idle
+
         # 15. Food reach bonus (head tip close to food)
         head_tip_pos = self.data.site_xpos[self.head_tip_site_id]
         head_food_dist = float(np.linalg.norm(head_tip_pos - food_pos))
@@ -454,6 +464,7 @@ class BrachioEnv(BaseDinoEnv):
             + reward_lateral
             + reward_spin
             + reward_speed
+            + reward_idle
             + reward_food
             + reward_approach
             + reward_head_proximity

--- a/environments/brachiosaurus/scripts/test_env.py
+++ b/environments/brachiosaurus/scripts/test_env.py
@@ -32,6 +32,7 @@ REWARD_KEYS = [
     "reward_energy",
     "reward_gait",
     "reward_food",
+    "reward_idle",
     "reward_total",
 ]
 

--- a/environments/brachiosaurus/tests/test_brachio_rewards.py
+++ b/environments/brachiosaurus/tests/test_brachio_rewards.py
@@ -42,6 +42,7 @@ class TestBrachioRewardComponents:
             + info["reward_lateral"]
             + info["reward_spin"]
             + info["reward_speed"]
+            + info["reward_idle"]
             + info["reward_food"]
             + info["reward_approach"]
             + info["reward_head_proximity"]

--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -442,9 +442,7 @@ class BaseDinoEnv(gym.Env, ABC):
         reward = -weight * excess_norm
         return reward, speed
 
-    def _compute_idle_penalty(
-        self, vel_2d: np.ndarray, weight: float, threshold: float = 0.05
-    ) -> tuple[float, float]:
+    def _compute_idle_penalty(self, vel_2d: np.ndarray, weight: float, threshold: float = 0.05) -> tuple[float, float]:
         """Penalise low 2D speed (standing still / barely moving).
 
         Applies a penalty that is strongest at zero speed and linearly

--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -442,6 +442,29 @@ class BaseDinoEnv(gym.Env, ABC):
         reward = -weight * excess_norm
         return reward, speed
 
+    def _compute_idle_penalty(
+        self, vel_2d: np.ndarray, weight: float, threshold: float = 0.05
+    ) -> tuple[float, float]:
+        """Penalise low 2D speed (standing still / barely moving).
+
+        Applies a penalty that is strongest at zero speed and linearly
+        decreases to zero when speed reaches *threshold*.
+
+        Args:
+            vel_2d: 2D velocity vector (qvel[0:2]).
+            weight: Penalty weight (positive value; returned reward is negative).
+            threshold: Speed (m/s) at or above which no penalty applies.
+
+        Returns:
+            (reward, absolute_speed) tuple.
+        """
+        speed = float(np.linalg.norm(vel_2d))
+        if speed >= threshold:
+            return 0.0, speed
+        idle_frac = 1.0 - speed / threshold
+        reward = -weight * idle_frac
+        return reward, speed
+
     def _init_gait_state(
         self,
         contact_threshold: float = 0.1,

--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -72,6 +72,7 @@ class DiagnosticsCallback(_BaseCallback):
         "reward_lateral",
         "reward_spin",
         "reward_speed",
+        "reward_idle",
         # Species-specific reward components
         "reward_bite",  # T-Rex
         "reward_food",  # Brachiosaurus

--- a/environments/shared/tests/test_species_integration.py
+++ b/environments/shared/tests/test_species_integration.py
@@ -44,6 +44,7 @@ SPECIES_REWARD_KEYS = {
         "reward_posture",
         "reward_gait",
         "reward_smoothness",
+        "reward_idle",
         "reward_total",
     ],
     "trex": [
@@ -60,6 +61,7 @@ SPECIES_REWARD_KEYS = {
         "reward_smoothness",
         "reward_heading",
         "reward_lateral",
+        "reward_idle",
         "reward_total",
     ],
     "brachiosaurus": [
@@ -69,6 +71,7 @@ SPECIES_REWARD_KEYS = {
         "reward_gait",
         "reward_food",
         "reward_approach",
+        "reward_idle",
         "reward_total",
     ],
 }

--- a/environments/shared/visualization.py
+++ b/environments/shared/visualization.py
@@ -198,6 +198,7 @@ def plot_diagnostics_graphs(
         "reward_claw_proximity": ("strike_claw_proximity_weight",),
         "reward_bite": ("bite_bonus",),
         "reward_food": ("food_reach_bonus",),
+        "reward_idle": ("idle_penalty_weight",),
     }
 
     def _signal_active(reward_key: str, stage_num: int) -> bool:

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -91,6 +91,8 @@ class TRexEnv(BaseDinoEnv):
         spin_penalty_weight: float = 0.0,
         speed_penalty_weight: float = 0.0,
         speed_penalty_threshold: float = 0.10,
+        idle_penalty_weight: float = 0.0,
+        idle_velocity_threshold: float = 0.05,
         forward_vel_max: float = 8.0,
         # Environment settings
         prey_distance_range: tuple[float, float] = (3.0, 8.0),
@@ -117,6 +119,8 @@ class TRexEnv(BaseDinoEnv):
         self.spin_penalty_weight = spin_penalty_weight
         self.speed_penalty_weight = speed_penalty_weight
         self.speed_penalty_threshold = speed_penalty_threshold
+        self.idle_penalty_weight = idle_penalty_weight
+        self.idle_velocity_threshold = idle_velocity_threshold
         self.forward_vel_max = forward_vel_max
 
         # Natural forward pitch (~10°). The nosedive penalty and termination
@@ -416,6 +420,12 @@ class TRexEnv(BaseDinoEnv):
         info["abs_speed"] = abs_speed
         info["reward_speed"] = reward_speed
 
+        # 14b. Idle penalty (penalise standing still / barely moving)
+        reward_idle, idle_speed = self._compute_idle_penalty(
+            vel_2d, self.idle_penalty_weight, self.idle_velocity_threshold
+        )
+        info["reward_idle"] = reward_idle
+
         # Total reward
         total_reward = (
             reward_forward
@@ -436,6 +446,7 @@ class TRexEnv(BaseDinoEnv):
             + reward_lateral
             + reward_spin
             + reward_speed
+            + reward_idle
         )
         info["reward_total"] = total_reward
 

--- a/environments/trex/scripts/test_env.py
+++ b/environments/trex/scripts/test_env.py
@@ -32,6 +32,7 @@ REWARD_KEYS = [
     "reward_energy",
     "reward_tail",
     "reward_bite",
+    "reward_idle",
     "reward_total",
 ]
 

--- a/environments/trex/tests/test_trex_rewards.py
+++ b/environments/trex/tests/test_trex_rewards.py
@@ -54,6 +54,7 @@ class TestTRexRewardComponents:
             + info["reward_lateral"]
             + info["reward_spin"]
             + info["reward_speed"]
+            + info["reward_idle"]
         )
         if terminated:
             expected += env.fall_penalty

--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -93,6 +93,8 @@ class RaptorEnv(BaseDinoEnv):
         spin_penalty_weight: float = 0.0,
         speed_penalty_weight: float = 0.0,
         speed_penalty_threshold: float = 0.10,
+        idle_penalty_weight: float = 0.0,
+        idle_velocity_threshold: float = 0.05,
         # Environment settings
         prey_distance_range: tuple[float, float] = (3.0, 8.0),
         prey_lateral_range: tuple[float, float] = (-2.0, 2.0),
@@ -119,6 +121,8 @@ class RaptorEnv(BaseDinoEnv):
         self.spin_penalty_weight = spin_penalty_weight
         self.speed_penalty_weight = speed_penalty_weight
         self.speed_penalty_threshold = speed_penalty_threshold
+        self.idle_penalty_weight = idle_penalty_weight
+        self.idle_velocity_threshold = idle_velocity_threshold
 
         # Natural forward pitch (~20°). The nosedive penalty and termination
         # are measured relative to this angle so the raptor isn't punished for
@@ -427,6 +431,12 @@ class RaptorEnv(BaseDinoEnv):
         info["abs_speed"] = abs_speed
         info["reward_speed"] = reward_speed
 
+        # 11b. Idle penalty (penalise standing still / barely moving)
+        reward_idle, idle_speed = self._compute_idle_penalty(
+            vel_2d, self.idle_penalty_weight, self.idle_velocity_threshold
+        )
+        info["reward_idle"] = reward_idle
+
         # Total reward
         total_reward = (
             reward_forward
@@ -447,6 +457,7 @@ class RaptorEnv(BaseDinoEnv):
             + reward_heading
             + reward_lateral
             + reward_speed
+            + reward_idle
         )
         info["reward_total"] = total_reward
 

--- a/environments/velociraptor/scripts/test_env.py
+++ b/environments/velociraptor/scripts/test_env.py
@@ -39,6 +39,7 @@ REWARD_KEYS = [
     "reward_energy",
     "reward_tail",
     "reward_strike",
+    "reward_idle",
     "reward_total",
 ]
 

--- a/environments/velociraptor/tests/test_raptor_rewards.py
+++ b/environments/velociraptor/tests/test_raptor_rewards.py
@@ -61,6 +61,8 @@ class TestRaptorRewardComponents:
             + info["reward_smoothness"]
             + info["reward_heading"]
             + info["reward_lateral"]
+            + info["reward_speed"]
+            + info["reward_idle"]
         )
         if terminated:
             expected += env.fall_penalty


### PR DESCRIPTION
## Summary
This PR addresses a critical training issue in the brachiosaurus stage 2 locomotion environment where the agent was exploiting a static-crouch stance to accumulate reward without actually walking. The fix introduces an idle penalty mechanism and rebalances reward weights to make forward locomotion the dominant reward signal.

## Key Changes

**Reward Structure Rebalancing:**
- Increased `forward_vel_weight` from 3.0 to 8.0 to make walking the dominant reward signal (~6.0/step at target speed vs ~0.45/step for passive rewards)
- Reduced `alive_bonus` from 0.75 to 0.1 to eliminate the standing-still exploit (was giving 750/episode for static crouch)
- Reduced `posture_weight` from 0.6 to 0.15 to prevent rewarding static upright stance over actual locomotion
- Reduced `height_weight` from 0.3 to 0.1 to further minimize passive standing reward
- Reduced `heading_weight` from 0.3 to 0.1 to remove contribution to static-crouch exploit

**New Idle Penalty Mechanism:**
- Added `_compute_idle_penalty()` method in `base_env.py` that linearly penalizes speeds below a threshold, reaching maximum penalty at zero speed
- Integrated idle penalty into brachiosaurus environment with configurable `idle_penalty_weight` (0.5) and `idle_velocity_threshold` (0.1 m/s)
- This provides insurance against static-crouch exploitation on stable quadrupeds (bipeds like T-Rex don't need this as standing is inherently unstable)

**Training Stability:**
- Increased `ent_coef` from 0.005 to 0.01 to prevent entropy collapse observed in previous runs around 9M steps
- Maintained `gamma` at 0.995 for longer horizon value estimation

## Implementation Details
- The idle penalty uses a linear decay from maximum penalty at zero speed to zero penalty at the threshold speed
- All changes are backward compatible with existing environment configurations through default parameter values
- The rebalancing ensures forward velocity reward dominates over all passive survival/posture rewards combined