### PR TITLE
Add auto-disconnect functionality to Colab notebooks

### DIFF
--- a/notebooks/ray_tune_sweep.ipynb
+++ b/notebooks/ray_tune_sweep.ipynb
@@ -601,6 +601,30 @@
     "print(f\"Best trial config: {best_config_path}\")\n",
     "print(f\"Best model: {best_model_dest}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 11. Auto-Disconnect\n",
+    "\n",
+    "Automatically disconnect the Colab runtime after completion to free up resources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import time\n",
+    "\n",
+    "print(\"Sweep finished. Disconnecting runtime in 5 seconds...\")\n",
+    "time.sleep(5)\n",
+    "\n",
+    "from google.colab import runtime\n",
+    "runtime.unassign()"
+   ],
+   "execution_count": null,
+   "outputs": []
   }
  ]
 }

--- a/notebooks/training.ipynb
+++ b/notebooks/training.ipynb
@@ -851,6 +851,30 @@
     "print(f\"Stage 3 final model: {final_path_3}.zip\")\n",
     "print(\"\\nTo run the other algorithm, change ALGORITHM at the top and re-run all cells.\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 12. Auto-Disconnect\n",
+    "\n",
+    "Automatically disconnect the Colab runtime after completion to free up resources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import time\n",
+    "\n",
+    "print(\"Training finished. Disconnecting runtime in 5 seconds...\")\n",
+    "time.sleep(5)\n",
+    "\n",
+    "from google.colab import runtime\n",
+    "runtime.unassign()"
+   ],
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
Added automatic runtime disconnection at the end of both training and hyperparameter sweep notebooks to free up Colab resources after execution completes.

## Key Changes
- **training.ipynb**: Added "Auto-Disconnect" section (Section 12) that disconnects the Colab runtime 5 seconds after training completion
- **ray_tune_sweep.ipynb**: Added "Auto-Disconnect" section (Section 11) that disconnects the Colab runtime 5 seconds after sweep completion
- Both implementations use `google.colab.runtime.unassign()` to release the runtime resources

## Implementation Details
- Each notebook now includes a final cell that:
  - Prints a completion message
  - Waits 5 seconds (allowing time to view the message)
  - Calls `runtime.unassign()` to disconnect the Colab runtime
- This prevents unnecessary resource consumption when notebooks finish execution
- The 5-second delay provides a brief window for users to see the completion status before disconnection