### PR TITLE
Replace deprecated donate_argnums with donate_argnames in JAX JIT

### DIFF
--- a/environments/shared/jax_trainer.py
+++ b/environments/shared/jax_trainer.py
@@ -240,7 +240,7 @@ def _build_jit_fns(config: TrainConfig, network, optimizer, reward_detail_fn):
 
     # --- Fused scan PPO epochs with KL early stopping ---
 
-    @jax.jit(donate_argnums=(0, 1))
+    @jax.jit(donate_argnames=("params", "opt_state"))
     def scan_ppo_epochs(
         params, opt_state, flat_obs, flat_act, flat_lp, flat_adv, flat_ret, flat_val, rng, clip_range, ent_coef
     ):


### PR DESCRIPTION
## Summary
Updated the JAX JIT decorator in the PPO trainer to use the newer `donate_argnames` parameter instead of the deprecated `donate_argnums` parameter.

## Key Changes
- Replaced `@jax.jit(donate_argnums=(0, 1))` with `@jax.jit(donate_argnames=("params", "opt_state"))` in the `scan_ppo_epochs` function
- This change maintains the same functionality while using JAX's recommended API for specifying which arguments should have their memory donated to the computation

## Implementation Details
The `donate_argnames` approach is more explicit and maintainable than positional indices, as it directly references parameter names rather than relying on argument order. This reduces the risk of bugs if function signatures change in the future.