### PR TITLE
Fix PPO ratio consistency by returning raw (unclipped) actions

### DIFF
--- a/environments/shared/jax_ppo.py
+++ b/environments/shared/jax_ppo.py
@@ -95,7 +95,11 @@ def make_actor_critic(action_dim: int, hidden_dims: tuple[int, ...] = (512, 256)
 
 
 def sample_action(params, network, obs, rng):
-    """Sample an action from the policy and return (action, log_prob, value).
+    """Sample an action from the policy and return (raw_action, log_prob, value).
+
+    Returns the **unclipped** action so that ``log_prob`` and the stored action
+    are consistent for PPO ratio computation.  Callers must clip to ``[-1, 1]``
+    before sending to the environment.
 
     Args:
         params: Network parameters.
@@ -104,7 +108,8 @@ def sample_action(params, network, obs, rng):
         rng: JAX PRNGKey.
 
     Returns:
-        (action, log_prob, value) tuple.
+        (raw_action, log_prob, value) tuple.  Clip ``raw_action`` before
+        passing to ``env.step()``.
     """
     check_jax()
     import jax
@@ -117,18 +122,15 @@ def sample_action(params, network, obs, rng):
     noise = jax.random.normal(rng, shape=action_mean.shape)
     raw_action = action_mean + action_std * noise
 
-    # Log probability computed on the *unclipped* action so the Gaussian
-    # PDF is correct (clipping squashes probability mass at the boundaries,
-    # biasing the PPO ratio if log_prob is computed after clipping).
+    # Log probability of the raw (unclipped) action under the Gaussian.
+    # The PPO loss must recompute log_prob using this same raw_action
+    # (stored in the batch) to keep the importance-sampling ratio correct.
     log_prob = -0.5 * jnp.sum(
         jnp.square((raw_action - action_mean) / (action_std + 1e-8)) + 2.0 * action_log_std + jnp.log(2.0 * jnp.pi),
         axis=-1,
     )
 
-    # Clamp to [-1, 1] after computing log_prob
-    action = jnp.clip(raw_action, -1.0, 1.0)
-
-    return action, log_prob, value
+    return raw_action, log_prob, value
 
 
 def compute_gae(

--- a/environments/shared/jax_trainer.py
+++ b/environments/shared/jax_trainer.py
@@ -488,8 +488,10 @@ def train(
                 rng, rng_act, rng_step = jax.random.split(rng, 3)
 
                 obs = normalize_obs(states.obs, obs_rms)
-                actions, log_probs, values = batched_sample(params, obs, rng_act)
+                raw_actions, log_probs, values = batched_sample(params, obs, rng_act)
 
+                # Clip actions for the environment; store raw actions for PPO
+                actions = jnp.clip(raw_actions, -1.0, 1.0)
                 states, rewards, terminated, truncated = env.step(states, actions, rng_step)
                 dones = terminated | truncated
 
@@ -497,7 +499,7 @@ def train(
                 gae_dones = terminated
 
                 all_obs.append(obs)
-                all_actions.append(actions)
+                all_actions.append(raw_actions)  # raw actions for PPO ratio consistency
                 all_log_probs.append(log_probs)
                 all_values.append(values)
                 all_rewards.append(rewards)
@@ -896,16 +898,18 @@ class JaxTrainer:
                 rng, action_rng = jax.random.split(rng)
 
                 obs = normalize_obs(states.obs, obs_stats_arg)
-                action, log_prob, value = jax.vmap(
+                raw_action, log_prob, value = jax.vmap(
                     sample_action,
                     in_axes=(None, None, 0, 0),
                 )(params, network, obs, jax.random.split(action_rng, num_envs))
 
+                # Clip for env; store raw action for PPO ratio consistency
+                action = jnp.clip(raw_action, -1.0, 1.0)
                 rng, step_rng = jax.random.split(rng)
                 new_states, rewards, terminated, truncated = env.step(states, action, step_rng)
                 dones = (terminated | truncated).astype(jnp.float32)
 
-                return (new_states, rng), (states.obs, action, log_prob, value, rewards, dones)
+                return (new_states, rng), (states.obs, raw_action, log_prob, value, rewards, dones)
 
             return jax.lax.scan(step_fn, (states, rng), None, length=rollout_len)
 

--- a/environments/shared/tests/test_jax_ppo.py
+++ b/environments/shared/tests/test_jax_ppo.py
@@ -6,12 +6,12 @@ import numpy as np
 import pytest
 
 # ---------------------------------------------------------------------------
-# Fix #1: log_prob must be computed BEFORE action clipping
+# Fix #1: sample_action returns raw (unclipped) action with matching log_prob
 # ---------------------------------------------------------------------------
 
 
 class TestSampleActionLogProb:
-    """Verify that log_prob is computed on the raw (unclipped) action."""
+    """Verify that sample_action returns raw actions with consistent log_prob."""
 
     @pytest.fixture()
     def _jax(self):
@@ -43,9 +43,29 @@ class TestSampleActionLogProb:
         assert all(np.isfinite(lp) for lp in log_probs)
         assert np.std(log_probs) > 0, "log_probs should vary across samples"
 
+    def test_raw_action_not_clipped(self, _jax):
+        """sample_action should return raw (unclipped) actions that may exceed [-1, 1]."""
+        jax, jnp = _jax
+        from environments.shared.jax_ppo import make_actor_critic, sample_action
+
+        network = make_actor_critic(action_dim=8, hidden_dims=(8,))
+        rng = jax.random.PRNGKey(99)
+        dummy = jnp.zeros(4)
+        params = network.init(rng, dummy)
+
+        # With std=1.0 (log_std init zeros) and 8 dims, some samples should exceed [-1, 1]
+        found_outside = False
+        rng, *rngs = jax.random.split(rng, 201)
+        for r in rngs:
+            action, _, _ = sample_action(params, network, dummy, r)
+            if float(jnp.max(jnp.abs(action))) > 1.0:
+                found_outside = True
+                break
+        assert found_outside, "Raw actions should sometimes exceed [-1, 1] bounds"
+
     def test_log_prob_matches_manual_gaussian(self, _jax):
         """log_prob should match the analytical diagonal-Gaussian formula
-        applied to the raw (pre-clip) action."""
+        applied to the raw (unclipped) action."""
         jax, jnp = _jax
         from environments.shared.jax_ppo import make_actor_critic, sample_action
 
@@ -61,14 +81,9 @@ class TestSampleActionLogProb:
         mean, log_std, _ = network.apply(params, dummy)
         std = jnp.exp(log_std)
 
-        # The action returned is clipped, but log_prob should be based on
-        # the unclipped sample. For actions well within [-1, 1] (std is
-        # initially small from zeros init), clipped == unclipped, so
-        # manual computation should match.
+        # action is raw (unclipped), so manual Gaussian log_prob must match exactly
         manual_lp = -0.5 * jnp.sum(jnp.square((action - mean) / (std + 1e-8)) + 2.0 * log_std + jnp.log(2.0 * jnp.pi))
-        # When action is within bounds, clipped == raw, so they must match
-        if jnp.all(jnp.abs(action) < 0.99):
-            assert float(log_prob) == pytest.approx(float(manual_lp), abs=1e-5)
+        assert float(log_prob) == pytest.approx(float(manual_lp), abs=1e-5)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in the PPO implementation where actions were being clipped before computing log probabilities, causing inconsistency in the importance-sampling ratio computation. The fix ensures that `sample_action` returns raw (unclipped) actions with matching log probabilities, while clipping is deferred to the environment step.

## Key Changes

- **`jax_ppo.py`**: Modified `sample_action()` to return raw (unclipped) actions instead of clipped actions
  - Removed the `jnp.clip(raw_action, -1.0, 1.0)` operation that was happening after log_prob computation
  - Updated docstring to clarify that callers must clip before passing to `env.step()`
  - Added detailed comments explaining why log_prob must be computed on raw actions for correct PPO ratio computation

- **`jax_trainer.py`**: Updated both training loops to handle the raw actions correctly
  - Renamed variables from `actions` to `raw_actions` for clarity
  - Added explicit clipping step immediately before `env.step()` calls
  - Store raw actions in the batch for PPO loss computation to maintain ratio consistency
  - Applied changes in both the main training loop and the rollout collection function

- **`test_jax_ppo.py`**: Enhanced test coverage
  - Updated test docstrings to reflect the new behavior
  - Added `test_raw_action_not_clipped()` to verify that sample_action returns unclipped actions
  - Simplified `test_log_prob_matches_manual_gaussian()` by removing the conditional check, since actions are now guaranteed to be raw

## Implementation Details

The core issue was that clipping actions after computing log probabilities biases the PPO importance-sampling ratio. By returning raw actions and deferring clipping to the environment interface, the log probability and stored action remain consistent, ensuring correct gradient computation in the PPO loss.