### PR TITLE
Add species tracking to stage configuration

### DIFF
--- a/environments/shared/config.py
+++ b/environments/shared/config.py
@@ -210,6 +210,7 @@ def save_stage_config(
     algorithm: str,
     extra: dict[str, Any] | None = None,
     env_class: type | None = None,
+    species: str | None = None,
 ) -> Path:
     """Save the reward weights and model hyperparameters for a stage to JSON.
 
@@ -231,6 +232,7 @@ def save_stage_config(
             (e.g. ``{"seed": 42, "n_envs": 4}``).
         env_class: Optional environment class whose ``__init__`` defaults are
             merged into ``env_kwargs`` for completeness.
+        species: Optional species name (e.g. ``"velociraptor"``, ``"trex"``).
 
     Returns:
         Path to the written JSON file.
@@ -265,6 +267,7 @@ def save_stage_config(
             env_kwargs[key] = list(value)
 
     data: dict[str, Any] = {
+        "species": species or "",
         "stage": stage,
         "name": stage_config.get("name", ""),
         "description": stage_config.get("description", ""),

--- a/environments/shared/tests/test_config.py
+++ b/environments/shared/tests/test_config.py
@@ -250,9 +250,10 @@ class TestSaveStageConfig:
             "sac_kwargs": {"learning_rate": 1e-4},
             "curriculum_kwargs": {"min_avg_reward": 10.0},
         }
-        out = save_stage_config(tmp_path / "stage1", 1, stage_config, "PPO")
+        out = save_stage_config(tmp_path / "stage1", 1, stage_config, "PPO", species="velociraptor")
         assert out.exists()
         data = json.loads(out.read_text())
+        assert data["species"] == "velociraptor"
         assert data["stage"] == 1
         assert data["name"] == "balance"
         assert data["algorithm"] == "PPO"

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -482,6 +482,7 @@ def train(
         algorithm.upper(),
         extra={"seed": seed, "n_envs": n_envs, "timesteps": total_timesteps},
         env_class=species_cfg.env_class,
+        species=species_cfg.species,
     )
 
     # Create environments
@@ -865,6 +866,7 @@ def train_curriculum(
             algorithm.upper(),
             extra={"seed": seed, "n_envs": n_envs, "timesteps": total_timesteps},
             env_class=species_cfg.env_class,
+            species=species_cfg.species,
         )
 
         effective_subproc = use_subproc or (algorithm == "sac" and n_envs > 1)


### PR DESCRIPTION
## Summary
This change adds optional species name tracking to the stage configuration system, allowing the species information to be persisted when saving training configurations.

## Key Changes
- Added `species` parameter to `save_stage_config()` function in `environments/shared/config.py`
- The species name is now included in the saved JSON configuration data (defaults to empty string if not provided)
- Updated `train()` and `train_curriculum()` methods in `environments/shared/train_base.py` to pass the species information when saving stage configs
- Added test coverage to verify species data is correctly saved and retrieved from configuration files

## Implementation Details
- The `species` parameter is optional (`str | None = None`) to maintain backward compatibility
- Species information is stored in the JSON output as `"species": species or ""`, ensuring the field is always present
- The species value is sourced from `species_cfg.species` in the training methods, maintaining consistency with the species configuration system