### PR TITLE
Fix Brachiosaurus tripedal gait and improve food reach success rate

### DIFF
--- a/configs/brachiosaurus/stage2_locomotion.toml
+++ b/configs/brachiosaurus/stage2_locomotion.toml
@@ -5,12 +5,12 @@ description = "Learn coordinated quadrupedal walking"
 [env]
 forward_vel_weight = 4.0               # Reduced from 8.0: was 13:1 vs gait signals, agent exploited speed over gait quality. At 0.75 m/s this gives ~3.0/step — still dominant but leaves room for posture/symmetry.
 forward_vel_max = 1.0                  # Keep at 1.0: allows gradient up to graduation target of 0.75 m/s.
-alive_bonus = 0.2                      # Increased from 0.1: complement higher fall_penalty to incentivize survival. Not enough to re-enable crouch exploit (idle penalty handles that).
-fall_penalty = -100.0                  # Increased from -50: 85% fallen termination rate means short fast episodes are rewarded. Make dying expensive so agent invests in stability.
-energy_penalty_weight = 0.005          # Increased from 0.002: CoT collapsed to near-zero. With 4 new tail actuators, also prevents wasteful tail thrashing.
+alive_bonus = 0.3                      # Increased from 0.2: reduce the 85% fall rate by rewarding survival more. Idle penalty still prevents crouch exploit.
+fall_penalty = -50.0                   # Reduced from -100: overly harsh penalty caused conservative policies that avoid movement. Align with T-Rex/Velociraptor.
+energy_penalty_weight = 0.003          # Reduced from 0.005: agent may be "saving energy" by lifting FR leg. Less pressure allows all four legs to engage.
 tail_stability_weight = 0.15           # Increased from 0.05: now that tail has actuators, give meaningful signal to use them.
 gait_stability_weight = 0.05
-gait_symmetry_weight = 0.5             # Increased from 0.15: gait symmetry was *worsening* over training (reaching 8-12). At 0.5 perfect alternation gives ~0.5/step, visible next to forward vel.
+gait_symmetry_weight = 2.0             # Increased from 0.5: agent developed tripedal gait with FR leg at zero contact. 0.5 was insufficient — needs strong signal to enforce all four legs.
 smoothness_weight = 0.05               # Penalize jerky actions for smoother movement
 posture_weight = 0.3                   # Increased from 0.15: 8° forward tilt is excessive, double the signal to keep body upright.
 nosedive_weight = 0.8                  # Increased from 0.4: 15% head_contact terminations — agent is nose-diving into ground. Needs much stronger penalty.
@@ -18,7 +18,7 @@ natural_pitch = -0.15                  # Slight upward neck angle target (radian
 height_weight = 0.2                    # Increased from 0.1: pelvis dropped from 1.22 to 1.15m, strengthen signal to maintain standing height.
 heading_weight = 0.1                   # Keep: heading already at 0.98, minimal directional signal sufficient.
 lateral_penalty_weight = 0.1           # Mild anti-crab-walk penalty
-idle_penalty_weight = 0.5              # Mild penalty for standing still. Insurance against static-crouch exploit on this stable quadruped.
+idle_penalty_weight = 0.3              # Reduced from 0.5: less pressure to move at all costs; let gait_symmetry_weight shape *how* it moves.
 idle_velocity_threshold = 0.1          # Speed (m/s) at which idle penalty reaches zero. Below this, agent is penalised for inaction.
 food_reach_bonus = 0.0
 food_approach_weight = 0.0
@@ -59,7 +59,7 @@ gradient_steps = 4               # Match train_freq to maintain update-to-data r
 net_arch = [512, 256]            # Larger first layer to match PPO's tapered architecture for Brachiosaurus's 75 obs dims
 
 [curriculum]
-timesteps = 16000000                   # Extended from 12M: reward was still climbing at 12M. With rebalanced rewards agent needs more time to find proper gait instead of fast exploit.
+timesteps = 20000000                   # Extended from 16M: reward was still climbing at 16M. Higher gait_symmetry_weight means agent needs more time to find a proper quadrupedal gait.
 min_avg_reward = 100.0
 min_avg_episode_length = 750
 min_avg_forward_vel = 0.75             # Gate on actual locomotion; without this, a standing-still policy passes on alive_bonus alone. Realistic walking speed for a heavy sauropod.

--- a/configs/brachiosaurus/stage3_food_reach.toml
+++ b/configs/brachiosaurus/stage3_food_reach.toml
@@ -3,7 +3,7 @@ name = "food_reach"
 description = "Walk to food and reach with neck"
 
 [env]
-forward_vel_weight = 0.5               # Halved from 1.0: prevent forward reward from dominating approach/food signals (matches T-Rex stage 3 pattern)
+forward_vel_weight = 0.3               # Reduced from 0.5: agent doesn't need to walk fast, it needs to walk *to food and reach*. Less speed pressure preserves stability.
 alive_bonus = 0.0                      # Zeroed: survival is learned in stages 1-2; any per-step alive reward adds opportunity cost that discourages food-reaching attempts
 fall_penalty = -10.0                   # Reduced from default -100: prevents agent from being overly conservative about approaching food
 energy_penalty_weight = 0.001
@@ -11,16 +11,16 @@ tail_stability_weight = 0.02           # Light tail stability penalty
 gait_stability_weight = 0.02
 smoothness_weight = 0.02               # Light action smoothness penalty
 posture_weight = 0.1                   # Light posture maintenance during reach
