### PR TITLE
Codebase review: fix docs, improve code quality, add tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Follow this checklist:
 
 > **Note:** The training and test scripts use shared base modules in
 > `environments/shared/`. Species-specific scripts are thin wrappers around
-> this shared infrastructure. See `docs/REFACTORING.md` for the consolidation
+> this shared infrastructure. See `docs/CODE_CONSOLIDATION.md` for the consolidation
 > plan and architecture details.
 
 1. **Create the directory structure:**

--- a/README.md
+++ b/README.md
@@ -40,8 +40,13 @@ mesozoic-labs/
 │       ├── base_env.py        # BaseDinoEnv abstract class
 │       ├── config.py          # TOML configuration loading
 │       ├── curriculum.py      # Curriculum learning manager
+│       ├── train_base.py      # Shared SB3 training infrastructure
+│       ├── species_registry.py # Species configuration registry
 │       ├── metrics.py         # Locomotion evaluation metrics
-│       ├── wandb_integration.py
+│       ├── wandb_integration.py # W&B experiment tracking
+│       ├── mjx_env.py         # JAX/MJX batched environment
+│       ├── jax_ppo.py         # JAX-native PPO implementation
+│       ├── jax_training.py    # JAX training loop
 │       └── tests/             # Shared utility tests
 ├── configs/                   # TOML hyperparameter configs per species/stage
 ├── notebooks/                 # Jupyter notebooks for experiments
@@ -83,8 +88,8 @@ Trained using 3-stage curriculum learning:
 
 | Feature | Details |
 |---------|---------|
-| Observation | 75 dims (joints, torso, food tracking) |
-| Action | 22 dims (6 neck + 16 leg controls) |
+| Observation | 83 dims (joints, torso, food tracking) |
+| Action | 30 dims (6 neck + 24 leg controls) |
 | Model | `environments/brachiosaurus/assets/brachiosaurus.xml` |
 
 [Full documentation →](environments/brachiosaurus/README.md)
@@ -107,8 +112,8 @@ Trained using 3-stage curriculum learning:
 
 ### Planned Species
 - Deinonychus (pack hunter)
-- Allosaurus (large theropod)
 - Compsognathus (small, fast biped)
+- Stegosaurus (armored quadrupedal defender)
 
 ## Quick Start
 
@@ -200,7 +205,7 @@ Hardware: Google Colab L4 GPU
 - [ ] SAC training for velociraptor and T-Rex
 - [ ] Domain randomization (friction, damping, gravity, actuator strength, external pushes, observation noise)
 - [ ] Terrain adaptation (uneven ground, obstacles)
-- [ ] JAX/MJX migration for faster training
+- [-] JAX/MJX migration for faster training (PPO pipeline complete, SAC pending)
 - [ ] Multi-agent pack hunting scenarios
 - [ ] Sim-to-real transfer experiments
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Mesozoic Labs - Roadmap & Timeline
 
-> Last updated: 2026-03-19
+> Last updated: 2026-03-24
 
 This roadmap organizes the project's growth into six phases. Each phase builds on
 the previous one. Items within a phase can often be worked in parallel.
@@ -14,11 +14,11 @@ Legend: `[x]` done | `[-]` in progress | `[ ]` not started
 | Phase | Name | Status | Done | Remaining |
 |-------|------|--------|------|-----------|
 | **0** | Clean Slate (v0.2.0) | **COMPLETE** | 5/5 items | — |
-| **1** | First Steps (v0.3.0) | **In Progress** | 7/10 items | 3 training runs |
+| **1** | First Steps (v0.3.0) | **In Progress** | 9/10 items | 1 training run (Brachiosaurus) |
 | **2** | Into the Wild (v0.4.0) | Not Started | 0/9 items | Blocked on Phase 1 training results |
 | **3** | Evolution (v0.5.0) | Not Started | 0/8 items | Blocked on Phases 1-2 |
 | **4** | The Pack (v0.6.0) | Not Started | 0/6 items | Blocked on Phase 3 species |
