### PR TITLE
Reduce JAX logging verbosity and add cell IDs to notebook

### DIFF
--- a/environments/shared/jax_ppo.py
+++ b/environments/shared/jax_ppo.py
@@ -125,6 +125,9 @@ def sample_action(params, network, obs, rng):
     return action, log_prob, value
 
 
+_compute_gae_jit = None
+
+
 def compute_gae(
     rewards,
     values,
@@ -148,26 +151,38 @@ def compute_gae(
     import jax
     import jax.numpy as jnp
 
-    T = rewards.shape[0]
+    global _compute_gae_jit
+    if _compute_gae_jit is None:
 
-    def body_fn(carry, t):
-        gae = carry
-        delta = rewards[t] + gamma * values[t + 1] * (1 - dones[t]) - values[t]
-        gae = delta + gamma * gae_lambda * (1 - dones[t]) * gae
-        return gae, gae
+        @jax.jit
+        def _impl(rewards, values, dones, gamma, gae_lambda):
+            T = rewards.shape[0]
 
-    # Scan backwards through time
-    indices = jnp.arange(T - 1, -1, -1)
-    _, advantages = jax.lax.scan(
-        body_fn,
-        jnp.zeros_like(values[0]),
-        indices,
+            def body_fn(carry, t):
+                gae = carry
+                delta = (
+                    rewards[t]
+                    + gamma * values[t + 1] * (1 - dones[t])
+                    - values[t]
+                )
+                gae = delta + gamma * gae_lambda * (1 - dones[t]) * gae
+                return gae, gae
+
+            indices = jnp.arange(T - 1, -1, -1)
+            _, advantages = jax.lax.scan(
+                body_fn,
+                jnp.zeros_like(values[0]),
+                indices,
+            )
+            advantages = advantages[::-1]
+            returns = advantages + values[:T]
+            return advantages, returns
+
+        _compute_gae_jit = _impl
+
+    return _compute_gae_jit(
+        rewards, values, dones, jnp.float32(gamma), jnp.float32(gae_lambda)
     )
-    # Reverse to get chronological order
-    advantages = advantages[::-1]
-    returns = advantages + values[:T]
-
-    return advantages, returns
 
 
 def ppo_loss(params, network, batch, config: PPOConfig):

--- a/environments/shared/jax_training.py
+++ b/environments/shared/jax_training.py
@@ -282,4 +282,13 @@ def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        level=logging.INFO,
+    )
+    # Silence verbose JAX dispatch/pxla WARNING logs that duplicate
+    # every jax_log_compiles message via Python logging.
+    for _noisy in ("jax._src.dispatch", "jax._src.interpreters.pxla"):
+        logging.getLogger(_noisy).setLevel(logging.ERROR)
     main()

--- a/notebooks/jax_training.ipynb
+++ b/notebooks/jax_training.ipynb
@@ -8,7 +8,8 @@
    },
    "source": [
     "<a href=\"https://colab.research.google.com/github/kuds/mesozoic-labs/blob/main/notebooks/jax_training.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-   ]
+   ],
+   "id": "cell_000"
   },
   {
    "cell_type": "markdown",
@@ -25,12 +26,13 @@
     "**Requirements:** Colab GPU runtime (A100 recommended).\n",
     "\n",
     "**Supported Species:**\n",
-    "- `trex` \u2014 T-Rex: balance \u2192 locomotion \u2192 bite\n",
-    "- `velociraptor` \u2014 Raptor: balance \u2192 locomotion \u2192 strike\n",
-    "- `brachiosaurus` \u2014 Brachio: balance \u2192 locomotion \u2192 food reach\n",
+    "- `trex` — T-Rex: balance → locomotion → bite\n",
+    "- `velociraptor` — Raptor: balance → locomotion → strike\n",
+    "- `brachiosaurus` — Brachio: balance → locomotion → food reach\n",
     "\n",
     "Set `SPECIES` in the configuration cell below to choose."
-   ]
+   ],
+   "id": "cell_001"
   },
   {
    "cell_type": "code",
@@ -63,13 +65,14 @@
     "print(\"Setup complete.\")"
    ],
    "outputs": [],
