### PR TITLE
Drop donate_argnums from jax.jit decorator

### DIFF
--- a/environments/shared/jax_trainer.py
+++ b/environments/shared/jax_trainer.py
@@ -240,7 +240,7 @@ def _build_jit_fns(config: TrainConfig, network, optimizer, reward_detail_fn):
 
     # --- Fused scan PPO epochs with KL early stopping ---
 
-    @jax.jit(donate_argnames=("params", "opt_state"))
+    @jax.jit
     def scan_ppo_epochs(
         params, opt_state, flat_obs, flat_act, flat_lp, flat_adv, flat_ret, flat_val, rng, clip_range, ent_coef
     ):


### PR DESCRIPTION
The installed JAX version doesn't support keyword arguments in the @jax.jit() decorator form. Buffer donation is a memory optimization hint and not required for correctness.