### PR TITLE
Increase SAC gradient steps from 2 to 8 across all training stages

### DIFF
--- a/configs/velociraptor/stage1_balance.toml
+++ b/configs/velociraptor/stage1_balance.toml
@@ -49,7 +49,7 @@ ent_coef = "auto"                # SAC's key advantage: auto-tuned entropy elimi
 buffer_size = 300_000            # Sufficient for 6M-step Stage 1; smaller buffer keeps transitions recent
 learning_starts = 10_000         # Collect 10K random transitions before gradient updates begin
 train_freq = 16                  # Collect 16 env steps before training — amortises gradient cost over more env steps
-gradient_steps = 2               # 8:1 data-to-update ratio — SAC is sample-efficient enough; halves GPU stalls per env batch
+gradient_steps = 8               # 2:1 data-to-update ratio — more gradient updates per env batch smooths learning curves
 
 [sac.policy_kwargs]
 net_arch = [512, 256]            # Match PPO architecture for fair comparison

--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -45,7 +45,7 @@ ent_coef = "auto"                # Auto-entropy naturally decreases exploration 
 buffer_size = 1_000_000          # Larger buffer retains Stage 1 balance transitions, reducing catastrophic forgetting
 learning_starts = 10_000
 train_freq = 16                  # Collect 16 env steps before training — amortises gradient cost over more env steps
-gradient_steps = 2               # 8:1 data-to-update ratio — SAC is sample-efficient enough; halves GPU stalls per env batch
+gradient_steps = 8               # 2:1 data-to-update ratio — more gradient updates per env batch smooths learning curves
 
 [sac.policy_kwargs]
 net_arch = [512, 256]

--- a/configs/velociraptor/stage3_strike.toml
+++ b/configs/velociraptor/stage3_strike.toml
@@ -50,7 +50,7 @@ ent_coef = "auto"                # Auto-entropy is especially valuable for spars
 buffer_size = 1_000_000          # Large buffer retains locomotion transitions from Stage 2
 learning_starts = 10_000
 train_freq = 16                  # Collect 16 env steps before training — amortises gradient cost over more env steps
-gradient_steps = 2               # 8:1 data-to-update ratio — SAC is sample-efficient enough; halves GPU stalls per env batch
+gradient_steps = 8               # 2:1 data-to-update ratio — more gradient updates per env batch smooths learning curves
 
 [sac.policy_kwargs]
 net_arch = [512, 256]


### PR DESCRIPTION
## Summary
Increased the number of gradient steps per environment batch from 2 to 8 across all three Velociraptor training stages (balance, locomotion, and strike). This adjustment changes the data-to-update ratio from 8:1 to 2:1, prioritizing more frequent gradient updates for smoother learning curves.

## Key Changes
- **stage1_balance.toml**: `gradient_steps = 2` → `gradient_steps = 8`
- **stage2_locomotion.toml**: `gradient_steps = 2` → `gradient_steps = 8`
- **stage3_strike.toml**: `gradient_steps = 2` → `gradient_steps = 8`
- Updated inline comments to reflect the new 2:1 data-to-update ratio and rationale (smoother learning curves via more gradient updates per env batch)

## Implementation Details
This change affects the SAC (Soft Actor-Critic) training loop across all stages. With `train_freq = 16` remaining constant, the agent will now perform 8 gradient update steps for every 16 environment steps collected, compared to the previous 2 steps. This increases computational cost per environment batch but aims to improve training stability and convergence smoothness by reducing variance in the learning signal.

https://claude.ai/code/session_01Kx6cnqpbJCLYZeFacdagQV