### PR TITLE
Handle missing model_path gracefully in stage summary reporting

### DIFF
--- a/environments/shared/reporting.py
+++ b/environments/shared/reporting.py
@@ -272,14 +272,15 @@ def write_stage_summary(
             lines.append(f"  Fwd vel:      {bm_vel} +/- {bm_vel_s} m/s")
         if bm_sr != "":
             lines.append(f"  Success rate: {bm_sr:.0%}")
-    _model_path = str(results_dict["model_path"])
-    if not Path(_model_path).suffix:
-        _model_path += ".zip"
-    model_lines = [f"Best model:     {_model_path}"]
-    if "vecnorm_path" in results_dict:
-        model_lines.append(f"VecNormalize:   {results_dict['vecnorm_path']}")
-    model_lines.append("")
-    lines.extend(model_lines)
+    _model_path = results_dict.get("model_path", "")
+    if _model_path:
+        _model_path = str(_model_path)
+        if not Path(_model_path).suffix:
+            _model_path += ".zip"
+        lines.append(f"Best model:     {_model_path}")
+        if "vecnorm_path" in results_dict:
+            lines.append(f"VecNormalize:   {results_dict['vecnorm_path']}")
+        lines.append("")
     summary_text = "\n".join(lines) + "\n"
     summary_path.write_text(summary_text)
     return summary_path


### PR DESCRIPTION
## Summary
Updated the stage summary reporting logic to gracefully handle cases where `model_path` may be missing from the results dictionary, preventing potential errors when generating summary reports.

## Key Changes
- Changed `model_path` retrieval from direct dictionary access to using `.get()` with an empty string default
- Added a conditional check to only process and append model-related lines when `model_path` is present
- Simplified the model lines construction by directly appending to the main `lines` list instead of using an intermediate `model_lines` list
- Maintained all existing functionality for path suffix handling and VecNormalize information when model path is available

## Implementation Details
The refactoring makes the code more defensive by:
1. Using `.get("model_path", "")` instead of direct dictionary access, eliminating potential KeyError exceptions
2. Only executing model path processing logic when a valid path exists
3. Reducing code complexity by removing the intermediate list variable while maintaining the same output format