### PR TITLE
Add SAC hyperparameter sweep configuration for Velociraptor

### DIFF
--- a/configs/velociraptor/sweep_sac.json
+++ b/configs/velociraptor/sweep_sac.json
@@ -1,0 +1,81 @@
+{
+  "_comment": "Velociraptor SAC sweep — raptor-specific ranges informed by prior SAC/PPO run data",
+
+  "stage1": {
+    "trials": 20,
+    "timesteps": 6000000,
+    "parallel": 3,
+    "n_envs": 8,
+
+    "_comment_sac": "SAC core: the successful run used lr=3e-4, gamma=0.99, buffer=300K. Collapse pattern in failed runs suggests lr sensitivity — sweep conservatively around 3e-4 and test larger buffers for stability.",
+    "sac_learning_rate":  {"type": "double", "min": 5e-5, "max": 3e-4, "scale": "log"},
+    "sac_batch_size":     {"type": "discrete", "values": [128, 256, 512]},
+    "sac_gamma":          {"type": "double", "min": 0.988, "max": 0.995, "scale": "linear"},
+    "sac_buffer_size":    {"type": "discrete", "values": [300000, 500000, 1000000]},
+    "sac_tau":            {"type": "double", "min": 0.002, "max": 0.01, "scale": "log"},
+    "sac_train_freq":     {"type": "discrete", "values": [8, 16, 32]},
+    "sac_gradient_steps": {"type": "discrete", "values": [4, 8, 16]},
+
+    "_comment_env": "Reward shaping: alive_bonus is the dominant signal in Stage 1. The good PPO runs used 1.75; sweep around it. Posture weight matters for preventing spin-to-balance.",
+    "env_alive_bonus":         {"type": "double", "min": 1.5, "max": 2.5, "scale": "linear"},
+    "env_posture_weight":      {"type": "double", "min": 1.0, "max": 2.0, "scale": "linear"},
+    "env_drift_penalty_weight": {"type": "double", "min": 0.1, "max": 0.5, "scale": "linear"},
+    "env_speed_penalty_weight": {"type": "double", "min": 0.1, "max": 0.5, "scale": "linear"}
+  },
+
+  "stage2": {
+    "trials": 20,
+    "timesteps": 10000000,
+    "parallel": 3,
+    "n_envs": 8,
+
+    "_comment_sac": "SAC locomotion: only one successful SAC run exists (lr=1e-4, gamma=0.99). Widen LR range and test whether higher gamma helps or hurts with replay buffer.",
+    "sac_learning_rate":  {"type": "double", "min": 3e-5, "max": 2e-4, "scale": "log"},
+    "sac_batch_size":     {"type": "discrete", "values": [256, 512]},
+    "sac_gamma":          {"type": "double", "min": 0.988, "max": 0.995, "scale": "linear"},
+    "sac_buffer_size":    {"type": "discrete", "values": [500000, 1000000, 2000000]},
+    "sac_tau":            {"type": "double", "min": 0.002, "max": 0.01, "scale": "log"},
+    "sac_train_freq":     {"type": "discrete", "values": [8, 16]},
+    "sac_gradient_steps": {"type": "discrete", "values": [4, 8, 16]},
+
+    "_comment_env": "Core reward tradeoff: forward_vel_weight vs alive_bonus. Successful PPO runs used fwd=2.0, alive=0.5. Sweep the forward signal strength and velocity cap.",
+    "env_forward_vel_weight":  {"type": "double", "min": 1.5, "max": 3.0, "scale": "linear"},
+    "env_forward_vel_max":     {"type": "double", "min": 2.0, "max": 4.0, "scale": "linear"},
+    "env_alive_bonus":         {"type": "double", "min": 0.2, "max": 0.75, "scale": "linear"},
+    "env_posture_weight":      {"type": "double", "min": 0.1, "max": 0.4, "scale": "linear"},
+    "env_nosedive_weight":     {"type": "double", "min": 0.1, "max": 0.5, "scale": "linear"},
+
+    "_comment_curriculum": "Ramp schedule is critical for statue-to-walking transition. The one SAC success used ramp=2M, start=0.2.",
+    "curriculum_warmup_timesteps":  {"type": "discrete", "values": [200000, 300000, 500000]},
+    "curriculum_ramp_timesteps":    {"type": "discrete", "values": [1000000, 2000000, 3000000]},
+    "curriculum_ramp_start_value":  {"type": "double", "min": 0.1, "max": 0.3, "scale": "linear"}
+  },
+
+  "stage3": {
+    "trials": 25,
+    "timesteps": 10000000,
+    "parallel": 3,
+    "n_envs": 8,
+
+    "_comment_sac": "SAC strike: this is where SAC shines — auto-entropy keeps exploring for sparse strike_bonus. Only one config tested (lr=1e-4, gamma=0.99) hit 0.9 success. More budget here to find reliable configs.",
+    "sac_learning_rate":  {"type": "double", "min": 3e-5, "max": 2e-4, "scale": "log"},
+    "sac_batch_size":     {"type": "discrete", "values": [256, 512]},
+    "sac_gamma":          {"type": "double", "min": 0.985, "max": 0.995, "scale": "linear"},
+    "sac_buffer_size":    {"type": "discrete", "values": [1000000, 2000000]},
+    "sac_tau":            {"type": "double", "min": 0.002, "max": 0.01, "scale": "log"},
+    "sac_train_freq":     {"type": "discrete", "values": [8, 16]},
+    "sac_gradient_steps": {"type": "discrete", "values": [8, 16]},
+
+    "_comment_env": "Strike reward: sweep the sparse bonus magnitude and approach shaping. Lower strike_bonus may train faster if approach_weight provides enough gradient. Also sweep prey distance — closer prey means faster strike discovery.",
+    "env_strike_bonus":                 {"type": "double", "min": 500.0, "max": 2000.0, "scale": "log"},
+    "env_strike_approach_weight":       {"type": "double", "min": 2.0, "max": 5.0, "scale": "linear"},
+    "env_strike_claw_proximity_weight": {"type": "double", "min": 0.5, "max": 2.0, "scale": "linear"},
+    "env_forward_vel_weight":           {"type": "double", "min": 0.5, "max": 2.0, "scale": "linear"},
+    "env_heading_weight":               {"type": "double", "min": 0.1, "max": 0.5, "scale": "linear"},
+
+    "_comment_curriculum": "Warmup is critical here — critic must adapt to strike reward landscape before policy starts chasing it.",
+    "curriculum_warmup_timesteps":  {"type": "discrete", "values": [200000, 300000, 500000]},
+    "curriculum_ramp_timesteps":    {"type": "discrete", "values": [300000, 500000, 1000000]},
+    "curriculum_ramp_start_value":  {"type": "double", "min": 0.05, "max": 0.2, "scale": "linear"}
+  }
+}


