### PR TITLE
Fix mobile navbar sidebar stacking context and z-index issues

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -126,17 +126,23 @@ body {
 /* Dark mode logo is handled via srcDark in docusaurus.config.ts
    instead of CSS filter: invert(1) for better cross-browser consistency */
 
+/* When the mobile sidebar is open, remove backdrop-filter from navbar
+   so the sidebar's position:fixed isn't trapped in the navbar's stacking context
+   (backdrop-filter creates a new containing block for fixed descendants) */
+.navbar-sidebar--show.navbar {
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+
 /* Mobile navbar sidebar fixes */
 .navbar-sidebar {
   background-color: var(--ifm-background-surface-color);
-  z-index: 200;
   width: 80vw;
   max-width: 350px;
 }
 
 .navbar-sidebar__backdrop {
   background-color: rgba(0, 0, 0, 0.5);
-  z-index: 199;
 }
 
 .navbar-sidebar__brand {
@@ -160,15 +166,6 @@ body {
   min-height: 44px;
   display: flex;
   align-items: center;
-}
-
-/* Ensure hamburger toggle is tappable on mobile */
-.navbar__toggle {
-  min-width: 44px;
-  min-height: 44px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .navbar__title {


### PR DESCRIPTION
## Summary
This PR fixes layout issues with the mobile navbar sidebar by removing problematic z-index values and the backdrop-filter property that was creating an unintended stacking context, preventing the sidebar from displaying correctly when open.

## Key Changes
- **Removed z-index declarations** from `.navbar-sidebar` (was 200) and `.navbar-sidebar__backdrop` (was 199) to rely on natural stacking order and prevent stacking context conflicts
- **Disabled backdrop-filter on navbar when sidebar is open** by adding a new `.navbar-sidebar--show.navbar` rule that sets `backdrop-filter: none`, since backdrop-filter creates a new containing block that traps fixed-position descendants
- **Removed hamburger toggle styling** (`.navbar__toggle` rule with min-width/height of 44px) that appears to be redundant or handled elsewhere

## Implementation Details
The backdrop-filter removal is the key fix here—when backdrop-filter is applied to the navbar, it creates a new stacking context and containing block, which prevents the sidebar's `position: fixed` from working as intended. By conditionally removing it when the sidebar is open (`.navbar-sidebar--show` class), the sidebar can properly escape the navbar's containing block and display correctly.