-   "execution_count": null
+   "execution_count": null,
+   "id": "cell_002"
   },
   {
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "# GPU diagnostics \u2014 run this anytime to check utilization\n",
+    "# GPU diagnostics — run this anytime to check utilization\n",
     "# (especially useful to run from a second terminal during training)\n",
     "import subprocess\n",
     "result = subprocess.run(\n",
@@ -95,7 +98,8 @@
     "#   watch -n 2 nvidia-smi\n"
    ],
    "outputs": [],
-   "execution_count": null
+   "execution_count": null,
+   "id": "cell_003"
   },
   {
    "cell_type": "code",
@@ -107,7 +111,7 @@
     "!git clone https://github.com/kuds/mesozoic-labs.git /content/mesozoic-labs 2>/dev/null || echo 'Already cloned'\n",
     "!pip install -e \"/content/mesozoic-labs[jax]\" -q\n",
     "\n",
-    "# Ensure the repo root is on sys.path so `from environments.\u2026` works\n",
+    "# Ensure the repo root is on sys.path so `from environments.…` works\n",
     "# even if the editable install did not fully resolve.\n",
     "import sys\n",
     "if '/content/mesozoic-labs' not in sys.path:\n",
@@ -119,66 +123,18 @@
     "print(\"mesozoic-labs[jax] installed.\")"
    ],
    "outputs": [],