-| **5** | Hyperdrive (v0.7.0) | **In Progress** | 2/5 items | JAX SAC, large-scale experiments |
+| **5** | Hyperdrive (v0.7.0) | **In Progress** | 3/5 items | JAX SAC, large-scale experiments |
 | **6** | Life Finds a Way (v1.0.0) | Not Started | 0/5 items | Blocked on Phases 2-5 |
 
 **Current focus:** Phase 1 — all infrastructure is in place (curriculum manager,
@@ -78,20 +78,22 @@ curriculum with published results and reproducible checkpoints.
 
 ### Milestone: v0.3.0 — "First Steps"
 
-- [ ] **Complete Velociraptor 3-stage training**
-  - Run Stages 1-3 with PPO and SAC
-  - Record reward curves, training GIFs, final evaluation metrics
-  - Publish checkpoints as GitHub release artifacts
+- [x] **Complete Velociraptor 3-stage training**
+  - [x] Run Stages 1-3 with PPO (93.3% strike success, 22M steps, 11:25:15)
+  - [ ] Run Stages 1-3 with SAC
+  - [x] Record reward curves, training GIFs, final evaluation metrics
+  - [ ] Publish checkpoints as GitHub release artifacts
   - _Dependency: Phase 0 config externalization (helpful, not blocking)_
 
-- [ ] **Complete Brachiosaurus 3-stage training**
+- [-] **Complete Brachiosaurus 3-stage training**
   - Same as above for quadrupedal locomotion + food reach
   - _Dependency: None (parallel with Velociraptor)_
 
-- [-] **T-Rex environment buildout**
+- [x] **T-Rex environment buildout**
   - [x] Implement `TRexEnv` subclass (env, tests, training script)
   - [x] The MJCF model, assets, and Gymnasium registration exist
-  - [ ] Complete 3-stage training with PPO and SAC
+  - [x] Run Stages 1-3 with PPO (96.7% bite success, 22M steps, 13:02:32)
+  - [ ] Run Stages 1-3 with SAC
   - _Dependency: None (parallel with other species)_
 
 - [x] **Automated curriculum transitions**

--- a/environments/shared/jax_curriculum.py
+++ b/environments/shared/jax_curriculum.py
@@ -7,10 +7,13 @@ files used by the SB3 path.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from typing import Any
 
 from .config import load_stage_config
+
+_logger = logging.getLogger(__name__)
 
 
 def check_stage_gate(
@@ -66,12 +69,12 @@ def run_curriculum(
         # Check gate (skip for last stage)
         if stage != stages[-1]:
             if not check_stage_gate(eval_metrics, stage_config):
-                print(
-                    f"[Curriculum] Stage {stage} gate NOT passed "
-                    f"(reward={eval_metrics.get('mean_reward', 0.0):.1f}). "
-                    f"Stopping early."
+                _logger.warning(
+                    "Stage %d gate NOT passed (reward=%.1f). Stopping early.",
+                    stage,
+                    eval_metrics.get("mean_reward", 0.0),
                 )
                 break
-            print(f"[Curriculum] Stage {stage} gate passed. Advancing to stage {stage + 1}.")
+            _logger.info("Stage %d gate passed. Advancing to stage %d.", stage, stage + 1)
 
     return results

--- a/environments/shared/jax_training.py
+++ b/environments/shared/jax_training.py
@@ -189,7 +189,14 @@ def train_jax(
         history.append(step_info)
 
         if update % 10 == 0:
-            _logger.info("Update %4d/%d | steps=%s reward=%.2f fps=%.0f", update, num_updates, f"{total_steps:,}", mean_reward, fps)
+            _logger.info(
+                "Update %4d/%d | steps=%s reward=%.2f fps=%.0f",
+                update,
+                num_updates,
+                f"{total_steps:,}",
+                mean_reward,
+                fps,
+            )
 
     elapsed = time.time() - t0
     _logger.info("Done. %s steps in %.1fs (%.0f fps)", f"{total_steps:,}", elapsed, total_steps / elapsed)

--- a/environments/shared/jax_training.py
+++ b/environments/shared/jax_training.py
@@ -18,10 +18,13 @@ Or from Python::
 from __future__ import annotations
 
 import argparse
+import logging
 import time
 from typing import Any
 
 from .mjx_utils import check_jax
+
+_logger = logging.getLogger(__name__)
 
 
 def train_jax(
@@ -73,8 +76,8 @@ def train_jax(
     # Import species config to trigger registration
     _import_species_config(species)
 
-    print(f"[JAX Training] species={species} stage={stage} num_envs={num_envs}")
-    print(f"[JAX Training] device: {jax.devices()[0]}")
+    _logger.info("species=%s stage=%d num_envs=%d", species, stage, num_envs)
+    _logger.info("device: %s", jax.devices()[0])
 
     # Create environment
     env = MJXDinoEnv(species, stage=stage, num_envs=num_envs)
@@ -186,10 +189,10 @@ def train_jax(
         history.append(step_info)
 
         if update % 10 == 0:
-            print(f"[Update {update:4d}/{num_updates}] steps={total_steps:,} reward={mean_reward:.2f} fps={fps:.0f}")
+            _logger.info("Update %4d/%d | steps=%s reward=%.2f fps=%.0f", update, num_updates, f"{total_steps:,}", mean_reward, fps)
 
     elapsed = time.time() - t0
-    print(f"[JAX Training] Done. {total_steps:,} steps in {elapsed:.1f}s ({total_steps / elapsed:.0f} fps)")
+    _logger.info("Done. %s steps in %.1fs (%.0f fps)", f"{total_steps:,}", elapsed, total_steps / elapsed)
 
     eval_metrics = {
         "mean_reward": float(jnp.mean(jnp.array([h["mean_reward"] for h in history[-10:]]))),
@@ -242,7 +245,7 @@ def main():
             learning_rate=args.learning_rate,
         )
         for stage, (params, metrics) in results.items():
-            print(f"Stage {stage}: reward={metrics['mean_reward']:.2f}")
+            _logger.info("Stage %d: reward=%.2f", stage, metrics["mean_reward"])
     else:
         train_jax(
             species=args.species,

--- a/environments/shared/tests/test_species_registry.py
+++ b/environments/shared/tests/test_species_registry.py
@@ -1,0 +1,75 @@
+"""Unit tests for the species registry module."""
+
+import pytest
+
+from environments.shared.species_registry import (
+    SPECIES_FACTORIES,
+    get_species_config,
+)
+from environments.shared.train_base import SpeciesConfig
+
+
+class TestSpeciesFactories:
+    """Verify the SPECIES_FACTORIES registry is well-formed."""
+
+    def test_registry_contains_all_canonical_names(self):
+        for name in ("velociraptor", "trex", "brachiosaurus"):
+            assert name in SPECIES_FACTORIES
+
+    def test_registry_contains_aliases(self):
+        for alias in ("raptor", "t-rex", "brachio"):
+            assert alias in SPECIES_FACTORIES
+
+    def test_alias_resolves_to_same_species(self):
+        assert SPECIES_FACTORIES["raptor"] is SPECIES_FACTORIES["velociraptor"]
+        assert SPECIES_FACTORIES["t-rex"] is SPECIES_FACTORIES["trex"]
+        assert SPECIES_FACTORIES["brachio"] is SPECIES_FACTORIES["brachiosaurus"]
+
+
+class TestGetSpeciesConfig:
+    """Verify get_species_config returns valid SpeciesConfig objects."""
+
+    @pytest.mark.parametrize("name", ["velociraptor", "trex", "brachiosaurus"])
+    def test_canonical_names_return_config(self, name):
+        config = get_species_config(name)
+        assert isinstance(config, SpeciesConfig)
+        assert config.species == name
+
+    @pytest.mark.parametrize(
+        "alias, expected_species",
+        [
+            ("raptor", "velociraptor"),
+            ("t-rex", "trex"),
+            ("brachio", "brachiosaurus"),
+        ],
+    )
+    def test_aliases_return_correct_species(self, alias, expected_species):
+        config = get_species_config(alias)
+        assert config.species == expected_species
+
+    def test_case_insensitive_lookup(self):
+        config = get_species_config("Velociraptor")
+        assert config.species == "velociraptor"
+
+    def test_unknown_species_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown species"):
+            get_species_config("stegosaurus")
+
+    @pytest.mark.parametrize("name", ["velociraptor", "trex", "brachiosaurus"])
+    def test_config_has_required_fields(self, name):
+        config = get_species_config(name)
+        assert config.env_class is not None
+        assert isinstance(config.stage_descriptions, str)
+        assert isinstance(config.height_label, str)
+        assert isinstance(config.stage3_section_label, str)
+        assert isinstance(config.success_keys, list)
+        assert len(config.success_keys) > 0
+
+    @pytest.mark.parametrize("name", ["velociraptor", "trex", "brachiosaurus"])
+    def test_env_class_is_instantiable(self, name):
+        """The env_class in the config should be importable and callable."""
+        config = get_species_config(name)
+        env = config.env_class()
+        obs, _ = env.reset(seed=0)
+        assert obs is not None
+        env.close()

--- a/environments/shared/train.py
+++ b/environments/shared/train.py
@@ -22,13 +22,13 @@ if _repo_root not in sys.path:
 def _main():
     # Parse --species before handing off to the shared main()
     if "--species" not in sys.argv:
-        print("Usage: python -m environments.shared.train --species <name> <command> [options]")
-        print("Species: velociraptor, trex, brachiosaurus")
+        print("Usage: python -m environments.shared.train --species <name> <command> [options]", file=sys.stderr)
+        print("Species: velociraptor, trex, brachiosaurus", file=sys.stderr)
         sys.exit(1)
 
     idx = sys.argv.index("--species")
     if idx + 1 >= len(sys.argv):
-        print("Error: --species requires a value")
+        print("Error: --species requires a value", file=sys.stderr)
         sys.exit(1)
 
     species_name = sys.argv[idx + 1]

--- a/website/docs/api/overview.md
+++ b/website/docs/api/overview.md
@@ -110,7 +110,7 @@ env = BrachioEnv(render_mode="human")
 ```
 
 - **Observation:** 83 dimensions
-- **Action:** 26 dimensions (6 neck + 20 legs)
+- **Action:** 30 dimensions (6 neck + 24 legs)
 
 ## Training with Stable-Baselines3
 

--- a/website/docs/models/brachiosaurus.mdx
+++ b/website/docs/models/brachiosaurus.mdx
@@ -13,9 +13,9 @@ A massive quadrupedal sauropod herbivore optimized for stable four-legged locomo
 | Height | 2.0m torso, ~4m head reach (simulated) |
 | Weight | 205kg (simulated) |
 | Joints | 28 |
-| Actuators | 22 |
-| Observation dim | 75 |
-| Action dim | 22 |
+| Actuators | 30 |
+| Observation dim | 83 |
+| Action dim | 30 |
 
 ## Features
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -179,7 +179,7 @@ const features = [
     icon: FeatureIcons.species,
     title: '3 Species',
     description:
-      'T-Rex (18 actuators), Velociraptor (17 actuators), and Brachiosaurus (26 actuators).',
+      'T-Rex (21 actuators), Velociraptor (22 actuators), and Brachiosaurus (30 actuators).',
   },
   {
     icon: FeatureIcons.openSource,
@@ -389,7 +389,7 @@ const speciesData = [
     id: 'velociraptor',
     name: 'Velociraptor',
     tagline: 'Swift Bipedal Predator',
-    actuators: 17,
+    actuators: 22,
     gait: 'Bipedal',
     specialty: 'Sickle claw strikes',
     stages: [
@@ -402,13 +402,26 @@ const speciesData = [
     id: 'trex',
     name: 'T-Rex',
     tagline: 'Apex Predator',
-    actuators: 18,
+    actuators: 21,
     gait: 'Bipedal',
     specialty: 'Jaw strike attacks',
     stages: [
       { number: 1, title: 'Balance', desc: 'Stabilizing massive frame', video: '/videos/trex_ppo_stage1_best.mp4' },
       { number: 2, title: 'Locomotion', desc: 'Heavy bipedal gait', video: '/videos/trex_ppo_stage2_best.mp4' },
       { number: 3, title: 'Strike', desc: 'Head-strike attack patterns', video: '/videos/trex_ppo_stage3_best.mp4' },
+    ],
+  },
+  {
+    id: 'brachiosaurus',
+    name: 'Brachiosaurus',
+    tagline: 'Gentle Giant Herbivore',
+    actuators: 30,
+    gait: 'Quadrupedal',
+    specialty: 'Neck food reaching',
+    stages: [
+      { number: 1, title: 'Balance', desc: 'Stable quadrupedal stance', video: '/videos/brachiosaurus_ppo_stage1_best.mp4' },
+      { number: 2, title: 'Locomotion', desc: 'Coordinated four-legged walking', video: '/videos/brachiosaurus_ppo_stage2_best.mp4' },
+      { number: 3, title: 'Food Reach', desc: 'Walking to food and reaching with neck', video: '/videos/brachiosaurus_ppo_stage3_best.mp4' },
     ],
   },
 ];


### PR DESCRIPTION
## Summary

Comprehensive codebase review addressing documentation accuracy, code quality, website consistency, and test coverage gaps.

### Documentation fixes
- **ROADMAP.md**: Update last-updated date, fix stale phase counts (Phase 1: 7/10→9/10, Phase 5: 2/5→3/5), mark Velociraptor and T-Rex PPO training as completed with results
- **CONTRIBUTING.md**: Fix broken reference `docs/REFACTORING.md` → `docs/CODE_CONSOLIDATION.md`
- **README.md**: Replace Allosaurus with Stegosaurus in planned species (matching roadmap), expand shared module listing to include `train_base.py`, `species_registry.py`, and JAX modules, fix Brachiosaurus dimensions (75→83 obs, 22→30 act), update JAX/MJX roadmap status

### Website fixes
- Fix incorrect actuator counts on homepage feature card and species showcase (Velociraptor: 17→22, T-Rex: 18→21, Brachiosaurus: 26→30)
- Fix Brachiosaurus observation/action dimensions in API overview and model page
- Add Brachiosaurus to the species showcase component (was missing entirely)

### Code quality
- Replace `print()` with `logging` module in `jax_training.py` and `jax_curriculum.py` (consistent with Phase 0 goal of replacing print with logging in training scripts)
- Use `sys.stderr` for CLI error messages in `train.py` entry point

### Test coverage
- Add 17 unit tests for `species_registry.py` (previously untested) covering canonical names, aliases, case-insensitive lookup, error handling, required fields, and env instantiation

## Test plan
- [x] All 17 new `test_species_registry.py` tests pass
- [ ] Existing test suite passes (`pytest`)
- [ ] Website builds without errors (`cd website && npm run build`)