### PR TITLE
Fix hamburger menu dark overlay and improve mobile nav

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -77,8 +77,24 @@ body {
 
 /* Navbar customization */
 .navbar {
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  background-color: var(--ifm-navbar-background-color);
+  z-index: 200;
+}
+
+@supports (backdrop-filter: blur(10px)) {
+  .navbar {
+    -webkit-backdrop-filter: blur(10px);
+    backdrop-filter: blur(10px);
+  }
+}
+
+@supports not (backdrop-filter: blur(10px)) {
+  :root {
+    --ifm-navbar-background-color: #0a0a0f;
+  }
+  [data-theme='dark'] {
+    --ifm-navbar-background-color: #0a0a0f;
+  }
 }
 
 .navbar__brand {
@@ -113,11 +129,19 @@ body {
 /* Mobile navbar sidebar fixes */
 .navbar-sidebar {
   background-color: var(--ifm-background-surface-color);
-  z-index: 100;
+  z-index: 200;
+  width: 80vw;
+  max-width: 350px;
+}
+
+.navbar-sidebar__backdrop {
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 199;
 }
 
 .navbar-sidebar__brand {
   align-items: center;
+  padding: 0.75rem 1rem;
 }
 
 .navbar-sidebar__brand .navbar__logo {
@@ -125,6 +149,17 @@ body {
   width: 2rem;
   min-width: 2rem;
   min-height: 2rem;
+}
+
+.navbar-sidebar .menu {
+  padding: 0.5rem 0;
+}
+
+.navbar-sidebar .menu__link {
+  padding: 0.75rem 1rem;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
 }
 
 /* Ensure hamburger toggle is tappable on mobile */

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -112,8 +112,7 @@ body {
 
 /* Mobile navbar sidebar fixes */
 .navbar-sidebar {
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  background-color: var(--ifm-background-surface-color);
   z-index: 100;
 }
 


### PR DESCRIPTION
## Summary

- **Fix dark overlay on navbar ribbon** when the hamburger menu sidebar opens — replaced translucent `backdrop-filter: blur` with an opaque theme-aware background color
- **Add `z-index: 200` to navbar** to prevent layering issues with other page elements
- **Add `@supports` fallback** for browsers that don't support `backdrop-filter`, providing a solid opaque navbar background instead of content bleeding through
- **Improve mobile sidebar UX**: proper width sizing (`80vw` / `max-width: 350px`), 44px touch targets on menu links, explicit backdrop overlay, and comfortable padding

## Test plan

- [ ] Open the site on a mobile device or narrow browser window
- [ ] Tap the hamburger menu — sidebar should open with a clean background (no dark overlay on the navbar)
- [ ] Verify menu items are easy to tap (44px min touch targets)
- [ ] Tap outside the sidebar to dismiss it
- [ ] Test in both light and dark mode
- [ ] Test in an older browser without backdrop-filter support (e.g. IE11 or disable in DevTools) — navbar should have a solid background