### PR TITLE
Refactor PPO training: minibatch shuffling, LR logging, and reward improvements

### DIFF
--- a/environments/shared/jax_curriculum.py
+++ b/environments/shared/jax_curriculum.py
@@ -86,7 +86,7 @@ def run_curriculum(
             "target_kl": "target_kl",
         }
         for toml_key, param_name in _JAX_KEY_MAP.items():
-            if toml_key in jax_kwargs and param_name not in stage_train_kwargs:
+            if toml_key in jax_kwargs:
                 stage_train_kwargs[param_name] = jax_kwargs[toml_key]
 
         # Always pass env_kwargs so reward weights reach the MJX env

--- a/environments/shared/jax_ppo.py
+++ b/environments/shared/jax_ppo.py
@@ -67,7 +67,7 @@ def make_actor_critic(action_dim: int, hidden_dims: tuple[int, ...] = (512, 256)
         """Shared-backbone actor-critic for continuous control."""
 
         action_dim: int
-        hidden_dims: tuple[int, ...] = (256, 256)
+        hidden_dims: tuple[int, ...] = (512, 256)
 
         @nn.compact
         def __call__(self, obs):
@@ -115,16 +115,18 @@ def sample_action(params, network, obs, rng):
 
     # Sample from Gaussian
     noise = jax.random.normal(rng, shape=action_mean.shape)
-    action = action_mean + action_std * noise
+    raw_action = action_mean + action_std * noise
 
-    # Clamp to [-1, 1]
-    action = jnp.clip(action, -1.0, 1.0)
-
-    # Log probability (diagonal Gaussian)
+    # Log probability computed on the *unclipped* action so the Gaussian
+    # PDF is correct (clipping squashes probability mass at the boundaries,
+    # biasing the PPO ratio if log_prob is computed after clipping).
     log_prob = -0.5 * jnp.sum(
-        jnp.square((action - action_mean) / (action_std + 1e-8)) + 2.0 * action_log_std + jnp.log(2.0 * jnp.pi),
+        jnp.square((raw_action - action_mean) / (action_std + 1e-8)) + 2.0 * action_log_std + jnp.log(2.0 * jnp.pi),
         axis=-1,
     )
+
+    # Clamp to [-1, 1] after computing log_prob
+    action = jnp.clip(raw_action, -1.0, 1.0)
 
     return action, log_prob, value
 

--- a/environments/shared/jax_reward_termination.py
+++ b/environments/shared/jax_reward_termination.py
@@ -119,7 +119,11 @@ def compute_total_reward(
     if approach_w > 0 and target_pos is not None and prev_target_distance is not None:
         target_dist = jnp.linalg.norm(target_pos - pelvis_xpos)
         r_approach, _ = reward_approach_shaping(
-            target_dist, prev_target_distance, approach_w, forward_vel_max, dt,
+            target_dist,
+            prev_target_distance,
+            approach_w,
+            forward_vel_max,
+            dt,
         )
         total = total + r_approach
 
@@ -189,9 +193,7 @@ def compute_total_reward(
         terminated = terminated | (tilt > max_tilt_angle)
         forward_z = quat_to_forward_z(root_quat)
         nosedive_threshold = reward_cfg.get("nosedive_termination_threshold", 0.5)
-        nosedive_terminated, _ = check_nosedive_termination(
-            forward_z, natural_forward_z, threshold=nosedive_threshold
-        )
+        nosedive_terminated, _ = check_nosedive_termination(forward_z, natural_forward_z, threshold=nosedive_threshold)
         terminated = terminated | nosedive_terminated
         total = jnp.where(terminated & ~success, total + fall_penalty, total)
 

--- a/environments/shared/jax_reward_termination.py
+++ b/environments/shared/jax_reward_termination.py
@@ -23,6 +23,7 @@ from .reward_functions import (
     reward_action_smoothness,
     reward_alive,
     reward_angular_velocity_penalty,
+    reward_approach_shaping,
     reward_drift_penalty,
     reward_energy,
     reward_forward_velocity,
@@ -48,6 +49,7 @@ def compute_total_reward(
     *,
     root_body_id: int,
     healthy_z_min: float,
+    healthy_z_max: float = 2.0,
     max_tilt_angle: float,
     natural_forward_z: float,
     n_actuators: int,
@@ -57,6 +59,14 @@ def compute_total_reward(
     prev_action: Array | None = None,
     sensor_tail_gyro_start: int | None = None,
     forward_ref_2d: Array | None = None,
+    target_pos: Array | None = None,
+    prev_target_distance: Array | None = None,
+    forward_vel_max: float = 8.0,
+    dt: float = 0.01,
+    fall_penalty: float = 0.0,
+    success_site_positions: Array | None = None,
+    success_threshold: float = 0.3,
+    success_bonus: float = 0.0,
 ) -> Array:
     """Compute total scalar reward matching ``mjx_env.py`` step logic.
 
@@ -73,20 +83,21 @@ def compute_total_reward(
     vel_2d = data.qvel[:2]
     forward_dir = forward_ref_2d if forward_ref_2d is not None else jnp.array([1.0, 0.0])
     pelvis_z = data.xpos[root_body_id, 2]
+    pelvis_xpos = data.xpos[root_body_id]
     root_quat = data.sensordata[sensor_quat_start : sensor_quat_start + 4]
 
     # Forward velocity
     r_forward, _ = reward_forward_velocity(
         vel_2d,
         forward_dir,
-        reward_cfg.get("forward_vel_max", 8.0),
+        reward_cfg.get("forward_vel_max", forward_vel_max),
         reward_cfg.get("forward_vel_weight", 0.0),
     )
 
     # Alive bonus (height-gated, optionally foot-contact-gated)
     raw_alive = reward_alive(reward_cfg.get("alive_bonus", 0.1))
     height_frac = jnp.clip(
-        (pelvis_z - healthy_z_min) / (0.90 - healthy_z_min),
+        (pelvis_z - healthy_z_min) / (healthy_z_max - healthy_z_min),
         0.0,
         1.0,
     )
@@ -103,6 +114,15 @@ def compute_total_reward(
 
     total = r_forward + r_alive + r_energy + r_posture
 
+    # Approach shaping (reward moving toward target)
+    approach_w = reward_cfg.get("bite_approach_weight", reward_cfg.get("approach_weight", 0.0))
+    if approach_w > 0 and target_pos is not None and prev_target_distance is not None:
+        target_dist = jnp.linalg.norm(target_pos - pelvis_xpos)
+        r_approach, _ = reward_approach_shaping(
+            target_dist, prev_target_distance, approach_w, forward_vel_max, dt,
+        )
+        total = total + r_approach
+
     # Conditional components (weight > 0 resolved at trace time)
     foot_contact_w = reward_cfg.get("foot_contact_weight", 0.0)
     if foot_contact_w > 0:
@@ -111,7 +131,7 @@ def compute_total_reward(
 
     height_w = reward_cfg.get("height_weight", 0.0)
     if height_w > 0:
-        total = total + reward_height_maintenance(pelvis_z, healthy_z_min, 0.90, height_w)
+        total = total + reward_height_maintenance(pelvis_z, healthy_z_min, healthy_z_max, height_w)
 
     nosedive_w = reward_cfg.get("nosedive_weight", 0.0)
     if nosedive_w > 0:
@@ -154,6 +174,27 @@ def compute_total_reward(
         r_heading, _ = reward_heading_alignment(body_fwd_2d, forward_dir, heading_w)
         total = total + r_heading
 
+    # Success bonus (stage 3 proximity-based contact detection)
+    success = jnp.bool_(False)
+    if success_bonus > 0 and success_site_positions is not None:
+        for i in range(success_site_positions.shape[0]):
+            dist = jnp.linalg.norm(success_site_positions[i] - target_pos)
+            success = success | (dist < success_threshold)
+        total = jnp.where(success, total + success_bonus, total)
+
+    # Fall penalty on termination (but not on success)
+    if fall_penalty != 0.0:
+        tilt = quat_to_tilt(root_quat)
+        terminated = (pelvis_z < healthy_z_min) | (pelvis_z > healthy_z_max)
+        terminated = terminated | (tilt > max_tilt_angle)
+        forward_z = quat_to_forward_z(root_quat)
+        nosedive_threshold = reward_cfg.get("nosedive_termination_threshold", 0.5)
+        nosedive_terminated, _ = check_nosedive_termination(
+            forward_z, natural_forward_z, threshold=nosedive_threshold
+        )
+        terminated = terminated | nosedive_terminated
+        total = jnp.where(terminated & ~success, total + fall_penalty, total)
+
     return total
 
 
@@ -164,6 +205,7 @@ def compute_reward_components(
     *,
     root_body_id: int,
     healthy_z_min: float,
+    healthy_z_max: float = 2.0,
     max_tilt_angle: float,
     natural_forward_z: float,
     n_actuators: int,
@@ -195,7 +237,7 @@ def compute_reward_components(
 
     raw_alive = reward_alive(reward_cfg.get("alive_bonus", 0.1))
     height_frac = jnp.clip(
-        (pelvis_z - healthy_z_min) / (0.90 - healthy_z_min),
+        (pelvis_z - healthy_z_min) / (healthy_z_max - healthy_z_min),
         0.0,
         1.0,
     )
@@ -220,7 +262,7 @@ def compute_reward_components(
 
     height_w = reward_cfg.get("height_weight", 0.0)
     if height_w > 0:
-        components["height"] = reward_height_maintenance(pelvis_z, healthy_z_min, 0.90, height_w)
+        components["height"] = reward_height_maintenance(pelvis_z, healthy_z_min, healthy_z_max, height_w)
 
     nosedive_w = reward_cfg.get("nosedive_weight", 0.0)
     if nosedive_w > 0:

--- a/environments/shared/jax_setup.py
+++ b/environments/shared/jax_setup.py
@@ -629,7 +629,7 @@ def print_eval_summary(
     """Print evaluation results and gate status."""
     import numpy as np
 
-    print(f"\nEvaluation results ({eval_results.n_episodes} episodes):")
+    print(f"\nEvaluation results ({len(eval_results.rewards)} episodes):")
     print(f"  Mean reward:   {eval_results.mean_reward:.2f} +/- {eval_results.std_reward:.2f}")
     print(f"  Mean length:   {eval_results.mean_length:.1f} +/- {eval_results.std_length:.1f}")
     print(f"  Mean fwd vel:  {eval_results.mean_forward_vel:.3f} m/s")

--- a/environments/shared/jax_setup.py
+++ b/environments/shared/jax_setup.py
@@ -439,6 +439,7 @@ def make_reward_fns(ctx: SpeciesContext):
     reward_kw = dict(
         root_body_id=ctx.root_body_id,
         healthy_z_min=ctx.healthy_z_range[0],
+        healthy_z_max=ctx.healthy_z_range[1],
         max_tilt_angle=ctx.max_tilt_angle,
         natural_forward_z=ctx.natural_forward_z,
         n_actuators=ctx.mj_model.nu,

--- a/environments/shared/jax_trainer.py
+++ b/environments/shared/jax_trainer.py
@@ -361,7 +361,6 @@ def train(
     from .jax_ppo import compute_gae
     from .jax_training_utils import (
         EpisodeStatsAccumulator,
-        RolloutProfiler,
         StabilityMonitor,
         TrainingCSVLogger,
         compute_episode_stats,
@@ -400,15 +399,12 @@ def train(
     best_params = None
     best_update = -1
 
-    # Episode tracking (on-device)
-    _ep_returns = jnp.zeros(NUM_ENVS)
-    _ep_lengths = jnp.zeros(NUM_ENVS, dtype=jnp.int32)
+    # Episode tracking
     _ep_stats_acc = EpisodeStatsAccumulator()
 
     # Library utilities
     _ckpt_mgr = CheckpointManager(config.model_dir, prefix="checkpoint", max_keep=config.max_checkpoints)
     _stability = StabilityMonitor()
-    _profiler = RolloutProfiler(interval=50)
     _csv_logger = TrainingCSVLogger(config.output_dir / "training_log.csv")
     csv_path = _csv_logger.path
 
@@ -497,9 +493,6 @@ def train(
                 states, rewards, terminated, truncated = env.step(states, actions, rng_step)
                 dones = terminated | truncated
 
-                _ep_returns = _ep_returns + rewards
-                _ep_lengths = _ep_lengths + 1
-
                 # For GAE: only zero bootstrap on true termination, not truncation
                 gae_dones = terminated
 
@@ -510,9 +503,6 @@ def train(
                 all_rewards.append(rewards)
                 all_dones.append(gae_dones.astype(jnp.float32))
                 all_full_dones.append(dones.astype(jnp.float32))
-
-                _ep_returns = jnp.where(dones, 0.0, _ep_returns)
-                _ep_lengths = jnp.where(dones, 0, _ep_lengths)
 
             obs_t = jnp.stack(all_obs)
             act_t = jnp.stack(all_actions)
@@ -575,6 +565,14 @@ def train(
             _t_ppo = time.time() - _t_phase
             _cum_t_ppo += _t_ppo
 
+            # Compute current learning rate for logging
+            if config.learning_rate_end is not None and config.learning_rate_end != config.learning_rate:
+                total_lr_steps = config.num_updates * config.ppo_epochs
+                lr_step = min(relative_update * config.ppo_epochs, total_lr_steps)
+                current_lr = config.learning_rate + (config.learning_rate_end - config.learning_rate) * lr_step / total_lr_steps
+            else:
+                current_lr = config.learning_rate
+
             avg_reward = float(rew_t.mean())
 
             # Episode return stats
@@ -596,6 +594,7 @@ def train(
                     "loss": avg_loss,
                     "grad_norm": avg_grad_norm,
                     "fall_rate": fall_rate,
+                    "learning_rate": current_lr,
                     "t_rollout": _t_rollout,
                     "t_ppo": _t_ppo,
                     **avg_aux,
@@ -610,7 +609,7 @@ def train(
                     _comp_means["update"] = update
                     reward_component_history.append(_comp_means)
                 except Exception:
-                    pass
+                    _logger.debug("Reward component diagnostics failed at update %d", update, exc_info=True)
 
             # ---------- Stability watchdog ----------
             _kl = avg_aux.get("approx_kl", 0.0)
@@ -648,6 +647,7 @@ def train(
                     "steps": steps_done,
                     "sps": f"{sps:.0f}",
                     "fall_rate": f"{fall_rate:.4f}",
+                    "learning_rate": f"{current_lr:.2e}",
                     "elapsed": f"{elapsed:.1f}",
                     "t_rollout": f"{_t_rollout:.3f}",
                     "t_ppo": f"{_t_ppo:.3f}",
@@ -727,10 +727,6 @@ def train(
 
     if _stability.total_warnings > 0:
         print(f"\nTotal stability warnings: {_stability.total_warnings}")
-
-    _prof_summary = _profiler.summary()
-    if _prof_summary:
-        print(f"\n{_prof_summary}")
 
     # Save final parameters
     params_path = config.model_dir / "params.pkl"
@@ -914,7 +910,7 @@ class JaxTrainer:
         return collect_rollout
 
     def _build_scan_ppo_update(self):
-        """Build the JIT-compiled PPO updater with KL early stopping."""
+        """Build the JIT-compiled PPO updater with minibatch shuffling and KL early stopping."""
         import jax
         import jax.numpy as jnp
 
@@ -923,37 +919,58 @@ class JaxTrainer:
         optimizer = self.optimizer
         network = self.network
         ppo_config = self.ppo_config
+        n_minibatches = ppo_config.n_minibatches
 
         @jax.jit
         def scan_ppo_update(params, opt_state, batch, rng):
+            total_samples = batch["obs"].shape[0]
+            minibatch_size = total_samples // n_minibatches
+
             def epoch_fn(carry, _):
                 params, opt_state, rng, kl_exceeded = carry
-                new_params, new_opt_state, loss_info = ppo_update(
-                    params,
-                    opt_state,
-                    optimizer,
-                    network,
-                    batch,
-                    ppo_config,
-                )
-                approx_kl = loss_info["approx_kl"]
+                rng, rng_perm = jax.random.split(rng)
+                perm = jax.random.permutation(rng_perm, total_samples)
 
-                use_target_kl = ppo_config.target_kl is not None
-                kl_over = use_target_kl & (approx_kl > ppo_config.target_kl)
-                should_skip = kl_exceeded | kl_over
+                def to_mbs(arr):
+                    return arr[perm[: n_minibatches * minibatch_size]].reshape(
+                        n_minibatches, minibatch_size, *arr.shape[1:]
+                    )
 
-                out_params = jax.tree.map(
-                    lambda new, old: jnp.where(should_skip, old, new),
-                    new_params,
-                    params,
-                )
-                out_opt_state = jax.tree.map(
-                    lambda new, old: jnp.where(should_skip, old, new) if hasattr(new, "shape") else new,
-                    new_opt_state,
-                    opt_state,
-                )
+                mb_batch = jax.tree.map(to_mbs, batch)
 
-                return (out_params, out_opt_state, rng, should_skip), loss_info
+                def mb_step(carry, mb):
+                    params, opt_state, kl_exceeded = carry
+                    new_params, new_opt_state, loss_info = ppo_update(
+                        params,
+                        opt_state,
+                        optimizer,
+                        network,
+                        mb,
+                        ppo_config,
+                    )
+                    approx_kl = loss_info["approx_kl"]
+
+                    use_target_kl = ppo_config.target_kl is not None
+                    kl_over = use_target_kl & (approx_kl > ppo_config.target_kl)
+                    should_skip = kl_exceeded | kl_over
+
+                    out_params = jax.tree.map(
+                        lambda new, old: jnp.where(should_skip, old, new),
+                        new_params,
+                        params,
+                    )
+                    out_opt_state = jax.tree.map(
+                        lambda new, old: jnp.where(should_skip, old, new) if hasattr(new, "shape") else new,
+                        new_opt_state,
+                        opt_state,
+                    )
+
+                    return (out_params, out_opt_state, should_skip), loss_info
+
+                (params, opt_state, kl_exceeded), all_mb_info = jax.lax.scan(
+                    mb_step, (params, opt_state, kl_exceeded), mb_batch
+                )
+                return (params, opt_state, rng, kl_exceeded), all_mb_info
 
             init_carry = (params, opt_state, rng, jnp.bool_(False))
             (params, opt_state, _, _), all_info = jax.lax.scan(
@@ -962,7 +979,8 @@ class JaxTrainer:
                 None,
                 length=ppo_config.n_epochs,
             )
-            return params, opt_state
+            mean_info = jax.tree.map(jnp.mean, all_info)
+            return params, opt_state, mean_info
 
         return scan_ppo_update
 
@@ -1106,12 +1124,13 @@ class JaxTrainer:
                 t_ppo_start = time.time()
                 rng, ppo_rng = jax.random.split(state.rng)
                 state.rng = rng
-                state.params, state.opt_state = self._scan_ppo_update(
+                state.params, state.opt_state, ppo_info = self._scan_ppo_update(
                     state.params,
                     state.opt_state,
                     batch,
                     ppo_rng,
                 )
+                ppo_info = {k: float(v) for k, v in ppo_info.items()}
                 t_ppo = time.time() - t_ppo_start
                 state.t_ppo_cumulative += t_ppo
 
@@ -1129,6 +1148,7 @@ class JaxTrainer:
                     "elapsed": elapsed,
                     "t_rollout": t_rollout,
                     "t_ppo": t_ppo,
+                    **ppo_info,
                 }
                 state.history.append(update_metrics)
                 self._dispatch("on_update_end", state, update_metrics)

--- a/environments/shared/jax_trainer.py
+++ b/environments/shared/jax_trainer.py
@@ -569,7 +569,9 @@ def train(
             if config.learning_rate_end is not None and config.learning_rate_end != config.learning_rate:
                 total_lr_steps = config.num_updates * config.ppo_epochs
                 lr_step = min(relative_update * config.ppo_epochs, total_lr_steps)
-                current_lr = config.learning_rate + (config.learning_rate_end - config.learning_rate) * lr_step / total_lr_steps
+                current_lr = (
+                    config.learning_rate + (config.learning_rate_end - config.learning_rate) * lr_step / total_lr_steps
+                )
             else:
                 current_lr = config.learning_rate
 

--- a/environments/shared/jax_training.py
+++ b/environments/shared/jax_training.py
@@ -34,7 +34,6 @@ def train_jax(
     rollout_len: int = 64,
     seed: int = 42,
     checkpoint_dir: str | None = None,
-    wandb_project: str | None = None,
     init_params: Any | None = None,
     learning_rate: float = 3e-4,
     learning_rate_end: float | None = None,
@@ -62,7 +61,6 @@ def train_jax(
         rollout_len: Number of steps per rollout.
         seed: Random seed.
         checkpoint_dir: Optional directory for saving checkpoints.
-        wandb_project: Optional W&B project name for logging.
         init_params: Optional initial network parameters (for curriculum).
         learning_rate: PPO learning rate.
         learning_rate_end: Final LR for linear decay (None = constant LR).
@@ -173,7 +171,6 @@ def main():
     parser.add_argument("--rollout-len", type=int, default=64)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--checkpoint-dir", type=str, default=None)
-    parser.add_argument("--wandb-project", type=str, default=None)
     parser.add_argument("--learning-rate", type=float, default=3e-4)
     parser.add_argument("--curriculum", action="store_true", help="Run full 3-stage curriculum")
 
@@ -219,7 +216,6 @@ def main():
             rollout_len=jax_kwargs.get("rollout_len", args.rollout_len),
             seed=args.seed,
             checkpoint_dir=args.checkpoint_dir,
-            wandb_project=args.wandb_project,
             learning_rate=jax_kwargs.get("learning_rate", args.learning_rate),
             learning_rate_end=jax_kwargs.get("learning_rate_end"),
             gamma=jax_kwargs.get("gamma", 0.99),

--- a/environments/shared/jax_training_utils.py
+++ b/environments/shared/jax_training_utils.py
@@ -205,6 +205,7 @@ DEFAULT_CSV_FIELDS: list[str] = [
     "steps",
     "sps",
     "fall_rate",
+    "learning_rate",
     "elapsed",
     "t_rollout",
     "t_ppo",

--- a/environments/shared/mjx_env.py
+++ b/environments/shared/mjx_env.py
@@ -401,7 +401,9 @@ class MJXDinoEnv:
 
             height_w = weights.get("height_weight", 0.0)
             if height_w > 0:
-                r_height = reward_height_maintenance(pelvis_xpos[2], config.healthy_z_range[0], config.healthy_z_range[1], height_w)
+                r_height = reward_height_maintenance(
+                    pelvis_xpos[2], config.healthy_z_range[0], config.healthy_z_range[1], height_w
+                )
                 total_reward = total_reward + r_height
 
             # Tail stability: penalise tail tip angular velocity

--- a/environments/shared/mjx_env.py
+++ b/environments/shared/mjx_env.py
@@ -339,7 +339,7 @@ class MJXDinoEnv:
             # no reward for lying flat or balancing on head/nose
             raw_alive = reward_alive(weights.get("alive_bonus", 0.1))
             height_frac = jnp.clip(
-                (pelvis_xpos[2] - config.healthy_z_range[0]) / (0.90 - config.healthy_z_range[0]),
+                (pelvis_xpos[2] - config.healthy_z_range[0]) / (config.healthy_z_range[1] - config.healthy_z_range[0]),
                 0.0,
                 1.0,
             )
@@ -401,7 +401,7 @@ class MJXDinoEnv:
 
             height_w = weights.get("height_weight", 0.0)
             if height_w > 0:
-                r_height = reward_height_maintenance(pelvis_xpos[2], config.healthy_z_range[0], 0.90, height_w)
+                r_height = reward_height_maintenance(pelvis_xpos[2], config.healthy_z_range[0], config.healthy_z_range[1], height_w)
                 total_reward = total_reward + r_height
 
             # Tail stability: penalise tail tip angular velocity

--- a/environments/shared/tests/test_jax_ppo.py
+++ b/environments/shared/tests/test_jax_ppo.py
@@ -1,0 +1,128 @@
+"""Tests for jax_ppo module — focuses on fixes from the JAX review."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fix #1: log_prob must be computed BEFORE action clipping
+# ---------------------------------------------------------------------------
+
+
+class TestSampleActionLogProb:
+    """Verify that log_prob is computed on the raw (unclipped) action."""
+
+    @pytest.fixture()
+    def _jax(self):
+        jax = pytest.importorskip("jax")
+        jnp = pytest.importorskip("jax.numpy")
+        return jax, jnp
+
+    def test_log_prob_independent_of_clip_boundary(self, _jax):
+        """Actions near ±1 should have log_probs consistent with the Gaussian,
+        not distorted by the clip operation."""
+        jax, jnp = _jax
+        from environments.shared.jax_ppo import make_actor_critic, sample_action
+
+        network = make_actor_critic(action_dim=2, hidden_dims=(8,))
+        rng = jax.random.PRNGKey(0)
+        dummy = jnp.zeros(4)
+        params = network.init(rng, dummy)
+
+        # Sample many actions and collect log_probs
+        rng, *rngs = jax.random.split(rng, 101)
+        log_probs = []
+        actions = []
+        for r in rngs:
+            a, lp, _ = sample_action(params, network, dummy, r)
+            log_probs.append(float(lp))
+            actions.append(np.array(a))
+
+        # log_probs should be finite and not all identical
+        assert all(np.isfinite(lp) for lp in log_probs)
+        assert np.std(log_probs) > 0, "log_probs should vary across samples"
+
+    def test_log_prob_matches_manual_gaussian(self, _jax):
+        """log_prob should match the analytical diagonal-Gaussian formula
+        applied to the raw (pre-clip) action."""
+        jax, jnp = _jax
+        from environments.shared.jax_ppo import make_actor_critic, sample_action
+
+        network = make_actor_critic(action_dim=2, hidden_dims=(8,))
+        rng = jax.random.PRNGKey(42)
+        dummy = jnp.zeros(4)
+        params = network.init(rng, dummy)
+
+        rng, sample_rng = jax.random.split(rng)
+        action, log_prob, _ = sample_action(params, network, dummy, sample_rng)
+
+        # Recompute what the network outputs
+        mean, log_std, _ = network.apply(params, dummy)
+        std = jnp.exp(log_std)
+
+        # The action returned is clipped, but log_prob should be based on
+        # the unclipped sample. For actions well within [-1, 1] (std is
+        # initially small from zeros init), clipped == unclipped, so
+        # manual computation should match.
+        manual_lp = -0.5 * jnp.sum(
+            jnp.square((action - mean) / (std + 1e-8))
+            + 2.0 * log_std
+            + jnp.log(2.0 * jnp.pi)
+        )
+        # When action is within bounds, clipped == raw, so they must match
+        if jnp.all(jnp.abs(action) < 0.99):
+            assert float(log_prob) == pytest.approx(float(manual_lp), abs=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Fix #12: hidden_dims default consistency
+# ---------------------------------------------------------------------------
+
+
+class TestActorCriticDefaults:
+    def test_default_hidden_dims_match(self):
+        """The inner class default should match the outer function default."""
+        jax = pytest.importorskip("jax")
+        from environments.shared.jax_ppo import make_actor_critic
+
+        network = make_actor_critic(action_dim=3)
+        # The network's hidden_dims attribute should be (512, 256)
+        assert network.hidden_dims == (512, 256)
+
+    def test_custom_hidden_dims_propagated(self):
+        """Custom hidden_dims should be passed through correctly."""
+        jax = pytest.importorskip("jax")
+        from environments.shared.jax_ppo import make_actor_critic
+
+        network = make_actor_critic(action_dim=3, hidden_dims=(64, 32))
+        assert network.hidden_dims == (64, 32)
+
+
+# ---------------------------------------------------------------------------
+# PPOConfig: learning rate schedule total_steps
+# ---------------------------------------------------------------------------
+
+
+class TestMakeOptimizer:
+    def test_constant_lr(self):
+        optax = pytest.importorskip("optax")
+        from environments.shared.jax_ppo import PPOConfig, make_optimizer
+
+        cfg = PPOConfig(learning_rate=1e-3, learning_rate_end=None)
+        opt = make_optimizer(cfg)
+        assert opt is not None
+
+    def test_linear_decay_lr(self):
+        optax = pytest.importorskip("optax")
+        from environments.shared.jax_ppo import PPOConfig, make_optimizer
+
+        cfg = PPOConfig(
+            learning_rate=3e-4,
+            learning_rate_end=1e-5,
+            total_updates=100,
+            n_epochs=4,
+        )
+        opt = make_optimizer(cfg)
+        assert opt is not None

--- a/environments/shared/tests/test_jax_ppo.py
+++ b/environments/shared/tests/test_jax_ppo.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Fix #1: log_prob must be computed BEFORE action clipping
 # ---------------------------------------------------------------------------
@@ -66,11 +65,7 @@ class TestSampleActionLogProb:
         # the unclipped sample. For actions well within [-1, 1] (std is
         # initially small from zeros init), clipped == unclipped, so
         # manual computation should match.
-        manual_lp = -0.5 * jnp.sum(
-            jnp.square((action - mean) / (std + 1e-8))
-            + 2.0 * log_std
-            + jnp.log(2.0 * jnp.pi)
-        )
+        manual_lp = -0.5 * jnp.sum(jnp.square((action - mean) / (std + 1e-8)) + 2.0 * log_std + jnp.log(2.0 * jnp.pi))
         # When action is within bounds, clipped == raw, so they must match
         if jnp.all(jnp.abs(action) < 0.99):
             assert float(log_prob) == pytest.approx(float(manual_lp), abs=1e-5)
@@ -84,7 +79,7 @@ class TestSampleActionLogProb:
 class TestActorCriticDefaults:
     def test_default_hidden_dims_match(self):
         """The inner class default should match the outer function default."""
-        jax = pytest.importorskip("jax")
+        pytest.importorskip("jax")
         from environments.shared.jax_ppo import make_actor_critic
 
         network = make_actor_critic(action_dim=3)
@@ -93,7 +88,7 @@ class TestActorCriticDefaults:
 
     def test_custom_hidden_dims_propagated(self):
         """Custom hidden_dims should be passed through correctly."""
-        jax = pytest.importorskip("jax")
+        pytest.importorskip("jax")
         from environments.shared.jax_ppo import make_actor_critic
 
         network = make_actor_critic(action_dim=3, hidden_dims=(64, 32))
@@ -107,7 +102,7 @@ class TestActorCriticDefaults:
 
 class TestMakeOptimizer:
     def test_constant_lr(self):
-        optax = pytest.importorskip("optax")
+        pytest.importorskip("optax")
         from environments.shared.jax_ppo import PPOConfig, make_optimizer
 
         cfg = PPOConfig(learning_rate=1e-3, learning_rate_end=None)
@@ -115,7 +110,7 @@ class TestMakeOptimizer:
         assert opt is not None
 
     def test_linear_decay_lr(self):
-        optax = pytest.importorskip("optax")
+        pytest.importorskip("optax")
         from environments.shared.jax_ppo import PPOConfig, make_optimizer
 
         cfg = PPOConfig(

--- a/environments/shared/tests/test_jax_reward_termination.py
+++ b/environments/shared/tests/test_jax_reward_termination.py
@@ -67,7 +67,9 @@ class TestHealthyZMax:
         # With healthy_z_max=1.5, a pelvis at 1.2 should get partial credit
         data = _make_mock_data(pelvis_z=1.2)
         r_high_max = compute_total_reward(
-            data, action, reward_cfg,
+            data,
+            action,
+            reward_cfg,
             root_body_id=1,
             healthy_z_min=0.3,
             healthy_z_max=1.5,
@@ -80,7 +82,9 @@ class TestHealthyZMax:
         # (fully healthy), but with 1.5 it should be partial
         data2 = _make_mock_data(pelvis_z=1.2)
         r_low_max = compute_total_reward(
-            data2, action, reward_cfg,
+            data2,
+            action,
+            reward_cfg,
             root_body_id=1,
             healthy_z_min=0.3,
             healthy_z_max=0.9,
@@ -103,7 +107,9 @@ class TestHealthyZMax:
         data = _make_mock_data(pelvis_z=0.6)
 
         components = compute_reward_components(
-            data, action, reward_cfg,
+            data,
+            action,
+            reward_cfg,
             root_body_id=1,
             healthy_z_min=0.3,
             healthy_z_max=1.5,
@@ -133,7 +139,9 @@ class TestRewardAlignment:
         # Pelvis below healthy_z_min -> terminated
         data = _make_mock_data(pelvis_z=0.1)
         r_with_penalty = compute_total_reward(
-            data, action, reward_cfg,
+            data,
+            action,
+            reward_cfg,
             root_body_id=1,
             healthy_z_min=0.3,
             healthy_z_max=1.5,
@@ -144,7 +152,9 @@ class TestRewardAlignment:
         )
 
         r_without_penalty = compute_total_reward(
-            data, action, reward_cfg,
+            data,
+            action,
+            reward_cfg,
             root_body_id=1,
             healthy_z_min=0.3,
             healthy_z_max=1.5,
@@ -155,9 +165,7 @@ class TestRewardAlignment:
         )
 
         assert float(r_with_penalty) < float(r_without_penalty)
-        assert float(r_with_penalty) == pytest.approx(
-            float(r_without_penalty) - 100.0, abs=0.01
-        )
+        assert float(r_with_penalty) == pytest.approx(float(r_without_penalty) - 100.0, abs=0.01)
 
     def test_no_fall_penalty_when_healthy(self):
         """Fall penalty should NOT be applied when agent is healthy."""
@@ -169,7 +177,9 @@ class TestRewardAlignment:
         # Pelvis well within healthy range
         data = _make_mock_data(pelvis_z=0.8)
         r_with = compute_total_reward(
-            data, action, reward_cfg,
+            data,
+            action,
+            reward_cfg,
             root_body_id=1,
             healthy_z_min=0.3,
             healthy_z_max=1.5,
@@ -179,7 +189,9 @@ class TestRewardAlignment:
             fall_penalty=-100.0,
         )
         r_without = compute_total_reward(
-            data, action, reward_cfg,
+            data,
+            action,
+            reward_cfg,
             root_body_id=1,
             healthy_z_min=0.3,
             healthy_z_max=1.5,
@@ -195,8 +207,7 @@ class TestRewardAlignment:
         from environments.shared.jax_reward_termination import compute_total_reward
 
         action = np.zeros(5)
-        reward_cfg = {"alive_bonus": 0.0, "forward_vel_weight": 0.0,
-                      "approach_weight": 1.0}
+        reward_cfg = {"alive_bonus": 0.0, "forward_vel_weight": 0.0, "approach_weight": 1.0}
 
         # Agent at x=2, target at x=5
         xpos = np.zeros((15, 3))
@@ -205,7 +216,9 @@ class TestRewardAlignment:
         target = jnp.array([5.0, 0.0, 0.5])
 
         r_closer = compute_total_reward(
-            data, action, reward_cfg,
+            data,
+            action,
+            reward_cfg,
             root_body_id=1,
             healthy_z_min=0.3,
             healthy_z_max=1.5,
@@ -219,7 +232,9 @@ class TestRewardAlignment:
         )
 
         r_farther = compute_total_reward(
-            data, action, reward_cfg,
+            data,
+            action,
+            reward_cfg,
             root_body_id=1,
             healthy_z_min=0.3,
             healthy_z_max=1.5,

--- a/environments/shared/tests/test_jax_reward_termination.py
+++ b/environments/shared/tests/test_jax_reward_termination.py
@@ -1,0 +1,282 @@
+"""Tests for jax_reward_termination — focuses on fixes from the JAX review.
+
+Requires JAX to be installed (uses jax.numpy internally).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+jnp = pytest.importorskip("jax.numpy")
+
+
+def _make_mock_data(
+    pelvis_z=0.8,
+    vel_2d=(1.0, 0.0),
+    quat=(1.0, 0.0, 0.0, 0.0),
+    sensordata=None,
+    xpos=None,
+    qpos=None,
+    qvel=None,
+):
+    """Create a mock MJX data object for reward/termination tests.
+
+    Uses jnp arrays since jax_reward_termination functions use jax.numpy.
+    """
+    n_sensors = 20
+    if sensordata is None:
+        sensordata = np.zeros(n_sensors)
+        sensordata[6:10] = quat
+    if xpos is None:
+        xpos = np.zeros((15, 3))
+        xpos[1, 2] = pelvis_z
+    if qpos is None:
+        qpos = np.zeros(20)
+    if qvel is None:
+        qvel = np.zeros(15)
+        qvel[0], qvel[1] = vel_2d
+
+    data = MagicMock()
+    data.qvel = jnp.array(qvel)
+    data.qpos = jnp.array(qpos)
+    data.xpos = jnp.array(xpos)
+    data.sensordata = jnp.array(sensordata)
+    data.site_xpos = jnp.zeros((5, 3))
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Fix #11: healthy_z_max replaces hardcoded 0.90
+# ---------------------------------------------------------------------------
+
+
+class TestHealthyZMax:
+    """Verify that healthy_z_max is used instead of hardcoded 0.90."""
+
+    def test_height_frac_uses_healthy_z_max(self):
+        """alive bonus height_frac should scale to healthy_z_max, not 0.90."""
+        from environments.shared.jax_reward_termination import compute_total_reward
+
+        action = np.zeros(5)
+        reward_cfg = {"alive_bonus": 1.0, "forward_vel_weight": 0.0}
+
+        # With healthy_z_max=1.5, a pelvis at 1.2 should get partial credit
+        data = _make_mock_data(pelvis_z=1.2)
+        r_high_max = compute_total_reward(
+            data, action, reward_cfg,
+            root_body_id=1,
+            healthy_z_min=0.3,
+            healthy_z_max=1.5,
+            max_tilt_angle=1.0,
+            natural_forward_z=0.0,
+            n_actuators=5,
+        )
+
+        # With healthy_z_max=0.9, pelvis at 1.2 would clip to 1.0
+        # (fully healthy), but with 1.5 it should be partial
+        data2 = _make_mock_data(pelvis_z=1.2)
+        r_low_max = compute_total_reward(
+            data2, action, reward_cfg,
+            root_body_id=1,
+            healthy_z_min=0.3,
+            healthy_z_max=0.9,
+            max_tilt_angle=1.0,
+            natural_forward_z=0.0,
+            n_actuators=5,
+        )
+
+        # With z_max=0.9, pelvis 1.2 is above max so height_frac clips to 1.0
+        # With z_max=1.5, pelvis 1.2 gives height_frac = (1.2-0.3)/(1.5-0.3) = 0.75
+        # So r_low_max (full credit) should be >= r_high_max (partial credit)
+        assert float(r_low_max) >= float(r_high_max)
+
+    def test_compute_reward_components_uses_healthy_z_max(self):
+        """compute_reward_components should also use healthy_z_max."""
+        from environments.shared.jax_reward_termination import compute_reward_components
+
+        action = np.zeros(5)
+        reward_cfg = {"alive_bonus": 1.0, "forward_vel_weight": 0.0}
+        data = _make_mock_data(pelvis_z=0.6)
+
+        components = compute_reward_components(
+            data, action, reward_cfg,
+            root_body_id=1,
+            healthy_z_min=0.3,
+            healthy_z_max=1.5,
+            max_tilt_angle=1.0,
+            natural_forward_z=0.0,
+            n_actuators=5,
+        )
+        assert "alive" in components
+        assert "_pelvis_z" in components
+
+
+# ---------------------------------------------------------------------------
+# Fix #9: compute_total_reward alignment with mjx_env.step
+# ---------------------------------------------------------------------------
+
+
+class TestRewardAlignment:
+    """Verify new reward terms (fall_penalty, approach, success) work."""
+
+    def test_fall_penalty_applied_on_termination(self):
+        """Fall penalty should be applied when the agent is terminated."""
+        from environments.shared.jax_reward_termination import compute_total_reward
+
+        action = np.zeros(5)
+        reward_cfg = {"alive_bonus": 0.1, "forward_vel_weight": 0.0}
+
+        # Pelvis below healthy_z_min -> terminated
+        data = _make_mock_data(pelvis_z=0.1)
+        r_with_penalty = compute_total_reward(
+            data, action, reward_cfg,
+            root_body_id=1,
+            healthy_z_min=0.3,
+            healthy_z_max=1.5,
+            max_tilt_angle=1.0,
+            natural_forward_z=0.0,
+            n_actuators=5,
+            fall_penalty=-100.0,
+        )
+
+        r_without_penalty = compute_total_reward(
+            data, action, reward_cfg,
+            root_body_id=1,
+            healthy_z_min=0.3,
+            healthy_z_max=1.5,
+            max_tilt_angle=1.0,
+            natural_forward_z=0.0,
+            n_actuators=5,
+            fall_penalty=0.0,
+        )
+
+        assert float(r_with_penalty) < float(r_without_penalty)
+        assert float(r_with_penalty) == pytest.approx(
+            float(r_without_penalty) - 100.0, abs=0.01
+        )
+
+    def test_no_fall_penalty_when_healthy(self):
+        """Fall penalty should NOT be applied when agent is healthy."""
+        from environments.shared.jax_reward_termination import compute_total_reward
+
+        action = np.zeros(5)
+        reward_cfg = {"alive_bonus": 0.1, "forward_vel_weight": 0.0}
+
+        # Pelvis well within healthy range
+        data = _make_mock_data(pelvis_z=0.8)
+        r_with = compute_total_reward(
+            data, action, reward_cfg,
+            root_body_id=1,
+            healthy_z_min=0.3,
+            healthy_z_max=1.5,
+            max_tilt_angle=1.0,
+            natural_forward_z=0.0,
+            n_actuators=5,
+            fall_penalty=-100.0,
+        )
+        r_without = compute_total_reward(
+            data, action, reward_cfg,
+            root_body_id=1,
+            healthy_z_min=0.3,
+            healthy_z_max=1.5,
+            max_tilt_angle=1.0,
+            natural_forward_z=0.0,
+            n_actuators=5,
+            fall_penalty=0.0,
+        )
+        assert float(r_with) == pytest.approx(float(r_without), abs=1e-6)
+
+    def test_approach_shaping_reward(self):
+        """Approach shaping should reward getting closer to target."""
+        from environments.shared.jax_reward_termination import compute_total_reward
+
+        action = np.zeros(5)
+        reward_cfg = {"alive_bonus": 0.0, "forward_vel_weight": 0.0,
+                      "approach_weight": 1.0}
+
+        # Agent at x=2, target at x=5
+        xpos = np.zeros((15, 3))
+        xpos[1] = [2.0, 0.0, 0.8]
+        data = _make_mock_data(pelvis_z=0.8, xpos=xpos)
+        target = jnp.array([5.0, 0.0, 0.5])
+
+        r_closer = compute_total_reward(
+            data, action, reward_cfg,
+            root_body_id=1,
+            healthy_z_min=0.3,
+            healthy_z_max=1.5,
+            max_tilt_angle=1.0,
+            natural_forward_z=0.0,
+            n_actuators=5,
+            target_pos=target,
+            prev_target_distance=jnp.float32(4.0),  # was 4m away
+            forward_vel_max=8.0,
+            dt=0.02,
+        )
+
+        r_farther = compute_total_reward(
+            data, action, reward_cfg,
+            root_body_id=1,
+            healthy_z_min=0.3,
+            healthy_z_max=1.5,
+            max_tilt_angle=1.0,
+            natural_forward_z=0.0,
+            n_actuators=5,
+            target_pos=target,
+            prev_target_distance=jnp.float32(2.5),  # was 2.5m away (moved away)
+            forward_vel_max=8.0,
+            dt=0.02,
+        )
+
+        # Getting closer should yield higher reward than moving away
+        assert float(r_closer) > float(r_farther)
+
+
+# ---------------------------------------------------------------------------
+# Termination
+# ---------------------------------------------------------------------------
+
+
+class TestIsTerminated:
+    def test_healthy_not_terminated(self):
+        from environments.shared.jax_reward_termination import is_terminated
+
+        data = _make_mock_data(pelvis_z=0.8)
+        terminated = is_terminated(
+            data,
+            root_body_id=1,
+            healthy_z_range=(0.3, 1.5),
+            max_tilt_angle=1.0,
+            natural_forward_z=0.0,
+        )
+        assert not bool(terminated)
+
+    def test_below_min_z_terminated(self):
+        from environments.shared.jax_reward_termination import is_terminated
+
+        data = _make_mock_data(pelvis_z=0.1)
+        terminated = is_terminated(
+            data,
+            root_body_id=1,
+            healthy_z_range=(0.3, 1.5),
+            max_tilt_angle=1.0,
+            natural_forward_z=0.0,
+        )
+        assert bool(terminated)
+
+    def test_above_max_z_terminated(self):
+        from environments.shared.jax_reward_termination import is_terminated
+
+        data = _make_mock_data(pelvis_z=2.0)
+        terminated = is_terminated(
+            data,
+            root_body_id=1,
+            healthy_z_range=(0.3, 1.5),
+            max_tilt_angle=1.0,
+            natural_forward_z=0.0,
+        )
+        assert bool(terminated)

--- a/environments/shared/tests/test_jax_training_utils.py
+++ b/environments/shared/tests/test_jax_training_utils.py
@@ -1,0 +1,162 @@
+"""Tests for jax_training_utils — focuses on fixes from the JAX review."""
+
+from __future__ import annotations
+
+import csv
+
+import numpy as np
+import pytest
+
+from environments.shared.jax_training_utils import (
+    DEFAULT_CSV_FIELDS,
+    EpisodeStatsAccumulator,
+    StabilityMonitor,
+    TrainingCSVLogger,
+    compute_episode_stats,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fix #8: learning_rate in CSV fields
+# ---------------------------------------------------------------------------
+
+
+class TestCSVFields:
+    def test_learning_rate_in_default_fields(self):
+        """DEFAULT_CSV_FIELDS should include learning_rate."""
+        assert "learning_rate" in DEFAULT_CSV_FIELDS
+
+    def test_csv_logger_writes_learning_rate(self, tmp_path):
+        """CSV logger should accept and write a learning_rate column."""
+        path = tmp_path / "test.csv"
+        logger = TrainingCSVLogger(path)
+        logger.log({
+            "update": 0,
+            "reward_per_step": "0.1",
+            "learning_rate": "3.00e-04",
+        })
+        logger.close()
+
+        with open(path) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["learning_rate"] == "3.00e-04"
+
+
+# ---------------------------------------------------------------------------
+# StabilityMonitor
+# ---------------------------------------------------------------------------
+
+
+class TestStabilityMonitor:
+    def test_stable_returns_no_message(self):
+        mon = StabilityMonitor()
+        halt, unstable, msg = mon.check(0.01, 5.0, 1.0, update=0)
+        assert not halt
+        assert not unstable
+        assert msg == ""
+
+    def test_kl_halt(self):
+        mon = StabilityMonitor(kl_halt=1e6)
+        halt, unstable, msg = mon.check(2e6, 0.0, 0.0, update=5)
+        assert halt
+        assert unstable
+        assert "HALTING" in msg
+
+    def test_consecutive_warnings_reset_on_stable(self):
+        mon = StabilityMonitor(kl_warn=0.5, max_warnings=3)
+        # Two warnings
+        mon.check(1.0, 0.0, 0.0, update=0)
+        mon.check(1.0, 0.0, 0.0, update=1)
+        assert mon._consecutive_warnings == 2
+        # One stable step resets
+        mon.check(0.01, 0.0, 0.0, update=2)
+        assert mon._consecutive_warnings == 0
+        assert mon.total_warnings == 2
+
+    def test_total_warnings_accumulate(self):
+        mon = StabilityMonitor(kl_warn=0.5, max_warnings=10)
+        mon.check(1.0, 0.0, 0.0, update=0)
+        mon.check(0.01, 0.0, 0.0, update=1)  # reset consecutive
+        mon.check(1.0, 0.0, 0.0, update=2)
+        assert mon.total_warnings == 2
+
+
+# ---------------------------------------------------------------------------
+# EpisodeStatsAccumulator
+# ---------------------------------------------------------------------------
+
+
+class TestEpisodeStatsAccumulator:
+    def test_multi_rollout_tracking(self):
+        """Episodes spanning multiple rollouts should be tracked correctly."""
+        acc = EpisodeStatsAccumulator()
+        # Rollout 1: no episodes complete (2 envs, 3 steps)
+        rewards1 = np.array([[1.0, 2.0], [1.0, 2.0], [1.0, 2.0]])
+        dones1 = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
+        rets1, lens1 = compute_episode_stats(rewards1, dones1, acc)
+        assert len(rets1) == 0
+
+        # Rollout 2: env 0 finishes at step 1
+        rewards2 = np.array([[1.0, 2.0], [1.0, 2.0]])
+        dones2 = np.array([[0.0, 0.0], [1.0, 0.0]])
+        rets2, lens2 = compute_episode_stats(rewards2, dones2, acc)
+        assert len(rets2) == 1
+        # Total: 3 steps from rollout1 + 2 from rollout2 = 5 steps
+        assert lens2[0] == 5
+        # Total return: 5 * 1.0 = 5.0
+        assert rets2[0] == pytest.approx(5.0)
+
+    def test_without_accumulator(self):
+        """Without accumulator, only within-rollout episodes are captured."""
+        rewards = np.array([[1.0, 2.0], [1.0, 2.0], [1.0, 2.0]])
+        dones = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+        rets, lens = compute_episode_stats(rewards, dones)
+        assert len(rets) == 2
+        assert lens[0] == 2  # env 0: steps 0-1
+        assert lens[1] == 3  # env 1: steps 0-2
+
+
+# ---------------------------------------------------------------------------
+# Fix #13: TOML kwargs override in curriculum
+# ---------------------------------------------------------------------------
+
+
+class TestCurriculumTomlOverride:
+    def test_toml_kwargs_override_train_kwargs(self):
+        """TOML jax_kwargs should override existing train_kwargs."""
+        from environments.shared.jax_curriculum import run_curriculum
+
+        calls = []
+
+        def mock_train(species, stage, **kwargs):
+            calls.append(kwargs.copy())
+            return {"w": 1.0}, {"mean_reward": 999.0}
+
+        # Patch load_stage_config to return a config with jax_kwargs
+        import environments.shared.jax_curriculum as jc
+        original_load = jc.load_stage_config
+
+        def mock_load(species, stage):
+            return {
+                "jax_kwargs": {"learning_rate": 1e-5, "num_updates": 200},
+                "env_kwargs": {},
+                "curriculum": {"min_avg_reward": -999.0},
+            }
+
+        jc.load_stage_config = mock_load
+        try:
+            run_curriculum(
+                "trex",
+                mock_train,
+                stages=(1,),
+                learning_rate=3e-4,  # This should be overridden by TOML
+            )
+        finally:
+            jc.load_stage_config = original_load
+
+        assert len(calls) == 1
+        # TOML value (1e-5) should override the kwarg (3e-4)
+        assert calls[0]["learning_rate"] == 1e-5
+        assert calls[0]["num_updates"] == 200

--- a/environments/shared/tests/test_jax_training_utils.py
+++ b/environments/shared/tests/test_jax_training_utils.py
@@ -15,7 +15,6 @@ from environments.shared.jax_training_utils import (
     compute_episode_stats,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fix #8: learning_rate in CSV fields
 # ---------------------------------------------------------------------------
@@ -30,11 +29,13 @@ class TestCSVFields:
         """CSV logger should accept and write a learning_rate column."""
         path = tmp_path / "test.csv"
         logger = TrainingCSVLogger(path)
-        logger.log({
-            "update": 0,
-            "reward_per_step": "0.1",
-            "learning_rate": "3.00e-04",
-        })
+        logger.log(
+            {
+                "update": 0,
+                "reward_per_step": "0.1",
+                "learning_rate": "3.00e-04",
+            }
+        )
         logger.close()
 
         with open(path) as f:
@@ -136,6 +137,7 @@ class TestCurriculumTomlOverride:
 
         # Patch load_stage_config to return a config with jax_kwargs
         import environments.shared.jax_curriculum as jc
+
         original_load = jc.load_stage_config
 
         def mock_load(species, stage):

--- a/notebooks/jax_training.ipynb
+++ b/notebooks/jax_training.ipynb
@@ -2,17 +2,18 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "cell_000",
    "metadata": {
-    "id": "view-in-github",
-    "colab_type": "text"
+    "colab_type": "text",
+    "id": "view-in-github"
    },
    "source": [
     "<a href=\"https://colab.research.google.com/github/kuds/mesozoic-labs/blob/main/notebooks/jax_training.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-   ],
-   "id": "cell_000"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_001",
    "metadata": {
     "id": "76bca92f"
    },
@@ -26,19 +27,21 @@
     "**Requirements:** Colab GPU runtime (A100 recommended).\n",
     "\n",
     "**Supported Species:**\n",
-    "- `trex` \u2014 T-Rex: balance \u2192 locomotion \u2192 bite\n",
-    "- `velociraptor` \u2014 Raptor: balance \u2192 locomotion \u2192 strike\n",
-    "- `brachiosaurus` \u2014 Brachio: balance \u2192 locomotion \u2192 food reach\n",
+    "- `trex` — T-Rex: balance → locomotion → bite\n",
+    "- `velociraptor` — Raptor: balance → locomotion → strike\n",
+    "- `brachiosaurus` — Brachio: balance → locomotion → food reach\n",
     "\n",
     "Set `SPECIES` in the configuration cell below to choose."
-   ],
-   "id": "cell_001"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "cell_002",
    "metadata": {
     "id": "37b200c6"
    },
+   "outputs": [],
    "source": [
     "# Install dependencies and verify GPU\n",
     "!pip install mujoco mujoco-mjx \"jax[cuda12]\" flax optax\n",
@@ -58,72 +61,77 @@
     "\n",
     "import jax\n",
     "import mujoco\n",
-    "from mujoco import mjx\n",
     "\n",
     "print(f\"JAX devices: {jax.devices()}\")\n",
     "print(f\"MuJoCo: {mujoco.__version__}\")\n",
     "print(\"Setup complete.\")"
-   ],
-   "outputs": [],
-   "execution_count": null,
-   "id": "cell_002"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "cell_003",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# GPU diagnostics \u2014 run this anytime to check utilization\n",
+    "# GPU diagnostics — run this anytime to check utilization\n",
     "# (especially useful to run from a second terminal during training)\n",
     "import subprocess\n",
+    "\n",
     "result = subprocess.run(\n",
-    "    ['nvidia-smi', '--query-gpu=name,utilization.gpu,utilization.memory,memory.used,memory.total,temperature.gpu,power.draw',\n",
-    "     '--format=csv,noheader,nounits'],\n",
-    "    capture_output=True, text=True,\n",
-    "    env={**__import__('os').environ, 'COLUMNS': '200'},\n",
+    "    [\n",
+    "        \"nvidia-smi\",\n",
+    "        \"--query-gpu=name,utilization.gpu,utilization.memory,memory.used,memory.total,temperature.gpu,power.draw\",\n",
+    "        \"--format=csv,noheader,nounits\",\n",
+    "    ],\n",
+    "    capture_output=True,\n",
+    "    text=True,\n",
+    "    env={**__import__(\"os\").environ, \"COLUMNS\": \"200\"},\n",
     ")\n",
     "if result.returncode == 0:\n",
-    "    lines = result.stdout.strip().split('\\n')\n",
+    "    lines = result.stdout.strip().split(\"\\n\")\n",
     "    for line in lines:\n",
-    "        parts = [p.strip() for p in line.split(',')]\n",
+    "        parts = [p.strip() for p in line.split(\",\")]\n",
     "        if len(parts) >= 7:\n",
-    "            print(f'GPU:         {parts[0]}')\n",
-    "            print(f'Utilization: {parts[1]} % (compute)  {parts[2]} % (memory)')\n",
-    "            print(f'Memory:      {parts[3]} MiB / {parts[4]} MiB')\n",
-    "            print(f'Temperature: {parts[5]}   Power: {parts[6]} W')\n",
+    "            print(f\"GPU:         {parts[0]}\")\n",
+    "            print(f\"Utilization: {parts[1]} % (compute)  {parts[2]} % (memory)\")\n",
+    "            print(f\"Memory:      {parts[3]} MiB / {parts[4]} MiB\")\n",
+    "            print(f\"Temperature: {parts[5]}   Power: {parts[6]} W\")\n",
     "        else:\n",
     "            print(line)\n",
     "else:\n",
-    "    print('nvidia-smi failed:', result.stderr)\n",
+    "    print(\"nvidia-smi failed:\", result.stderr)\n",
     "\n",
     "# Tip: You can also run this from a Colab terminal:\n",
-    "#   watch -n 2 nvidia-smi\n"
-   ],
-   "outputs": [],
-   "execution_count": null,
-   "id": "cell_003"
+    "#   watch -n 2 nvidia-smi"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "cell_004",
    "metadata": {
     "id": "13b4104a"
    },
+   "outputs": [],
    "source": [
     "# Clone mesozoic-labs and install with JAX extras\n",
     "# (On Colab/Kaggle, clones the repo; locally, assumes the notebook lives inside the repo)\n",
-    "import os, sys\n",
+    "import os\n",
+    "import sys\n",
     "\n",
     "_COLAB = \"COLAB_GPU\" in os.environ or os.path.exists(\"/content\")\n",
     "_KAGGLE = \"KAGGLE_KERNEL_RUN_TYPE\" in os.environ or os.path.exists(\"/kaggle\")\n",
     "if _COLAB:\n",
     "    !git clone https://github.com/kuds/mesozoic-labs.git /content/mesozoic-labs 2>/dev/null || echo 'Already cloned'\n",
     "    !pip install -e \"/content/mesozoic-labs[jax]\" -q\n",
-    "    _REPO_ROOT = '/content/mesozoic-labs'\n",
+    "    _REPO_ROOT = \"/content/mesozoic-labs\"\n",
     "elif _KAGGLE:\n",
     "    !git clone https://github.com/kuds/mesozoic-labs.git /kaggle/working/mesozoic-labs 2>/dev/null || echo 'Already cloned'\n",
     "    !pip install -e \"/kaggle/working/mesozoic-labs[jax]\" -q\n",
-    "    _REPO_ROOT = '/kaggle/working/mesozoic-labs'\n",
+    "    _REPO_ROOT = \"/kaggle/working/mesozoic-labs\"\n",
     "else:\n",
-    "    # Running locally \u2014 walk up from cwd until we find pyproject.toml\n",
+    "    # Running locally — walk up from cwd until we find pyproject.toml\n",
     "    _REPO_ROOT = os.getcwd()\n",
     "    _d = _REPO_ROOT\n",
     "    while _d != os.path.dirname(_d):\n",
@@ -132,7 +140,7 @@
     "            break\n",
     "        _d = os.path.dirname(_d)\n",
     "\n",
-    "# Ensure the repo root is on sys.path so `from environments.\u2026` works\n",
+    "# Ensure the repo root is on sys.path so `from environments.…` works\n",
     "# even if the editable install did not fully resolve.\n",
     "if _REPO_ROOT not in sys.path:\n",
     "    sys.path.insert(0, _REPO_ROOT)\n",
@@ -149,56 +157,145 @@
     "from IPython.display import clear_output\n",
     "\n",
     "clear_output()\n",
-    "print(f\"mesozoic-labs[jax] ready (repo: {_REPO_ROOT})\")\n"
-   ],
-   "outputs": [],
-   "execution_count": null,
-   "id": "cell_004"
+    "print(f\"mesozoic-labs[jax] ready (repo: {_REPO_ROOT})\")"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "cell_005",
    "metadata": {
     "id": "8ceadf08"
    },
-   "source": [
-    "import logging\nimport time\n\n# Silence JAX compilation spam (tracing/compiling/XLA warnings every update)\nlogging.getLogger(\"jax._src.dispatch\").setLevel(logging.ERROR)\nlogging.getLogger(\"jax._src.interpreters.pxla\").setLevel(logging.ERROR)\n\nimport jax\nimport jax.numpy as jnp\nimport matplotlib.pyplot as plt\nimport mujoco\nimport numpy as np\nimport optax\nfrom mujoco import mjx\n\n# Shared modules from mesozoic-labs\nfrom environments.shared.jax_reward_termination import (\n    compute_total_reward,\n    compute_reward_components,\n    is_terminated as is_terminated_fn,\n)\nfrom environments.shared.jax_ppo import (\n    PPOConfig,\n    make_actor_critic,\n    make_optimizer,\n    sample_action,\n    compute_gae,\n    ppo_loss,\n)\nfrom environments.shared.jax_normalization import RunningMeanStd, normalize_obs, update_running_stats, decay_running_stats\nfrom environments.shared.jax_eval import EvalConfig, evaluate_policy_cpu, check_stage_gate\nfrom environments.shared.jax_viz import plot_training_curves, plot_locomotion_diagnostics, plot_reward_components, record_training_video, create_frame_collage\nfrom environments.shared.mjx_utils import scale_action_jax\nfrom environments.shared.mjx_env import MJXDinoEnv\nfrom environments.shared.obs_functions import SensorLayout, build_bipedal_obs\n\nprint(f\"JAX {jax.__version__}, devices: {jax.devices()}\")\nprint(f\"MuJoCo {mujoco.__version__}\")\n\n# Verify GPU\nassert jax.devices()[0].platform == \"gpu\", \"No GPU detected \u2014 JAX is using CPU. Check runtime type.\"\nprint(\"GPU OK\")"
-   ],
    "outputs": [],
-   "execution_count": null,
-   "id": "cell_005"
+   "source": [
+    "import logging\n",
+    "import time\n",
+    "\n",
+    "# Silence JAX compilation spam (tracing/compiling/XLA warnings every update)\n",
+    "logging.getLogger(\"jax._src.dispatch\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"jax._src.interpreters.pxla\").setLevel(logging.ERROR)\n",
+    "\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import mujoco\n",
+    "\n",
+    "from environments.shared.jax_normalization import (\n",
+    "    RunningMeanStd,\n",
+    "    decay_running_stats,\n",
+    "    normalize_obs,\n",
+    ")\n",
+    "from environments.shared.jax_ppo import (\n",
+    "    PPOConfig,\n",
+    "    make_actor_critic,\n",
+    "    make_optimizer,\n",
+    ")\n",
+    "\n",
+    "# Shared modules from mesozoic-labs\n",
+    "from environments.shared.jax_viz import (\n",
+    "    create_frame_collage,\n",
+    "    plot_locomotion_diagnostics,\n",
+    "    plot_reward_components,\n",
+    "    plot_training_curves,\n",
+    "    record_training_video,\n",
+    ")\n",
+    "\n",
+    "print(f\"JAX {jax.__version__}, devices: {jax.devices()}\")\n",
+    "print(f\"MuJoCo {mujoco.__version__}\")\n",
+    "\n",
+    "# Verify GPU\n",
+    "assert jax.devices()[0].platform == \"gpu\", \"No GPU detected — JAX is using CPU. Check runtime type.\"\n",
+    "print(\"GPU OK\")"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cell_006",
    "metadata": {
     "id": "01e3cccc"
    },
    "outputs": [],
-   "source": "# ============================================================\n# USER CONFIGURATION\n# ============================================================\nSPECIES = \"trex\"  # Choose: \"trex\", \"velociraptor\", \"brachiosaurus\"\nCURRENT_STAGE = 1  # Curriculum stage: 1=balance, 2=locomotion, 3=species-specific\nUSE_GOOGLE_DRIVE = True  # Set to True to save outputs to Google Drive (persistent across sessions)\nVERBOSE = 1  # 0=eval/summary only, 1=periodic updates (default), 2=every update\n\n# Resume from a previous checkpoint (set to a .pkl path, or None to start fresh)\nRESUME_FROM = None  # e.g. \"checkpoint_100.pkl\"\n\n# ============================================================\n# Setup via shared library (replaces ~80 lines of hardcoded config)\n# ============================================================\nfrom environments.shared.jax_setup import (\n    setup_species,\n    setup_output_dirs,\n    create_env,\n    make_obs_fn,\n    make_scale_action_fn,\n    make_reward_fns,\n    print_species_summary,\n)\n\nctx = setup_species(SPECIES, stage=CURRENT_STAGE)\n\n# Storage directories\nif USE_GOOGLE_DRIVE:\n    from google.colab import drive\n    drive.mount(\"/content/drive\")\n    _STORAGE_ROOT = \"/content/drive/MyDrive/mesozoic-labs/logs\"\nelse:\n    _STORAGE_ROOT = \"logs\"\n\n_dirs = setup_output_dirs(SPECIES, CURRENT_STAGE, storage_root=_STORAGE_ROOT)\nRUN_DIR = _dirs[\"run_dir\"]\nSTAGE_DIR = _dirs[\"stage_dir\"]\nMODEL_DIR = _dirs[\"model_dir\"]\nOUTPUT_DIR = STAGE_DIR  # backward compat\n\nprint_species_summary(ctx)\nprint(f\"Run dir:    {RUN_DIR}\")\nprint(f\"Stage dir:  {STAGE_DIR}\")\nprint(f\"Drive:      {USE_GOOGLE_DRIVE}\")\nif RESUME_FROM:\n    print(f\"Resuming from checkpoint: {RESUME_FROM}\")",
-   "id": "cell_006"
+   "source": [
+    "# ============================================================\n",
+    "# USER CONFIGURATION\n",
+    "# ============================================================\n",
+    "SPECIES = \"trex\"  # Choose: \"trex\", \"velociraptor\", \"brachiosaurus\"\n",
+    "CURRENT_STAGE = 1  # Curriculum stage: 1=balance, 2=locomotion, 3=species-specific\n",
+    "USE_GOOGLE_DRIVE = True  # Set to True to save outputs to Google Drive (persistent across sessions)\n",
+    "VERBOSE = 1  # 0=eval/summary only, 1=periodic updates (default), 2=every update\n",
+    "\n",
+    "# Resume from a previous checkpoint (set to a .pkl path, or None to start fresh)\n",
+    "RESUME_FROM = None  # e.g. \"checkpoint_100.pkl\"\n",
+    "\n",
+    "# ============================================================\n",
+    "# Setup via shared library (replaces ~80 lines of hardcoded config)\n",
+    "# ============================================================\n",
+    "from environments.shared.jax_setup import (\n",
+    "    create_env,\n",
+    "    make_obs_fn,\n",
+    "    make_reward_fns,\n",
+    "    make_scale_action_fn,\n",
+    "    print_species_summary,\n",
+    "    setup_output_dirs,\n",
+    "    setup_species,\n",
+    ")\n",
+    "\n",
+    "ctx = setup_species(SPECIES, stage=CURRENT_STAGE)\n",
+    "\n",
+    "# Storage directories\n",
+    "if USE_GOOGLE_DRIVE:\n",
+    "    from google.colab import drive\n",
+    "\n",
+    "    drive.mount(\"/content/drive\")\n",
+    "    _STORAGE_ROOT = \"/content/drive/MyDrive/mesozoic-labs/logs\"\n",
+    "else:\n",
+    "    _STORAGE_ROOT = \"logs\"\n",
+    "\n",
+    "_dirs = setup_output_dirs(SPECIES, CURRENT_STAGE, storage_root=_STORAGE_ROOT)\n",
+    "RUN_DIR = _dirs[\"run_dir\"]\n",
+    "STAGE_DIR = _dirs[\"stage_dir\"]\n",
+    "MODEL_DIR = _dirs[\"model_dir\"]\n",
+    "OUTPUT_DIR = STAGE_DIR  # backward compat\n",
+    "\n",
+    "print_species_summary(ctx)\n",
+    "print(f\"Run dir:    {RUN_DIR}\")\n",
+    "print(f\"Stage dir:  {STAGE_DIR}\")\n",
+    "print(f\"Drive:      {USE_GOOGLE_DRIVE}\")\n",
+    "if RESUME_FROM:\n",
+    "    print(f\"Resuming from checkpoint: {RESUME_FROM}\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_007",
    "metadata": {
     "id": "17b9607c"
    },
    "source": [
     "## 1. Load Model into MJX"
-   ],
-   "id": "cell_007"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cell_008",
    "metadata": {
     "id": "44372d64"
    },
    "outputs": [],
-   "source": "# Model already loaded by setup_species() \u2014 just display info\nmj_model = ctx.mj_model\nprint(f\"{SPECIES.title()} model loaded:\")\nprint(f\"  Bodies: {mj_model.nbody}, Joints: {mj_model.njnt}, Actuators: {mj_model.nu}\")\nprint(f\"  qpos: {mj_model.nq}, qvel: {mj_model.nv}, Geoms: {mj_model.ngeom}\")\nprint(f\"  Total mass: {sum(mj_model.body_mass):.2f} kg, Timestep: {mj_model.opt.timestep * 1000:.1f} ms\")",
-   "id": "cell_008"
+   "source": [
+    "# Model already loaded by setup_species() — just display info\n",
+    "mj_model = ctx.mj_model\n",
+    "print(f\"{SPECIES.title()} model loaded:\")\n",
+    "print(f\"  Bodies: {mj_model.nbody}, Joints: {mj_model.njnt}, Actuators: {mj_model.nu}\")\n",
+    "print(f\"  qpos: {mj_model.nq}, qvel: {mj_model.nv}, Geoms: {mj_model.ngeom}\")\n",
+    "print(f\"  Total mass: {sum(mj_model.body_mass):.2f} kg, Timestep: {mj_model.opt.timestep * 1000:.1f} ms\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_009",
    "metadata": {
     "id": "7ef8059f"
    },
@@ -212,33 +309,64 @@
     "**Note:** The shared `reward_functions` use `float()` / Python `if` which break\n",
     "`jax.vmap` tracing. The reward and termination functions below are re-implemented\n",
     "in pure JAX (`jnp` only) for vmap compatibility."
-   ],
-   "id": "cell_009"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "cell_010",
    "metadata": {
     "id": "1fa0ca64"
    },
-   "source": [
-    "# ---------- Constants (resolved by setup_species) ----------\n# All body/site IDs, sensor layout, termination checks, and TOML config\n# are now in ctx (SpeciesContext). Extract frequently-used values for\n# backward compatibility with downstream cells.\n\n_stage_cfg = ctx.stage_config\n_jax_kw = ctx.jax_kwargs\nreward_cfg = ctx.reward_cfg\nSENSOR_LAYOUT = ctx.sensor_layout\nROOT_BODY_ID = ctx.root_body_id\nOBS_DIM = ctx.obs_dim\nACT_DIM = ctx.act_dim\nCTRL_RANGE = ctx.ctrl_range\nNUM_ENVS = _jax_kw.get(\"num_envs\", 2048)\nFRAME_SKIP = ctx.frame_skip\nMAX_EPISODE_STEPS = ctx.max_episode_steps\nHEALTHY_Z_MIN, HEALTHY_Z_MAX = ctx.healthy_z_range\nMAX_TILT_ANGLE = ctx.max_tilt_angle\nNATURAL_FORWARD_Z = ctx.natural_forward_z\n_NOSEDIVE_TERMINATION_THRESHOLD = reward_cfg.get(\"nosedive_termination_threshold\", 0.5)\n\nprint(f\"Obs dim: {OBS_DIM}, Act dim: {ACT_DIM}\")\nprint(f\"Termination: {len(ctx.termination_body_checks)} body, {len(ctx.termination_site_checks)} site checks\")\nprint(f\"Reward keys: {[k for k, v in reward_cfg.items() if isinstance(v, (int, float)) and v != 0]}\")"
-   ],
    "outputs": [],
-   "execution_count": null,
-   "id": "cell_010"
+   "source": [
+    "# ---------- Constants (resolved by setup_species) ----------\n",
+    "# All body/site IDs, sensor layout, termination checks, and TOML config\n",
+    "# are now in ctx (SpeciesContext). Extract frequently-used values for\n",
+    "# backward compatibility with downstream cells.\n",
+    "\n",
+    "_stage_cfg = ctx.stage_config\n",
+    "_jax_kw = ctx.jax_kwargs\n",
+    "reward_cfg = ctx.reward_cfg\n",
+    "SENSOR_LAYOUT = ctx.sensor_layout\n",
+    "ROOT_BODY_ID = ctx.root_body_id\n",
+    "OBS_DIM = ctx.obs_dim\n",
+    "ACT_DIM = ctx.act_dim\n",
+    "CTRL_RANGE = ctx.ctrl_range\n",
+    "NUM_ENVS = _jax_kw.get(\"num_envs\", 2048)\n",
+    "FRAME_SKIP = ctx.frame_skip\n",
+    "MAX_EPISODE_STEPS = ctx.max_episode_steps\n",
+    "HEALTHY_Z_MIN, HEALTHY_Z_MAX = ctx.healthy_z_range\n",
+    "MAX_TILT_ANGLE = ctx.max_tilt_angle\n",
+    "NATURAL_FORWARD_Z = ctx.natural_forward_z\n",
+    "_NOSEDIVE_TERMINATION_THRESHOLD = reward_cfg.get(\"nosedive_termination_threshold\", 0.5)\n",
+    "\n",
+    "print(f\"Obs dim: {OBS_DIM}, Act dim: {ACT_DIM}\")\n",
+    "print(f\"Termination: {len(ctx.termination_body_checks)} body, {len(ctx.termination_site_checks)} site checks\")\n",
+    "print(f\"Reward keys: {[k for k, v in reward_cfg.items() if isinstance(v, (int, float)) and v != 0]}\")"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "cell_011",
    "metadata": {
     "id": "7c774e04"
    },
-   "source": "# Observation and action functions (from library)\nget_obs = make_obs_fn(ctx)\nscale_action = make_scale_action_fn(ctx)\ncompute_reward, compute_reward_detailed, is_terminated = make_reward_fns(ctx)\n\nprint(f\"Observation dim: {OBS_DIM}\")\nprint(f\"Action dim: {ACT_DIM}\")",
    "outputs": [],
-   "execution_count": null,
-   "id": "cell_011"
+   "source": [
+    "# Observation and action functions (from library)\n",
+    "get_obs = make_obs_fn(ctx)\n",
+    "scale_action = make_scale_action_fn(ctx)\n",
+    "compute_reward, compute_reward_detailed, is_terminated = make_reward_fns(ctx)\n",
+    "\n",
+    "print(f\"Observation dim: {OBS_DIM}\")\n",
+    "print(f\"Action dim: {ACT_DIM}\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_012",
    "metadata": {
     "id": "e3c020d2"
    },
@@ -246,44 +374,101 @@
     "## 3. Batched MJX Step\n",
     "\n",
     "A single `jax.jit`-compiled function that steps `N` parallel environments."
-   ],
-   "id": "cell_012"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cell_013",
    "metadata": {
     "id": "be8d3af1"
    },
    "outputs": [],
-   "source": "# Create MJXDinoEnv via library helper (applies solver tuning + env_kwargs merge)\nenv = create_env(ctx, num_envs=NUM_ENVS)\nmjx_model = env.mjx_model\n\nprint(f\"MJXDinoEnv created: {SPECIES} stage {CURRENT_STAGE}\")\nprint(f\"  num_envs={NUM_ENVS}, action_dim={env.action_dim}, frame_skip={env.config.frame_skip}\")\nprint(f\"  fall_penalty={env.config.fall_penalty}, max_steps={env.config.max_episode_steps}\")\nprint(f\"  reward keys: {list(env.config.reward_weights.keys())}\")",
-   "id": "cell_013"
+   "source": [
+    "# Create MJXDinoEnv via library helper (applies solver tuning + env_kwargs merge)\n",
+    "env = create_env(ctx, num_envs=NUM_ENVS)\n",
+    "mjx_model = env.mjx_model\n",
+    "\n",
+    "print(f\"MJXDinoEnv created: {SPECIES} stage {CURRENT_STAGE}\")\n",
+    "print(f\"  num_envs={NUM_ENVS}, action_dim={env.action_dim}, frame_skip={env.config.frame_skip}\")\n",
+    "print(f\"  fall_penalty={env.config.fall_penalty}, max_steps={env.config.max_episode_steps}\")\n",
+    "print(f\"  reward keys: {list(env.config.reward_weights.keys())}\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_014",
    "metadata": {
     "id": "252ba7a5"
    },
    "source": [
     "## 4. Policy Network (Flax)\n",
     "Uses the shared `ActorCritic` from `environments.shared.jax_ppo`."
-   ],
-   "id": "cell_014"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "cell_015",
    "metadata": {
     "id": "87ca3be9"
    },
-   "source": [
-    "from pathlib import Path\n\n# Initialize using the shared ActorCritic from jax_ppo\nnetwork = make_actor_critic(action_dim=ACT_DIM)\nrng = jax.random.PRNGKey(42)\ndummy_obs = jnp.zeros((OBS_DIM,))\nparams = network.init(rng, dummy_obs)\n\n# Observation normalization (stabilizes training across species/stages)\nobs_rms = RunningMeanStd.create(OBS_DIM)\n\n# Resume from checkpoint if specified\n_resume_update = 0\n_jax_kw_resume = {}\ntry:\n    from environments.shared.config import load_stage_config as _lsc\n    _jax_kw_resume = _lsc(SPECIES, CURRENT_STAGE).get(\"jax_kwargs\", {})\nexcept Exception:\n    pass\n\nif RESUME_FROM:\n    import pickle\n    _ckpt_path = OUTPUT_DIR / RESUME_FROM if not Path(RESUME_FROM).is_absolute() else Path(RESUME_FROM)\n    with open(_ckpt_path, \"rb\") as f:\n        _ckpt = pickle.load(f)\n    params = jax.device_put(_ckpt[\"params\"])\n    _resume_update = _ckpt.get(\"update\", 0)\n    if \"obs_rms\" in _ckpt:\n        obs_rms = _ckpt[\"obs_rms\"]\n        # When transitioning between stages, the obs distribution shifts\n        # (e.g. near-zero velocity in balance \u2192 sustained velocity in\n        # locomotion).  With 2048 envs the prior count can be ~65M, making\n        # update_running_stats nearly a no-op.  Decay the count so new\n        # data adapts the statistics within a few updates.\n        _obs_decay = _jax_kw_resume.get(\"obs_rms_decay_on_resume\", 0.01)\n        if _obs_decay < 1.0:\n            _old_count = obs_rms.count\n            obs_rms = decay_running_stats(obs_rms, decay_factor=_obs_decay)\n            print(f\"  obs_rms count decayed: {_old_count:,.0f} \u2192 {obs_rms.count:,.0f} (factor={_obs_decay})\")\n    print(f\"Resumed from {_ckpt_path} (update {_resume_update})\")\n    if \"reward_history\" in _ckpt:\n        print(f\"  Prior history: {len(_ckpt['reward_history'])} updates, best reward: {max(_ckpt['reward_history']):.4f}\")\n\nn_params = sum(p.size for p in jax.tree.leaves(params))\nprint(f\"ActorCritic parameters: {n_params:,}\")"
-   ],
    "outputs": [],
-   "execution_count": null,
-   "id": "cell_015"
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "# Initialize using the shared ActorCritic from jax_ppo\n",
+    "network = make_actor_critic(action_dim=ACT_DIM)\n",
+    "rng = jax.random.PRNGKey(42)\n",
+    "dummy_obs = jnp.zeros((OBS_DIM,))\n",
+    "params = network.init(rng, dummy_obs)\n",
+    "\n",
+    "# Observation normalization (stabilizes training across species/stages)\n",
+    "obs_rms = RunningMeanStd.create(OBS_DIM)\n",
+    "\n",
+    "# Resume from checkpoint if specified\n",
+    "_resume_update = 0\n",
+    "_jax_kw_resume = {}\n",
+    "try:\n",
+    "    from environments.shared.config import load_stage_config as _lsc\n",
+    "\n",
+    "    _jax_kw_resume = _lsc(SPECIES, CURRENT_STAGE).get(\"jax_kwargs\", {})\n",
+    "except Exception:\n",
+    "    pass\n",
+    "\n",
+    "if RESUME_FROM:\n",
+    "    import pickle\n",
+    "\n",
+    "    _ckpt_path = OUTPUT_DIR / RESUME_FROM if not Path(RESUME_FROM).is_absolute() else Path(RESUME_FROM)\n",
+    "    with open(_ckpt_path, \"rb\") as f:\n",
+    "        _ckpt = pickle.load(f)\n",
+    "    params = jax.device_put(_ckpt[\"params\"])\n",
+    "    _resume_update = _ckpt.get(\"update\", 0)\n",
+    "    if \"obs_rms\" in _ckpt:\n",
+    "        obs_rms = _ckpt[\"obs_rms\"]\n",
+    "        # When transitioning between stages, the obs distribution shifts\n",
+    "        # (e.g. near-zero velocity in balance → sustained velocity in\n",
+    "        # locomotion).  With 2048 envs the prior count can be ~65M, making\n",
+    "        # update_running_stats nearly a no-op.  Decay the count so new\n",
+    "        # data adapts the statistics within a few updates.\n",
+    "        _obs_decay = _jax_kw_resume.get(\"obs_rms_decay_on_resume\", 0.01)\n",
+    "        if _obs_decay < 1.0:\n",
+    "            _old_count = obs_rms.count\n",
+    "            obs_rms = decay_running_stats(obs_rms, decay_factor=_obs_decay)\n",
+    "            print(f\"  obs_rms count decayed: {_old_count:,.0f} → {obs_rms.count:,.0f} (factor={_obs_decay})\")\n",
+    "    print(f\"Resumed from {_ckpt_path} (update {_resume_update})\")\n",
+    "    if \"reward_history\" in _ckpt:\n",
+    "        print(\n",
+    "            f\"  Prior history: {len(_ckpt['reward_history'])} updates, best reward: {max(_ckpt['reward_history']):.4f}\"\n",
+    "        )\n",
+    "\n",
+    "n_params = sum(p.size for p in jax.tree.leaves(params))\n",
+    "print(f\"ActorCritic parameters: {n_params:,}\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_016",
    "metadata": {
     "id": "de84103d"
    },
@@ -292,128 +477,334 @@
     "Core PPO functions (`sample_action`, `compute_gae`, `ppo_loss`) are now\n",
     "imported from `environments.shared.jax_ppo`. Notebook-specific wrappers\n",
     "below adapt them for the training loop."
-   ],
-   "id": "cell_016"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "cell_017",
    "metadata": {
     "id": "d273d125"
    },
+   "outputs": [],
    "source": [
     "# PPO wrapper functions now built internally by jax_trainer module.\n",
     "# (sample_action, ppo_loss, scan_ppo_epochs are JIT-compiled in train())\n",
     "print(\"PPO functions handled by jax_trainer module.\")"
-   ],
-   "outputs": [],
-   "execution_count": null,
-   "id": "cell_017"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_018",
    "metadata": {
     "id": "5794cd7a"
    },
    "source": [
     "## 6. Training Loop"
-   ],
-   "id": "cell_018"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cell_019",
    "metadata": {
     "id": "0891be9a"
    },
    "outputs": [],
    "source": [
-    "# ---------- Hyperparameters (loaded from TOML [jax] section) ----------\n\n# JAX/MJX training hyperparameters (from TOML, with notebook defaults as fallback)\nNUM_ENVS = _jax_kw.get(\"num_envs\", 2048)\nROLLOUT_LEN = _jax_kw.get(\"rollout_len\", 64)\nNUM_UPDATES = _jax_kw.get(\"num_updates\", 500)\nPPO_EPOCHS = _jax_kw.get(\"ppo_epochs\", 4)\nMINIBATCH_SIZE = _jax_kw.get(\"minibatch_size\", 512)\nLEARNING_RATE = _jax_kw.get(\"learning_rate\", 3e-4)\nMAX_GRAD_NORM = _jax_kw.get(\"max_grad_norm\", 0.5)\nGAMMA = _jax_kw.get(\"gamma\", 0.99)\nGAE_LAMBDA = _jax_kw.get(\"gae_lambda\", 0.95)\nCLIP_RANGE = _jax_kw.get(\"clip_range\", 0.2)\nENT_COEF = _jax_kw.get(\"ent_coef\", 0.01)\nFALL_PENALTY = _jax_kw.get(\"fall_penalty\", -10.0)\nRESET_NOISE_SCALE = _jax_kw.get(\"reset_noise_scale\", 0.05)\nINIT_QPOS_NOISE = _jax_kw.get(\"init_qpos_noise\", 0.01)\nINIT_YAW_NOISE = _jax_kw.get(\"init_yaw_noise\", 0.1)\n\n# Curriculum warmup (constrains policy updates while critic adapts to new reward landscape)\nWARMUP_UPDATES = _jax_kw.get(\"warmup_updates\", 0)          # 0 = no warmup (Stage 1 default)\nWARMUP_CLIP_RANGE = _jax_kw.get(\"warmup_clip_range\", 0.02)\nWARMUP_ENT_COEF = _jax_kw.get(\"warmup_ent_coef\", 0.02)\n\n# Reward ramp (linearly ramp a reward weight from a fraction to its full value)\nRAMP_UPDATES = _jax_kw.get(\"ramp_updates\", 0)              # 0 = no ramp (Stage 1 default)\nRAMP_ATTR = _jax_kw.get(\"ramp_attr\", \"forward_vel_weight\")\nRAMP_START_FRACTION = _jax_kw.get(\"ramp_start_fraction\", 0.1)\n\nprint(\"Training config (from TOML [jax] section):\")\nprint(f\"  Species: {SPECIES}\")\nprint(f\"  Envs: {NUM_ENVS}\")\nprint(f\"  Rollout length: {ROLLOUT_LEN}\")\nprint(f\"  Updates: {NUM_UPDATES}\")\nprint(f\"  Total env steps: {NUM_ENVS * ROLLOUT_LEN * NUM_UPDATES:,}\")\nprint(f\"  Stage: {CURRENT_STAGE} ({ctx.stage_name})\")\nprint(f\"  Learning rate: {LEARNING_RATE}\")\nprint(f\"  Gamma: {GAMMA}\")\nprint(f\"  Clip range: {CLIP_RANGE}\")\nprint(f\"  Entropy coef: {ENT_COEF}\")\nprint(f\"  Max grad norm: {MAX_GRAD_NORM}\")\nprint(f\"  Fall penalty: {FALL_PENALTY}\")\nprint(f\"  Reset noise: joints={RESET_NOISE_SCALE}, xy={INIT_QPOS_NOISE}, yaw={INIT_YAW_NOISE}\")\nif WARMUP_UPDATES > 0:\n    print(f\"  Warmup: {WARMUP_UPDATES} updates (clip={WARMUP_CLIP_RANGE}, ent={WARMUP_ENT_COEF})\")\nif RAMP_UPDATES > 0:\n    print(f\"  Reward ramp: {RAMP_ATTR} from {RAMP_START_FRACTION:.0%} to 100% over {RAMP_UPDATES} updates\")\nprint(f\"  Reward config: {reward_cfg}\")"
-   ],
-   "id": "cell_019"
+    "# ---------- Hyperparameters (loaded from TOML [jax] section) ----------\n",
+    "\n",
+    "# JAX/MJX training hyperparameters (from TOML, with notebook defaults as fallback)\n",
+    "NUM_ENVS = _jax_kw.get(\"num_envs\", 2048)\n",
+    "ROLLOUT_LEN = _jax_kw.get(\"rollout_len\", 64)\n",
+    "NUM_UPDATES = _jax_kw.get(\"num_updates\", 500)\n",
+    "PPO_EPOCHS = _jax_kw.get(\"ppo_epochs\", 4)\n",
+    "MINIBATCH_SIZE = _jax_kw.get(\"minibatch_size\", 512)\n",
+    "LEARNING_RATE = _jax_kw.get(\"learning_rate\", 3e-4)\n",
+    "MAX_GRAD_NORM = _jax_kw.get(\"max_grad_norm\", 0.5)\n",
+    "GAMMA = _jax_kw.get(\"gamma\", 0.99)\n",
+    "GAE_LAMBDA = _jax_kw.get(\"gae_lambda\", 0.95)\n",
+    "CLIP_RANGE = _jax_kw.get(\"clip_range\", 0.2)\n",
+    "ENT_COEF = _jax_kw.get(\"ent_coef\", 0.01)\n",
+    "FALL_PENALTY = _jax_kw.get(\"fall_penalty\", -10.0)\n",
+    "RESET_NOISE_SCALE = _jax_kw.get(\"reset_noise_scale\", 0.05)\n",
+    "INIT_QPOS_NOISE = _jax_kw.get(\"init_qpos_noise\", 0.01)\n",
+    "INIT_YAW_NOISE = _jax_kw.get(\"init_yaw_noise\", 0.1)\n",
+    "\n",
+    "# Curriculum warmup (constrains policy updates while critic adapts to new reward landscape)\n",
+    "WARMUP_UPDATES = _jax_kw.get(\"warmup_updates\", 0)  # 0 = no warmup (Stage 1 default)\n",
+    "WARMUP_CLIP_RANGE = _jax_kw.get(\"warmup_clip_range\", 0.02)\n",
+    "WARMUP_ENT_COEF = _jax_kw.get(\"warmup_ent_coef\", 0.02)\n",
+    "\n",
+    "# Reward ramp (linearly ramp a reward weight from a fraction to its full value)\n",
+    "RAMP_UPDATES = _jax_kw.get(\"ramp_updates\", 0)  # 0 = no ramp (Stage 1 default)\n",
+    "RAMP_ATTR = _jax_kw.get(\"ramp_attr\", \"forward_vel_weight\")\n",
+    "RAMP_START_FRACTION = _jax_kw.get(\"ramp_start_fraction\", 0.1)\n",
+    "\n",
+    "print(\"Training config (from TOML [jax] section):\")\n",
+    "print(f\"  Species: {SPECIES}\")\n",
+    "print(f\"  Envs: {NUM_ENVS}\")\n",
+    "print(f\"  Rollout length: {ROLLOUT_LEN}\")\n",
+    "print(f\"  Updates: {NUM_UPDATES}\")\n",
+    "print(f\"  Total env steps: {NUM_ENVS * ROLLOUT_LEN * NUM_UPDATES:,}\")\n",
+    "print(f\"  Stage: {CURRENT_STAGE} ({ctx.stage_name})\")\n",
+    "print(f\"  Learning rate: {LEARNING_RATE}\")\n",
+    "print(f\"  Gamma: {GAMMA}\")\n",
+    "print(f\"  Clip range: {CLIP_RANGE}\")\n",
+    "print(f\"  Entropy coef: {ENT_COEF}\")\n",
+    "print(f\"  Max grad norm: {MAX_GRAD_NORM}\")\n",
+    "print(f\"  Fall penalty: {FALL_PENALTY}\")\n",
+    "print(f\"  Reset noise: joints={RESET_NOISE_SCALE}, xy={INIT_QPOS_NOISE}, yaw={INIT_YAW_NOISE}\")\n",
+    "if WARMUP_UPDATES > 0:\n",
+    "    print(f\"  Warmup: {WARMUP_UPDATES} updates (clip={WARMUP_CLIP_RANGE}, ent={WARMUP_ENT_COEF})\")\n",
+    "if RAMP_UPDATES > 0:\n",
+    "    print(f\"  Reward ramp: {RAMP_ATTR} from {RAMP_START_FRACTION:.0%} to 100% over {RAMP_UPDATES} updates\")\n",
+    "print(f\"  Reward config: {reward_cfg}\")"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cell_reward_wrappers",
    "metadata": {
     "id": "reward_termination_wrappers"
    },
    "outputs": [],
-   "source": "# Reward and termination wrappers already created by make_reward_fns() above.\n# compute_reward, compute_reward_detailed, is_terminated are ready to use.\nprint(f\"Active reward components: {[k for k, v in reward_cfg.items() if isinstance(v, (int, float)) and v != 0]}\")",
-   "id": "cell_reward_wrappers"
+   "source": [
+    "# Reward and termination wrappers already created by make_reward_fns() above.\n",
+    "# compute_reward, compute_reward_detailed, is_terminated are ready to use.\n",
+    "print(f\"Active reward components: {[k for k, v in reward_cfg.items() if isinstance(v, (int, float)) and v != 0]}\")"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cell_020",
    "metadata": {
     "id": "051c1063"
    },
    "outputs": [],
-   "source": "# Initialize environments using MJXDinoEnv.reset()\n# Use a different seed from network init (PRNGKey(42)) to avoid correlated streams\nrng = jax.random.PRNGKey(0)\nrng, reset_rng = jax.random.split(rng)\nstates = env.reset(reset_rng)\n\nprint(f\"Initialized {NUM_ENVS} parallel environments via MJXDinoEnv.reset().\")\nprint(f\"Obs shape: {states.obs.shape}\")\nprint(f\"Reset noise: joints=\u00b1{env.config.reset_noise_scale}, \"\n      f\"xy=\u00b1{env.config.init_qpos_noise}m, yaw=\u00b1{env.config.init_yaw_noise}rad\")",
-   "id": "cell_020"
+   "source": [
+    "# Initialize environments using MJXDinoEnv.reset()\n",
+    "# Use a different seed from network init (PRNGKey(42)) to avoid correlated streams\n",
+    "rng = jax.random.PRNGKey(0)\n",
+    "rng, reset_rng = jax.random.split(rng)\n",
+    "states = env.reset(reset_rng)\n",
+    "\n",
+    "print(f\"Initialized {NUM_ENVS} parallel environments via MJXDinoEnv.reset().\")\n",
+    "print(f\"Obs shape: {states.obs.shape}\")\n",
+    "print(\n",
+    "    f\"Reset noise: joints=±{env.config.reset_noise_scale}, \"\n",
+    "    f\"xy=±{env.config.init_qpos_noise}m, yaw=±{env.config.init_yaw_noise}rad\"\n",
+    ")"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "cell_021",
    "metadata": {
     "id": "d683e245"
    },
-   "source": [
-    "# Optimizer (with gradient clipping and LR decay)\nfrom environments.shared.jax_ppo import PPOConfig, make_optimizer\n\nLEARNING_RATE_END = _jax_kw.get(\"learning_rate_end\", None)\nVF_CLIP_RANGE = _jax_kw.get(\"vf_clip_range\", None)\nTARGET_KL = _jax_kw.get(\"target_kl\", 0.05)\n\nppo_config = PPOConfig(\n    learning_rate=LEARNING_RATE,\n    learning_rate_end=LEARNING_RATE_END,\n    max_grad_norm=MAX_GRAD_NORM,\n    total_updates=NUM_UPDATES,\n    n_epochs=PPO_EPOCHS,\n    clip_range=CLIP_RANGE,\n    vf_clip_range=VF_CLIP_RANGE,\n    vf_coef=0.5,\n    ent_coef=ENT_COEF,\n    gamma=GAMMA,\n    gae_lambda=GAE_LAMBDA,\n    target_kl=TARGET_KL,\n)\noptimizer = make_optimizer(ppo_config)\nopt_state = optimizer.init(params)\n\nif LEARNING_RATE_END is not None:\n    print(f\"LR schedule: {LEARNING_RATE} -> {LEARNING_RATE_END} (linear decay over {NUM_UPDATES * PPO_EPOCHS} steps)\")\nif VF_CLIP_RANGE is not None:\n    print(f\"Value function clipping: +/- {VF_CLIP_RANGE}\")\nif TARGET_KL is not None:\n    print(f\"KL early stopping: target_kl={TARGET_KL}\")\n\nprint(\"Optimizer created (PPO updates handled by jax_trainer module).\")"
-   ],
    "outputs": [],
-   "execution_count": null,
-   "id": "cell_021"
+   "source": [
+    "# Optimizer (with gradient clipping and LR decay)\n",
+    "\n",
+    "LEARNING_RATE_END = _jax_kw.get(\"learning_rate_end\", None)\n",
+    "VF_CLIP_RANGE = _jax_kw.get(\"vf_clip_range\", None)\n",
+    "TARGET_KL = _jax_kw.get(\"target_kl\", 0.05)\n",
+    "\n",
+    "ppo_config = PPOConfig(\n",
+    "    learning_rate=LEARNING_RATE,\n",
+    "    learning_rate_end=LEARNING_RATE_END,\n",
+    "    max_grad_norm=MAX_GRAD_NORM,\n",
+    "    total_updates=NUM_UPDATES,\n",
+    "    n_epochs=PPO_EPOCHS,\n",
+    "    clip_range=CLIP_RANGE,\n",
+    "    vf_clip_range=VF_CLIP_RANGE,\n",
+    "    vf_coef=0.5,\n",
+    "    ent_coef=ENT_COEF,\n",
+    "    gamma=GAMMA,\n",
+    "    gae_lambda=GAE_LAMBDA,\n",
+    "    target_kl=TARGET_KL,\n",
+    ")\n",
+    "optimizer = make_optimizer(ppo_config)\n",
+    "opt_state = optimizer.init(params)\n",
+    "\n",
+    "if LEARNING_RATE_END is not None:\n",
+    "    print(f\"LR schedule: {LEARNING_RATE} -> {LEARNING_RATE_END} (linear decay over {NUM_UPDATES * PPO_EPOCHS} steps)\")\n",
+    "if VF_CLIP_RANGE is not None:\n",
+    "    print(f\"Value function clipping: +/- {VF_CLIP_RANGE}\")\n",
+    "if TARGET_KL is not None:\n",
+    "    print(f\"KL early stopping: target_kl={TARGET_KL}\")\n",
+    "\n",
+    "print(\"Optimizer created (PPO updates handled by jax_trainer module).\")"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cell_022",
    "metadata": {
     "id": "23d32deb"
    },
    "outputs": [],
    "source": [
-    "# ---------- Main Training Loop (via shared jax_trainer module) ----------\nfrom environments.shared.jax_trainer import TrainConfig, train\n\ntrain_config = TrainConfig(\n    # Core PPO\n    num_envs=NUM_ENVS,\n    rollout_len=ROLLOUT_LEN,\n    num_updates=NUM_UPDATES,\n    ppo_epochs=PPO_EPOCHS,\n    minibatch_size=MINIBATCH_SIZE,\n    learning_rate=LEARNING_RATE,\n    learning_rate_end=LEARNING_RATE_END,\n    max_grad_norm=MAX_GRAD_NORM,\n    gamma=GAMMA,\n    gae_lambda=GAE_LAMBDA,\n    clip_range=CLIP_RANGE,\n    ent_coef=ENT_COEF,\n    vf_clip_range=VF_CLIP_RANGE,\n    target_kl=TARGET_KL,\n    # Dimensions\n    obs_dim=OBS_DIM,\n    act_dim=ACT_DIM,\n    # Curriculum\n    warmup_updates=WARMUP_UPDATES,\n    warmup_clip_range=WARMUP_CLIP_RANGE,\n    warmup_ent_coef=WARMUP_ENT_COEF,\n    ramp_updates=RAMP_UPDATES,\n    ramp_attr=RAMP_ATTR,\n    ramp_start_fraction=RAMP_START_FRACTION,\n    # Checkpointing & logging\n    checkpoint_freq=25,\n    max_checkpoints=5,\n    verbose=VERBOSE,\n    # Output paths\n    output_dir=STAGE_DIR,\n    model_dir=MODEL_DIR,\n    # Resume\n    start_update=_resume_update,\n    # Metadata\n    species=SPECIES,\n    stage=CURRENT_STAGE,\n    frame_skip=FRAME_SKIP,\n)\n\n# Reward component diagnostics function (optional)\n_reward_detail_fn = lambda data, action: compute_reward_detailed(data, action, reward_cfg)\n\nrng = jax.random.PRNGKey(0)\n\nresult = train(\n    config=train_config,\n    env=env,\n    network=network,\n    params=params,\n    opt_state=opt_state,\n    obs_rms=obs_rms,\n    reward_cfg=reward_cfg,\n    rng=rng,\n    reward_detail_fn=_reward_detail_fn,\n    optimizer=optimizer,\n)\n\n# Unpack results for downstream cells (plotting, eval, artifacts)\nparams = result.params\nobs_rms = result.obs_rms\nbest_params = result.best_params\nbest_reward = result.best_reward\nbest_update = result.best_update\nreward_history = result.reward_history\nloss_history = result.loss_history\nepisode_return_history = result.episode_return_history\ndiagnostics_history = result.diagnostics_history\nreward_component_history = result.reward_component_history\ntotal_steps = result.total_steps\nelapsed = result.elapsed\ncsv_path = result.csv_path"
-   ],
-   "id": "cell_022"
+    "# ---------- Main Training Loop (via shared jax_trainer module) ----------\n",
+    "from environments.shared.jax_trainer import TrainConfig, train\n",
+    "\n",
+    "train_config = TrainConfig(\n",
+    "    # Core PPO\n",
+    "    num_envs=NUM_ENVS,\n",
+    "    rollout_len=ROLLOUT_LEN,\n",
+    "    num_updates=NUM_UPDATES,\n",
+    "    ppo_epochs=PPO_EPOCHS,\n",
+    "    minibatch_size=MINIBATCH_SIZE,\n",
+    "    learning_rate=LEARNING_RATE,\n",
+    "    learning_rate_end=LEARNING_RATE_END,\n",
+    "    max_grad_norm=MAX_GRAD_NORM,\n",
+    "    gamma=GAMMA,\n",
+    "    gae_lambda=GAE_LAMBDA,\n",
+    "    clip_range=CLIP_RANGE,\n",
+    "    ent_coef=ENT_COEF,\n",
+    "    vf_clip_range=VF_CLIP_RANGE,\n",
+    "    target_kl=TARGET_KL,\n",
+    "    # Dimensions\n",
+    "    obs_dim=OBS_DIM,\n",
+    "    act_dim=ACT_DIM,\n",
+    "    # Curriculum\n",
+    "    warmup_updates=WARMUP_UPDATES,\n",
+    "    warmup_clip_range=WARMUP_CLIP_RANGE,\n",
+    "    warmup_ent_coef=WARMUP_ENT_COEF,\n",
+    "    ramp_updates=RAMP_UPDATES,\n",
+    "    ramp_attr=RAMP_ATTR,\n",
+    "    ramp_start_fraction=RAMP_START_FRACTION,\n",
+    "    # Checkpointing & logging\n",
+    "    checkpoint_freq=25,\n",
+    "    max_checkpoints=5,\n",
+    "    verbose=VERBOSE,\n",
+    "    # Output paths\n",
+    "    output_dir=STAGE_DIR,\n",
+    "    model_dir=MODEL_DIR,\n",
+    "    # Resume\n",
+    "    start_update=_resume_update,\n",
+    "    # Metadata\n",
+    "    species=SPECIES,\n",
+    "    stage=CURRENT_STAGE,\n",
+    "    frame_skip=FRAME_SKIP,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Reward component diagnostics function (optional)\n",
+    "def _reward_detail_fn(data, action):\n",
+    "    return compute_reward_detailed(data, action, reward_cfg)\n",
+    "\n",
+    "\n",
+    "rng = jax.random.PRNGKey(0)\n",
+    "\n",
+    "result = train(\n",
+    "    config=train_config,\n",
+    "    env=env,\n",
+    "    network=network,\n",
+    "    params=params,\n",
+    "    opt_state=opt_state,\n",
+    "    obs_rms=obs_rms,\n",
+    "    reward_cfg=reward_cfg,\n",
+    "    rng=rng,\n",
+    "    reward_detail_fn=_reward_detail_fn,\n",
+    "    optimizer=optimizer,\n",
+    ")\n",
+    "\n",
+    "# Unpack results for downstream cells (plotting, eval, artifacts)\n",
+    "params = result.params\n",
+    "obs_rms = result.obs_rms\n",
+    "best_params = result.best_params\n",
+    "best_reward = result.best_reward\n",
+    "best_update = result.best_update\n",
+    "reward_history = result.reward_history\n",
+    "loss_history = result.loss_history\n",
+    "episode_return_history = result.episode_return_history\n",
+    "diagnostics_history = result.diagnostics_history\n",
+    "reward_component_history = result.reward_component_history\n",
+    "total_steps = result.total_steps\n",
+    "elapsed = result.elapsed\n",
+    "csv_path = result.csv_path"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_023",
+   "metadata": {
+    "id": "92cca468"
+   },
    "source": [
     "## Stage Gate Evaluation\n",
     "\n",
     "Run full evaluation episodes on CPU to check whether the curriculum gate\n",
     "thresholds (min reward and min episode length) have been met. Both conditions\n",
     "must pass before advancing to the next training stage."
-   ],
-   "metadata": {
-    "id": "92cca468"
-   },
-   "id": "cell_023"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "# ---------- Stage Gate Evaluation (via shared library) ----------\nfrom environments.shared.jax_setup import run_stage_evaluation, print_eval_summary\n\neval_results, stage_results, gate_passed, gate_failures = run_stage_evaluation(\n    ctx, env, params, network, obs_rms,\n    n_episodes=30,\n    best_params=best_params,\n    best_reward=best_reward,\n    best_update=best_update,\n    total_steps=total_steps if 'total_steps' in dir() else 0,\n    elapsed=elapsed if 'elapsed' in dir() else 0.0,\n)\n\n# Expose diagnostic variables for downstream plotting cells\ndiag_tilt = eval_results.diag_tilt\ndiag_fwd_vel = eval_results.diag_fwd_vel\ndiag_pelvis_h = eval_results.diag_pelvis_h\ndiag_l_foot = eval_results.diag_l_foot\ndiag_r_foot = eval_results.diag_r_foot\ndiag_energy = eval_results.diag_energy\ndiag_reward_components = eval_results.diag_reward_components\nframes = getattr(eval_results, 'frames', [])\n\nprint_eval_summary(eval_results, gate_passed, gate_failures, CURRENT_STAGE)",
+   "execution_count": null,
+   "id": "cell_024",
    "metadata": {
     "id": "338820bf"
    },
-   "execution_count": null,
    "outputs": [],
-   "id": "cell_024"
+   "source": [
+    "# ---------- Stage Gate Evaluation (via shared library) ----------\n",
+    "from environments.shared.jax_setup import print_eval_summary, run_stage_evaluation\n",
+    "\n",
+    "eval_results, stage_results, gate_passed, gate_failures = run_stage_evaluation(\n",
+    "    ctx,\n",
+    "    env,\n",
+    "    params,\n",
+    "    network,\n",
+    "    obs_rms,\n",
+    "    n_episodes=30,\n",
+    "    best_params=best_params,\n",
+    "    best_reward=best_reward,\n",
+    "    best_update=best_update,\n",
+    "    total_steps=total_steps if \"total_steps\" in dir() else 0,\n",
+    "    elapsed=elapsed if \"elapsed\" in dir() else 0.0,\n",
+    ")\n",
+    "\n",
+    "# Expose diagnostic variables for downstream plotting cells\n",
+    "diag_tilt = eval_results.diag_tilt\n",
+    "diag_fwd_vel = eval_results.diag_fwd_vel\n",
+    "diag_pelvis_h = eval_results.diag_pelvis_h\n",
+    "diag_l_foot = eval_results.diag_l_foot\n",
+    "diag_r_foot = eval_results.diag_r_foot\n",
+    "diag_energy = eval_results.diag_energy\n",
+    "diag_reward_components = eval_results.diag_reward_components\n",
+    "frames = getattr(eval_results, \"frames\", [])\n",
+    "\n",
+    "print_eval_summary(eval_results, gate_passed, gate_failures, CURRENT_STAGE)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_025",
+   "metadata": {
+    "id": "e59d05a7"
+   },
    "source": [
     "## Save Results & Stage Summary\n",
     "\n",
     "Save structured training artifacts: stage summary text file, collected results\n",
     "CSV (compatible with sweep analysis tooling), and model checkpoints."
-   ],
-   "metadata": {
-    "id": "e59d05a7"
-   },
-   "id": "cell_025"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "cell_026",
+   "metadata": {
+    "id": "a371e4f8"
+   },
+   "outputs": [],
    "source": [
     "from environments.shared.reporting import save_jax_stage_artifacts\n",
     "\n",
@@ -442,33 +833,28 @@
     "# Print the stage summary inline\n",
     "print()\n",
     "print(artifact_paths[\"stage_summary\"].read_text())"
-   ],
-   "metadata": {
-    "id": "a371e4f8"
-   },
-   "execution_count": null,
-   "outputs": [],
-   "id": "cell_026"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_027",
    "metadata": {
     "id": "0ca78d21"
    },
    "source": [
     "## 7. Training Curves & Locomotion Diagnostics"
-   ],
-   "id": "cell_027"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cell_028",
    "metadata": {
     "id": "f53d96a5"
    },
    "outputs": [],
    "source": [
-    "# Training curves \u2014 uses shared plot_training_curves from jax_viz\n",
+    "# Training curves — uses shared plot_training_curves from jax_viz\n",
     "curve_path = OUTPUT_DIR / \"training_curves.png\"\n",
     "\n",
     "plot_training_curves(\n",
@@ -483,13 +869,18 @@
     ")\n",
     "\n",
     "print(f\"Training curves saved to: {curve_path}\")"
-   ],
-   "id": "cell_028"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "cell_029",
+   "metadata": {
+    "id": "BWIat2AvUKsv"
+   },
+   "outputs": [],
    "source": [
-    "# Locomotion diagnostics \u2014 uses shared plot_locomotion_diagnostics from jax_viz\n",
+    "# Locomotion diagnostics — uses shared plot_locomotion_diagnostics from jax_viz\n",
     "\n",
     "plot_locomotion_diagnostics(\n",
     "    eval_results,\n",
@@ -502,16 +893,11 @@
     ")\n",
     "\n",
     "print(f\"Locomotion diagnostics saved to: {STAGE_DIR}\")"
-   ],
-   "metadata": {
-    "id": "BWIat2AvUKsv"
-   },
-   "execution_count": null,
-   "outputs": [],
-   "id": "cell_029"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_reward_diag_header",
    "metadata": {
     "id": "reward_diag_header"
    },
@@ -520,12 +906,12 @@
     "\n",
     "Per-component reward breakdown sampled during training.  \n",
     "Shows which reward terms the agent is exploiting vs ignoring, plus body state variables vs termination thresholds."
-   ],
-   "id": "cell_reward_diag_header"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cell_reward_diag",
    "metadata": {
     "id": "reward_components_diag"
    },
@@ -559,12 +945,12 @@
     "        print(f\"  {k:20s}: {v:+.4f}\")\n",
     "    print(f\"  {'total':20s}: {total:+.4f}\")\n",
     "else:\n",
-    "    print(\"No reward component data collected. Re-run training with updated code.\")\n"
-   ],
-   "id": "cell_reward_diag"
+    "    print(\"No reward component data collected. Re-run training with updated code.\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_030",
    "metadata": {
     "id": "51e15e88"
    },
@@ -574,28 +960,104 @@
     "Record a video of the best trained policy (highest reward during training) using\n",
     "the CPU MuJoCo renderer. The JAX policy is evaluated deterministically (using the\n",
     "action mean)."
-   ],
-   "id": "cell_030"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cell_031",
    "metadata": {
     "id": "70d1f455"
    },
    "outputs": [],
-   "source": "try:\n    import mediapy  # noqa: F401\n    _HAS_MEDIAPY = True\nexcept ImportError:\n    _HAS_MEDIAPY = False\n    print(\"mediapy not installed \u2014 installing now...\")\n    import subprocess\n    subprocess.check_call([\"pip\", \"install\", \"-q\", \"mediapy\"])\n    import mediapy  # noqa: F401\n    _HAS_MEDIAPY = True\n    print(\"mediapy installed successfully.\")\n\nif _HAS_MEDIAPY:\n    video_params = best_params if best_params is not None else jax.device_get(params)\n    print(f\"Recording video with best model (update {best_update}, reward {best_reward:+.4f})\")\n\n    video_path = str(OUTPUT_DIR / \"evaluation.mp4\")\n\n    frames, episode_reward = record_training_video(\n        mj_model, video_params, network, obs_rms,\n        get_obs_fn=get_obs,\n        normalize_obs_fn=normalize_obs,\n        scale_action_fn=scale_action,\n        reward_fn=compute_reward,\n        reward_cfg=reward_cfg,\n        max_episode_steps=ctx.max_episode_steps,\n        frame_skip=ctx.frame_skip,\n        root_body_id=ctx.root_body_id,\n        healthy_z_range=ctx.healthy_z_range,\n        max_tilt_angle=ctx.max_tilt_angle,\n        natural_forward_z=ctx.natural_forward_z,\n        termination_body_heights=ctx.termination_body_heights,\n        termination_site_heights=ctx.termination_site_heights,\n        success_sites=ctx.success_sites,\n        success_threshold=ctx.success_threshold,\n        target_body=\"prey\",\n        sensor_quat_start=ctx.sensor_layout.quat_start,\n        output_path=video_path,\n        fps=50,\n        camera_track_body=ctx.camera_track_body,\n        camera_distance=ctx.camera_distance,\n        show=True,\n    )\n\n    print(f\"Episode reward: {episode_reward:.2f} | {len(frames)} frames\")\n    print(f\"Saved to: {video_path}\")",
-   "id": "cell_031"
+   "source": [
+    "try:\n",
+    "    import mediapy  # noqa: F401\n",
+    "\n",
+    "    _HAS_MEDIAPY = True\n",
+    "except ImportError:\n",
+    "    _HAS_MEDIAPY = False\n",
+    "    print(\"mediapy not installed — installing now...\")\n",
+    "    import subprocess\n",
+    "\n",
+    "    subprocess.check_call([\"pip\", \"install\", \"-q\", \"mediapy\"])\n",
+    "    import mediapy  # noqa: F401\n",
+    "\n",
+    "    _HAS_MEDIAPY = True\n",
+    "    print(\"mediapy installed successfully.\")\n",
+    "\n",
+    "if _HAS_MEDIAPY:\n",
+    "    video_params = best_params if best_params is not None else jax.device_get(params)\n",
+    "    print(f\"Recording video with best model (update {best_update}, reward {best_reward:+.4f})\")\n",
+    "\n",
+    "    video_path = str(OUTPUT_DIR / \"evaluation.mp4\")\n",
+    "\n",
+    "    frames, episode_reward = record_training_video(\n",
+    "        mj_model,\n",
+    "        video_params,\n",
+    "        network,\n",
+    "        obs_rms,\n",
+    "        get_obs_fn=get_obs,\n",
+    "        normalize_obs_fn=normalize_obs,\n",
+    "        scale_action_fn=scale_action,\n",
+    "        reward_fn=compute_reward,\n",
+    "        reward_cfg=reward_cfg,\n",
+    "        max_episode_steps=ctx.max_episode_steps,\n",
+    "        frame_skip=ctx.frame_skip,\n",
+    "        root_body_id=ctx.root_body_id,\n",
+    "        healthy_z_range=ctx.healthy_z_range,\n",
+    "        max_tilt_angle=ctx.max_tilt_angle,\n",
+    "        natural_forward_z=ctx.natural_forward_z,\n",
+    "        termination_body_heights=ctx.termination_body_heights,\n",
+    "        termination_site_heights=ctx.termination_site_heights,\n",
+    "        success_sites=ctx.success_sites,\n",
+    "        success_threshold=ctx.success_threshold,\n",
+    "        target_body=\"prey\",\n",
+    "        sensor_quat_start=ctx.sensor_layout.quat_start,\n",
+    "        output_path=video_path,\n",
+    "        fps=50,\n",
+    "        camera_track_body=ctx.camera_track_body,\n",
+    "        camera_distance=ctx.camera_distance,\n",
+    "        show=True,\n",
+    "    )\n",
+    "\n",
+    "    print(f\"Episode reward: {episode_reward:.2f} | {len(frames)} frames\")\n",
+    "    print(f\"Saved to: {video_path}\")"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "# Create a frame collage for quick visual review\n# Single image with labelled frame numbers and timestamps\n\ncollage_path = STAGE_DIR / \"eval_collage.png\"\ncollage_fig = create_frame_collage(\n    frames,\n    output_path=collage_path,\n    num_frames=10,\n    cols=5,\n    title=f\"{SPECIES.capitalize()} Stage {CURRENT_STAGE} \u2014 Eval Rollout ({len(frames)} frames, {len(frames)/50:.1f}s)\",\n    fps=50,\n    show=True,\n)\nprint(f\"Collage saved to: {collage_path}\")\n\n# Auto-download in Google Colab\ntry:\n    from google.colab import files\n    files.download(str(collage_path))\nexcept ImportError:\n    pass",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a frame collage for quick visual review\n",
+    "# Single image with labelled frame numbers and timestamps\n",
+    "\n",
+    "collage_path = STAGE_DIR / \"eval_collage.png\"\n",
+    "collage_fig = create_frame_collage(\n",
+    "    frames,\n",
+    "    output_path=collage_path,\n",
+    "    num_frames=10,\n",
+    "    cols=5,\n",
+    "    title=f\"{SPECIES.capitalize()} Stage {CURRENT_STAGE} — Eval Rollout ({len(frames)} frames, {len(frames) / 50:.1f}s)\",\n",
+    "    fps=50,\n",
+    "    show=True,\n",
+    ")\n",
+    "print(f\"Collage saved to: {collage_path}\")\n",
+    "\n",
+    "# Auto-download in Google Colab\n",
+    "try:\n",
+    "    from google.colab import files\n",
+    "\n",
+    "    files.download(str(collage_path))\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_032",
    "metadata": {
     "id": "12f07d75"
    },
@@ -623,45 +1085,53 @@
     "\n",
     "To train a different species, change `SPECIES` in the configuration cell and\n",
     "restart from the beginning."
-   ],
-   "id": "cell_032"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell_033",
+   "metadata": {
+    "id": "ba693752"
+   },
    "source": [
     "## 10. Auto-Disconnect (Optional)\n",
     "\n",
     "Optionally disconnect the Colab runtime after completion to free up resources.\n",
     "Set `AUTO_DISCONNECT = True` in the configuration cell or toggle below."
-   ],
-   "metadata": {
-    "id": "ba693752"
-   },
-   "id": "cell_033"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "cell_034",
+   "metadata": {
+    "id": "2ec9c173"
+   },
+   "outputs": [],
    "source": [
     "AUTO_DISCONNECT = True  # Set to True to disconnect runtime after training\n",
     "\n",
     "if AUTO_DISCONNECT:\n",
     "    import time\n",
+    "\n",
     "    print(\"Training finished. Disconnecting runtime in 5 seconds...\")\n",
     "    time.sleep(5)\n",
     "    from google.colab import runtime\n",
+    "\n",
     "    runtime.unassign()\n",
     "else:\n",
-    "    print(\"Training finished. Runtime kept alive \u2014 remember to disconnect manually when done.\")"
-   ],
-   "metadata": {
-    "id": "2ec9c173"
-   },
-   "execution_count": null,
-   "outputs": [],
-   "id": "cell_034"
+    "    print(\"Training finished. Runtime kept alive — remember to disconnect manually when done.\")"
+   ]
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "A100",
+   "include_colab_link": true,
+   "machine_shape": "hm",
+   "provenance": []
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"
@@ -669,13 +1139,6 @@
   "language_info": {
    "name": "python",
    "version": "3.11.0"
-  },
-  "accelerator": "GPU",
-  "colab": {
-   "gpuType": "A100",
-   "provenance": [],
-   "machine_shape": "hm",
-   "include_colab_link": true
   }
  },
  "nbformat": 4,

--- a/notebooks/jax_training.ipynb
+++ b/notebooks/jax_training.ipynb
@@ -26,9 +26,9 @@
     "**Requirements:** Colab GPU runtime (A100 recommended).\n",
     "\n",
     "**Supported Species:**\n",
-    "- `trex` — T-Rex: balance → locomotion → bite\n",
-    "- `velociraptor` — Raptor: balance → locomotion → strike\n",
-    "- `brachiosaurus` — Brachio: balance → locomotion → food reach\n",
+    "- `trex` \u2014 T-Rex: balance \u2192 locomotion \u2192 bite\n",
+    "- `velociraptor` \u2014 Raptor: balance \u2192 locomotion \u2192 strike\n",
+    "- `brachiosaurus` \u2014 Brachio: balance \u2192 locomotion \u2192 food reach\n",
     "\n",
     "Set `SPECIES` in the configuration cell below to choose."
    ],
@@ -72,7 +72,7 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "# GPU diagnostics — run this anytime to check utilization\n",
+    "# GPU diagnostics \u2014 run this anytime to check utilization\n",
     "# (especially useful to run from a second terminal during training)\n",
     "import subprocess\n",
     "result = subprocess.run(\n",
@@ -123,7 +123,7 @@
     "    !pip install -e \"/kaggle/working/mesozoic-labs[jax]\" -q\n",
     "    _REPO_ROOT = '/kaggle/working/mesozoic-labs'\n",
     "else:\n",
-    "    # Running locally — walk up from cwd until we find pyproject.toml\n",
+    "    # Running locally \u2014 walk up from cwd until we find pyproject.toml\n",
     "    _REPO_ROOT = os.getcwd()\n",
     "    _d = _REPO_ROOT\n",
     "    while _d != os.path.dirname(_d):\n",
@@ -132,7 +132,7 @@
     "            break\n",
     "        _d = os.path.dirname(_d)\n",
     "\n",
-    "# Ensure the repo root is on sys.path so `from environments.…` works\n",
+    "# Ensure the repo root is on sys.path so `from environments.\u2026` works\n",
     "# even if the editable install did not fully resolve.\n",
     "if _REPO_ROOT not in sys.path:\n",
     "    sys.path.insert(0, _REPO_ROOT)\n",
@@ -161,7 +161,7 @@
     "id": "8ceadf08"
    },
    "source": [
-    "import logging\nimport time\n\n# Silence JAX compilation spam (tracing/compiling/XLA warnings every update)\nlogging.getLogger(\"jax._src.dispatch\").setLevel(logging.ERROR)\nlogging.getLogger(\"jax._src.interpreters.pxla\").setLevel(logging.ERROR)\n\nimport jax\nimport jax.numpy as jnp\nimport matplotlib.pyplot as plt\nimport mujoco\nimport numpy as np\nimport optax\nfrom mujoco import mjx\n\n# Shared modules from mesozoic-labs\nfrom environments.shared.jax_reward_termination import (\n    compute_total_reward,\n    compute_reward_components,\n    is_terminated as is_terminated_fn,\n)\nfrom environments.shared.jax_ppo import (\n    PPOConfig,\n    make_actor_critic,\n    make_optimizer,\n    sample_action,\n    compute_gae,\n    ppo_loss,\n)\nfrom environments.shared.jax_normalization import RunningMeanStd, normalize_obs, update_running_stats, decay_running_stats\nfrom environments.shared.jax_eval import EvalConfig, evaluate_policy_cpu, check_stage_gate\nfrom environments.shared.jax_viz import plot_training_curves, plot_locomotion_diagnostics, plot_reward_components, record_training_video, create_frame_collage\nfrom environments.shared.mjx_utils import scale_action_jax\nfrom environments.shared.mjx_env import MJXDinoEnv\nfrom environments.shared.obs_functions import SensorLayout, build_bipedal_obs\n\nprint(f\"JAX {jax.__version__}, devices: {jax.devices()}\")\nprint(f\"MuJoCo {mujoco.__version__}\")\n\n# Verify GPU\nassert jax.devices()[0].platform == \"gpu\", \"No GPU detected — JAX is using CPU. Check runtime type.\"\nprint(\"GPU OK\")"
+    "import logging\nimport time\n\n# Silence JAX compilation spam (tracing/compiling/XLA warnings every update)\nlogging.getLogger(\"jax._src.dispatch\").setLevel(logging.ERROR)\nlogging.getLogger(\"jax._src.interpreters.pxla\").setLevel(logging.ERROR)\n\nimport jax\nimport jax.numpy as jnp\nimport matplotlib.pyplot as plt\nimport mujoco\nimport numpy as np\nimport optax\nfrom mujoco import mjx\n\n# Shared modules from mesozoic-labs\nfrom environments.shared.jax_reward_termination import (\n    compute_total_reward,\n    compute_reward_components,\n    is_terminated as is_terminated_fn,\n)\nfrom environments.shared.jax_ppo import (\n    PPOConfig,\n    make_actor_critic,\n    make_optimizer,\n    sample_action,\n    compute_gae,\n    ppo_loss,\n)\nfrom environments.shared.jax_normalization import RunningMeanStd, normalize_obs, update_running_stats, decay_running_stats\nfrom environments.shared.jax_eval import EvalConfig, evaluate_policy_cpu, check_stage_gate\nfrom environments.shared.jax_viz import plot_training_curves, plot_locomotion_diagnostics, plot_reward_components, record_training_video, create_frame_collage\nfrom environments.shared.mjx_utils import scale_action_jax\nfrom environments.shared.mjx_env import MJXDinoEnv\nfrom environments.shared.obs_functions import SensorLayout, build_bipedal_obs\n\nprint(f\"JAX {jax.__version__}, devices: {jax.devices()}\")\nprint(f\"MuJoCo {mujoco.__version__}\")\n\n# Verify GPU\nassert jax.devices()[0].platform == \"gpu\", \"No GPU detected \u2014 JAX is using CPU. Check runtime type.\"\nprint(\"GPU OK\")"
    ],
    "outputs": [],
    "execution_count": null,
@@ -194,7 +194,7 @@
     "id": "44372d64"
    },
    "outputs": [],
-   "source": "# Model already loaded by setup_species() — just display info\nmj_model = ctx.mj_model\nprint(f\"{SPECIES.title()} model loaded:\")\nprint(f\"  Bodies: {mj_model.nbody}, Joints: {mj_model.njnt}, Actuators: {mj_model.nu}\")\nprint(f\"  qpos: {mj_model.nq}, qvel: {mj_model.nv}, Geoms: {mj_model.ngeom}\")\nprint(f\"  Total mass: {sum(mj_model.body_mass):.2f} kg, Timestep: {mj_model.opt.timestep * 1000:.1f} ms\")",
+   "source": "# Model already loaded by setup_species() \u2014 just display info\nmj_model = ctx.mj_model\nprint(f\"{SPECIES.title()} model loaded:\")\nprint(f\"  Bodies: {mj_model.nbody}, Joints: {mj_model.njnt}, Actuators: {mj_model.nu}\")\nprint(f\"  qpos: {mj_model.nq}, qvel: {mj_model.nv}, Geoms: {mj_model.ngeom}\")\nprint(f\"  Total mass: {sum(mj_model.body_mass):.2f} kg, Timestep: {mj_model.opt.timestep * 1000:.1f} ms\")",
    "id": "cell_008"
   },
   {
@@ -276,7 +276,7 @@
     "id": "87ca3be9"
    },
    "source": [
-    "from pathlib import Path\n\n# Initialize using the shared ActorCritic from jax_ppo\nnetwork = make_actor_critic(action_dim=ACT_DIM)\nrng = jax.random.PRNGKey(42)\ndummy_obs = jnp.zeros((OBS_DIM,))\nparams = network.init(rng, dummy_obs)\n\n# Observation normalization (stabilizes training across species/stages)\nobs_rms = RunningMeanStd.create(OBS_DIM)\n\n# Resume from checkpoint if specified\n_resume_update = 0\n_jax_kw_resume = {}\ntry:\n    from environments.shared.config import load_stage_config as _lsc\n    _jax_kw_resume = _lsc(SPECIES, CURRENT_STAGE).get(\"jax_kwargs\", {})\nexcept Exception:\n    pass\n\nif RESUME_FROM:\n    import pickle\n    _ckpt_path = OUTPUT_DIR / RESUME_FROM if not Path(RESUME_FROM).is_absolute() else Path(RESUME_FROM)\n    with open(_ckpt_path, \"rb\") as f:\n        _ckpt = pickle.load(f)\n    params = jax.device_put(_ckpt[\"params\"])\n    _resume_update = _ckpt.get(\"update\", 0)\n    if \"obs_rms\" in _ckpt:\n        obs_rms = _ckpt[\"obs_rms\"]\n        # When transitioning between stages, the obs distribution shifts\n        # (e.g. near-zero velocity in balance → sustained velocity in\n        # locomotion).  With 2048 envs the prior count can be ~65M, making\n        # update_running_stats nearly a no-op.  Decay the count so new\n        # data adapts the statistics within a few updates.\n        _obs_decay = _jax_kw_resume.get(\"obs_rms_decay_on_resume\", 0.01)\n        if _obs_decay < 1.0:\n            _old_count = obs_rms.count\n            obs_rms = decay_running_stats(obs_rms, decay_factor=_obs_decay)\n            print(f\"  obs_rms count decayed: {_old_count:,.0f} → {obs_rms.count:,.0f} (factor={_obs_decay})\")\n    print(f\"Resumed from {_ckpt_path} (update {_resume_update})\")\n    if \"reward_history\" in _ckpt:\n        print(f\"  Prior history: {len(_ckpt['reward_history'])} updates, best reward: {max(_ckpt['reward_history']):.4f}\")\n\nn_params = sum(p.size for p in jax.tree.leaves(params))\nprint(f\"ActorCritic parameters: {n_params:,}\")"
+    "from pathlib import Path\n\n# Initialize using the shared ActorCritic from jax_ppo\nnetwork = make_actor_critic(action_dim=ACT_DIM)\nrng = jax.random.PRNGKey(42)\ndummy_obs = jnp.zeros((OBS_DIM,))\nparams = network.init(rng, dummy_obs)\n\n# Observation normalization (stabilizes training across species/stages)\nobs_rms = RunningMeanStd.create(OBS_DIM)\n\n# Resume from checkpoint if specified\n_resume_update = 0\n_jax_kw_resume = {}\ntry:\n    from environments.shared.config import load_stage_config as _lsc\n    _jax_kw_resume = _lsc(SPECIES, CURRENT_STAGE).get(\"jax_kwargs\", {})\nexcept Exception:\n    pass\n\nif RESUME_FROM:\n    import pickle\n    _ckpt_path = OUTPUT_DIR / RESUME_FROM if not Path(RESUME_FROM).is_absolute() else Path(RESUME_FROM)\n    with open(_ckpt_path, \"rb\") as f:\n        _ckpt = pickle.load(f)\n    params = jax.device_put(_ckpt[\"params\"])\n    _resume_update = _ckpt.get(\"update\", 0)\n    if \"obs_rms\" in _ckpt:\n        obs_rms = _ckpt[\"obs_rms\"]\n        # When transitioning between stages, the obs distribution shifts\n        # (e.g. near-zero velocity in balance \u2192 sustained velocity in\n        # locomotion).  With 2048 envs the prior count can be ~65M, making\n        # update_running_stats nearly a no-op.  Decay the count so new\n        # data adapts the statistics within a few updates.\n        _obs_decay = _jax_kw_resume.get(\"obs_rms_decay_on_resume\", 0.01)\n        if _obs_decay < 1.0:\n            _old_count = obs_rms.count\n            obs_rms = decay_running_stats(obs_rms, decay_factor=_obs_decay)\n            print(f\"  obs_rms count decayed: {_old_count:,.0f} \u2192 {obs_rms.count:,.0f} (factor={_obs_decay})\")\n    print(f\"Resumed from {_ckpt_path} (update {_resume_update})\")\n    if \"reward_history\" in _ckpt:\n        print(f\"  Prior history: {len(_ckpt['reward_history'])} updates, best reward: {max(_ckpt['reward_history']):.4f}\")\n\nn_params = sum(p.size for p in jax.tree.leaves(params))\nprint(f\"ActorCritic parameters: {n_params:,}\")"
    ],
    "outputs": [],
    "execution_count": null,
@@ -348,7 +348,7 @@
     "id": "051c1063"
    },
    "outputs": [],
-   "source": "# Initialize environments using MJXDinoEnv.reset()\n# Use a different seed from network init (PRNGKey(42)) to avoid correlated streams\nrng = jax.random.PRNGKey(0)\nrng, reset_rng = jax.random.split(rng)\nstates = env.reset(reset_rng)\n\nprint(f\"Initialized {NUM_ENVS} parallel environments via MJXDinoEnv.reset().\")\nprint(f\"Obs shape: {states.obs.shape}\")\nprint(f\"Reset noise: joints=±{env.config.reset_noise_scale}, \"\n      f\"xy=±{env.config.init_qpos_noise}m, yaw=±{env.config.init_yaw_noise}rad\")",
+   "source": "# Initialize environments using MJXDinoEnv.reset()\n# Use a different seed from network init (PRNGKey(42)) to avoid correlated streams\nrng = jax.random.PRNGKey(0)\nrng, reset_rng = jax.random.split(rng)\nstates = env.reset(reset_rng)\n\nprint(f\"Initialized {NUM_ENVS} parallel environments via MJXDinoEnv.reset().\")\nprint(f\"Obs shape: {states.obs.shape}\")\nprint(f\"Reset noise: joints=\u00b1{env.config.reset_noise_scale}, \"\n      f\"xy=\u00b1{env.config.init_qpos_noise}m, yaw=\u00b1{env.config.init_yaw_noise}rad\")",
    "id": "cell_020"
   },
   {
@@ -468,7 +468,7 @@
    },
    "outputs": [],
    "source": [
-    "# Training curves — uses shared plot_training_curves from jax_viz\n",
+    "# Training curves \u2014 uses shared plot_training_curves from jax_viz\n",
     "curve_path = OUTPUT_DIR / \"training_curves.png\"\n",
     "\n",
     "plot_training_curves(\n",
@@ -489,7 +489,7 @@
   {
    "cell_type": "code",
    "source": [
-    "# Locomotion diagnostics — uses shared plot_locomotion_diagnostics from jax_viz\n",
+    "# Locomotion diagnostics \u2014 uses shared plot_locomotion_diagnostics from jax_viz\n",
     "\n",
     "plot_locomotion_diagnostics(\n",
     "    eval_results,\n",
@@ -584,12 +584,12 @@
     "id": "70d1f455"
    },
    "outputs": [],
-   "source": "try:\n    import mediapy  # noqa: F401\n    _HAS_MEDIAPY = True\nexcept ImportError:\n    _HAS_MEDIAPY = False\n    print(\"mediapy not installed — installing now...\")\n    import subprocess\n    subprocess.check_call([\"pip\", \"install\", \"-q\", \"mediapy\"])\n    import mediapy  # noqa: F401\n    _HAS_MEDIAPY = True\n    print(\"mediapy installed successfully.\")\n\nif _HAS_MEDIAPY:\n    video_params = best_params if best_params is not None else jax.device_get(params)\n    print(f\"Recording video with best model (update {best_update}, reward {best_reward:+.4f})\")\n\n    video_path = str(OUTPUT_DIR / \"evaluation.mp4\")\n\n    frames, episode_reward = record_training_video(\n        mj_model, video_params, network, obs_rms,\n        get_obs_fn=get_obs,\n        normalize_obs_fn=normalize_obs,\n        scale_action_fn=scale_action,\n        reward_fn=compute_reward,\n        reward_cfg=reward_cfg,\n        max_episode_steps=ctx.max_episode_steps,\n        frame_skip=ctx.frame_skip,\n        root_body_id=ctx.root_body_id,\n        healthy_z_range=ctx.healthy_z_range,\n        max_tilt_angle=ctx.max_tilt_angle,\n        natural_forward_z=ctx.natural_forward_z,\n        termination_body_heights=ctx.termination_body_heights,\n        termination_site_heights=ctx.termination_site_heights,\n        success_sites=ctx.success_sites,\n        success_threshold=ctx.success_threshold,\n        target_body=\"prey\",\n        sensor_quat_start=ctx.sensor_layout.quat_start,\n        output_path=video_path,\n        fps=50,\n        camera_track_body=ctx.camera_track_body,\n        camera_distance=ctx.camera_distance,\n        show=True,\n    )\n\n    print(f\"Episode reward: {episode_reward:.2f} | {len(frames)} frames\")\n    print(f\"Saved to: {video_path}\")",
+   "source": "try:\n    import mediapy  # noqa: F401\n    _HAS_MEDIAPY = True\nexcept ImportError:\n    _HAS_MEDIAPY = False\n    print(\"mediapy not installed \u2014 installing now...\")\n    import subprocess\n    subprocess.check_call([\"pip\", \"install\", \"-q\", \"mediapy\"])\n    import mediapy  # noqa: F401\n    _HAS_MEDIAPY = True\n    print(\"mediapy installed successfully.\")\n\nif _HAS_MEDIAPY:\n    video_params = best_params if best_params is not None else jax.device_get(params)\n    print(f\"Recording video with best model (update {best_update}, reward {best_reward:+.4f})\")\n\n    video_path = str(OUTPUT_DIR / \"evaluation.mp4\")\n\n    frames, episode_reward = record_training_video(\n        mj_model, video_params, network, obs_rms,\n        get_obs_fn=get_obs,\n        normalize_obs_fn=normalize_obs,\n        scale_action_fn=scale_action,\n        reward_fn=compute_reward,\n        reward_cfg=reward_cfg,\n        max_episode_steps=ctx.max_episode_steps,\n        frame_skip=ctx.frame_skip,\n        root_body_id=ctx.root_body_id,\n        healthy_z_range=ctx.healthy_z_range,\n        max_tilt_angle=ctx.max_tilt_angle,\n        natural_forward_z=ctx.natural_forward_z,\n        termination_body_heights=ctx.termination_body_heights,\n        termination_site_heights=ctx.termination_site_heights,\n        success_sites=ctx.success_sites,\n        success_threshold=ctx.success_threshold,\n        target_body=\"prey\",\n        sensor_quat_start=ctx.sensor_layout.quat_start,\n        output_path=video_path,\n        fps=50,\n        camera_track_body=ctx.camera_track_body,\n        camera_distance=ctx.camera_distance,\n        show=True,\n    )\n\n    print(f\"Episode reward: {episode_reward:.2f} | {len(frames)} frames\")\n    print(f\"Saved to: {video_path}\")",
    "id": "cell_031"
   },
   {
    "cell_type": "code",
-   "source": "# Create a frame collage for quick visual review\n# Single image with labelled frame numbers and timestamps\n\ncollage_path = STAGE_DIR / \"eval_collage.png\"\ncollage_fig = create_frame_collage(\n    frames,\n    output_path=collage_path,\n    num_frames=10,\n    cols=5,\n    title=f\"{SPECIES.capitalize()} Stage {CURRENT_STAGE} — Eval Rollout ({len(frames)} frames, {len(frames)/50:.1f}s)\",\n    fps=50,\n    show=True,\n)\nprint(f\"Collage saved to: {collage_path}\")\n\n# Auto-download in Google Colab\ntry:\n    from google.colab import files\n    files.download(str(collage_path))\nexcept ImportError:\n    pass",
+   "source": "# Create a frame collage for quick visual review\n# Single image with labelled frame numbers and timestamps\n\ncollage_path = STAGE_DIR / \"eval_collage.png\"\ncollage_fig = create_frame_collage(\n    frames,\n    output_path=collage_path,\n    num_frames=10,\n    cols=5,\n    title=f\"{SPECIES.capitalize()} Stage {CURRENT_STAGE} \u2014 Eval Rollout ({len(frames)} frames, {len(frames)/50:.1f}s)\",\n    fps=50,\n    show=True,\n)\nprint(f\"Collage saved to: {collage_path}\")\n\n# Auto-download in Google Colab\ntry:\n    from google.colab import files\n    files.download(str(collage_path))\nexcept ImportError:\n    pass",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -651,7 +651,7 @@
     "    from google.colab import runtime\n",
     "    runtime.unassign()\n",
     "else:\n",
-    "    print(\"Training finished. Runtime kept alive — remember to disconnect manually when done.\")"
+    "    print(\"Training finished. Runtime kept alive \u2014 remember to disconnect manually when done.\")"
    ],
    "metadata": {
     "id": "2ec9c173"


### PR DESCRIPTION
## Summary
This PR refactors the JAX-based PPO training pipeline with three major improvements: (1) implements minibatch shuffling within PPO epochs for better sample utilization, (2) adds learning rate tracking and logging throughout training, and (3) enhances reward computation with approach shaping, success bonuses, and fall penalties for multi-stage curriculum learning.

## Key Changes

### PPO Training & Optimization
- **Minibatch shuffling**: Refactored `scan_ppo_update` to shuffle and split batches into minibatches within each epoch, improving gradient diversity and convergence
- **Learning rate scheduling**: Added linear LR decay computation and logging; current LR is now tracked and reported in metrics
- **PPO info aggregation**: Modified `scan_ppo_update` to return aggregated loss info (mean across epochs/minibatches) for better diagnostics
- **Network architecture**: Increased first hidden layer from 256 to 512 units for improved representational capacity

### Action Sampling Fix
- **Log probability correction**: Compute log_prob on unclipped actions before clipping to [-1, 1], ensuring correct Gaussian PDF and unbiased PPO ratios (previously computed after clipping, which squashed probability mass at boundaries)

### Reward System Enhancements
- **Approach shaping**: Added `reward_approach_shaping` for target-seeking behavior (useful for bite/strike stages)
- **Success detection**: Implemented proximity-based success bonus when reaching target sites
- **Fall penalty**: Added configurable penalty on termination (excluding success states) to discourage unsafe behaviors
- **Parameterized height bounds**: Replaced hardcoded `0.90` with configurable `healthy_z_max` parameter throughout reward computation

### Training Infrastructure
- **Removed profiler**: Eliminated `RolloutProfiler` and on-device episode tracking arrays (`_ep_returns`, `_ep_lengths`) in favor of `EpisodeStatsAccumulator`
- **Improved error handling**: Added debug logging for reward component diagnostics failures instead of silent pass
- **CSV logging**: Added `learning_rate` field to training metrics

### Configuration & Curriculum
- **JAX kwargs mapping**: Fixed curriculum stage config to always pass `jax_kwargs` parameters (removed conditional check that was preventing parameter override)
- **Reward function signatures**: Updated `compute_total_reward` and `compute_reward_components` to accept new parameters: `healthy_z_max`, `target_pos`, `prev_target_distance`, `forward_vel_max`, `dt`, `fall_penalty`, `success_site_positions`, `success_threshold`, `success_bonus`

### Documentation
- Updated Jupyter notebook with Unicode em-dashes and improved comments for clarity

## Implementation Details
- Minibatch shuffling uses `jax.random.permutation` to create deterministic but randomized batch orderings per epoch
- KL early stopping now operates at minibatch granularity, allowing fine-grained control over training stability
- Learning rate decay is computed on-the-fly based on `relative_update` and total training steps for efficiency
- Approach shaping and success detection integrate seamlessly with existing reward pipeline via conditional weight checks