-   "execution_count": null
+   "execution_count": null,
+   "id": "cell_004"
   },
   {
    "cell_type": "code",
    "metadata": {
     "id": "8ceadf08"
    },
-   "source": [
-    "import time\n",
-    "\n",
-    "import jax\n",
-    "import jax.numpy as jnp\n",
-    "import matplotlib.pyplot as plt\n",
-    "import mujoco\n",
-    "import numpy as np\n",
-    "import optax\n",
-    "from mujoco import mjx\n",
-    "\n",
-    "# Shared modules from mesozoic-labs\n",
-    "from environments.shared.reward_functions import (\n",
-    "    reward_forward_velocity,\n",
-    "    reward_alive,\n",
-    "    reward_energy,\n",
-    "    reward_posture,\n",
-    "    reward_approach_shaping,\n",
-    "    quat_to_tilt,\n",
-    "    check_height_tilt_termination,\n",
-    ")\n",
-    "from environments.shared.obs_functions import SensorLayout, build_bipedal_obs\n",
-    "from environments.shared.mjx_utils import scale_action_jax\n",
-    "from environments.shared.jax_ppo import (\n",
-    "    make_actor_critic,\n",
-    "    sample_action,\n",
-    "    compute_gae,\n",
-    "    ppo_loss,\n",
-    "    ppo_update as lib_ppo_update,\n",
-    "    make_optimizer,\n",
-    "    PPOConfig,\n",
-    ")\n",
-    "from environments.shared.jax_normalization import RunningMeanStd, normalize_obs, update_running_stats, decay_running_stats\n",
-    "from environments.shared.jax_eval import EvalConfig, evaluate_policy_cpu, check_stage_gate\n",
-    "from environments.shared.jax_viz import plot_training_curves, plot_locomotion_diagnostics, record_training_video\n",
-    "\n",
-    "# ==================== JAX Performance Logging ====================\n",
-    "# Log every JIT compilation so unexpected recompilations are visible.\n",
-    "# Set JAX_LOG_COMPILES=1 env var before import for even more detail.\n",
-    "jax.config.update(\"jax_log_compiles\", True)\n",
-    "\n",
-    "# Pre-allocate all GPU memory (avoids fragmentation-induced recompilation)\n",
-    "import os as _os\n",
-    "_os.environ.setdefault(\"XLA_PYTHON_CLIENT_PREALLOCATE\", \"true\")\n",
-    "_os.environ.setdefault(\"XLA_PYTHON_CLIENT_MEM_FRACTION\", \"0.90\")\n",
-    "\n",
-    "print(f\"JAX compilation logging: enabled (recompilations will print to stderr)\")\n",
-    "print(f\"JAX backend: {jax.default_backend()}\")\n",
-    "print(f\"JAX devices: {jax.device_count()} x {jax.devices()[0].device_kind}\")\n",
-    ""
-   ],
+   "source": "import logging\nimport time\n\nimport jax\nimport jax.numpy as jnp\nimport matplotlib.pyplot as plt\nimport mujoco\nimport numpy as np\nimport optax\nfrom mujoco import mjx\n\n# Shared modules from mesozoic-labs\nfrom environments.shared.reward_functions import (\n    reward_forward_velocity,\n    reward_alive,\n    reward_energy,\n    reward_posture,\n    reward_approach_shaping,\n    quat_to_tilt,\n    check_height_tilt_termination,\n)\nfrom environments.shared.obs_functions import SensorLayout, build_bipedal_obs\nfrom environments.shared.mjx_utils import scale_action_jax\nfrom environments.shared.jax_ppo import (\n    make_actor_critic,\n    sample_action,\n    compute_gae,\n    ppo_loss,\n    ppo_update as lib_ppo_update,\n    make_optimizer,\n    PPOConfig,\n)\nfrom environments.shared.jax_normalization import RunningMeanStd, normalize_obs, update_running_stats, decay_running_stats\nfrom environments.shared.jax_eval import EvalConfig, evaluate_policy_cpu, check_stage_gate\nfrom environments.shared.jax_viz import plot_training_curves, plot_locomotion_diagnostics, record_training_video\n\n# ==================== JAX Performance Logging ====================\n# Log every JIT compilation so unexpected recompilations are visible.\n# Set JAX_LOG_COMPILES=1 env var before import for even more detail.\njax.config.update(\"jax_log_compiles\", True)\n\n# Silence the verbose WARNING-level dispatch/pxla logs that duplicate\n# every compile event.  The jax_log_compiles flag already prints a\n# concise line via absl; the Python logging WARNING duplicates each\n# message twice (once with timestamp, once without).\nfor _noisy in (\"jax._src.dispatch\", \"jax._src.interpreters.pxla\"):\n    logging.getLogger(_noisy).setLevel(logging.ERROR)\n\n# Pre-allocate all GPU memory (avoids fragmentation-induced recompilation)\nimport os as _os\n_os.environ.setdefault(\"XLA_PYTHON_CLIENT_PREALLOCATE\", \"true\")\n_os.environ.setdefault(\"XLA_PYTHON_CLIENT_MEM_FRACTION\", \"0.90\")\n\nprint(f\"JAX compilation logging: enabled (recompilations will print to stderr)\")\nprint(f\"JAX backend: {jax.default_backend()}\")\nprint(f\"JAX devices: {jax.device_count()} x {jax.devices()[0].device_kind}\")",
    "outputs": [],
-   "execution_count": null
+   "execution_count": null,
+   "id": "cell_005"
   },
   {
    "cell_type": "code",
@@ -260,7 +216,8 @@
     "print(f\"Verbose:    {VERBOSE}\")\n",
     "if RESUME_FROM:\n",
     "    print(f\"Resuming from checkpoint: {RESUME_FROM}\")"
-   ]
+   ],
+   "id": "cell_006"
   },
   {
    "cell_type": "markdown",
@@ -269,7 +226,8 @@
    },
    "source": [
     "## 1. Load Model into MJX"
-   ]
+   ],
+   "id": "cell_007"
   },
   {
    "cell_type": "code",
@@ -326,7 +284,8 @@
     "mjx_model = mjx.put_model(mj_model)\n",
     "print(f\"\\nModel placed on {jax.devices()[0]}\")\n",
     ""
-   ]
+   ],
+   "id": "cell_008"
   },
   {
    "cell_type": "markdown",
@@ -343,7 +302,8 @@
     "**Note:** The shared `reward_functions` use `float()` / Python `if` which break\n",
     "`jax.vmap` tracing. The reward and termination functions below are re-implemented\n",
     "in pure JAX (`jnp` only) for vmap compatibility."
-   ]
+   ],
+   "id": "cell_009"
   },
   {
    "cell_type": "code",
@@ -376,7 +336,8 @@
     "print(f\"Action dim: {mj_model.nu}\")"
    ],
    "outputs": [],
-   "execution_count": null
+   "execution_count": null,
+   "id": "cell_010"
   },
   {
    "cell_type": "code",
@@ -448,7 +409,8 @@
     "print(f\"Action dim: {ACT_DIM}\")"
    ],
    "outputs": [],
