### PR TITLE
Fix mobile navbar logo appearing too small

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -79,7 +79,7 @@ body {
 }
 
 .navbar__logo {
-  height: 2rem;
+  height: 2.5rem;
   width: auto;
   margin-right: 0.5rem;
 }


### PR DESCRIPTION
Increase navbar logo height from 2rem to 2.5rem so the dinosaur icon doesn't look shrunk on mobile viewports.