### PR TITLE
Expand hyperparameter sweep ranges for Velociraptor SAC training

### DIFF
--- a/configs/velociraptor/sweep_sac.json
+++ b/configs/velociraptor/sweep_sac.json
@@ -20,7 +20,8 @@
     "env_alive_bonus":         {"type": "double", "min": 1.5, "max": 2.5, "scale": "linear"},
     "env_posture_weight":      {"type": "double", "min": 1.0, "max": 2.0, "scale": "linear"},
     "env_drift_penalty_weight": {"type": "double", "min": 0.1, "max": 0.5, "scale": "linear"},
-    "env_speed_penalty_weight": {"type": "double", "min": 0.1, "max": 0.5, "scale": "linear"}
+    "env_speed_penalty_weight": {"type": "double", "min": 0.1, "max": 0.5, "scale": "linear"},
+    "env_nosedive_weight":      {"type": "double", "min": 1.0, "max": 2.5, "scale": "linear"}
   },
 
   "stage2": {
@@ -44,6 +45,8 @@
     "env_alive_bonus":         {"type": "double", "min": 0.2, "max": 0.75, "scale": "linear"},
     "env_posture_weight":      {"type": "double", "min": 0.1, "max": 0.4, "scale": "linear"},
     "env_nosedive_weight":     {"type": "double", "min": 0.1, "max": 0.5, "scale": "linear"},
+    "env_heading_weight":      {"type": "double", "min": 0.1, "max": 0.5, "scale": "linear"},
+    "env_lateral_penalty_weight": {"type": "double", "min": 0.05, "max": 0.2, "scale": "linear"},
 
     "_comment_curriculum": "Ramp schedule is critical for statue-to-walking transition. The one SAC success used ramp=2M, start=0.2.",
     "curriculum_warmup_timesteps":  {"type": "discrete", "values": [200000, 300000, 500000]},
@@ -71,7 +74,10 @@
     "env_strike_approach_weight":       {"type": "double", "min": 2.0, "max": 5.0, "scale": "linear"},
     "env_strike_claw_proximity_weight": {"type": "double", "min": 0.5, "max": 2.0, "scale": "linear"},
     "env_forward_vel_weight":           {"type": "double", "min": 0.5, "max": 2.0, "scale": "linear"},
+    "env_forward_vel_max":              {"type": "double", "min": 2.0, "max": 4.0, "scale": "linear"},
     "env_heading_weight":               {"type": "double", "min": 0.1, "max": 0.5, "scale": "linear"},
+    "env_prey_distance_min":            {"type": "double", "min": 1.5, "max": 3.0, "scale": "linear"},
+    "env_prey_distance_max":            {"type": "double", "min": 5.0, "max": 8.0, "scale": "linear"},
 
     "_comment_curriculum": "Warmup is critical here — critic must adapt to strike reward landscape before policy starts chasing it.",
     "curriculum_warmup_timesteps":  {"type": "discrete", "values": [200000, 300000, 500000]},


### PR DESCRIPTION
## Summary
Extended the hyperparameter search space in the Velociraptor SAC sweep configuration to include additional reward shaping parameters and tuning ranges across multiple training stages.

## Key Changes
- **Stage 1**: Added `env_nosedive_weight` parameter (range: 1.0-2.5) to penalize nosedive behaviors during initial training
- **Stage 2**: Introduced two new parameters for improved locomotion control:
  - `env_heading_weight` (range: 0.1-0.5) for directional alignment
  - `env_lateral_penalty_weight` (range: 0.05-0.2) for lateral movement constraints
- **Stage 3**: Added three new parameters for strike behavior refinement:
  - `env_forward_vel_max` (range: 2.0-4.0) to cap forward velocity during strikes
  - `env_prey_distance_min` (range: 1.5-3.0) to set minimum approach distance
  - `env_prey_distance_max` (range: 5.0-8.0) to set maximum engagement distance

## Implementation Details
All new parameters follow the existing configuration pattern with linear scaling and reasonable min/max bounds based on the training stage requirements. These additions enable finer-grained control over reward shaping across the three-stage curriculum learning approach.