### PR TITLE
Add stage_config.json creation per trial in Ray Tune notebook

### DIFF
--- a/environments/shared/scripts/sweep/ray_tune.py
+++ b/environments/shared/scripts/sweep/ray_tune.py
@@ -516,6 +516,18 @@ def train_trial(config: dict[str, Any]) -> None:
     if drive_sweep_dir:
         drive_best_model_dir = Path(drive_sweep_dir) / "trials" / trial_id / "models"
 
+        # Sync stage_config.json to Drive immediately so it survives session
+        # crashes.  Later syncs (in RayTuneReportCallback and post-training)
+        # will overwrite with the same content, which is harmless.
+        drive_trial_dir = Path(drive_sweep_dir) / "trials" / trial_id
+        drive_trial_dir.mkdir(parents=True, exist_ok=True)
+        _stage_cfg_src = trial_dir / "stage_config.json"
+        if _stage_cfg_src.exists():
+            try:
+                shutil.copy2(str(_stage_cfg_src), str(drive_trial_dir / "stage_config.json"))
+            except OSError as e:
+                logger.warning("Early Drive sync of stage_config.json failed: %s", e)
+
     _train_start_time = time.time()
 
     # Create environments.

--- a/notebooks/ray_tune_sweep.ipynb
+++ b/notebooks/ray_tune_sweep.ipynb
@@ -282,6 +282,13 @@
   },
   {
    "cell_type": "code",
+   "source": "import copy\n\nfrom environments.shared.config import save_stage_config\nfrom environments.shared.scripts.sweep.ray_tune import apply_sampled_config\n\n# \u2500\u2500 Create stage_config.json for each top trial \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n# Reconstructs the per-trial config by applying the trial's sampled\n# hyperparameters to the base stage config.  This ensures stage_config.json\n# is present in the Drive trial directory even if sync was interrupted\n# during the sweep (e.g. ASHA-pruned trials, session crash).\n\n_param_cols = [c for c in results_df.columns if c.startswith((\"ppo_\", \"sac_\", \"env_\", \"curriculum_\"))]\n_created = 0\n\nfor trial_dir, _ in _top_trials:\n    trial_name = trial_dir.name\n\n    # Match trial directory name to results_df trial_id\n    _trial_row = results_df[results_df[\"trial_id\"].astype(str) == trial_name]\n    if _trial_row.empty:\n        print(f\"  Warning: {trial_name} not found in results_df \u2014 skipping stage_config.json\")\n        continue\n\n    # Apply the trial's sampled hyperparameters to a fresh copy of the base config\n    _trial_stage_configs = copy.deepcopy(STAGE_CONFIGS)\n    _trial_hparams = {\n        col: _trial_row.iloc[0][col]\n        for col in _param_cols\n        if col in _trial_row.columns and pd.notna(_trial_row.iloc[0][col])\n    }\n    apply_sampled_config(_trial_stage_configs, STAGE, _trial_hparams, ALGORITHM)\n\n    _cfg_path = save_stage_config(\n        trial_dir,\n        STAGE,\n        _trial_stage_configs[STAGE],\n        ALGORITHM.upper(),\n        extra={\"seed\": SEED, \"n_envs\": N_ENVS, \"trial_id\": trial_name},\n        env_class=SPECIES_CFG.env_class,\n        species=SPECIES,\n    )\n    _created += 1\n    print(f\"  {trial_name}: {_cfg_path}\")\n\nprint(f\"\\nstage_config.json created for {_created}/{len(_top_trials)} top trials.\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
    "source": [
     "import warnings\n",
     "\n",


### PR DESCRIPTION
Adds a new cell in the post-sweep analysis section (7b) that
reconstructs and saves stage_config.json for each top trial by
applying the trial's sampled hyperparameters to the base stage
config. This ensures the file is present on Drive even if sync
was interrupted during the sweep (ASHA-pruned trials, session crash).

https://claude.ai/code/session_01XDicXaiodr1to5o9JeXSDn