### PR TITLE
Add resume functionality for Ray Tune hyperparameter sweeps

### DIFF
--- a/environments/shared/scripts/sweep/__init__.py
+++ b/environments/shared/scripts/sweep/__init__.py
@@ -30,7 +30,14 @@ from .ray_orchestration import (
     export_best_trial,
     run_ray_sweep,
 )
-from .ray_search_space import build_search_space, detect_gpu_info, detect_gpu_model, load_resume_settings, save_search_space, to_ray_tune
+from .ray_search_space import (
+    build_search_space,
+    detect_gpu_info,
+    detect_gpu_model,
+    load_resume_settings,
+    save_search_space,
+    to_ray_tune,
+)
 from .ray_tune import (
     DriveProgressLogCallback,
     ExperimentStateSyncCallback,

--- a/environments/shared/scripts/sweep/__init__.py
+++ b/environments/shared/scripts/sweep/__init__.py
@@ -30,7 +30,7 @@ from .ray_orchestration import (
     export_best_trial,
     run_ray_sweep,
 )
-from .ray_search_space import build_search_space, detect_gpu_info, detect_gpu_model, save_search_space, to_ray_tune
+from .ray_search_space import build_search_space, detect_gpu_info, detect_gpu_model, load_resume_settings, save_search_space, to_ray_tune
 from .ray_tune import (
     DriveProgressLogCallback,
     ExperimentStateSyncCallback,
@@ -98,6 +98,7 @@ __all__ = [
     "_submit_stage_sweep",
     "_sweep_state_local_path",
     "_validate_machine_type",
+    "load_resume_settings",
     "launch_all_stages",
     "launch_sweep",
     "plot_sweep_results",

--- a/environments/shared/scripts/sweep/ray_search_space.py
+++ b/environments/shared/scripts/sweep/ray_search_space.py
@@ -306,9 +306,7 @@ def load_resume_settings(search_space_path: str | Path) -> dict[str, Any]:
     settings["resume_sweep_dir"] = resume_section.get("sweep_dir", "")
     # Point config_path back to this file itself so the same parameters are
     # used on resume.
-    settings["sweep_config_path"] = resume_section.get(
-        "config_path", str(path)
-    )
+    settings["sweep_config_path"] = resume_section.get("config_path", str(path))
 
     # Flatten runtime settings into top-level keys.
     runtime = data.get("runtime", {})

--- a/environments/shared/scripts/sweep/ray_search_space.py
+++ b/environments/shared/scripts/sweep/ray_search_space.py
@@ -172,6 +172,7 @@ def save_search_space(
     collapse_patience: int = 0,
     use_asha: bool = True,
     load_path: str = "",
+    config_path: str = "",
 ) -> Path:
     """Write the resolved search space to *dest_dir* as JSON for record keeping.
 
@@ -238,8 +239,95 @@ def save_search_space(
     if runtime:
         payload["runtime"] = runtime
 
+    # Resume settings — stored so the notebook can reload them when resuming
+    # a sweep without needing to manually re-enter paths.
+    resume: dict[str, Any] = {}
+    resume["sweep_dir"] = str(dest_dir)
+    if config_path:
+        resume["config_path"] = config_path
+    payload["resume"] = resume
+
     payload["parameters"] = search_space
 
     filepath.write_text(json.dumps(payload, indent=2, default=str) + "\n")
     logger.info("Search space saved to %s (%d params)", filepath, len(search_space))
     return filepath
+
+
+def load_resume_settings(search_space_path: str | Path) -> dict[str, Any]:
+    """Load resume and runtime settings from a saved search space JSON file.
+
+    Returns a dict with keys that map directly to notebook configuration
+    variables::
+
+        {
+            "species": "brachiosaurus",
+            "stage": 2,
+            "algorithm": "ppo",
+            "resume": True,
+            "resume_sweep_dir": "/content/drive/.../stage2_ppo_20260326_160015",
+            "sweep_config_path": "/content/drive/.../search_space_stage2_ppo.json",
+            # Runtime settings (from the "runtime" section):
+            "max_concurrent": 3,
+            "n_envs": 8,
+            "timesteps_per_trial": 16000000,
+            "num_trials": 50,
+            "eval_freq": 50000,
+            "seed": 42,
+            "use_asha": True,
+            "grace_period": 40,
+            "reduction_factor": 2,
+            "collapse_min_evals": 8,
+            "collapse_patience": 5,
+            "load_path": "...",
+        }
+
+    Parameters
+    ----------
+    search_space_path:
+        Path to a ``search_space_stage{N}_{algo}.json`` file previously
+        written by :func:`save_search_space`.
+    """
+    path = Path(search_space_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Search space file not found: {path}")
+
+    data: dict[str, Any] = json.loads(path.read_text())
+
+    settings: dict[str, Any] = {
+        "species": data.get("species", ""),
+        "stage": data.get("stage", 0),
+        "algorithm": data.get("algorithm", ""),
+        "resume": True,
+    }
+
+    # Resume section — sweep_dir and config_path.
+    resume_section = data.get("resume", {})
+    settings["resume_sweep_dir"] = resume_section.get("sweep_dir", "")
+    # Point config_path back to this file itself so the same parameters are
+    # used on resume.
+    settings["sweep_config_path"] = resume_section.get(
+        "config_path", str(path)
+    )
+
+    # Flatten runtime settings into top-level keys.
+    runtime = data.get("runtime", {})
+    for key in (
+        "max_concurrent",
+        "n_envs",
+        "timesteps_per_trial",
+        "num_trials",
+        "eval_freq",
+        "seed",
+        "use_asha",
+        "grace_period",
+        "reduction_factor",
+        "collapse_min_evals",
+        "collapse_patience",
+        "load_path",
+        "gpu_model",
+    ):
+        if key in runtime:
+            settings[key] = runtime[key]
+
+    return settings

--- a/environments/shared/scripts/sweep/search_space.py
+++ b/environments/shared/scripts/sweep/search_space.py
@@ -106,10 +106,12 @@ def _split_stage_block(block: dict) -> tuple[dict, dict]:
 def _search_space_for_stage(config: dict, stage: int) -> dict:
     """Extract the search space for a specific stage.
 
-    If *config* has ``"stage1"``/``"stage2"``/``"stage3"`` keys, return
-    the search-space parameters for the requested stage (job settings like
-    ``trials`` and ``timesteps`` are filtered out).  Otherwise return
-    *config* as-is (flat format — same space for all stages).
+    Supports three JSON formats:
+
+    1. **Per-stage** — top-level ``"stage1"``/``"stage2"``/``"stage3"`` keys.
+    2. **Saved snapshot** — has a ``"parameters"`` key (written by
+       :func:`save_search_space`).  Parameters are returned directly.
+    3. **Flat** — a plain dict of parameter specs applied to all stages.
     """
     if _is_per_stage(config):
         key = f"stage{stage}"
@@ -118,6 +120,9 @@ def _search_space_for_stage(config: dict, stage: int) -> dict:
             sys.exit(1)
         search_space, _ = _split_stage_block(config[key])
         return search_space
+    # Saved snapshot format (from save_search_space): extract parameters dict.
+    if "parameters" in config and isinstance(config["parameters"], dict):
+        return config["parameters"]
     return config
 
 

--- a/environments/shared/tests/test_sweep_ray_search_space.py
+++ b/environments/shared/tests/test_sweep_ray_search_space.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from environments.shared.scripts.sweep import (
     build_search_space,
+    load_resume_settings,
     save_search_space,
 )
 
@@ -202,3 +203,105 @@ class TestSaveSearchSpace:
     def test_fallback_filename_without_metadata(self, tmp_path):
         path = save_search_space({"x": {"type": "double", "min": 0, "max": 1, "scale": "linear"}}, tmp_path)
         assert path.name == "search_space.json"
+
+    def test_writes_resume_section(self, tmp_path):
+        space = {"ppo_lr": {"type": "double", "min": 1e-5, "max": 1e-3, "scale": "log"}}
+        result_path = save_search_space(
+            space,
+            tmp_path,
+            species="brachiosaurus",
+            stage=2,
+            algorithm="ppo",
+            config_path="/some/custom/config.json",
+        )
+        data = json.loads(result_path.read_text())
+        assert "resume" in data
+        assert data["resume"]["sweep_dir"] == str(tmp_path)
+        assert data["resume"]["config_path"] == "/some/custom/config.json"
+
+    def test_resume_section_without_config_path(self, tmp_path):
+        space = {"x": {"type": "double", "min": 0, "max": 1, "scale": "linear"}}
+        result_path = save_search_space(space, tmp_path, species="trex", stage=1, algorithm="ppo")
+        data = json.loads(result_path.read_text())
+        assert "resume" in data
+        assert data["resume"]["sweep_dir"] == str(tmp_path)
+        assert "config_path" not in data["resume"]
+
+
+# ── load_resume_settings ─────────────────────────────────────────────────
+
+
+class TestLoadResumeSettings:
+    """load_resume_settings reads back settings from a saved search space file."""
+
+    def test_loads_all_settings(self, tmp_path):
+        space = {
+            "ppo_lr": {"type": "double", "min": 1e-5, "max": 1e-3, "scale": "log"},
+            "env_bonus": {"type": "double", "min": 0.1, "max": 5.0, "scale": "linear"},
+        }
+        saved_path = save_search_space(
+            space,
+            tmp_path,
+            species="brachiosaurus",
+            stage=2,
+            algorithm="ppo",
+            max_concurrent=3,
+            n_envs=8,
+            timesteps_per_trial=16_000_000,
+            num_trials=50,
+            eval_freq=50_000,
+            seed=42,
+            use_asha=True,
+            grace_period=40,
+            reduction_factor=2,
+            collapse_min_evals=8,
+            collapse_patience=5,
+            load_path="/some/model/path",
+            config_path="/some/config.json",
+        )
+        settings = load_resume_settings(saved_path)
+        assert settings["species"] == "brachiosaurus"
+        assert settings["stage"] == 2
+        assert settings["algorithm"] == "ppo"
+        assert settings["resume"] is True
+        assert settings["resume_sweep_dir"] == str(tmp_path)
+        assert settings["sweep_config_path"] == "/some/config.json"
+        assert settings["max_concurrent"] == 3
+        assert settings["n_envs"] == 8
+        assert settings["timesteps_per_trial"] == 16_000_000
+        assert settings["num_trials"] == 50
+        assert settings["eval_freq"] == 50_000
+        assert settings["seed"] == 42
+        assert settings["use_asha"] is True
+        assert settings["grace_period"] == 40
+        assert settings["reduction_factor"] == 2
+        assert settings["collapse_min_evals"] == 8
+        assert settings["collapse_patience"] == 5
+        assert settings["load_path"] == "/some/model/path"
+
+    def test_defaults_config_path_to_file_itself(self, tmp_path):
+        space = {"x": {"type": "double", "min": 0, "max": 1, "scale": "linear"}}
+        saved_path = save_search_space(space, tmp_path, species="trex", stage=1, algorithm="ppo")
+        settings = load_resume_settings(saved_path)
+        # When no config_path was stored, falls back to the file itself
+        assert settings["sweep_config_path"] == str(saved_path)
+
+    def test_file_not_found(self, tmp_path):
+        import pytest
+
+        with pytest.raises(FileNotFoundError):
+            load_resume_settings(tmp_path / "nonexistent.json")
+
+    def test_build_search_space_from_saved_file(self, tmp_path):
+        """Saved search space JSON can be used as config_path for build_search_space."""
+        space = {
+            "ppo_lr": {"type": "double", "min": 1e-5, "max": 1e-3, "scale": "log"},
+            "env_bonus": {"type": "double", "min": 0.1, "max": 5.0, "scale": "linear"},
+        }
+        saved_path = save_search_space(space, tmp_path, species="velociraptor", stage=1, algorithm="ppo")
+        # Loading the saved file back via build_search_space should work
+        result = build_search_space("velociraptor", 1, "ppo", config_path=saved_path)
+        assert "ppo_lr" in result
+        assert "env_bonus" in result
+        assert "species" not in result
+        assert "runtime" not in result

--- a/notebooks/ray_tune_sweep.ipynb
+++ b/notebooks/ray_tune_sweep.ipynb
@@ -31,12 +31,16 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "cell-1"
+   },
    "source": "# Ray Tune Hyperparameter Sweep\n\nRun hyperparameter tuning sweeps directly on a Colab GPU using [Ray Tune](https://docs.ray.io/en/latest/tune/index.html).\n\n**Key features:**\n- **ASHA scheduler** for early stopping of underperforming trials\n- **Single-stage sweeps** — tune one curriculum stage at a time\n- **Per-species reward signal search spaces** — automatically includes the correct reward parameters for each species and stage\n- **Google Drive persistence** — all results, models, and checkpoints saved to Drive\n- **Warm-start support** — load a checkpoint from a prior stage or prior sweep\n- **Cross-session resume** — if your Colab session terminates mid-sweep, experiment state is restored from Drive on the next session so completed trials are kept and only partial trials restart\n\n**Recommended runtime:** Colab Pro+ with A100 GPU (more CPU cores for MuJoCo vectorized envs)\n\n### GPU-Specific Settings\n\nThese settings control the sweep budget and parallelism — set them in\nSection 2 based on your GPU. Hyperparameters like `batch_size`, `n_steps`,\n`buffer_size`, `net_arch`, etc. are part of the search space\n(defined in `configs/sweep_ppo.json` / `configs/sweep_sac.json`) and are\nsampled automatically per trial.\n\n#### PPO Sweeps\n\n| Setting | A100 (40 GB) | L4 (24 GB) | T4 (16 GB) |\n|---|---|---|---|\n| `MAX_CONCURRENT` | 3 | 2 | 1 |\n| `N_ENVS` | 8 | 4 | 4 |\n| `NUM_TRIALS` | 50 | 30 | 16 |\n| `TIMESTEPS_PER_TRIAL` | 6M | 4M | 3M |\n| `EVAL_FREQ` | 50,000 | 50,000 | 50,000 |\n| Estimated sweep time | ~4–6 h | ~6–8 h | ~8–12 h |\n\n**Search space notes for constrained GPUs:** On a T4, consider narrowing\nthe search space in `configs/sweep_ppo.json` — remove `batch_size: 512`,\ndrop `n_steps: 4096`, and limit `net_arch` to small/medium/tapered variants\nto avoid OOM with concurrent rollout buffers.\n\n#### SAC Sweeps\n\n| Setting | A100 (40 GB) | L4 (24 GB) | T4 (16 GB) |\n|---|---|---|---|\n| `MAX_CONCURRENT` | 2 | 1 | 1 |\n| `N_ENVS` | 4 | 2 | 2 |\n| `NUM_TRIALS` | 30 | 20 | 12 |\n| `TIMESTEPS_PER_TRIAL` | 6M | 4M | 2M |\n| `EVAL_FREQ` | 50,000 | 50,000 | 50,000 |\n| Estimated sweep time | ~6–8 h | ~8–12 h | ~12–16 h |\n\n**Search space notes for constrained GPUs:** On a T4 or L4, consider\nnarrowing `sac_buffer_size` in `configs/sweep_sac.json` — drop the 2M\noption to avoid OOM. The `train_freq` and `gradient_steps` values in the\nsearch space (4–16) are safe for all GPUs.\n\n> **Why fewer concurrent SAC trials?** SAC's replay buffer (`buffer_size`\n> up to 2M transitions in the search space) consumes significantly more\n> GPU memory than PPO's on-policy rollout buffer. Each concurrent SAC trial\n> also performs more gradient steps per environment step, increasing GPU\n> utilization per trial.\n\n### Per-Stage Early Stopping Settings\n\n| Setting | Stage 1 (balance) | Stage 2 (locomotion) | Stage 3 (behavior) |\n|---|---|---|---|\n| `GRACE_PERIOD` | 20 (~1M steps) | 40 (~2M steps) | 40 (~2M steps) |\n| `REDUCTION_FACTOR` | 2 | 2 | 2 |\n| `COLLAPSE_MIN_EVALS` | 8 | 12 | 12 |\n| `COLLAPSE_PATIENCE` | 5 | 5 | 5 |\n\n- **Stage 1:** Dense, immediate reward signal (alive bonus, posture). Trials that can't balance within ~1M steps are unlikely to recover.\n- **Stage 2:** Curriculum ramp delays the locomotion reward signal (~500k ramp + warm-start adaptation). Needs more time before pruning.\n- **Stage 3:** Similar to Stage 2 — species-specific behavior rewards (strike, bite) need time to emerge alongside reduced locomotion weights.\n\n### Resuming an Interrupted Sweep\n\nWorks across Colab sessions:\n\n1. Re-run Sections 1–2 (Setup, Configuration) with `RESUME = True`\n2. The sweep directory is auto-detected (or set `RESUME_SWEEP_DIR` manually)\n3. Section 2 automatically restores Ray Tune experiment state from Google Drive\n4. Run Section 5–6 — completed trials are kept, partial trials restart from scratch\n\n**How cross-session resume works:** During the sweep, an `ExperimentStateSyncCallback` periodically copies Ray Tune's experiment metadata from `/tmp/` to Google Drive. On resume, Section 2 copies it back to `/tmp/` so that `Tuner.restore()` can find all completed trial results."
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "cell-2"
+   },
    "source": [
     "## 1. Setup & Installation"
    ]
@@ -87,15 +91,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "cell-4"
+   },
    "outputs": [],
-   "source": [
-    "import json\nimport logging\nimport sys\nimport time\nfrom datetime import datetime\nfrom pathlib import Path\n\nimport numpy as np\n\nlogging.basicConfig(\n    level=logging.INFO,\n    format=\"%(asctime)s [%(levelname)s] %(name)s: %(message)s\",\n    datefmt=\"%Y-%m-%d %H:%M:%S\",\n)\n\nif IN_COLAB:\n    repo_root = Path(\"/content/mesozoic-labs\")\nelse:\n    repo_root = Path(\"..\").resolve()\n\nif str(repo_root) not in sys.path:\n    sys.path.insert(0, str(repo_root))\n\nimport mujoco\n\nfrom environments.shared.config import load_all_stages\nfrom environments.shared.species_registry import get_species_config\nfrom environments.shared.scripts.sweep import (\n    NET_ARCH_PRESETS,\n    build_search_space,\n    detect_gpu_info,\n    save_search_space,\n    to_ray_tune,\n)\n\nprint(f\"MuJoCo version: {mujoco.__version__}\")\nprint(f\"Repo root: {repo_root}\")"
-   ]
+   "source": "import json\nimport logging\nimport sys\nimport time\nfrom datetime import datetime\nfrom pathlib import Path\n\nimport numpy as np\n\nlogging.basicConfig(\n    level=logging.INFO,\n    format=\"%(asctime)s [%(levelname)s] %(name)s: %(message)s\",\n    datefmt=\"%Y-%m-%d %H:%M:%S\",\n)\n\nif IN_COLAB:\n    repo_root = Path(\"/content/mesozoic-labs\")\nelse:\n    repo_root = Path(\"..\").resolve()\n\nif str(repo_root) not in sys.path:\n    sys.path.insert(0, str(repo_root))\n\nimport mujoco\n\nfrom environments.shared.config import load_all_stages\nfrom environments.shared.species_registry import get_species_config\nfrom environments.shared.scripts.sweep import (\n    NET_ARCH_PRESETS,\n    build_search_space,\n    detect_gpu_info,\n    load_resume_settings,\n    save_search_space,\n    to_ray_tune,\n)\n\nprint(f\"MuJoCo version: {mujoco.__version__}\")\nprint(f\"Repo root: {repo_root}\")"
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "cell-5"
+   },
    "source": [
     "## 2. Configuration"
    ]
@@ -107,7 +113,7 @@
     "id": "cell-6"
    },
    "outputs": [],
-   "source": "# ===== Species & Algorithm =====\nSPECIES = \"velociraptor\"  # @param [\"velociraptor\", \"brachiosaurus\", \"trex\"]\nALGORITHM = \"ppo\"         # @param [\"ppo\", \"sac\"]\n\n# ===== Sweep Stage =====\nSTAGE = 1                 # @param {type:\"integer\"} — curriculum stage (1, 2, or 3)\n\n# ===== Ray Tune Budget =====\n# See GPU settings table in the intro cell. For L4: NUM_TRIALS=16, MAX_CONCURRENT=2 (PPO) or 1 (SAC).\nNUM_TRIALS = 50           # @param {type:\"integer\"} — total trials to run\nMAX_CONCURRENT = 3        # @param {type:\"integer\"} — concurrent trials (3 for A100, 2 for L4, 1 for T4/SAC)\nTIMESTEPS_PER_TRIAL = 6_000_000  # @param {type:\"integer\"} — training timesteps per trial (3M for L4)\n\n# ===== Training =====\nN_ENVS = 8                # @param {type:\"integer\"} — parallel envs per trial\nSEED = 42                 # @param {type:\"integer\"}\nEVAL_FREQ = 50_000        # @param {type:\"integer\"} — how often to evaluate (also used as ASHA report interval)\n\n# ===== Scheduler =====\n# True: use ASHA early stopping (prune underperforming trials).\n# False: use FIFO scheduler (all trials run to completion — pure random search).\nUSE_ASHA = True           # @param {type:\"boolean\"}\n\n# ===== ASHA Early Stopping (only used when USE_ASHA=True) =====\n# See per-stage recommendations in the intro cell.\n# Stage 1: grace_period=20, Stage 2+3: grace_period=40\nGRACE_PERIOD = 30         # @param {type:\"integer\"} — minimum reports before ASHA can stop a trial\nREDUCTION_FACTOR = 2      # @param {type:\"integer\"} — keep top 1/N trials at each rung\n\n# ===== Reward Collapse Early Stopping =====\n# Stops a trial if eval reward drops significantly from its peak (within a single trial).\n# This is independent of ASHA (which compares trials against each other).\nCOLLAPSE_MIN_EVALS = 8    # @param {type:\"integer\"} — minimum evals before collapse detection activates\nCOLLAPSE_PATIENCE = 5     # @param {type:\"integer\"} — consecutive drops below threshold before stopping\n\n# ===== Warm-start (optional) =====\n# Path to a model checkpoint to load (e.g. from a prior stage).\n# Leave empty to train from scratch.\nLOAD_PATH = \"\"  # @param {type:\"string\"}\n\n# ===== Resume (optional) =====\n# Set to True to resume a previously interrupted sweep.\n# Set RESUME_SWEEP_DIR to the Drive path of the previous sweep, or leave\n# empty to auto-detect the latest sweep for this species/stage/algorithm.\nRESUME = False            # @param {type:\"boolean\"}\nRESUME_SWEEP_DIR = \"\"     # @param {type:\"string\"}\n\n# ===== Google Drive =====\nUSE_GOOGLE_DRIVE = True   # @param {type:\"boolean\"}\n\nprint(f\"Species:    {SPECIES}\")\nprint(f\"Algorithm:  {ALGORITHM.upper()}\")\nprint(f\"Stage:      {STAGE}\")\nprint(f\"Trials:     {NUM_TRIALS} ({MAX_CONCURRENT} concurrent)\")\nprint(f\"Timesteps:  {TIMESTEPS_PER_TRIAL:,} per trial\")\nprint(f\"Scheduler:  {'ASHA' if USE_ASHA else 'FIFO (no pruning)'}\")\nif USE_ASHA:\n    print(f\"ASHA:       grace_period={GRACE_PERIOD}, reduction_factor={REDUCTION_FACTOR}\")\nprint(f\"Collapse:   min_evals={COLLAPSE_MIN_EVALS}, patience={COLLAPSE_PATIENCE}\")\nprint(f\"Load path:  {LOAD_PATH or '(none — training from scratch)'}\")\nprint(f\"Resume:     {RESUME}{f' from {RESUME_SWEEP_DIR}' if RESUME and RESUME_SWEEP_DIR else ''}\")"
+   "source": "# ===== Species & Algorithm =====\nSPECIES = \"velociraptor\"  # @param [\"velociraptor\", \"brachiosaurus\", \"trex\"]\nALGORITHM = \"ppo\"         # @param [\"ppo\", \"sac\"]\n\n# ===== Sweep Stage =====\nSTAGE = 1                 # @param {type:\"integer\"} — curriculum stage (1, 2, or 3)\n\n# ===== Ray Tune Budget =====\n# See GPU settings table in the intro cell. For L4: NUM_TRIALS=16, MAX_CONCURRENT=2 (PPO) or 1 (SAC).\nNUM_TRIALS = 50           # @param {type:\"integer\"} — total trials to run\nMAX_CONCURRENT = 3        # @param {type:\"integer\"} — concurrent trials (3 for A100, 2 for L4, 1 for T4/SAC)\nTIMESTEPS_PER_TRIAL = 6_000_000  # @param {type:\"integer\"} — training timesteps per trial (3M for L4)\n\n# ===== Training =====\nN_ENVS = 8                # @param {type:\"integer\"} — parallel envs per trial\nSEED = 42                 # @param {type:\"integer\"}\nEVAL_FREQ = 50_000        # @param {type:\"integer\"} — how often to evaluate (also used as ASHA report interval)\n\n# ===== Scheduler =====\n# True: use ASHA early stopping (prune underperforming trials).\n# False: use FIFO scheduler (all trials run to completion — pure random search).\nUSE_ASHA = True           # @param {type:\"boolean\"}\n\n# ===== ASHA Early Stopping (only used when USE_ASHA=True) =====\n# See per-stage recommendations in the intro cell.\n# Stage 1: grace_period=20, Stage 2+3: grace_period=40\nGRACE_PERIOD = 30         # @param {type:\"integer\"} — minimum reports before ASHA can stop a trial\nREDUCTION_FACTOR = 2      # @param {type:\"integer\"} — keep top 1/N trials at each rung\n\n# ===== Reward Collapse Early Stopping =====\n# Stops a trial if eval reward drops significantly from its peak (within a single trial).\n# This is independent of ASHA (which compares trials against each other).\nCOLLAPSE_MIN_EVALS = 8    # @param {type:\"integer\"} — minimum evals before collapse detection activates\nCOLLAPSE_PATIENCE = 5     # @param {type:\"integer\"} — consecutive drops below threshold before stopping\n\n# ===== Warm-start (optional) =====\n# Path to a model checkpoint to load (e.g. from a prior stage).\n# Leave empty to train from scratch.\nLOAD_PATH = \"\"  # @param {type:\"string\"}\n\n# ===== Resume (optional) =====\n# Set to True to resume a previously interrupted sweep.\n# Set RESUME_SWEEP_DIR to the Drive path of the previous sweep, or leave\n# empty to auto-detect the latest sweep for this species/stage/algorithm.\nRESUME = False            # @param {type:\"boolean\"}\nRESUME_SWEEP_DIR = \"\"     # @param {type:\"string\"}\n\n# ===== Resume from search space JSON (optional) =====\n# Point this to a saved search_space_stage*_*.json file to automatically\n# load RESUME, RESUME_SWEEP_DIR, SWEEP_CONFIG_PATH, and all runtime\n# settings from it.  This overrides the manual settings above.\nRESUME_SEARCH_SPACE_PATH = \"\"  # @param {type:\"string\"}\n\nif RESUME_SEARCH_SPACE_PATH:\n    _rs = load_resume_settings(RESUME_SEARCH_SPACE_PATH)\n    SPECIES = _rs[\"species\"]\n    ALGORITHM = _rs[\"algorithm\"]\n    STAGE = _rs[\"stage\"]\n    RESUME = True\n    RESUME_SWEEP_DIR = _rs.get(\"resume_sweep_dir\", \"\")\n    SWEEP_CONFIG_PATH = _rs.get(\"sweep_config_path\", \"\")\n    # Override runtime settings from the saved file.\n    NUM_TRIALS = _rs.get(\"num_trials\", NUM_TRIALS)\n    MAX_CONCURRENT = _rs.get(\"max_concurrent\", MAX_CONCURRENT)\n    TIMESTEPS_PER_TRIAL = _rs.get(\"timesteps_per_trial\", TIMESTEPS_PER_TRIAL)\n    N_ENVS = _rs.get(\"n_envs\", N_ENVS)\n    SEED = _rs.get(\"seed\", SEED)\n    EVAL_FREQ = _rs.get(\"eval_freq\", EVAL_FREQ)\n    USE_ASHA = _rs.get(\"use_asha\", USE_ASHA)\n    GRACE_PERIOD = _rs.get(\"grace_period\", GRACE_PERIOD)\n    REDUCTION_FACTOR = _rs.get(\"reduction_factor\", REDUCTION_FACTOR)\n    COLLAPSE_MIN_EVALS = _rs.get(\"collapse_min_evals\", COLLAPSE_MIN_EVALS)\n    COLLAPSE_PATIENCE = _rs.get(\"collapse_patience\", COLLAPSE_PATIENCE)\n    LOAD_PATH = _rs.get(\"load_path\", LOAD_PATH)\n    print(f\"Loaded resume settings from: {RESUME_SEARCH_SPACE_PATH}\")\n\n# ===== Google Drive =====\nUSE_GOOGLE_DRIVE = True   # @param {type:\"boolean\"}\n\nprint(f\"Species:    {SPECIES}\")\nprint(f\"Algorithm:  {ALGORITHM.upper()}\")\nprint(f\"Stage:      {STAGE}\")\nprint(f\"Trials:     {NUM_TRIALS} ({MAX_CONCURRENT} concurrent)\")\nprint(f\"Timesteps:  {TIMESTEPS_PER_TRIAL:,} per trial\")\nprint(f\"Scheduler:  {'ASHA' if USE_ASHA else 'FIFO (no pruning)'}\")\nif USE_ASHA:\n    print(f\"ASHA:       grace_period={GRACE_PERIOD}, reduction_factor={REDUCTION_FACTOR}\")\nprint(f\"Collapse:   min_evals={COLLAPSE_MIN_EVALS}, patience={COLLAPSE_PATIENCE}\")\nprint(f\"Load path:  {LOAD_PATH or '(none — training from scratch)'}\")\nprint(f\"Resume:     {RESUME}{f' from {RESUME_SWEEP_DIR}' if RESUME and RESUME_SWEEP_DIR else ''}\")"
   },
   {
    "cell_type": "code",
@@ -120,7 +126,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "cell-8"
+   },
    "source": [
     "## 3. Load Species & Stage Configs"
    ]
@@ -128,7 +136,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "cell-9"
+   },
    "outputs": [],
    "source": [
     "SPECIES_CFG = get_species_config(SPECIES)\n",
@@ -145,27 +155,33 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "cell-10"
+   },
    "source": "## 4. Search Space\n\nThe search space is loaded from a JSON config file (`configs/sweep_ppo.json` or\n`configs/sweep_sac.json`) so you can adjust parameter ranges without touching Python code.\n\nEach config file uses a per-stage layout where job settings (`trials`, `timesteps`, etc.)\nlive alongside parameter specs. Only entries with a `\"type\"` key are treated as search-space\nparameters — everything else is metadata.\n\nTo customise the search space, either:\n1. **Edit the JSON config** in `configs/sweep_{algorithm}.json` directly, or\n2. **Pass a custom config path** via `SWEEP_CONFIG_PATH` below.\n\nThe resolved search space is saved to Google Drive for record keeping.\n\n**Per-stage rationale:**\n- **Stage 1 (balance):** `alive_bonus` is the dominant reward signal — worth sweeping alongside species-specific stability rewards (posture, nosedive, drift, etc.)\n- **Stage 2 (locomotion):** `alive_bonus` must stay low to avoid standing-trap; sweep forward velocity, curriculum ramp, and species-specific locomotion rewards\n- **Stage 3 (behavior):** Sweep species-specific attack/goal rewards (strike, bite, food_reach) alongside reduced locomotion weights"
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "cell-11"
+   },
    "outputs": [],
-   "source": [
-    "# Optional: override the default config file path.\n# Leave empty to use configs/sweep_{algorithm}.json from the repo root.\nSWEEP_CONFIG_PATH = \"\"  # @param {type:\"string\"}\n\n_config_path = SWEEP_CONFIG_PATH or None  # None → use default\n\n# Build the search space from the JSON config file.\n_search_space_dict = build_search_space(SPECIES, STAGE, ALGORITHM, config_path=_config_path)\nSEARCH_SPACE = to_ray_tune(_search_space_dict)\n\nprint(f\"Search space for Stage {STAGE} / {SPECIES} ({ALGORITHM.upper()}): {len(SEARCH_SPACE)} params\")\nfor name in SEARCH_SPACE:\n    print(f\"  {name}\")\n\n# Save the resolved search space to the sweep directory on Google Drive\n# so each run has a permanent record of exactly which ranges were used.\n_saved_path = save_search_space(\n    _search_space_dict,\n    SWEEP_DIR,\n    species=SPECIES,\n    stage=STAGE,\n    algorithm=ALGORITHM,\n    gpu_info=detect_gpu_info(),\n    max_concurrent=MAX_CONCURRENT,\n    n_envs=N_ENVS,\n    timesteps_per_trial=TIMESTEPS_PER_TRIAL,\n    num_trials=NUM_TRIALS,\n    eval_freq=EVAL_FREQ,\n    seed=SEED,\n    use_asha=USE_ASHA,\n    grace_period=GRACE_PERIOD,\n    reduction_factor=REDUCTION_FACTOR,\n    collapse_min_evals=COLLAPSE_MIN_EVALS,\n    collapse_patience=COLLAPSE_PATIENCE,\n    load_path=LOAD_PATH,\n)\nprint(f\"\\nSearch space saved for record keeping: {_saved_path}\")"
-   ]
+   "source": "# Optional: override the default config file path.\n# Leave empty to use configs/sweep_{algorithm}.json from the repo root.\n# Note: when resuming via RESUME_SEARCH_SPACE_PATH, this is set automatically.\nif \"SWEEP_CONFIG_PATH\" not in dir():\n    SWEEP_CONFIG_PATH = \"\"  # @param {type:\"string\"}\n\n_config_path = SWEEP_CONFIG_PATH or None  # None → use default\n\n# Build the search space from the JSON config file.\n_search_space_dict = build_search_space(SPECIES, STAGE, ALGORITHM, config_path=_config_path)\nSEARCH_SPACE = to_ray_tune(_search_space_dict)\n\nprint(f\"Search space for Stage {STAGE} / {SPECIES} ({ALGORITHM.upper()}): {len(SEARCH_SPACE)} params\")\nfor name in SEARCH_SPACE:\n    print(f\"  {name}\")\n\n# Save the resolved search space to the sweep directory on Google Drive\n# so each run has a permanent record of exactly which ranges were used.\n_saved_path = save_search_space(\n    _search_space_dict,\n    SWEEP_DIR,\n    species=SPECIES,\n    stage=STAGE,\n    algorithm=ALGORITHM,\n    gpu_info=detect_gpu_info(),\n    max_concurrent=MAX_CONCURRENT,\n    n_envs=N_ENVS,\n    timesteps_per_trial=TIMESTEPS_PER_TRIAL,\n    num_trials=NUM_TRIALS,\n    eval_freq=EVAL_FREQ,\n    seed=SEED,\n    use_asha=USE_ASHA,\n    grace_period=GRACE_PERIOD,\n    reduction_factor=REDUCTION_FACTOR,\n    collapse_min_evals=COLLAPSE_MIN_EVALS,\n    collapse_patience=COLLAPSE_PATIENCE,\n    load_path=LOAD_PATH,\n    config_path=SWEEP_CONFIG_PATH,\n)\nprint(f\"\\nSearch space saved for record keeping: {_saved_path}\")"
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "cell-12"
+   },
    "source": "## 5. Trial Training Function\n\nEach Ray Tune trial runs a function from `environments.shared.scripts.sweep.ray_tune`.\nIt applies the sampled hyperparameters to the TOML stage config, trains using the\nproject's existing infrastructure, and reports `best_mean_reward` plus a Ray checkpoint\nto Ray Tune at each evaluation round."
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "cell-13"
+   },
    "outputs": [],
    "source": [
     "from environments.shared.scripts.sweep.ray_tune import train_trial\n",
@@ -175,26 +191,34 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "cell-14"
+   },
    "source": "## 6. Run the Sweep\n\nRay Tune manages the trial scheduling. Two scheduler modes are available\n(controlled by `USE_ASHA` in Section 2):\n\n- **ASHA** (`USE_ASHA=True`): Stops underperforming trials early based on\n  intermediate `best_mean_reward` reports, saving compute.\n- **FIFO** (`USE_ASHA=False`): Pure random search — all trials run to completion\n  with no pruning. Useful for collecting unbiased data across the full search space.\n\n**ASHA parameters (when enabled):**\n- `grace_period`: Minimum number of reports before a trial can be stopped (default 30 ≈ 1.5M steps)\n- `reduction_factor`: Keep top ~50% of trials at each rung\n\n**Note:** If you see `TuneError: insufficient resources`, reduce `MAX_CONCURRENT` in Section 2."
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "cell-15"
+   },
    "outputs": [],
    "source": "import os\n\nimport ray\nfrom ray import tune\nfrom ray.tune.schedulers import ASHAScheduler, FIFOScheduler\n\nfrom environments.shared.scripts.sweep.ray_tune import (\n    DriveProgressLogCallback,\n    ExperimentStateSyncCallback,\n    TrialTerminationCallback,\n)\n\nos.environ[\"TUNE_WARN_EXCESSIVE_EXPERIMENT_CHECKPOINT_SYNC_THRESHOLD_S\"] = \"0\"\n\nif ray.is_initialized():\n    ray.shutdown()\n\nray.init(ignore_reinit_error=True)\nprint(f\"Ray initialized: {ray.cluster_resources()}\")\n\n# Scheduler: ASHA for early stopping, or FIFO for pure random search (no pruning)\nmax_reports = TIMESTEPS_PER_TRIAL // EVAL_FREQ\nif USE_ASHA:\n    scheduler = ASHAScheduler(\n        metric=\"best_mean_reward\",\n        mode=\"max\",\n        max_t=max_reports,\n        grace_period=GRACE_PERIOD,\n        reduction_factor=REDUCTION_FACTOR,\n    )\n    _scheduler_desc = f\"ASHA (grace={GRACE_PERIOD}, reduction={REDUCTION_FACTOR})\"\nelse:\n    scheduler = FIFOScheduler()\n    _scheduler_desc = \"FIFO (no pruning — all trials run to completion)\"\n\ntrial_callback = TrialTerminationCallback(report_interval_s=300)\n\n# Sync callback: periodically copies Ray experiment state to Drive so that\n# cross-session resume works even if the Colab session terminates mid-sweep.\n_experiment_name = f\"{SPECIES}_stage{STAGE}_{ALGORITHM}\"\n_local_experiment_dir = LOCAL_RAY_DIR / _experiment_name\n_drive_ray_results_dir = SWEEP_DIR / \"ray_results\"\n\nstate_sync_callback = ExperimentStateSyncCallback(\n    local_experiment_dir=_local_experiment_dir,\n    drive_ray_results_dir=_drive_ray_results_dir,\n    sync_interval_s=300,\n)\n\n# Progress log callback: writes a trial_progress.csv to Drive on each trial\n# completion so you can check sweep progress even when the notebook is\n# disconnected. Unlike collected_results.csv (written post-sweep with full\n# evaluation metrics), this is updated incrementally with ASHA-reported metrics.\nprogress_log_callback = DriveProgressLogCallback(drive_sweep_dir=SWEEP_DIR)\n\n# Ray Train v2 decoupled RunConfig from Tune — use the Tune-namespaced\n# versions for Tuner configuration to avoid Train v2 deprecation errors.\nfrom ray.tune import RunConfig as TuneRunConfig\nfrom ray.tune import CheckpointConfig as TuneCheckpointConfig\n\n# Fixed parameters passed to every trial (prefixed with _ to distinguish from search space)\nfixed_config = {\n    \"_species\": SPECIES,\n    \"_algorithm\": ALGORITHM,\n    \"_stage\": STAGE,\n    \"_timesteps\": TIMESTEPS_PER_TRIAL,\n    \"_n_envs\": N_ENVS,\n    \"_seed\": SEED,\n    \"_eval_freq\": EVAL_FREQ,\n    \"_load_path\": LOAD_PATH or \"\",\n    \"_local_trials_dir\": str(LOCAL_TRIALS_DIR),\n    \"_drive_sweep_dir\": str(SWEEP_DIR),\n    \"_collapse_min_evals\": COLLAPSE_MIN_EVALS,\n    \"_collapse_patience\": COLLAPSE_PATIENCE,\n}\n\nfull_config = {**fixed_config, **SEARCH_SPACE}\n\nprint(f\"\\nStarting Ray Tune sweep:\")\nprint(f\"  Species:    {SPECIES}\")\nprint(f\"  Stage:      {STAGE}\")\nprint(f\"  Algorithm:  {ALGORITHM.upper()}\")\nprint(f\"  Trials:     {NUM_TRIALS} ({MAX_CONCURRENT} concurrent)\")\nprint(f\"  Timesteps:  {TIMESTEPS_PER_TRIAL:,} per trial\")\nprint(f\"  Params:     {len(SEARCH_SPACE)} search-space dimensions\")\nprint(f\"  Scheduler:  {_scheduler_desc}\")\nprint(f\"  Collapse:   min_evals={COLLAPSE_MIN_EVALS}, patience={COLLAPSE_PATIENCE}\")\nprint(f\"  Local:      {LOCAL_RAY_DIR}\")\nprint(f\"  Drive:      {SWEEP_DIR}\")\nprint(f\"  Progress:   {SWEEP_DIR / 'trial_progress.csv'}\")\nif LOAD_PATH:\n    print(f\"  Warm-start: {LOAD_PATH}\")"
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "cell-16"
+   },
    "outputs": [],
    "source": "import shutil as _shutil\n\nfrom environments.shared.scripts.sweep.ray_tune import collect_ray_results\nfrom environments.shared.scripts.sweep.results import plot_sweep_results, write_results_csv\nfrom environments.shared.scripts.sweep.scoring import compute_quality_scores\n\n# Allocate fractional GPU per trial to prevent OOM with concurrent trials\n_gpu_fraction = 1.0 / max(MAX_CONCURRENT, 1)\n_trainable = tune.with_resources(train_trial, {\"cpu\": 2, \"gpu\": _gpu_fraction})\n\nif RESUME and _local_experiment_dir.exists():\n    print(f\"Restoring Tuner from: {_local_experiment_dir}\")\n    print(\"  Completed trials will be kept; partial trials will restart from scratch.\")\n    tuner = tune.Tuner.restore(\n        path=str(_local_experiment_dir),\n        trainable=_trainable,\n        resume_unfinished=True,\n        resume_errored=True,\n        param_space=full_config,\n    )\nelif RESUME:\n    print(\n        \"Warning: RESUME=True but no experiment state found locally or on Drive. \"\n        \"Starting a fresh sweep instead.\"\n    )\n    RESUME = False  # fall through to fresh sweep\n\nif not RESUME:\n    tuner = tune.Tuner(\n        _trainable,\n        param_space=full_config,\n        tune_config=tune.TuneConfig(\n            scheduler=scheduler,\n            num_samples=NUM_TRIALS,\n            max_concurrent_trials=MAX_CONCURRENT,\n        ),\n        run_config=TuneRunConfig(\n            name=f\"{SPECIES}_stage{STAGE}_{ALGORITHM}\",\n            storage_path=str(LOCAL_RAY_DIR),\n            checkpoint_config=TuneCheckpointConfig(num_to_keep=2),\n            verbose=0,\n            callbacks=[trial_callback, state_sync_callback, progress_log_callback],\n        ),\n    )\n\nresults = tuner.fit()\nprint(\"\\nSweep complete!\")\n\n# ── Final sync of Ray Tune experiment state to Drive ─────────────────\n# This ensures the final state (all trials completed) is on Drive,\n# complementing the periodic syncs that happened during the sweep.\nif _local_experiment_dir.exists():\n    print(f\"Syncing final Ray results to Drive: {_drive_ray_results_dir}\")\n    try:\n        _shutil.copytree(\n            str(_local_experiment_dir),\n            str(_drive_ray_results_dir / _local_experiment_dir.name),\n            dirs_exist_ok=True,\n        )\n        print(\"  Ray results synced to Drive successfully.\")\n    except OSError as e:\n        print(f\"  Warning: Drive sync of Ray results failed: {e}\")"
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "cell-17"
+   },
    "source": [
     "## 7. Results & Analysis"
    ]
@@ -249,7 +273,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "cell-20"
+   },
    "outputs": [],
    "source": "from environments.shared.scripts.sweep.ray_tune import collect_ray_results\nfrom environments.shared.scripts.sweep.results import plot_sweep_results, write_results_csv\nfrom environments.shared.scripts.sweep.scoring import compute_quality_scores\n\n# ── Standardized sweep CSV ──\n_sweep_rows = collect_ray_results(results_df, STAGE, STAGE_CONFIGS[STAGE])\n\n# Apply quality scoring (post-analysis ranking — does not affect training objective)\ncompute_quality_scores(_sweep_rows, STAGE)\n\ncollected_csv = write_results_csv(_sweep_rows, SWEEP_DIR / \"collected_results.csv\")\nprint(f\"Standardized CSV saved to: {collected_csv}\")\n\n# ── Sweep analysis plots ──\nplot_sweep_results(collected_csv, SPECIES, ALGORITHM, save_dir=SWEEP_DIR)\nprint(f\"Sweep analysis plots saved to: {SWEEP_DIR}\")\n\n# Also save the raw Ray Tune DataFrame for Ray-specific columns\nraw_csv = SWEEP_DIR / \"sweep_results_raw.csv\"\nresults_df.to_csv(str(raw_csv), index=False)\nprint(f\"Raw Ray Tune CSV saved to: {raw_csv}\")"
   },
@@ -554,7 +580,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "cell-29"
+   },
    "source": [
     "## 10. Cleanup"
    ]


### PR DESCRIPTION
## Summary
This PR adds the ability to save and restore hyperparameter sweep configurations from JSON files, enabling users to resume interrupted sweeps without manually re-entering all settings. A new `load_resume_settings()` function reads back sweep metadata and runtime parameters from previously saved search space files.

## Key Changes

- **New `load_resume_settings()` function** in `ray_search_space.py`: Reads a saved search space JSON file and returns a dict with all sweep configuration and runtime settings mapped to notebook variables. Includes fallback logic to use the search space file itself as the config path if none was explicitly stored.

- **Enhanced `save_search_space()` function**: Now accepts an optional `config_path` parameter and writes a `"resume"` section to the JSON output containing `sweep_dir` and optionally `config_path`. This metadata enables resuming sweeps across Colab sessions.

- **Updated `_search_space_for_stage()` in `search_space.py`**: Extended to recognize and extract parameters from saved snapshot format (files with a `"parameters"` key), allowing saved search space JSON files to be used directly as config paths in `build_search_space()`.

- **Notebook integration** in `ray_tune_sweep.ipynb`:
  - Added `load_resume_settings` to imports
  - New `RESUME_SEARCH_SPACE_PATH` configuration variable that auto-loads all settings from a previously saved search space file
  - Automatic population of `SPECIES`, `ALGORITHM`, `STAGE`, `RESUME`, `RESUME_SWEEP_DIR`, and all runtime settings when a search space path is provided

- **Comprehensive test coverage** in `test_sweep_ray_search_space.py`:
  - Tests for writing and reading resume sections
  - Tests for config path fallback behavior
  - Tests for loading all runtime settings
  - Tests for file not found error handling
  - Tests for round-trip compatibility (saved file can be used as config_path)

## Implementation Details

The resume metadata is stored in a dedicated `"resume"` section of the search space JSON, separate from the `"runtime"` section. This allows the notebook to automatically restore sweep state without requiring users to manually copy paths or re-enter configuration values. The `load_resume_settings()` function flattens the nested structure into top-level keys that map directly to notebook cell variables for seamless integration.