### PR TITLE
Add retry logic and caching for Google Drive FUSE operations

### DIFF
--- a/environments/shared/scripts/sweep/ray_orchestration.py
+++ b/environments/shared/scripts/sweep/ray_orchestration.py
@@ -307,7 +307,10 @@ def run_ray_sweep(
     # ExperimentStateSyncCallback already synced periodically during the
     # sweep, so most files are already on Drive.  Only copy files that are
     # newer (by mtime) to avoid redundant I/O on the FUSE mount.
+    # Uses retry logic for transient FUSE errors.
     if local_experiment_dir.exists():
+        from .ray_tune import _copy_to_drive
+
         drive_dest = drive_ray_results_dir / local_experiment_dir.name
         logger.info("Final incremental sync to Drive: %s", drive_dest)
         try:
@@ -320,8 +323,8 @@ def run_ray_sweep(
                 if dst.exists() and dst.stat().st_mtime >= src_file.stat().st_mtime:
                     continue
                 dst.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(str(src_file), str(dst))
-                copied += 1
+                if _copy_to_drive(src_file, dst):
+                    copied += 1
             logger.info("Final sync complete: %d files copied", copied)
         except OSError as e:
             logger.warning("Drive sync of Ray results failed: %s", e)

--- a/environments/shared/scripts/sweep/ray_orchestration.py
+++ b/environments/shared/scripts/sweep/ray_orchestration.py
@@ -303,15 +303,26 @@ def run_ray_sweep(
 
     results = tuner.fit()
 
-    # Final sync of experiment state to Drive
+    # Final incremental sync of experiment state to Drive.
+    # ExperimentStateSyncCallback already synced periodically during the
+    # sweep, so most files are already on Drive.  Only copy files that are
+    # newer (by mtime) to avoid redundant I/O on the FUSE mount.
     if local_experiment_dir.exists():
-        logger.info("Syncing final Ray results to Drive: %s", drive_ray_results_dir)
+        drive_dest = drive_ray_results_dir / local_experiment_dir.name
+        logger.info("Final incremental sync to Drive: %s", drive_dest)
         try:
-            shutil.copytree(
-                str(local_experiment_dir),
-                str(drive_ray_results_dir / local_experiment_dir.name),
-                dirs_exist_ok=True,
-            )
+            copied = 0
+            for src_file in local_experiment_dir.rglob("*"):
+                if not src_file.is_file():
+                    continue
+                rel = src_file.relative_to(local_experiment_dir)
+                dst = drive_dest / rel
+                if dst.exists() and dst.stat().st_mtime >= src_file.stat().st_mtime:
+                    continue
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(str(src_file), str(dst))
+                copied += 1
+            logger.info("Final sync complete: %d files copied", copied)
         except OSError as e:
             logger.warning("Drive sync of Ray results failed: %s", e)
 

--- a/environments/shared/scripts/sweep/ray_tune.py
+++ b/environments/shared/scripts/sweep/ray_tune.py
@@ -64,7 +64,7 @@ def _sync_best_model(src_dir: str | Path, drive_dir: str | Path) -> None:
 def _sync_trial_metadata(
     source_dir: str | Path,
     drive_trial_dir: str | Path,
-    filenames: tuple[str, ...] = ("evaluations.npz", "diagnostics.npz", "stage_config.json"),
+    filenames: tuple[str, ...] = ("evaluations.npz", "diagnostics.npz", "stage_config.json", "metrics.json"),
 ) -> None:
     """Copy trial metadata files (evaluations, diagnostics, config) to Drive."""
     source_dir = Path(source_dir)
@@ -720,6 +720,8 @@ def train_trial(config: dict[str, Any]) -> None:
             species_cfg.success_keys,
             n_episodes=n_eval_episodes,
         )
+        import json as _json
+
         import numpy as _np
 
         _training_duration_s = time.time() - _train_start_time
@@ -735,6 +737,105 @@ def train_trial(config: dict[str, Any]) -> None:
             "timesteps": timesteps,
             "done": True,
         }
+
+        # ── Quality evaluation (matches Vertex AI's _report_hpt_metrics) ──
+        # Collect spinning detection, heading alignment, and reward
+        # component breakdown so Ray Tune trials produce the same eval_*
+        # metrics that Vertex AI trials write to metrics.json.
+        try:
+            from ...evaluation import eval_policy_quality
+
+            quality_metrics = eval_policy_quality(
+                eval_model, eval_env, species_cfg.success_keys, n_episodes=n_eval_episodes,
+            )
+            final_metrics.update(quality_metrics)
+            logger.info(
+                "Quality eval complete: %d metrics (angular_vel=%.3f, heading_align=%.3f)",
+                len(quality_metrics),
+                quality_metrics.get("eval_mean_pelvis_angular_velocity", float("nan")),
+                quality_metrics.get("eval_mean_heading_alignment", float("nan")),
+            )
+        except Exception:
+            logger.warning("Quality evaluation failed — skipping quality metrics.", exc_info=True)
+
+        # ── Write metrics.json sidecar (matches Vertex AI trial output) ───
+        # Enables offline result collection via collect_results_from_disk()
+        # and provides a consistent artifact format across both backends.
+        aux_metrics: dict[str, Any] = {
+            "best_mean_reward": final_metrics["best_mean_reward"],
+            "best_mean_episode_length": final_metrics["best_mean_episode_length"],
+            "last_mean_reward": float(eval_callback.last_mean_reward)
+            if hasattr(eval_callback, "last_mean_reward") and eval_callback.last_mean_reward is not None
+            else final_metrics["best_mean_reward"],
+            "last_mean_episode_length": float(_np.mean(eval_lengths)) if eval_lengths else 0.0,
+            "mean_forward_vel": final_metrics["mean_forward_vel"],
+            "std_forward_vel": final_metrics["std_forward_vel"],
+            "best_mean_forward_vel": final_metrics["mean_forward_vel"],
+            "mean_distance_traveled": final_metrics["mean_distance_traveled"],
+            "mean_success_rate": final_metrics["mean_success_rate"],
+            "best_mean_success_rate": final_metrics["mean_success_rate"],
+            "training_duration_seconds": final_metrics["training_duration_seconds"],
+        }
+        # Include eval_* quality metrics
+        for key, value in final_metrics.items():
+            if key.startswith("eval_"):
+                aux_metrics[key] = value
+        # Include key hyperparameters so offline collection works even
+        # without stage_config.json
+        algo_key_cfg = f"{algorithm}_kwargs"
+        algo_kwargs_cfg = stage_config.get(algo_key_cfg, {})
+        _hparam_keys = (
+            ("learning_rate", "batch_size", "gamma", "n_steps", "ent_coef")
+            if algorithm == "ppo"
+            else ("learning_rate", "batch_size", "gamma", "tau", "buffer_size", "ent_coef")
+        )
+        for k in _hparam_keys:
+            if k in algo_kwargs_cfg:
+                val = algo_kwargs_cfg[k]
+                if not callable(val):
+                    aux_metrics[f"{algorithm}_{k}"] = val
+        net_arch = algo_kwargs_cfg.get("policy_kwargs", {}).get("net_arch")
+        if net_arch is not None:
+            aux_metrics[f"{algorithm}_net_arch"] = str(net_arch)
+
+        metrics_path = trial_dir / "metrics.json"
+        with open(metrics_path, "w") as f:
+            _json.dump(aux_metrics, f, indent=2)
+        logger.info("Metrics sidecar written to: %s", metrics_path)
+
+        # ── Generate stage artifacts (summary, graphs) ────────────────────
+        # Produces the same training_curves.png, diagnostics graphs, and
+        # stage_summary.txt that Vertex AI trials generate, making Ray Tune
+        # trial directories self-contained for post-analysis.
+        try:
+            from ...reporting import generate_stage_artifacts
+
+            generate_stage_artifacts(
+                species_cfg=species_cfg,
+                stage_config=stage_config,
+                stage=stage,
+                algorithm=algorithm,
+                stage_dir=str(trial_dir),
+                seed=seed,
+                timesteps=timesteps,
+                record_videos=False,
+                generate_graphs=True,
+            )
+        except Exception:
+            logger.warning("Stage artifact generation failed.", exc_info=True)
+
+        # Sync metrics.json to Drive alongside other trial metadata
+        if drive_best_model_dir:
+            _sync_trial_metadata(
+                trial_dir,
+                drive_best_model_dir.parent,
+                filenames=(
+                    "evaluations.npz",
+                    "diagnostics.npz",
+                    "stage_config.json",
+                    "metrics.json",
+                ),
+            )
 
         # Final report
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -787,6 +888,11 @@ def collect_ray_results(
             "training_duration_seconds",
         ):
             row[metric] = rt_row.get(metric)
+
+        # Quality evaluation metrics (eval_* keys from eval_policy_quality)
+        for col in results_df.columns:
+            if col.startswith("eval_"):
+                row[col] = rt_row[col]
 
         # Curriculum thresholds
         row["reward_threshold"] = cur.get("min_avg_reward")

--- a/environments/shared/scripts/sweep/ray_tune.py
+++ b/environments/shared/scripts/sweep/ray_tune.py
@@ -65,16 +65,32 @@ def _sync_trial_metadata(
     source_dir: str | Path,
     drive_trial_dir: str | Path,
     filenames: tuple[str, ...] = ("evaluations.npz", "diagnostics.npz", "stage_config.json", "metrics.json"),
+    *,
+    skip_unchanged: bool = True,
 ) -> None:
-    """Copy trial metadata files (evaluations, diagnostics, config) to Drive."""
+    """Copy trial metadata files (evaluations, diagnostics, config) to Drive.
+
+    When *skip_unchanged* is True (the default), files whose size has not
+    changed since the last copy are skipped.  This avoids re-copying
+    ``stage_config.json`` (which never changes) on every best-reward
+    improvement, and reduces redundant writes of large ``evaluations.npz``
+    files that haven't grown since the last sync.
+    """
     source_dir = Path(source_dir)
     drive_trial_dir = Path(drive_trial_dir)
     drive_trial_dir.mkdir(parents=True, exist_ok=True)
     for name in filenames:
         src = source_dir / name
         if src.exists():
+            dst = drive_trial_dir / name
+            if skip_unchanged and dst.exists():
+                try:
+                    if src.stat().st_size == dst.stat().st_size:
+                        continue
+                except OSError:
+                    pass  # stat failed — fall through to copy
             try:
-                shutil.copy2(str(src), str(drive_trial_dir / name))
+                shutil.copy2(str(src), str(dst))
             except OSError as e:
                 logger.warning("Drive sync failed for %s: %s", name, e)
 
@@ -279,6 +295,10 @@ def _make_experiment_state_sync_callback_class():
             self._drive_dir = Path(drive_ray_results_dir) / self._local_dir.name
             self._sync_interval_s = sync_interval_s
             self._last_sync_time = 0.0
+            # Cache of {relative_path: (size, mtime)} for files already
+            # synced to Drive.  Avoids expensive stat() calls on the FUSE
+            # mount for files that haven't changed since the last sync.
+            self._synced_file_cache: dict[str, tuple[int, float]] = {}
 
         def _sync(self, reason: str = "") -> None:
             """Incrementally copy local experiment state to Drive."""
@@ -290,16 +310,20 @@ def _make_experiment_state_sync_callback_class():
                 for src_file in self._local_dir.rglob("*"):
                     if not src_file.is_file():
                         continue
-                    rel = src_file.relative_to(self._local_dir)
-                    dst = self._drive_dir / rel
-                    # Skip if destination is up-to-date
-                    if dst.exists() and dst.stat().st_mtime >= src_file.stat().st_mtime:
+                    rel = str(src_file.relative_to(self._local_dir))
+                    src_stat = src_file.stat()
+                    src_key = (src_stat.st_size, src_stat.st_mtime)
+                    # Skip if we already synced this exact version
+                    if self._synced_file_cache.get(rel) == src_key:
                         continue
+                    dst = self._drive_dir / rel
                     dst.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(str(src_file), str(dst))
+                    self._synced_file_cache[rel] = src_key
                     copied += 1
                 self._last_sync_time = time.time()
-                logger.info("Experiment state synced to Drive (%s, %d files copied)", reason, copied)
+                if copied:
+                    logger.info("Experiment state synced to Drive (%s, %d files copied)", reason, copied)
             except OSError as e:
                 logger.warning("Experiment state sync failed: %s", e)
 

--- a/environments/shared/scripts/sweep/ray_tune.py
+++ b/environments/shared/scripts/sweep/ray_tune.py
@@ -25,8 +25,45 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Drive sync helper
+# Drive sync helpers
 # ---------------------------------------------------------------------------
+
+# Retry settings for Google Drive FUSE writes.  Transient FUSE errors
+# (EIO, ETIMEDOUT, spurious ENOSPC from buffer pressure) typically
+# resolve within a few seconds.
+_DRIVE_RETRY_DELAYS = (1, 3, 5)  # seconds between retries
+
+
+def _copy_to_drive(src: str | Path, dst: str | Path) -> bool:
+    """Copy a single file to Drive with retry on transient FUSE errors.
+
+    Returns True if the copy succeeded, False if all retries failed.
+    """
+    for attempt in range(len(_DRIVE_RETRY_DELAYS) + 1):
+        try:
+            shutil.copy2(str(src), str(dst))
+            return True
+        except OSError as e:
+            if attempt < len(_DRIVE_RETRY_DELAYS):
+                delay = _DRIVE_RETRY_DELAYS[attempt]
+                logger.warning(
+                    "Drive write failed for %s (attempt %d/%d): %s — retrying in %ds",
+                    Path(src).name,
+                    attempt + 1,
+                    len(_DRIVE_RETRY_DELAYS) + 1,
+                    e,
+                    delay,
+                )
+                time.sleep(delay)
+            else:
+                logger.warning(
+                    "Drive write failed for %s after %d attempts: %s",
+                    Path(src).name,
+                    len(_DRIVE_RETRY_DELAYS) + 1,
+                    e,
+                )
+                return False
+    return False  # unreachable, but keeps type checkers happy
 
 
 def _sync_to_drive(src_dir: str | Path, drive_dir: str | Path, label: str = "") -> None:
@@ -38,10 +75,7 @@ def _sync_to_drive(src_dir: str | Path, drive_dir: str | Path, label: str = "") 
     drive_dir.mkdir(parents=True, exist_ok=True)
     for src_file in src_dir.iterdir():
         if src_file.is_file():
-            try:
-                shutil.copy2(str(src_file), str(drive_dir / src_file.name))
-            except OSError as e:
-                logger.warning("Drive sync failed for %s: %s", src_file.name, e)
+            _copy_to_drive(src_file, drive_dir / src_file.name)
 
 
 def _sync_best_model(src_dir: str | Path, drive_dir: str | Path) -> None:
@@ -55,10 +89,7 @@ def _sync_best_model(src_dir: str | Path, drive_dir: str | Path) -> None:
         if src_file.is_file() and (
             src_file.name.startswith("best_model") or src_file.name.startswith("stage") and "final" in src_file.name
         ):
-            try:
-                shutil.copy2(str(src_file), str(drive_dir / src_file.name))
-            except OSError as e:
-                logger.warning("Drive sync failed for %s: %s", src_file.name, e)
+            _copy_to_drive(src_file, drive_dir / src_file.name)
 
 
 def _sync_trial_metadata(
@@ -89,10 +120,7 @@ def _sync_trial_metadata(
                         continue
                 except OSError:
                     pass  # stat failed — fall through to copy
-            try:
-                shutil.copy2(str(src), str(dst))
-            except OSError as e:
-                logger.warning("Drive sync failed for %s: %s", name, e)
+            _copy_to_drive(src, dst)
 
 
 # ---------------------------------------------------------------------------
@@ -318,9 +346,9 @@ def _make_experiment_state_sync_callback_class():
                         continue
                     dst = self._drive_dir / rel
                     dst.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(str(src_file), str(dst))
-                    self._synced_file_cache[rel] = src_key
-                    copied += 1
+                    if _copy_to_drive(src_file, dst):
+                        self._synced_file_cache[rel] = src_key
+                        copied += 1
                 self._last_sync_time = time.time()
                 if copied:
                     logger.info("Experiment state synced to Drive (%s, %d files copied)", reason, copied)
@@ -408,16 +436,21 @@ def _make_drive_progress_log_callback_class():
                 if not key.startswith("_"):
                     row[key] = value
 
-            try:
-                self._csv_path.parent.mkdir(parents=True, exist_ok=True)
-                with open(self._csv_path, "a", newline="") as f:
-                    writer = csv.DictWriter(f, fieldnames=list(row.keys()))
-                    if not self._written_header:
-                        writer.writeheader()
-                        self._written_header = True
-                    writer.writerow(row)
-            except OSError as e:
-                logger.warning("Failed to write trial progress to %s: %s", self._csv_path, e)
+            self._csv_path.parent.mkdir(parents=True, exist_ok=True)
+            for attempt in range(len(_DRIVE_RETRY_DELAYS) + 1):
+                try:
+                    with open(self._csv_path, "a", newline="") as f:
+                        writer = csv.DictWriter(f, fieldnames=list(row.keys()))
+                        if not self._written_header:
+                            writer.writeheader()
+                            self._written_header = True
+                        writer.writerow(row)
+                    break  # success
+                except OSError as e:
+                    if attempt < len(_DRIVE_RETRY_DELAYS):
+                        time.sleep(_DRIVE_RETRY_DELAYS[attempt])
+                    else:
+                        logger.warning("Failed to write trial progress to %s: %s", self._csv_path, e)
 
         def on_trial_complete(self, iteration: int, trials: list[Any], trial: Any, **info: Any) -> None:
             # Distinguish ASHA-pruned trials from those that ran to completion.
@@ -587,10 +620,7 @@ def train_trial(config: dict[str, Any]) -> None:
         drive_trial_dir.mkdir(parents=True, exist_ok=True)
         _stage_cfg_src = trial_dir / "stage_config.json"
         if _stage_cfg_src.exists():
-            try:
-                shutil.copy2(str(_stage_cfg_src), str(drive_trial_dir / "stage_config.json"))
-            except OSError as e:
-                logger.warning("Early Drive sync of stage_config.json failed: %s", e)
+            _copy_to_drive(_stage_cfg_src, drive_trial_dir / "stage_config.json")
 
     _train_start_time = time.time()
 


### PR DESCRIPTION
## Summary
This PR improves the reliability and efficiency of syncing Ray Tune trial results to Google Drive by adding retry logic for transient FUSE errors and implementing a file change cache to avoid redundant writes.

## Key Changes

- **New `_copy_to_drive()` helper function**: Wraps `shutil.copy2()` with configurable retry logic (1s, 3s, 5s delays) to handle transient FUSE errors (EIO, ETIMEDOUT, ENOSPC). Returns a boolean indicating success/failure.

- **Enhanced `_sync_trial_metadata()`**: 
  - Added `skip_unchanged` parameter (default True) to skip re-copying files whose size hasn't changed since last sync
  - Avoids redundant writes of static files like `stage_config.json` and large `evaluations.npz` files
  - Added `metrics.json` to default filenames list

- **Improved `ExperimentStateSyncCallback._sync()`**:
  - Introduced `_synced_file_cache` dict tracking `{relative_path: (size, mtime)}` for already-synced files
  - Replaces expensive mtime-based destination checks with local cache lookups
  - Only logs sync completion when files were actually copied

- **CSV write retry logic**: Added retry mechanism to `_write_row()` for writing trial progress to CSV files on Drive

- **Quality metrics and artifacts**:
  - Added `eval_policy_quality()` evaluation to generate quality metrics (angular velocity, heading alignment)
  - Generates `metrics.json` sidecar file matching Vertex AI trial output format
  - Calls `generate_stage_artifacts()` to produce training curves, diagnostics graphs, and summaries
  - Syncs `metrics.json` to Drive alongside other trial metadata

- **Final sync optimization in `run_ray_sweep()`**: Replaced `shutil.copytree()` with incremental file-by-file sync using `_copy_to_drive()`, skipping files unchanged since last periodic sync

## Implementation Details

- Retry delays are configurable via `_DRIVE_RETRY_DELAYS` constant
- File cache uses relative paths as keys to handle directory structure changes
- Stat failures during cache checks gracefully fall through to copy attempt
- All Drive operations now use the centralized `_copy_to_drive()` function for consistent error handling
- Quality metrics collection includes hyperparameter values for offline result analysis

https://claude.ai/code/session_016bVhXGX45TJawhGx51SxqV