### PR TITLE
Add mjlab pilot scaffold for GPU-accelerated training

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Hardware: Google Colab L4 GPU
 - [ ] Domain randomization (friction, damping, gravity, actuator strength, external pushes, observation noise)
 - [ ] Terrain adaptation (uneven ground, obstacles)
 - [-] JAX/MJX migration for faster training (PPO pipeline complete, SAC pending)
+- [-] mjlab pilot (MuJoCo-Warp + Isaac-Lab manager API) — scaffold landed, velociraptor Stage 1 spike pending
 - [ ] Multi-agent pack hunting scenarios
 - [ ] Sim-to-real transfer experiments
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,7 +18,7 @@ Legend: `[x]` done | `[-]` in progress | `[ ]` not started
 | **2** | Into the Wild (v0.4.0) | Not Started | 0/9 items | Blocked on Phase 1 training results |
 | **3** | Evolution (v0.5.0) | Not Started | 0/8 items | Blocked on Phases 1-2 |
 | **4** | The Pack (v0.6.0) | Not Started | 0/6 items | Blocked on Phase 3 species |
-| **5** | Hyperdrive (v0.7.0) | **In Progress** | 3/5 items | JAX SAC, large-scale experiments |
+| **5** | Hyperdrive (v0.7.0) | **In Progress** | 3/6 items | JAX SAC, large-scale experiments, mjlab pilot |
 | **6** | Life Finds a Way (v1.0.0) | Not Started | 0/5 items | Blocked on Phases 2-5 |
 
 **Current focus:** Phase 1 — all infrastructure is in place (curriculum manager,
@@ -426,8 +426,26 @@ Parallel track that can start alongside Phase 4. GPU-accelerated batch simulatio
   - Discover training regimes not possible at CPU scale
   - _Dependency: Brax PPO pipeline_
 
+- [-] **mjlab pilot — evaluate manager-based GPU backend**
+  - Scaffold landed in `environments/shared/mjlab_env.py` and
+    `environments/velociraptor/mjlab_config.py` with an `[mjlab]`
+    optional extra in `pyproject.toml`
+  - mjlab pairs Isaac-Lab's manager-based API with MuJoCo-Warp
+    (GPU-accelerated MuJoCo); paper: Zakka et al., arXiv:2601.22074
+  - Pilot target: velociraptor Stage 1 balance on a single NVIDIA GPU
+    - Reach reward >= 1900 in <= 30 min (baseline: SB3 PPO 2:57:25)
+    - Achieve >= 2x envs/sec vs existing `MJXDinoEnv`
+    - Express env + curriculum in <= 60% of current MJX LOC
+  - If pilot succeeds: migrate all species to mjlab for the GPU track,
+    retire bespoke `jax_ppo.py` / `jax_training.py`, and fold domain
+    randomization (Phase 2) into mjlab event managers
+  - If pilot fails: keep existing MJX path, document findings, close out
+  - _Dependency: MJX environment for all species (completed above);
+    NVIDIA GPU in Colab / Vertex AI_
+
 **Exit criteria:** 100x+ speedup demonstrated. All species available on MJX backend.
-Published benchmark comparison (CPU vs. GPU vs. TPU).
+Published benchmark comparison (CPU vs. GPU vs. TPU). mjlab pilot concluded
+with a keep/retire decision on the custom JAX training stack.
 
 ---
 
@@ -519,6 +537,7 @@ Locomotion (P1) → Turning (P2) → Stage 4 prey pursuit (P2) → Reactive prey
                                                                                  → Learned prey (P4)
 
 Velociraptor trained (P1) → MJX port (P5) → Brax PPO (P5) → Scale experiments (P5)
+                                          → mjlab pilot (P5) → DR via event managers (P2)
 
 Compsognathus species (P3) → Physical prototype (P6) → Sim-to-real (P6)
 Sensor noise policies (P2) → HAL (P6) → ROS 2 bridge (P6)

--- a/environments/shared/mjlab_env.py
+++ b/environments/shared/mjlab_env.py
@@ -171,7 +171,9 @@ def make_mjlab_env(
     # return ManagerBasedRLEnv(cfg=env_cfg)
     raise NotImplementedError(
         "mjlab integration is a scaffold. Wire up ManagerBasedRLEnv once the "
-        "mjlab dep is installed locally. See module docstring for the pilot plan."
+        "mjlab dep is installed locally. See module docstring for the pilot plan. "
+        f"(species={cfg.species}, stage={stage}, reward_keys={sorted(reward_weights)}, "
+        f"num_envs={num_envs or cfg.num_envs_default}, device={device})"
     )
 
 

--- a/environments/shared/mjlab_env.py
+++ b/environments/shared/mjlab_env.py
@@ -1,0 +1,184 @@
+"""mjlab adapter scaffold for Mesozoic Labs.
+
+This module provides a thin bridge between the project's species registry
+and `mjlab <https://github.com/mujocolab/mjlab>`_ — a lightweight framework
+that pairs Isaac-Lab's manager-based API with MuJoCo Warp (GPU-accelerated
+MuJoCo).
+
+Why an adapter and not a drop-in?
+---------------------------------
+mjlab composes environments via **managers** (observation / reward /
+termination / event / curriculum managers) rather than a monolithic
+``gym.Env`` subclass. Our existing ``MJXDinoEnv`` and ``BaseDinoEnv`` use the
+classic single-class pattern. This module lets us reuse our MJCF models,
+TOML stage configs, and pure reward/obs functions while expressing the
+*composition* in mjlab's idiom.
+
+Status
+------
+**Proof of concept.** The adapter is intentionally small. It wires a species
+registered with ``register_species_mjlab`` into mjlab's ``ManagerBasedRLEnv``
+config objects. A working pilot should target velociraptor Stage 1 (balance)
+and compare throughput + wall-clock-to-reward against the existing MJX path.
+
+Requires the optional ``mjlab`` extra (NVIDIA GPU for training; macOS eval
+only). See ``pyproject.toml``::
+
+    pip install -e ".[mjlab]"
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+# mjlab is an optional dependency: import lazily so the module is importable
+# (and testable) even when mjlab/MuJoCo-Warp aren't installed.
+try:
+    import mjlab  # type: ignore  # noqa: F401
+
+    _MJLAB_AVAILABLE = True
+except ImportError:  # pragma: no cover - optional dep
+    _MJLAB_AVAILABLE = False
+
+
+def require_mjlab() -> None:
+    """Raise a helpful error if mjlab is not installed."""
+    if not _MJLAB_AVAILABLE:
+        raise ImportError(
+            "mjlab is not installed. Install with: pip install -e '.[mjlab]'\n"
+            "mjlab requires an NVIDIA GPU for training (macOS is evaluation-only).\n"
+            "See https://github.com/mujocolab/mjlab"
+        )
+
+
+@dataclass(frozen=True)
+class MJLabSpeciesConfig:
+    """Species-level mjlab configuration.
+
+    Maps 1:1 onto the fields mjlab's manager-based env expects. Each species
+    registers one of these; stage-specific reward weights continue to live in
+    the TOML stage configs under ``configs/<species>/<stage>.toml``.
+    """
+
+    species: str
+    mjcf_path: Path
+    frame_skip: int
+    episode_length_s: float  # mjlab uses seconds, not steps
+    num_envs_default: int = 4096  # MuJoCo Warp scales to thousands on one GPU
+
+    # Observation / action specification (for sanity checks only — mjlab
+    # infers these from the model + observation managers).
+    obs_dim: int = 0
+    action_dim: int = 0
+
+    # Manager factories — populated at registration time. Each returns a
+    # mjlab ManagerTermCfg / ObsGroupCfg / etc. Kept as opaque callables so
+    # this module remains importable without mjlab installed.
+    observation_manager_factory: Callable[[], Any] | None = None
+    reward_manager_factory: Callable[[dict[str, float]], Any] | None = None
+    termination_manager_factory: Callable[[], Any] | None = None
+    event_manager_factory: Callable[[], Any] | None = None  # domain randomization
+
+    # Sensible defaults for domain randomization ranges. Phase 2 roadmap item.
+    randomization: dict[str, tuple[float, float]] = field(
+        default_factory=lambda: {
+            "friction": (0.7, 1.3),
+            "damping_scale": (0.8, 1.2),
+            "gravity_scale": (0.95, 1.05),
+            "actuator_gain_scale": (0.9, 1.1),
+        }
+    )
+
+
+_MJLAB_REGISTRY: dict[str, MJLabSpeciesConfig] = {}
+
+
+def register_species_mjlab(config: MJLabSpeciesConfig) -> None:
+    """Register a species for mjlab. Mirrors ``register_species_mjx``."""
+    _MJLAB_REGISTRY[config.species] = config
+
+
+def get_species_mjlab(species: str) -> MJLabSpeciesConfig:
+    if species not in _MJLAB_REGISTRY:
+        raise KeyError(
+            f"Species '{species}' not registered for mjlab. "
+            f"Import environments.{species}.mjlab_config to register it. "
+            f"Available: {sorted(_MJLAB_REGISTRY)}"
+        )
+    return _MJLAB_REGISTRY[species]
+
+
+def make_mjlab_env(
+    species: str,
+    stage: int,
+    num_envs: int | None = None,
+    device: str = "cuda",
+) -> Any:
+    """Construct a mjlab ``ManagerBasedRLEnv`` for the given species + stage.
+
+    This is the single entry point scripts and notebooks should call. It:
+
+    1. Loads the species config from the mjlab registry.
+    2. Loads the stage reward weights from the TOML config.
+    3. Composes mjlab managers (obs/reward/term/events) from the species
+       factories.
+    4. Returns a mjlab env configured for ``num_envs`` parallel workers.
+
+    Parameters
+    ----------
+    species : str
+        One of the registered species (``"velociraptor"``, ``"trex"``,
+        ``"brachiosaurus"``).
+    stage : int
+        1 (balance), 2 (locomotion), or 3 (strike/bite/food_reach).
+    num_envs : int, optional
+        Number of parallel envs. Defaults to species config.
+    device : str
+        ``"cuda"`` for training, ``"cpu"`` for debugging, ``"mps"`` for
+        macOS eval (limited).
+    """
+    require_mjlab()
+
+    from environments.shared.config import load_stage_config  # lazy
+
+    cfg = get_species_mjlab(species)
+    stage_cfg = load_stage_config(species, stage)
+    reward_weights = dict(stage_cfg.get("reward_weights", {}))
+
+    # The following block is the integration point with mjlab's API. Kept
+    # as pseudo-code with explicit TODOs so the spike PR can land without
+    # pulling in the full mjlab dep tree in CI.
+    #
+    # from mjlab.envs import ManagerBasedRLEnv, ManagerBasedRLEnvCfg
+    # from mjlab.scene import InteractiveSceneCfg
+    #
+    # env_cfg = ManagerBasedRLEnvCfg(
+    #     scene=InteractiveSceneCfg(
+    #         num_envs=num_envs or cfg.num_envs_default,
+    #         env_spacing=4.0,
+    #         robot=_load_mjcf_asset(cfg.mjcf_path),
+    #     ),
+    #     observations=cfg.observation_manager_factory(),
+    #     rewards=cfg.reward_manager_factory(reward_weights),
+    #     terminations=cfg.termination_manager_factory(),
+    #     events=cfg.event_manager_factory(),
+    #     episode_length_s=cfg.episode_length_s,
+    #     decimation=cfg.frame_skip,
+    #     sim=_sim_cfg(device=device),
+    # )
+    # return ManagerBasedRLEnv(cfg=env_cfg)
+    raise NotImplementedError(
+        "mjlab integration is a scaffold. Wire up ManagerBasedRLEnv once the "
+        "mjlab dep is installed locally. See module docstring for the pilot plan."
+    )
+
+
+__all__ = [
+    "MJLabSpeciesConfig",
+    "register_species_mjlab",
+    "get_species_mjlab",
+    "make_mjlab_env",
+    "require_mjlab",
+]

--- a/environments/velociraptor/mjlab_config.py
+++ b/environments/velociraptor/mjlab_config.py
@@ -1,0 +1,79 @@
+"""Velociraptor mjlab species configuration.
+
+Registers the velociraptor with the mjlab adapter so that
+``make_mjlab_env("velociraptor", stage=1)`` works once the optional
+``mjlab`` dependency is installed.
+
+Pilot target: reproduce Stage 1 balance (ref: SB3 PPO 2:57:25, best reward
+1964.43) on a single NVIDIA GPU via MuJoCo-Warp batch simulation, then
+measure wall-clock speedup and envs/sec vs the existing ``MJXDinoEnv``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from environments.shared.mjlab_env import MJLabSpeciesConfig, register_species_mjlab
+
+_ASSETS = Path(__file__).parent / "assets"
+
+
+def _build_observation_manager() -> object:
+    """Compose the 67-dim velociraptor observation via mjlab obs terms.
+
+    Intentionally deferred: mirrors the observation layout already documented
+    in ``envs/raptor_env.py`` (joint pos/vel, pelvis quat/gyro/linvel/accel,
+    foot contacts, prey direction + distance). Implemented in the pilot PR.
+    """
+    # from mjlab.managers import ObservationGroupCfg, ObservationTermCfg
+    # from mjlab.envs.mdp import observations as mdp_obs
+    # return ObservationGroupCfg(
+    #     joint_pos=ObservationTermCfg(func=mdp_obs.joint_pos_rel),
+    #     joint_vel=ObservationTermCfg(func=mdp_obs.joint_vel_rel),
+    #     base_quat=ObservationTermCfg(func=mdp_obs.base_quat),
+    #     base_ang_vel=ObservationTermCfg(func=mdp_obs.base_ang_vel),
+    #     base_lin_vel=ObservationTermCfg(func=mdp_obs.base_lin_vel),
+    #     ...
+    # )
+    raise NotImplementedError("Pilot PR: wire mjlab obs terms for velociraptor.")
+
+
+def _build_reward_manager(weights: dict[str, float]) -> object:
+    """Compose the staged reward via mjlab reward terms.
+
+    Reuses the same pure reward functions in ``environments/shared/
+    reward_functions.py`` via small ``ManagerTermCfg`` wrappers, so the
+    velociraptor TOML stage configs remain the single source of truth.
+    """
+    raise NotImplementedError("Pilot PR: wrap shared reward functions as mjlab terms.")
+
+
+def _build_termination_manager() -> object:
+    """Fall/time-out/success terminations (mirrors MJXDinoEnv logic)."""
+    raise NotImplementedError("Pilot PR: define mjlab termination terms.")
+
+
+def _build_event_manager() -> object:
+    """Domain randomization via mjlab events (Phase 2 roadmap item).
+
+    Event managers are mjlab's idiomatic DR mechanism — friction, damping,
+    gravity, actuator gain, external pushes, reset noise.
+    """
+    raise NotImplementedError("Pilot PR: add DR event terms using randomization ranges.")
+
+
+register_species_mjlab(
+    MJLabSpeciesConfig(
+        species="velociraptor",
+        mjcf_path=_ASSETS / "raptor.xml",
+        frame_skip=5,
+        episode_length_s=10.0,  # 1000 steps * 0.01s timestep * frame_skip=5 / 5
+        num_envs_default=4096,
+        obs_dim=67,
+        action_dim=22,
+        observation_manager_factory=_build_observation_manager,
+        reward_manager_factory=_build_reward_manager,
+        termination_manager_factory=_build_termination_manager,
+        event_manager_factory=_build_event_manager,
+    )
+)

--- a/environments/velociraptor/scripts/train_mjlab.py
+++ b/environments/velociraptor/scripts/train_mjlab.py
@@ -1,0 +1,56 @@
+"""Spike training script for velociraptor via mjlab.
+
+Usage (once mjlab is installed)::
+
+    python environments/velociraptor/scripts/train_mjlab.py \\
+        --stage 1 --num-envs 4096 --timesteps 20_000_000
+
+Pilot success criteria (see ROADMAP Phase 5, mjlab pilot):
+
+1. Reaches Stage 1 balance reward >= 1900 in <= 30 min on a single L4 GPU
+   (vs SB3 PPO baseline of 2:57:25).
+2. envs/sec throughput >= 2x the existing MJXDinoEnv path.
+3. LOC to express env + curriculum <= 60% of current MJXDinoEnv LOC.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="mjlab training spike for velociraptor")
+    parser.add_argument("--stage", type=int, default=1, choices=[1, 2, 3])
+    parser.add_argument("--num-envs", type=int, default=4096)
+    parser.add_argument("--timesteps", type=int, default=20_000_000)
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--seed", type=int, default=0)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    # Import here so `--help` works without the optional dep installed.
+    import environments.velociraptor.mjlab_config  # noqa: F401  # registers species
+    from environments.shared.mjlab_env import make_mjlab_env
+
+    env = make_mjlab_env(
+        species="velociraptor",
+        stage=args.stage,
+        num_envs=args.num_envs,
+        device=args.device,
+    )
+
+    # Training loop is handed off to mjlab's built-in rl-games / rsl-rl
+    # integration. The exact runner selection is decided in the pilot PR.
+    raise NotImplementedError(
+        "Pilot PR: run mjlab's built-in PPO runner with curriculum hook. "
+        f"Env constructed for stage={args.stage}, num_envs={args.num_envs}, "
+        f"device={args.device}. env={env!r}"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,12 @@ jax = [
     "flax>=0.8.0",
     "optax>=0.1.7",
 ]
+mjlab = [
+    # mjlab (GPU-accelerated MuJoCo-Warp + Isaac-Lab-style manager API).
+    # Requires an NVIDIA GPU for training; macOS is evaluation-only.
+    # See https://github.com/mujocolab/mjlab
+    "mjlab",
+]
 viz = [
     "mediapy>=1.1.0",
     "matplotlib>=3.7.0",
@@ -145,6 +151,10 @@ omit = [
     "environments/shared/jax_setup.py",
     "environments/shared/jax_trainer.py",
     "environments/*/mjx_config.py",
+    # mjlab adapter — scaffold only, requires the optional [mjlab] extra
+    # and an NVIDIA GPU, so it's excluded from default CI coverage.
+    "environments/shared/mjlab_env.py",
+    "environments/*/mjlab_config.py",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
mjlab (Zakka et al., arXiv:2601.22074) pairs Isaac-Lab's manager-based
API with MuJoCo-Warp for GPU-accelerated RL. This lands a scaffold so a
spike PR can evaluate it against the existing MJXDinoEnv path without
blocking on the optional dep.

- environments/shared/mjlab_env.py: adapter with species registry,
  MJLabSpeciesConfig, make_mjlab_env() entry point, and require_mjlab()
  guard for the optional dependency
- environments/velociraptor/mjlab_config.py: velociraptor registration
  with stubs for obs/reward/termination/event managers
- environments/velociraptor/scripts/train_mjlab.py: training spike CLI
- pyproject.toml: [mjlab] optional extra + coverage omits
- docs/ROADMAP.md + README.md: pilot target under Phase 5, with
  keep/retire decision criteria for the custom JAX training stack