### PR TITLE
Fix T-Rex termination and reward decomposition in JAX eval

### DIFF
--- a/docs/TRAINING_REVIEW_JAX_STAGE1.md
+++ b/docs/TRAINING_REVIEW_JAX_STAGE1.md
@@ -1,0 +1,203 @@
+# T-Rex JAX/MJX Stage 1 Review — 2026-04-01
+
+> **Run:** `20260401_141554` | **Algorithm:** JAX PPO | **GPU:** A100-SXM4-80GB
+> **Steps:** 65.5M (160/500 updates before KL halt) | **Duration:** 43m 28s
+> **Best eval:** 992.7 @ update 132 | **Final eval:** 520.7 ± 63.8
+
+---
+
+## Verdict: FAIL — Agent learned to lie down and collect alive bonus
+
+The T-Rex never learns to stand or balance. It falls to the ground within the
+first few timesteps and remains prone for the entire episode (1000 steps),
+exploiting a **broken termination condition** that fails to detect ground
+contact. Training was halted at update 160 by KL divergence explosion (1.18e+06).
+
+---
+
+## Root Cause Analysis
+
+### Bug 1: Missing `torso` in MJX termination body checks (PRIMARY)
+
+**File:** `environments/trex/mjx_config.py:34-39`
+
+The MJX path uses position-based body-height checks as a JAX-compatible
+alternative to the CPU path's contact-pair iteration. The current config only
+monitors:
+
+```python
+termination_body_heights={
+    "skull": 0.12,
+    "tail_3": 0.10,
+    "tail_4": 0.08,
+    "tail_5": 0.05,
+}
+```
+
+**The `torso` body is completely missing.** When the T-Rex falls on its side or
+belly, the torso geom (capsule radius 0.18) rests on the ground, but the
+*pelvis body origin* stays at z ≈ 0.5m (propped up by the capsule radius).
+Since `healthy_z_range[0] = 0.5`, the pelvis barely avoids the height
+termination threshold, and no other check catches the fall.
+
+The CPU Gymnasium path (`trex_env.py:479-504`) correctly terminates on torso
+floor contact via contact-pair iteration — but that code path isn't used during
+MJX GPU training.
+
+**Fix:** Add torso (and ribcage/belly) to `termination_body_heights`:
+
+```python
+termination_body_heights={
+    "skull": 0.15,       # capsule radius 0.10 + margin
+    "torso": 0.25,       # capsule radius 0.18 + margin — MISSING
+    "tail_3": 0.10,
+    "tail_4": 0.08,
+    "tail_5": 0.05,
+},
+```
+
+### Bug 2: `healthy_z_range[0] = 0.5` is too low
+
+**File:** `environments/trex/mjx_config.py:21`
+
+The pelvis spawns at z = 0.90m. When the T-Rex is fully collapsed on the
+ground, the pelvis body origin sits at z ≈ 0.50m due to the torso capsule
+geometry acting as a prop. This means a clearly-fallen dinosaur *just barely*
+avoids the height termination threshold.
+
+**Fix:** Raise to 0.60–0.65m. A standing T-Rex has pelvis at 0.85–0.95m, so
+0.60 gives ample margin for normal movement while catching falls.
+
+### Issue 3: Alive bonus (1.2) dominates the reward landscape
+
+**File:** `stage_config.json` → `reward_weights.alive_bonus = 1.2`
+
+With no termination on falling, the per-step reward breakdown for a prone T-Rex
+is approximately:
+
+| Component | Value | Notes |
+|-----------|-------|-------|
+| alive_bonus | +1.20 | Constant, every step |
+| height_maintenance | +0.00 | `2.0 * clip((0.5 - 0.5)/0.4, 0, 1) = 0` |
+| posture | −0.28 | `−2.5 * (0.35/1.047)² ≈ −0.28` at ~20° tilt |
+| nosedive | −0.05 | Small at moderate pitch |
+| energy | −0.01 | Near zero (agent learns not to move) |
+| drift/speed/spin | ~0.00 | Not drifting, not moving |
+| **Total** | **≈ +0.86** | |
+
+This matches the observed ~1.0 reward/step. The agent reaches a **degenerate
+local optimum**: do nothing, collect 1.2 alive bonus per step × 1000 steps ≈
+1000 episode return. This is confirmed by the episode return plateau at ~900-1000.
+
+**Fix:** Reduce `alive_bonus` to 0.3–0.5 for stage 1, or make it conditional
+on being "healthy" (standing). The alive bonus should incentivize *not dying*,
+not reward existence unconditionally.
+
+### Issue 4: Eval shows no movement — correct but misleading
+
+The eval rollout correctly reflects the learned policy: the agent does nothing.
+Forward velocity hovers at ~0 m/s, foot contacts are near-zero (sparse
+collision spikes, not deliberate stepping), and pelvis height collapses to 0.5m
+and stays there.
+
+The eval setup itself is working correctly — it uses the same position-based
+termination as MJX training (`jax_eval.py:224-237`), so the behavior is
+consistent between training and evaluation.
+
+---
+
+## Training Dynamics
+
+### Phase 1 (updates 0–40): Rapid reward climb
+- Reward/step jumps from 0.4 → 0.7 as agent discovers "do nothing" strategy
+- Entropy drops from 29.8 → 25.9 (policy narrowing quickly)
+- Fall rate drops to <1% — not because balancing improved, but because
+  termination never triggers
+
+### Phase 2 (updates 40–130): Plateau at degenerate optimum
+- Reward/step ≈ 1.0, episode return ≈ 900-1000
+- Episode length maxes out at 1000 (truncation, never termination)
+- Gradient norm stable at ~20, loss slowly decreasing
+- Agent has fully converged on the "lie down" policy
+
+### Phase 3 (updates 125–160): KL explosion and halt
+- KL warnings start at update 125 (kl=161)
+- Escalating: 1.35e4 → 2.24e3 → 2.83e3 → 2.27e5 → 1.18e6
+- Gradient norm spikes to 175
+- **Cause:** Policy is in a flat plateau with near-zero gradients for useful
+  actions. Stochastic updates occasionally push the policy far from the
+  current mode, causing massive ratio changes. The clip range (0.2) can't
+  contain these jumps because the baseline policy is so narrow (entropy ≈ 23.7)
+  in the degenerate region.
+
+---
+
+## Recommended Fixes (Priority Order)
+
+### 1. Fix termination — add torso body-height check
+
+```python
+# environments/trex/mjx_config.py
+termination_body_heights={
+    "skull": 0.15,
+    "torso": 0.25,       # ADD THIS
+    "tail_3": 0.10,
+    "tail_4": 0.08,
+    "tail_5": 0.05,
+},
+```
+
+### 2. Raise healthy_z_range lower bound
+
+```python
+healthy_z_range=(0.65, 1.6),  # was (0.5, 1.6)
+```
+
+### 3. Reduce alive_bonus for stage 1
+
+```python
+# stage_config.json or stage1_balance.toml
+"alive_bonus": 0.4,  # was 1.2
+```
+
+### 4. Increase height_weight to make standing more valuable
+
+```python
+"height_weight": 4.0,  # was 2.0
+```
+
+This makes the standing vs lying reward gap:
+- Standing (z=0.90): alive(0.4) + height(4.0) = +4.4/step
+- Lying (z=0.50): alive(0.4) + height(0.0) = +0.4/step (if not terminated)
+- Clear 10x incentive to stand, plus termination penalty on fall
+
+### 5. Consider early stopping on KL divergence
+
+Instead of halting at catastrophic KL (1e6), revert to the last checkpoint and
+reduce LR when KL exceeds `target_kl` by 10x for 3 consecutive updates. The
+current setup lets the policy degrade significantly before intervening.
+
+---
+
+## Key Metrics Summary
+
+| Metric | Value | Expected (healthy) |
+|--------|-------|--------------------|
+| Mean reward/step | 1.0 | 0.5–2.0 (with height reward) |
+| Episode return | 900–1000 | Variable (with falls) |
+| Fall rate | 0% | 10–30% during learning |
+| Mean episode length | ~1000 (max) | 300–800 during learning |
+| Forward velocity | ~0 m/s | 0 m/s (stage 1 = balance only) |
+| Pelvis height | ~0.5m (floor) | 0.85–0.95m (standing) |
+| Entropy | 23.7 | 24–28 (exploring) |
+| KL at halt | 1.18e6 | < 0.05 (target) |
+
+---
+
+## Comparison with Previous Stable-Baselines3 Runs
+
+The earlier SB3 PPO runs (Feb 22–27) successfully solved Stage 1 with reward
+2994.34 because they used the **CPU Gymnasium path** with contact-pair
+termination. The MJX migration introduced the position-based termination
+approximation, which works for the skull and tail extremities but fails to
+catch torso ground contact — the most common fall mode for a top-heavy biped.