-   "execution_count": null
+   "execution_count": null,
+   "id": "cell_011"
   },
   {
    "cell_type": "markdown",
@@ -459,7 +421,8 @@
     "## 3. Batched MJX Step\n",
     "\n",
     "A single `jax.jit`-compiled function that steps `N` parallel environments."
-   ]
+   ],
+   "id": "cell_012"
   },
   {
    "cell_type": "code",
@@ -489,7 +452,8 @@
     "\n",
     "\n",
     "print(\"Batched step function compiled.\")"
-   ]
+   ],
+   "id": "cell_013"
   },
   {
    "cell_type": "markdown",
@@ -499,7 +463,8 @@
    "source": [
     "## 4. Policy Network (Flax)\n",
     "Uses the shared `ActorCritic` from `environments.shared.jax_ppo`."
-   ]
+   ],
+   "id": "cell_014"
   },
   {
    "cell_type": "code",
@@ -535,7 +500,7 @@
     "    if \"obs_rms\" in _ckpt:\n",
     "        obs_rms = _ckpt[\"obs_rms\"]\n",
     "        # When transitioning between stages, the obs distribution shifts\n",
-    "        # (e.g. near-zero velocity in balance \u2192 sustained velocity in\n",
+    "        # (e.g. near-zero velocity in balance → sustained velocity in\n",
     "        # locomotion).  With 2048 envs the prior count can be ~65M, making\n",
     "        # update_running_stats nearly a no-op.  Decay the count so new\n",
     "        # data adapts the statistics within a few updates.\n",
@@ -543,7 +508,7 @@
     "        if _obs_decay < 1.0:\n",
     "            _old_count = obs_rms.count\n",
     "            obs_rms = decay_running_stats(obs_rms, decay_factor=_obs_decay)\n",
-    "            print(f\"  obs_rms count decayed: {_old_count:,.0f} \u2192 {obs_rms.count:,.0f} (factor={_obs_decay})\")\n",
+    "            print(f\"  obs_rms count decayed: {_old_count:,.0f} → {obs_rms.count:,.0f} (factor={_obs_decay})\")\n",
     "    print(f\"Resumed from {_ckpt_path} (update {_resume_update})\")\n",
     "    if \"reward_history\" in _ckpt:\n",
     "        print(f\"  Prior history: {len(_ckpt['reward_history'])} updates, best reward: {max(_ckpt['reward_history']):.4f}\")\n",
@@ -552,7 +517,8 @@
     "print(f\"ActorCritic parameters: {n_params:,}\")"
    ],
    "outputs": [],
-   "execution_count": null
+   "execution_count": null,
+   "id": "cell_015"
   },
   {
    "cell_type": "markdown",
@@ -564,7 +530,8 @@
     "Core PPO functions (`sample_action`, `compute_gae`, `ppo_loss`) are now\n",
     "imported from `environments.shared.jax_ppo`. Notebook-specific wrappers\n",
     "below adapt them for the training loop."
-   ]
+   ],
+   "id": "cell_016"
   },
   {
    "cell_type": "code",
@@ -581,7 +548,7 @@
     "# Use shared compute_gae directly (same signature)\n",
     "# compute_gae is already imported from jax_ppo\n",
     "\n",
-    "# Use shared ppo_loss directly \u2014 it now includes clip_fraction and mean_std\n",
+    "# Use shared ppo_loss directly — it now includes clip_fraction and mean_std\n",
     "# in the returned info dict. Create a notebook wrapper that adapts the\n",
     "# interface for the training loop (positional args -> batch dict).\n",
     "def nb_ppo_loss(params, obs, actions, old_log_probs, advantages, returns,\n",
@@ -605,7 +572,8 @@
     "print(\"PPO functions defined (using shared modules from jax_ppo).\")"
    ],
    "outputs": [],
