### PR TITLE
Make VecNormalize path optional in stage summary reporting

### DIFF
--- a/environments/shared/reporting.py
+++ b/environments/shared/reporting.py
@@ -272,13 +272,11 @@ def write_stage_summary(
             lines.append(f"  Fwd vel:      {bm_vel} +/- {bm_vel_s} m/s")
         if bm_sr != "":
             lines.append(f"  Success rate: {bm_sr:.0%}")
-    lines.extend(
-        [
-            f"Best model:     {results_dict['model_path']}.zip",
-            f"VecNormalize:   {results_dict['vecnorm_path']}",
-            "",
-        ]
-    )
+    model_lines = [f"Best model:     {results_dict['model_path']}.zip"]
+    if "vecnorm_path" in results_dict:
+        model_lines.append(f"VecNormalize:   {results_dict['vecnorm_path']}")
+    model_lines.append("")
+    lines.extend(model_lines)
     summary_text = "\n".join(lines) + "\n"
     summary_path.write_text(summary_text)
     return summary_path


### PR DESCRIPTION
## Summary
Modified the stage summary reporting to handle cases where the `vecnorm_path` key may not be present in the results dictionary, making it an optional field in the output.

## Key Changes
- Refactored the model information section to conditionally include the VecNormalize path only when it exists in the results dictionary
- Changed from unconditionally appending all model lines to building the list conditionally
- Added a check for `"vecnorm_path" in results_dict` before including the VecNormalize line in the summary

## Implementation Details
The change improves robustness by preventing potential KeyError exceptions when the `vecnorm_path` is not provided in the results dictionary. The VecNormalize path is now treated as optional, while the model path remains required. This allows the reporting function to handle different result configurations gracefully.