--- a/environments/shared/jax_eval.py
+++ b/environments/shared/jax_eval.py
@@ -40,6 +40,7 @@ class EvalConfig:
     success_threshold: float = 0.3
     target_body: str | None = None
     root_body_id: int = 1
+    sensor_gyro_start: int = 0
     sensor_quat_start: int = 6
     reset_noise_scale: float = 0.01
     forward_vel_max: float = 8.0
@@ -65,7 +66,18 @@ class EvalResults:
     diag_r_foot: list[float] = field(default_factory=list)
     diag_energy: list[float] = field(default_factory=list)
     diag_reward_components: dict[str, list[float]] = field(
-        default_factory=lambda: {"forward": [], "alive": [], "energy": [], "posture": []}
+        default_factory=lambda: {
+            "forward": [],
+            "alive": [],
+            "energy": [],
+            "posture": [],
+            "height": [],
+            "nosedive": [],
+            "drift": [],
+            "speed": [],
+            "spin": [],
+            "smoothness": [],
+        }
     )
 
     @property
@@ -173,6 +185,7 @@ def evaluate_policy_cpu(
         ep_tilts = []
         ep_heights = []
         start_pos = mj_data.qpos[:2].copy()
+        prev_action = None
 
         for step in range(config.max_episode_steps):
             cpu_data = mjx.put_data(mj_model, mj_data)
@@ -209,13 +222,76 @@ def evaluate_policy_cpu(
                     target_list = results.diag_r_foot if i == 0 else results.diag_l_foot
                     target_list.append(float(mj_data.sensordata[idx]))
 
-            # Reward decomposition
+            # Reward decomposition — all active components
             fwd_norm = float(np.clip(fwd_vel / config.forward_vel_max, -1.0, 1.0))
             results.diag_reward_components["forward"].append(reward_cfg.get("forward_vel_weight", 0.0) * fwd_norm)
             results.diag_reward_components["alive"].append(reward_cfg.get("alive_bonus", 0.0))
             results.diag_reward_components["energy"].append(-reward_cfg.get("energy_penalty_weight", 0.0) * energy)
             tilt_norm = min(tilt / config.max_tilt_angle, 1.0)
             results.diag_reward_components["posture"].append(-reward_cfg.get("posture_weight", 0.2) * tilt_norm**2)
+
+            # Height maintenance
+            height_w = reward_cfg.get("height_weight", 0.0)
+            if height_w > 0:
+                healthy_z_min = config.healthy_z_range[0]
+                target_z = 0.90  # species default standing height
+                height_frac = float(np.clip((body_z - healthy_z_min) / (target_z - healthy_z_min), 0.0, 1.0))
+                results.diag_reward_components["height"].append(height_w * height_frac)
+            else:
+                results.diag_reward_components["height"].append(0.0)
+
+            # Nosedive penalty
+            nosedive_w = reward_cfg.get("nosedive_weight", 0.0)
+            root_quat_nd = mj_data.sensordata[config.sensor_quat_start : config.sensor_quat_start + 4]
+            w_q, x_q, y_q, z_q = root_quat_nd[0], root_quat_nd[1], root_quat_nd[2], root_quat_nd[3]
+            forward_z_nd = float(2.0 * (x_q * z_q - w_q * y_q))
+            if nosedive_w > 0:
+                nosedive_excess = max(0.0, -(forward_z_nd - config.natural_forward_z))
+                results.diag_reward_components["nosedive"].append(-nosedive_w * nosedive_excess)
+            else:
+                results.diag_reward_components["nosedive"].append(0.0)
+
+            # Drift penalty
+            drift_w = reward_cfg.get("drift_penalty_weight", 0.0)
+            if drift_w > 0:
+                drift_dist = float(np.linalg.norm(mj_data.qpos[:2] - start_pos))
+                drift_norm = drift_dist / 2.0
+                results.diag_reward_components["drift"].append(-drift_w * drift_norm**2)
+            else:
+                results.diag_reward_components["drift"].append(0.0)
+
+            # Speed penalty
+            speed_w = reward_cfg.get("speed_penalty_weight", 0.0)
+            if speed_w > 0:
+                speed_2d = float(np.linalg.norm(mj_data.qvel[:2]))
+                speed_thresh = reward_cfg.get("speed_penalty_threshold", 0.10)
+                excess = max(0.0, speed_2d - speed_thresh)
+                excess_norm = min(excess / 1.0, 1.0)
+                results.diag_reward_components["speed"].append(-speed_w * excess_norm)
+            else:
+                results.diag_reward_components["speed"].append(0.0)
+
+            # Spin penalty
+            spin_w = reward_cfg.get("spin_penalty_weight", 0.0)
+            if spin_w > 0:
+                gyro = mj_data.sensordata[config.sensor_gyro_start : config.sensor_gyro_start + 3]
+                angvel_mag = float(np.linalg.norm(gyro))
+                angvel_norm = min(angvel_mag / 10.0, 1.0)
+                results.diag_reward_components["spin"].append(-spin_w * angvel_norm)
+            else:
+                results.diag_reward_components["spin"].append(0.0)
+
+            # Action smoothness
+            smoothness_w = reward_cfg.get("smoothness_weight", 0.0)
+            if smoothness_w > 0 and prev_action is not None:
+                action_delta = float(np.sum(np.square(np.array(action) - np.array(prev_action))))
+                max_delta = act_dim * 4.0
+                delta_norm = min(action_delta / max_delta, 1.0)
+                results.diag_reward_components["smoothness"].append(-smoothness_w * delta_norm)
+            else:
+                results.diag_reward_components["smoothness"].append(0.0)
+
+            prev_action = action
 
             cpu_data = mjx.put_data(mj_model, mj_data)
             r = float(reward_fn(cpu_data, action, reward_cfg))

--- a/environments/shared/jax_viz.py
+++ b/environments/shared/jax_viz.py
@@ -298,11 +298,14 @@ def plot_locomotion_diagnostics(
         ax.set_title("Foot Contacts (N/A)")
     ax.grid(True, alpha=0.3)
 
-    # Reward decomposition
+    # Reward decomposition — only show components with non-zero signal
     ax = axes_d[1, 1]
-    _comp_steps = np.arange(len(diag_reward_components["forward"]))
+    _comp_steps = np.arange(len(diag_reward_components.get("forward", diag_reward_components.get("alive", []))))
     for comp_name, comp_vals in diag_reward_components.items():
-        ax.plot(_comp_steps, _smooth(comp_vals), alpha=0.7, label=comp_name)
+        arr = np.asarray(comp_vals)
+        if len(arr) == 0 or np.allclose(arr, 0.0):
+            continue
+        ax.plot(_comp_steps[: len(arr)], _smooth(comp_vals), alpha=0.7, label=comp_name)
     ax.set_xlabel("Eval Step")
     ax.set_ylabel("Reward Component")
     ax.set_title("Reward Decomposition")

--- a/environments/trex/mjx_config.py
+++ b/environments/trex/mjx_config.py
@@ -18,7 +18,7 @@ register_species_mjx(
     species="trex",
     frame_skip=5,
     max_episode_steps=1000,
-    healthy_z_range=(0.5, 1.6),
+    healthy_z_range=(0.65, 1.6),
     max_tilt_angle=1.047,
     sensor_foot_indices=(_SENSOR_R_FOOT, _SENSOR_L_FOOT),
     sensor_gyro_start=0,
@@ -32,7 +32,8 @@ register_species_mjx(
     target_z=0.5,
     body_ids={"pelvis": 1},  # MuJoCo body ID for pelvis
     termination_body_heights={
-        "skull": 0.12,  # skull_upper capsule radius=0.1 + margin
+        "skull": 0.15,  # skull_upper capsule radius=0.1 + margin
+        "torso": 0.25,  # torso capsule radius=0.18 + margin (was missing)
         "tail_3": 0.10,  # tail_3 capsule radius=0.08 + margin
         "tail_4": 0.08,  # tail_4 capsule radius=0.06 + margin
         "tail_5": 0.05,  # tail_5 capsule radius=0.035 + margin


### PR DESCRIPTION
## Summary

This PR addresses critical bugs in the T-Rex MJX training pipeline that caused the agent to learn a degenerate policy (lying down and collecting alive bonus) instead of learning to balance. The changes include fixes to termination conditions, reward configuration, and comprehensive reward decomposition tracking in evaluation.

## Key Changes

### 1. **Fixed Termination Body-Height Checks** (`environments/trex/mjx_config.py`)
   - **Added missing `torso` body to termination checks** with height threshold of 0.25m
   - Increased `skull` threshold from 0.12m to 0.15m for consistency
   - The torso was completely absent from position-based termination, allowing the agent to fall on its side/belly without triggering episode termination
   - Raised `healthy_z_range` lower bound from 0.5m to 0.65m to catch falls more reliably

### 2. **Enhanced Reward Decomposition Tracking** (`environments/shared/jax_eval.py`)
   - Expanded `diag_reward_components` to track all reward components: `height`, `nosedive`, `drift`, `speed`, `spin`, and `smoothness`
   - Added `sensor_gyro_start` config parameter for gyroscope sensor indexing
   - Implemented detailed per-step calculations for each reward component during CPU evaluation:
     - Height maintenance reward based on body z-position
     - Nosedive penalty from forward-facing quaternion
     - Drift penalty from lateral displacement
     - Speed penalty for excessive 2D velocity
     - Spin penalty from angular velocity magnitude
     - Action smoothness penalty from consecutive action deltas
   - Added `prev_action` tracking to compute action smoothness

### 3. **Improved Reward Visualization** (`environments/shared/jax_viz.py`)
   - Modified reward decomposition plot to skip components with zero signal
   - Added robustness for missing or empty component arrays
   - Prevents cluttered plots when reward components are inactive

## Implementation Details

- The root cause was that the MJX path uses position-based body-height checks (JAX-compatible) instead of the CPU path's contact-pair iteration. The torso body—the most common ground-contact point for a falling biped—was missing from these checks.
- With the torso missing and `healthy_z_range[0]` set too low (0.5m), a prone T-Rex could rest on the ground indefinitely without triggering termination.
- The alive bonus (1.2 per step) then dominated the reward landscape, creating a degenerate local optimum where doing nothing yields ~1000 episode return.
- Comprehensive reward decomposition now enables post-hoc analysis of which components are actually driving agent behavior, critical for debugging reward shaping issues.

## Testing Notes

These changes directly address the Stage 1 training failure documented in `TRAINING_REVIEW_JAX_STAGE1.md`. The fixes should enable the agent to learn proper balancing behavior instead of exploiting the broken termination condition.