-   "execution_count": null
+   "execution_count": null,
+   "id": "cell_017"
   },
   {
    "cell_type": "markdown",
@@ -614,7 +582,8 @@
    },
    "source": [
     "## 6. Training Loop"
-   ]
+   ],
+   "id": "cell_018"
   },
   {
    "cell_type": "code",
@@ -685,7 +654,8 @@
     "if RAMP_UPDATES > 0:\n",
     "    print(f\"  Reward ramp: {RAMP_ATTR} from {RAMP_START_FRACTION:.0%} to 100% over {RAMP_UPDATES} updates\")\n",
     "print(f\"  Reward config: {reward_cfg}\")"
-   ]
+   ],
+   "id": "cell_019"
   },
   {
    "cell_type": "code",
@@ -749,8 +719,9 @@
     "\n",
     "print(f\"Initialized {NUM_ENVS} parallel environments.\")\n",
     "print(f\"qpos batch shape: {env_batch.qpos.shape}\")\n",
-    "print(f\"Reset noise: joints=\u00b1{RESET_NOISE_SCALE}, xy=\u00b1{INIT_QPOS_NOISE}m, yaw=\u00b1{INIT_YAW_NOISE}rad\")"
-   ]
+    "print(f\"Reset noise: joints=±{RESET_NOISE_SCALE}, xy=±{INIT_QPOS_NOISE}m, yaw=±{INIT_YAW_NOISE}rad\")"
+   ],
+   "id": "cell_020"
   },
   {
    "cell_type": "code",
@@ -878,7 +849,8 @@
     ""
    ],
    "outputs": [],
-   "execution_count": null
+   "execution_count": null,
+   "id": "cell_021"
   },
   {
    "cell_type": "code",
@@ -890,7 +862,7 @@
    "source": [
     "# ---------- Main Training Loop ----------\n",
     "# Rollout: Python loop with async GPU dispatch (physics is the bottleneck,\n",
-    "# not dispatch overhead \u2014 scan added 281s compile time for 0% speedup).\n",
+    "# not dispatch overhead — scan added 281s compile time for 0% speedup).\n",
     "# PPO updates: jax.lax.scan (compiles fast, gives real speedup).\n",
     "\n",
     "import csv\n",
@@ -913,7 +885,7 @@
     "best_params = None\n",
     "best_update = -1\n",
     "\n",
-    "# Episode return accumulators (on-device \u2014 no host syncs during rollout)\n",
+    "# Episode return accumulators (on-device — no host syncs during rollout)\n",
     "_ep_returns = jnp.zeros(NUM_ENVS)\n",
     "_ep_lengths = jnp.zeros(NUM_ENVS, dtype=jnp.int32)\n",
     "\n",
@@ -1162,7 +1134,7 @@
     "        flat_adv = advantages.reshape(-1)\n",
     "        flat_ret = returns.reshape(-1)\n",
     "\n",
-    "        # ---------- PPO update (fused scan \u2014 compiles fast, real speedup) ----------\n",
+    "        # ---------- PPO update (fused scan — compiles fast, real speedup) ----------\n",
     "        _t_phase = time.time()\n",
     "        rng, rng_ppo = jax.random.split(rng)\n",
     "        params, opt_state, avg_loss, avg_aux, avg_grad_norm = scan_ppo_epochs(\n",
@@ -1376,7 +1348,8 @@
     "print(f\"\\nParameters and training history saved to: {params_path}\")\n",
     "print(f\"Training log CSV saved to: {csv_path}\")\n",
     ""
-   ]
+   ],
+   "id": "cell_022"
   },
   {
    "cell_type": "markdown",
@@ -1389,7 +1362,8 @@
    ],
    "metadata": {
     "id": "92cca468"
-   }
+   },
+   "id": "cell_023"
   },
   {
    "cell_type": "code",
@@ -1510,7 +1484,8 @@
     "id": "338820bf"
    },
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell_024"
   },
   {
    "cell_type": "markdown",
@@ -1522,7 +1497,8 @@
    ],
    "metadata": {
     "id": "e59d05a7"
-   }
+   },
+   "id": "cell_025"
   },
   {
    "cell_type": "code",
@@ -1739,7 +1715,8 @@
     "id": "a371e4f8"
    },
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell_026"
   },
   {
    "cell_type": "markdown",
@@ -1748,7 +1725,8 @@
    },
    "source": [
     "## 7. Training Curves & Locomotion Diagnostics"
-   ]
+   ],
+   "id": "cell_027"
   },
   {
    "cell_type": "code",
@@ -1758,7 +1736,7 @@
    },
    "outputs": [],
    "source": [
-    "# Training curves \u2014 uses shared plot_training_curves from jax_viz\n",
+    "# Training curves — uses shared plot_training_curves from jax_viz\n",
     "curve_path = OUTPUT_DIR / f\"{SPECIES}_jax_training_curves.png\"\n",
     "\n",
     "plot_training_curves(\n",
@@ -1773,12 +1751,13 @@
     ")\n",
     "\n",
     "print(f\"Training curves saved to: {curve_path}\")"
-   ]
+   ],
+   "id": "cell_028"
   },
   {
    "cell_type": "code",
    "source": [
-    "# Locomotion diagnostics \u2014 uses shared plot_locomotion_diagnostics from jax_viz\n",
+    "# Locomotion diagnostics — uses shared plot_locomotion_diagnostics from jax_viz\n",
     "\n",
     "plot_locomotion_diagnostics(\n",
     "    eval_results,\n",
@@ -1796,7 +1775,8 @@
     "id": "BWIat2AvUKsv"
    },
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell_029"
   },
   {
    "cell_type": "markdown",
@@ -1809,7 +1789,8 @@
     "Record a video of the best trained policy (highest reward during training) using\n",
     "the CPU MuJoCo renderer. The JAX policy is evaluated deterministically (using the\n",
     "action mean)."
-   ]
+   ],
+   "id": "cell_030"
   },
   {
    "cell_type": "code",
@@ -1850,7 +1831,8 @@
     "\n",
     "    print(f\"Episode reward: {episode_reward:.2f} | {len(frames)} frames\")\n",
     "    print(f\"Saved to: {video_path}\")"
-   ]
+   ],
+   "id": "cell_031"
   },
   {
    "cell_type": "markdown",
@@ -1881,7 +1863,8 @@
     "\n",
     "To train a different species, change `SPECIES` in the configuration cell and\n",
     "restart from the beginning."
-   ]
+   ],
+   "id": "cell_032"
   },
   {
    "cell_type": "markdown",
@@ -1893,7 +1876,8 @@
    ],
    "metadata": {
     "id": "ba693752"
-   }
+   },
+   "id": "cell_033"
   },
   {
    "cell_type": "code",
@@ -1907,13 +1891,14 @@
     "    from google.colab import runtime\n",
     "    runtime.unassign()\n",
     "else:\n",
-    "    print(\"Training finished. Runtime kept alive \u2014 remember to disconnect manually when done.\")"
+    "    print(\"Training finished. Runtime kept alive — remember to disconnect manually when done.\")"
    ],
    "metadata": {
     "id": "2ec9c173"
    },
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell_034"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
This PR reduces excessive logging output from JAX's internal dispatch and pxla modules while improving notebook organization by adding explicit cell IDs. The changes make training output cleaner and more readable without losing important compilation information.