### PR DESCRIPTION
## Summary
Add a comprehensive three-stage hyperparameter sweep configuration for training the Velociraptor agent using Soft Actor-Critic (SAC). This configuration is informed by prior SAC and PPO run data and targets three distinct behavioral stages: balance/posture (stage 1), locomotion (stage 2), and strike hunting (stage 3).

## Key Changes
- **Stage 1 (Balance)**: 20 trials sweeping SAC core parameters (learning rate, batch size, gamma, buffer size, tau, train frequency, gradient steps) and reward shaping (alive bonus, posture weight, drift/speed penalties). Focuses on stability with conservative learning rate ranges around the successful 3e-4 baseline.

- **Stage 2 (Locomotion)**: 20 trials expanding SAC parameter ranges (learning rate 3e-5 to 2e-4) and introducing curriculum learning parameters. Emphasizes the forward velocity vs. alive bonus tradeoff observed in successful PPO runs, with curriculum warmup and ramp scheduling to enable the statue-to-walking transition.

- **Stage 3 (Strike)**: 25 trials (largest budget) targeting sparse strike reward optimization where SAC's auto-entropy exploration excels. Sweeps strike bonus magnitude, approach shaping weights, and claw proximity rewards. Includes tighter curriculum parameters to allow critic adaptation before policy optimization.

## Notable Implementation Details
- Each stage includes detailed inline comments explaining the rationale for parameter ranges based on prior successful runs
- Learning rates use logarithmic scaling for finer control in the critical low-range
- Discrete values for batch sizes, buffer sizes, and training frequencies reflect practical constraints
- Curriculum learning parameters (warmup, ramp, start value) are stage-specific, with stage 3 using shorter ramps for faster strike discovery
- Configuration supports parallel execution (3 parallel trials per stage) with 8 environments per trial