### PR TITLE
Handle missing model_path in training summary reporting

### DIFF
--- a/environments/shared/reporting.py
+++ b/environments/shared/reporting.py
@@ -339,15 +339,13 @@ def write_training_summary(
             best_ts = r.get("best_eval_timestep", "")
             ts_label = f"  (at {best_ts:,} steps)" if isinstance(best_ts, int) else ""
             lines.append(f"  Best eval:      {best_r} +/- {best_s}{ts_label}")
-        model_path_str = str(r["model_path"])
-        if not Path(model_path_str).suffix:
-            model_path_str += ".zip"
-        lines.extend(
-            [
-                f"  Best model:     {model_path_str}",
-                "",
-            ]
-        )
+        model_path = r.get("model_path")
+        if model_path is not None:
+            model_path_str = str(model_path)
+            if not Path(model_path_str).suffix:
+                model_path_str += ".zip"
+            lines.append(f"  Best model:     {model_path_str}")
+        lines.append("")
 
     lines.extend(
         [

--- a/environments/shared/reporting.py
+++ b/environments/shared/reporting.py
@@ -898,6 +898,7 @@ def save_jax_stage_artifacts(
     logger.info("Models saved: %s, %s", best_model_path, final_model_path)
 
     # 6. Training summary (run-level)
+    stage_results.setdefault("model_path", str(best_model_path))
     training_summary_path = write_training_summary(
         run_dir,
         [stage_results],


### PR DESCRIPTION
## Summary
This change improves the robustness of training summary reporting by gracefully handling cases where `model_path` may not be present in results, while also ensuring the model path is consistently set in JAX stage artifacts.

## Key Changes
- **Defensive null checking**: Modified `write_training_summary()` to check if `model_path` exists before attempting to format and display it, preventing potential KeyError exceptions
- **Conditional model path output**: The "Best model" line is now only added to the summary when a model path is actually available
- **Ensure model path is set**: Added `setdefault()` call in `save_jax_stage_artifacts()` to guarantee `model_path` is populated in `stage_results` before writing the training summary

## Implementation Details
- Changed from direct dictionary access `r["model_path"]` to safer `r.get("model_path")` with None check
- Simplified the output logic by appending the empty line unconditionally rather than as part of a list extension
- The model path is now set to `str(best_model_path)` in the JAX artifacts function, ensuring downstream reporting always has this value available