### PR TITLE
Remove redundant JAX checks from hot paths and fix optax API

### DIFF
--- a/environments/shared/jax_normalization.py
+++ b/environments/shared/jax_normalization.py
@@ -54,7 +54,6 @@ def update_running_stats(
     Returns:
         Updated ``RunningMeanStd``.
     """
-    check_jax()
     import jax.numpy as jnp
 
     batch_mean = jnp.mean(batch, axis=0)
@@ -121,7 +120,6 @@ def normalize_obs(
     Returns:
         Normalised observation array.
     """
-    check_jax()
     import jax.numpy as jnp
 
     normed = (obs - stats.mean) / jnp.sqrt(stats.var + 1e-8)

--- a/environments/shared/jax_ppo.py
+++ b/environments/shared/jax_ppo.py
@@ -111,7 +111,6 @@ def sample_action(params, network, obs, rng):
         (raw_action, log_prob, value) tuple.  Clip ``raw_action`` before
         passing to ``env.step()``.
     """
-    check_jax()
     import jax
     import jax.numpy as jnp
 
@@ -152,7 +151,6 @@ def compute_gae(
     Returns:
         (advantages, returns) tuple, each of shape ``(T, num_envs)``.
     """
-    check_jax()
     import jax
     import jax.numpy as jnp
 
@@ -191,7 +189,6 @@ def ppo_loss(params, network, batch, config: PPOConfig):
     Returns:
         (total_loss, info_dict) tuple.
     """
-    check_jax()
     import jax.numpy as jnp
 
     action_mean, action_log_std, value = network.apply(params, batch["obs"])
@@ -255,7 +252,7 @@ def make_optimizer(config: PPOConfig):
     Returns:
         An ``optax.GradientTransformation``.
     """
-    check_jax()
+    check_jax()  # guard: called once at setup time
     import optax
 
     if config.learning_rate_end is not None and config.learning_rate_end != config.learning_rate:
@@ -288,7 +285,6 @@ def ppo_update(params, opt_state, optimizer, network, batch, config: PPOConfig):
     Returns:
         (new_params, new_opt_state, loss_info) tuple.
     """
-    check_jax()
     import jax
     import optax
 

--- a/environments/shared/jax_trainer.py
+++ b/environments/shared/jax_trainer.py
@@ -234,13 +234,13 @@ def _build_jit_fns(config: TrainConfig, network, optimizer, reward_detail_fn):
             vf_clip_range=vf_clip_range,
         )
         grad_norm = optax.global_norm(grads)
-        updates, opt_state = optimizer.update(grads, opt_state)
+        updates, opt_state = optimizer.update(grads, opt_state, params)
         params = optax.apply_updates(params, updates)
         return params, opt_state, loss, aux, grad_norm
 
     # --- Fused scan PPO epochs with KL early stopping ---
 
-    @jax.jit
+    @jax.jit(donate_argnums=(0, 1))
     def scan_ppo_epochs(
         params, opt_state, flat_obs, flat_act, flat_lp, flat_adv, flat_ret, flat_val, rng, clip_range, ent_coef
     ):


### PR DESCRIPTION
## Summary
This PR optimizes JAX PPO training by removing redundant `check_jax()` calls from frequently-executed code paths while keeping the check in setup-time functions. It also fixes an optax API compatibility issue and enables memory optimization through argument donation.

## Key Changes

- **Removed `check_jax()` from hot paths**: Eliminated redundant JAX availability checks from `sample_action()`, `compute_gae()`, `ppo_loss()`, `ppo_update()`, and normalization functions (`update_running_stats()`, `normalize_obs()`). These functions are called repeatedly during training and don't need repeated validation.

- **Kept `check_jax()` in setup function**: Retained the check in `make_optimizer()` with a clarifying comment, as this is called once at initialization time and serves as a guard for the entire training pipeline.

- **Fixed optax optimizer API call**: Updated `optimizer.update(grads, opt_state)` to `optimizer.update(grads, opt_state, params)` in `jax_trainer.py` to match the current optax API signature, which requires params for stateful optimizers.

- **Enabled memory optimization**: Added `donate_argnums=(0, 1)` to the `@jax.jit` decorator on `scan_ppo_epochs()` to allow JAX to reuse memory for the params and opt_state arguments, reducing memory pressure during training.

## Implementation Details

The removal of `check_jax()` from hot paths is a performance optimization since:
- The check is expensive (imports and validation)
- These functions are called thousands of times per training run
- A single check at setup time (in `make_optimizer()`) is sufficient to ensure JAX is available for the entire training session