-nosedive_weight = 0.2                  # Penalize excessive forward pitch
+nosedive_weight = 0.1                  # Reduced from 0.2: agent needs to pitch neck forward/downward to reach food — high nosedive penalty fights this
 heading_weight = 0.5                   # Face toward food for effective reach (matches T-Rex stage 3)
 lateral_penalty_weight = 0.3           # Penalize crab-walking toward food (matches T-Rex stage 3)
 food_reach_bonus = 1000.0              # Must greatly exceed discounted future per-step value; makes reaching food immediately net-positive (matches T-Rex bite_bonus)
-food_reach_threshold = 0.5
+food_reach_threshold = 0.8             # Widened from 0.5: easier success criterion for initial discovery — agent gets close but can't position head precisely enough
 food_approach_weight = 3.0             # 3x increase from 1.0: stronger delta-based gradient toward food (matches T-Rex bite_approach_weight)
-food_head_proximity_weight = 1.0       # Head-to-food proximity shaping: continuous gradient for head positioning near food (matches T-Rex bite_head_proximity_weight)
-food_distance_range = [2.0, 6.0]       # Tightened from [3.0, 8.0]: closer food makes reach discovery much more likely during exploration (matches T-Rex prey range)
+food_head_proximity_weight = 2.0       # Doubled from 1.0: stronger gradient pulling head toward food — this was the missing signal for the last-mile positioning
+food_distance_range = [1.5, 4.0]       # Tightened from [2.0, 6.0]: closer food spawns = more frequent reach attempts = denser reward signal
 food_lateral_range = [-1.5, 1.5]
-food_height_range = [2.5, 4.0]
+food_height_range = [2.0, 3.5]         # Lowered from [2.5, 4.0]: slightly lower food reduces coordination demand on neck extension
 max_episode_steps = 1000
 
 [ppo]
@@ -31,8 +31,8 @@ batch_size = 256
 n_epochs = 10
 gamma = 0.995
 gae_lambda = 0.95
-clip_range = 0.15                      # Widened from 0.1: allow larger policy updates to escape local optimum (matches T-Rex stage 3)
-ent_coef = 0.005                       # 5x increase from 0.001: more exploration needed to discover sparse food reach reward (matches T-Rex stage 3)
+clip_range = 0.2                       # Widened from 0.15: tighter clip likely caused reward collapse after 4M. Match Stage 2 value for stability.
+ent_coef = 0.01                        # Doubled from 0.005: more exploration needed to discover neck-extension behavior for food reach
 
 [ppo.policy_kwargs]
 net_arch = [512, 256]                  # Match Stage 1 setting 4 architecture to avoid weight truncation on checkpoint load
@@ -54,12 +54,12 @@ gradient_steps = 4               # Match train_freq to maintain update-to-data r
 net_arch = [512, 256]            # Match Stage 2 architecture to avoid weight truncation on checkpoint load
 
 [curriculum]
-timesteps = 8000000
+timesteps = 12000000                   # Extended from 8M: best model was at 3.9M and policy degraded after — more time with stable config gives room to recover and converge
 min_avg_reward = 100.0                  # Minimum average reward to confirm food-reaching behavior
 min_success_rate = 0.5                 # At least 25% food reach success — confirms behavior emerged
 required_consecutive = 3
-warmup_timesteps = 100000               # Timesteps to constrain policy updates while critic adapts (PPO only)
+warmup_timesteps = 300000               # Tripled from 100k: agent needs more time to adapt from locomotion to food-reach reward landscape without losing walking ability
 warmup_clip_range = 0.02                # Small clip range during warm-up to limit policy change
 warmup_ent_coef = 0.02                  # Higher entropy during warm-up to maintain exploration
-ramp_timesteps = 500000                 # Timesteps over which to linearly ramp forward_vel_weight
-ramp_start_value = 0.1                  # Starting fraction of forward_vel_weight during ramp
+ramp_timesteps = 1500000                # Tripled from 500k: gradual transition from "walk forward" to "walk toward food and reach" prevents catastrophic forgetting of locomotion
+ramp_start_value = 0.2                  # Increased from 0.1: start with slightly more approach signal so agent begins orienting toward food earlier


### PR DESCRIPTION
This pull request updates the reward structure and curriculum settings for Brachiosaurus locomotion and food-reaching tasks. The changes focus on improving gait quality, stability, and food-reaching behavior by rebalancing reward weights and adjusting curriculum durations. Key modifications include increasing the emphasis on gait symmetry, refining penalties and bonuses to encourage stable quadrupedal walking, and making food-reaching more achievable and rewarding.

**Locomotion reward and curriculum improvements:**

* Increased `gait_symmetry_weight` in `stage2_locomotion.toml` to strongly enforce four-legged walking and prevent tripedal gaits.
* Adjusted `alive_bonus`, `fall_penalty`, and `energy_penalty_weight` to better balance survival incentives and encourage stable, energy-efficient movement.
* Extended the curriculum `timesteps` in `stage2_locomotion.toml` to give the agent more time to develop a proper quadrupedal gait under the new reward structure.

**Food reach reward and curriculum improvements:**

* Reduced `forward_vel_weight` and `nosedive_weight` in `stage3_food_reach.toml` to prioritize food-reaching over speed and allow necessary forward pitching for reaching.
* Increased `food_reach_threshold` and `food_head_proximity_weight`, and tightened `food_distance_range` and `food_height_range` to make food-reaching more achievable and provide a stronger reward signal for precise head positioning.
* Widened `clip_range`, increased `ent_coef`, and extended curriculum `timesteps` and `warmup_timesteps` to support more exploration and a smoother transition from locomotion to food-reaching. [[1]](diffhunk://#diff-431203f2f192c9a1e59eb121925d78f0ae324e2dbc093fc86fe4dba7561ea2cdL34-R35) [[2]](diffhunk://#diff-431203f2f192c9a1e59eb121925d78f0ae324e2dbc093fc86fe4dba7561ea2cdL57-R65)