## Key Changes

**Logging Improvements:**
- Added `logging` module import and configuration to silence verbose WARNING-level logs from `jax._src.dispatch` and `jax._src.interpreters.pxla` that duplicate `jax_log_compiles` output
- Applied the same logging suppression in both the notebook and `jax_training.py` module
- Configured logging to use a consistent format with timestamps and log levels

**Notebook Organization:**
- Added explicit `id` fields to all notebook cells for better cell tracking and reproducibility
- Updated Unicode characters in markdown (em-dashes and arrows) for consistency

**Code Refactoring:**
- Refactored `compute_gae()` in `jax_ppo.py` to use a global JIT-compiled implementation that's cached on first call, improving performance by avoiding repeated JIT compilation
- The function now wraps the core computation in a `@jax.jit` decorator and caches it in a module-level variable

## Implementation Details

The logging configuration targets the specific JAX modules that produce duplicate output when `jax_log_compiles=True` is set. By setting these loggers to ERROR level, we preserve the concise compilation messages from `jax_log_compiles` while eliminating the verbose Python logging duplicates.

The `compute_gae` refactoring uses a lazy initialization pattern where the JIT-compiled function is created once and reused, reducing overhead for repeated calls during training.

https://claude.ai/code/session_01HkdnpGC83nn2uwZPyWr7tH