### PR TITLE
Rescale Stage 3 terminal bonuses to match shaping magnitude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Codebase Consolidation & Training Results (v0.3.0)
 
+### Changed (breaking — reward landscape)
+- **Stage 3 terminal-bonus rescale.** Reduced `strike_bonus`, `bite_bonus`, and
+  `food_reach_bonus` from `1000` to `75`, `75`, and `100` respectively
+  (Velociraptor / T-Rex / Brachiosaurus). The previous `1000` was calibrated to
+  beat PPO's strike-avoidance opportunity cost but relied on `VecNormalize`
+  silently rescaling it; once `norm_reward` was disabled for SAC (see previous
+  entry), the raw +1000 spike risked destabilising the critic and SAC's
+  auto-entropy coefficient. New values keep the bonus comparable to
+  accumulated shaping (~100–300 per episode) rather than dwarfing it. This is
+  a breaking change to the reward landscape — no cross-boundary checkpoint
+  resume, and historical W&B/TensorBoard reward curves get a discontinuity at
+  this commit. Also scaled `[curriculum] min_avg_reward` from `100 → 10`
+  proportionally (the binding graduation gate remains `min_success_rate`).
+  Sweep JSON `env_*_bonus` ranges tightened to stay centered on the new
+  defaults. Added a reward-scale contract header comment to each Stage 3
+  config. Full rationale in `docs/REWARD_SCALE_REDESIGN.md`.
+
 ### Added
 - Velociraptor SAC training results — all 3 stages passed (90.0% strike success, 22M steps, 22:59:18)
 - Brachiosaurus PPO training results — Stages 1-2 passed, Stage 3 (food_reach) at 16.7% success (target: 50%)

--- a/configs/brachiosaurus/stage3_food_reach.toml
+++ b/configs/brachiosaurus/stage3_food_reach.toml
@@ -1,3 +1,15 @@
+# Reward scale contract:
+# - Per-step components are clipped to [-1, 1] then weighted; total per-step
+#   magnitude should stay within ~[-3, +3].
+# - Terminal bonus should be roughly 10-30% of a typical successful episode
+#   return (comparable to accumulated shaping, not dwarfing it).
+# - food_reach gets a slightly larger bonus than strike/bite (100 vs 75) because
+#   it is the sparsest Stage 3 task (novel neck-extension motion not learned in
+#   Stages 1-2) and needs a marginally stronger success signal.
+# - Exceeding these bounds destabilises SAC's critic and makes the reward
+#   distribution non-stationary for both algorithms. See
+#   docs/REWARD_SCALE_REDESIGN.md.
+
 [stage]
 name = "food_reach"
 description = "Walk to food and reach with neck"
@@ -14,7 +26,7 @@ posture_weight = 0.1                   # Light posture maintenance during reach
 nosedive_weight = 0.1                  # Reduced from 0.2: agent needs to pitch neck forward/downward to reach food — high nosedive penalty fights this
 heading_weight = 0.5                   # Face toward food for effective reach (matches T-Rex stage 3)
 lateral_penalty_weight = 0.3           # Penalize crab-walking toward food (matches T-Rex stage 3)
-food_reach_bonus = 1000.0              # Must greatly exceed discounted future per-step value; makes reaching food immediately net-positive (matches T-Rex bite_bonus)
+food_reach_bonus = 100.0               # Rescaled from 1000 (see docs/REWARD_SCALE_REDESIGN.md): comparable to accumulated shaping (~100-300 per episode) instead of dwarfing it; slightly larger than strike/bite (75) because food-reach is sparsest of the Stage 3 tasks
 food_reach_threshold = 0.8             # Widened from 0.5: easier success criterion for initial discovery — agent gets close but can't position head precisely enough
 food_approach_weight = 3.0             # 3x increase from 1.0: stronger delta-based gradient toward food (matches T-Rex bite_approach_weight)
 food_head_proximity_weight = 2.0       # Doubled from 1.0: stronger gradient pulling head toward food — this was the missing signal for the last-mile positioning
@@ -40,8 +52,10 @@ net_arch = [512, 256]                  # Match Stage 1 setting 4 architecture to
 [sac]
 learning_rate = 1e-4              # Higher than PPO's 5e-5 — replay buffer stabilizes updates for faster sparse reward convergence
 batch_size = 256
-gamma = 0.99                     # At gamma=0.99, discounted future ≈ 250 vs food_reach_bonus=1000 — reaching is clearly net-positive;
-                                 # PPO's gamma=0.995 risks the hovering-near-food exploit seen in raptor Stage 3
+gamma = 0.99                     # Shorter horizon than PPO's 0.995: with alive_bonus=0 and the new
+                                 # food_reach_bonus=100 (post-rescale), the opportunity cost of reaching
+                                 # is dominated by a few steps of approach-delta shaping that decays
+                                 # toward 0 near food, so the bonus is comfortably net-positive at any gamma
 tau = 0.005
 ent_coef = "auto"                # Auto-entropy is especially valuable for the neck-reaching task —
                                  # Brachiosaurus needs to discover a novel motion (neck extension) not learned in Stages 1-2
@@ -82,7 +96,7 @@ net_arch = [512, 256]
 
 [curriculum]
 timesteps = 12000000                   # Extended from 8M: best model was at 3.9M and policy degraded after — more time with stable config gives room to recover and converge
-min_avg_reward = 100.0                  # Minimum average reward to confirm food-reaching behavior
+min_avg_reward = 10.0                   # Scaled down with food_reach_bonus 1000→100 (see docs/REWARD_SCALE_REDESIGN.md); acts as a shaping-floor sanity check — real graduation gate is min_success_rate
 min_success_rate = 0.5                 # At least 25% food reach success — confirms behavior emerged
 required_consecutive = 3
 warmup_timesteps = 300000               # Tripled from 100k: agent needs more time to adapt from locomotion to food-reach reward landscape without losing walking ability

--- a/configs/brachiosaurus/sweep_ppo.json
+++ b/configs/brachiosaurus/sweep_ppo.json
@@ -80,7 +80,7 @@
     "ppo_n_epochs":            {"type": "discrete", "values": [6, 10]},
 
     "_comment_food": "Food reach: the core objective — sweep the bonus and shaping signals aggressively",
-    "env_food_reach_bonus":            {"type": "double", "min": 500.0, "max": 2000.0, "scale": "log"},
+    "env_food_reach_bonus":            {"type": "double", "min": 50.0, "max": 200.0, "scale": "log"},
     "env_food_reach_threshold":        {"type": "double", "min": 0.6, "max": 1.0, "scale": "linear"},
     "env_food_approach_weight":        {"type": "double", "min": 2.0, "max": 5.0, "scale": "linear"},
     "env_food_head_proximity_weight":  {"type": "double", "min": 1.0, "max": 4.0, "scale": "linear"},

--- a/configs/brachiosaurus/sweep_sac.json
+++ b/configs/brachiosaurus/sweep_sac.json
@@ -71,7 +71,7 @@
     "sac_gradient_steps": {"type": "discrete", "values": [8, 16]},
 
     "_comment_food": "Food reach: sweep the sparse bonus and shaping signals",
-    "env_food_reach_bonus":            {"type": "double", "min": 500.0, "max": 2000.0, "scale": "log"},
+    "env_food_reach_bonus":            {"type": "double", "min": 50.0, "max": 200.0, "scale": "log"},
     "env_food_reach_threshold":        {"type": "double", "min": 0.6, "max": 1.0, "scale": "linear"},
     "env_food_approach_weight":        {"type": "double", "min": 2.0, "max": 5.0, "scale": "linear"},
     "env_food_head_proximity_weight":  {"type": "double", "min": 1.0, "max": 4.0, "scale": "linear"},

--- a/configs/trex/stage3_bite.toml
+++ b/configs/trex/stage3_bite.toml
@@ -1,3 +1,12 @@
+# Reward scale contract:
+# - Per-step components are clipped to [-1, 1] then weighted; total per-step
+#   magnitude should stay within ~[-3, +3].
+# - Terminal bonus should be roughly 10-30% of a typical successful episode
+#   return (comparable to accumulated shaping, not dwarfing it).
+# - Exceeding these bounds destabilises SAC's critic and makes the reward
+#   distribution non-stationary for both algorithms. See
+#   docs/REWARD_SCALE_REDESIGN.md.
+
 [stage]
 name = "bite"
 description = "Sprint and bite prey with jaws"
@@ -14,7 +23,7 @@ gait_symmetry_weight = 0.0             # Disabled: formula rewards asymmetry, no
 smoothness_weight = 0.02
 heading_weight = 0.5                   # Match stage 2: face toward prey for bite
 lateral_penalty_weight = 0.3           # Match stage 2: penalize crab-walking toward prey
-bite_bonus = 1000.0                    # Must greatly exceed discounted future per-step value; makes biting immediately net-positive (matches raptor strike_bonus)
+bite_bonus = 75.0                      # Rescaled from 1000 (see docs/REWARD_SCALE_REDESIGN.md): comparable to accumulated shaping (~100-300 per episode) instead of dwarfing it; ~25x a single per-step reward, still unambiguously net-positive against the ~0 opportunity cost of continuing
 bite_approach_weight = 3.0             # 3x increase from 1.0: stronger delta-based gradient toward prey
 bite_head_proximity_weight = 1.0       # Head-to-prey proximity shaping: provides final aiming gradient for head positioning near prey
 prey_distance_range = [2.0, 6.0]       # Tightened from [3.0, 8.0]: closer prey makes bite discovery much more likely during exploration
@@ -38,8 +47,10 @@ net_arch = [512, 256]
 [sac]
 learning_rate = 1e-4              # Higher than PPO's 5e-5 — replay buffer stabilizes updates; faster convergence on sparse bite reward
 batch_size = 256
-gamma = 0.99                     # At gamma=0.99, discounted future ≈ 250 vs bite_bonus=1000 — biting is clearly net-positive;
-                                 # PPO's gamma=0.995 made future value ~460, closer to the bonus threshold
+gamma = 0.99                     # Shorter horizon than PPO's 0.995: with alive_bonus=0 and the new
+                                 # bite_bonus=75 (post-rescale), the opportunity cost of biting is dominated
+                                 # by a few steps of approach-delta shaping that rapidly decays to 0 near
+                                 # prey, so the bonus is comfortably net-positive at any gamma
 tau = 0.005
 ent_coef = "auto"                # Auto-entropy handles sparse reward exploration — T-Rex's 96.7% PPO success rate
                                  # suggests the task structure is sound; SAC should solve it more sample-efficiently
@@ -80,7 +91,7 @@ net_arch = [512, 256]
 
 [curriculum]
 timesteps = 8000000
-min_avg_reward = 100.0
+min_avg_reward = 10.0                 # Scaled down with bite_bonus 1000→75 (see docs/REWARD_SCALE_REDESIGN.md); acts as a shaping-floor sanity check — real graduation gate is min_success_rate
 min_success_rate = 0.5                # At least 25% bite success — confirms hunting behavior emerged
 required_consecutive = 3
 warmup_timesteps = 100000               # Timesteps to constrain policy updates while critic adapts (PPO only)

--- a/configs/trex/sweep_ppo.json
+++ b/configs/trex/sweep_ppo.json
@@ -73,7 +73,7 @@
     "ppo_n_epochs":            {"type": "discrete", "values": [3, 6, 10]},
 
     "_comment_bite": "Bite reward: sweep the sparse bonus and approach shaping",
-    "env_bite_bonus":                   {"type": "double", "min": 500.0, "max": 2000.0, "scale": "log"},
+    "env_bite_bonus":                   {"type": "double", "min": 40.0, "max": 150.0, "scale": "log"},
     "env_bite_approach_weight":         {"type": "double", "min": 1.0, "max": 5.0, "scale": "linear"},
     "env_bite_head_proximity_weight":   {"type": "double", "min": 0.5, "max": 2.0, "scale": "linear"},
 

--- a/configs/trex/sweep_sac.json
+++ b/configs/trex/sweep_sac.json
@@ -73,7 +73,7 @@
     "sac_gradient_steps": {"type": "discrete", "values": [8, 16]},
 
     "_comment_bite": "Bite reward: sweep the sparse bonus and approach shaping",
-    "env_bite_bonus":                   {"type": "double", "min": 500.0, "max": 2000.0, "scale": "log"},
+    "env_bite_bonus":                   {"type": "double", "min": 40.0, "max": 150.0, "scale": "log"},
     "env_bite_approach_weight":         {"type": "double", "min": 2.0, "max": 5.0, "scale": "linear"},
     "env_bite_head_proximity_weight":   {"type": "double", "min": 0.5, "max": 2.0, "scale": "linear"},
 

--- a/configs/velociraptor/stage3_strike.toml
+++ b/configs/velociraptor/stage3_strike.toml
@@ -1,3 +1,12 @@
+# Reward scale contract:
+# - Per-step components are clipped to [-1, 1] then weighted; total per-step
+#   magnitude should stay within ~[-3, +3].
+# - Terminal bonus should be roughly 10-30% of a typical successful episode
+#   return (comparable to accumulated shaping, not dwarfing it).
+# - Exceeding these bounds destabilises SAC's critic and makes the reward
+#   distribution non-stationary for both algorithms. See
+#   docs/REWARD_SCALE_REDESIGN.md.
+
 [stage]
 name = "strike"
 description = "Sprint and strike prey with sickle claw"
@@ -16,9 +25,9 @@ gait_symmetry_weight = 0.0             # Disabled: don't constrain lunge maneuve
 smoothness_weight = 0.02
 heading_weight = 0.3                   # Match stage 2: face toward prey for strike
 lateral_penalty_weight = 0.1           # Match stage 2: penalize crab-walking toward prey
-strike_bonus = 1000.0                  # Must greatly exceed discounted future per-step value (~460 at gamma=0.995 over 500 steps); makes striking immediately net-positive
+strike_bonus = 75.0                    # Rescaled from 1000 (see docs/REWARD_SCALE_REDESIGN.md): comparable to accumulated shaping (~100-300 per episode) instead of dwarfing it; ~25x a single per-step reward, still unambiguously net-positive against the ~0 opportunity cost of continuing (alive_bonus=0, approach_delta→0 near prey)
 strike_approach_weight = 3.0           # Delta-based gradient toward prey; goes to ~0 at prey so doesn't reward hovering
-strike_proximity_weight = 0.0          # Zeroed: continuous proximity bonus rewarded hovering near prey without striking; with strike_bonus=1000 the agent should strike on arrival, not linger
+strike_proximity_weight = 0.0          # Zeroed: continuous proximity bonus rewarded hovering near prey without striking; agent should strike on arrival, not linger
 strike_claw_proximity_weight = 1.0     # Reduced from 2.0: still provides final aiming gradient for claw-to-prey positioning, but lower weight reduces incentive to hover with claw near prey
 prey_distance_range = [2.0, 6.0]       # Tightened from [3.0, 8.0]: closer prey makes strike discovery much more likely during exploration
 prey_lateral_range = [-1.5, 1.5]
@@ -41,9 +50,10 @@ net_arch = [512, 256]
 [sac]
 learning_rate = 1e-4              # Higher than PPO's 5e-5 — replay buffer stabilizes updates; faster convergence on sparse reward
 batch_size = 256
-gamma = 0.99                     # Critical: at gamma=0.99 discounted future ≈ 250 (vs 459 at 0.995),
-                                 # so strike_bonus=1000 is 4x the opportunity cost — the strike-avoidance
-                                 # problem that plagued PPO is structurally weaker here
+gamma = 0.99                     # Shorter horizon than PPO's 0.995: with alive_bonus=0 and the new
+                                 # strike_bonus=75 (post-rescale), the opportunity cost of striking is
+                                 # dominated by a few steps of approach-delta shaping that rapidly decays
+                                 # to 0 near prey, so the bonus is comfortably net-positive at any gamma
 tau = 0.005
 ent_coef = "auto"                # Auto-entropy is especially valuable for sparse rewards — maintains
                                  # exploration without the manual tuning PPO required (ent_coef=0.005)
@@ -84,7 +94,7 @@ net_arch = [512, 256]
 
 [curriculum]
 timesteps = 8000000
-min_avg_reward = 100.0
+min_avg_reward = 10.0                   # Scaled down with strike_bonus 1000→75 (see docs/REWARD_SCALE_REDESIGN.md); acts as a shaping-floor sanity check — real graduation gate is min_success_rate
 min_success_rate = 0.5                  # At least 25% strike success — confirms hunting behavior emerged
 required_consecutive = 3
 warmup_timesteps = 300000               # Increased from 100k: Stage 3 introduces new reward components, critic needs more adaptation time

--- a/configs/velociraptor/sweep_ppo.json
+++ b/configs/velociraptor/sweep_ppo.json
@@ -71,7 +71,7 @@
     "ppo_n_epochs":            {"type": "discrete", "values": [3, 6, 10]},
 
     "_comment_strike": "Strike reward: sweep the sparse bonus and approach shaping",
-    "env_strike_bonus":                 {"type": "double", "min": 500.0, "max": 2000.0, "scale": "log"},
+    "env_strike_bonus":                 {"type": "double", "min": 40.0, "max": 150.0, "scale": "log"},
     "env_strike_approach_weight":       {"type": "double", "min": 1.0, "max": 5.0, "scale": "linear"},
     "env_strike_claw_proximity_weight": {"type": "double", "min": 0.5, "max": 2.0, "scale": "linear"},
 

--- a/configs/velociraptor/sweep_sac.json
+++ b/configs/velociraptor/sweep_sac.json
@@ -70,7 +70,7 @@
     "sac_gradient_steps": {"type": "discrete", "values": [8, 16]},
 
     "_comment_env": "Strike reward: sweep the sparse bonus magnitude and approach shaping. Lower strike_bonus may train faster if approach_weight provides enough gradient. Also sweep prey distance — closer prey means faster strike discovery.",
-    "env_strike_bonus":                 {"type": "double", "min": 500.0, "max": 2000.0, "scale": "log"},
+    "env_strike_bonus":                 {"type": "double", "min": 40.0, "max": 150.0, "scale": "log"},
     "env_strike_approach_weight":       {"type": "double", "min": 2.0, "max": 5.0, "scale": "linear"},
     "env_strike_claw_proximity_weight": {"type": "double", "min": 0.5, "max": 2.0, "scale": "linear"},
     "env_forward_vel_weight":           {"type": "double", "min": 0.5, "max": 2.0, "scale": "linear"},

--- a/docs/RL_TRAINING_PLAN.md
+++ b/docs/RL_TRAINING_PLAN.md
@@ -70,7 +70,7 @@ defaults -- T-Rex should behave similarly.
 |-------|---------------|-------|-------------|------------|---------------|
 | 1 (balance) | 3e-4 | 0.99 | 300K | 4 | alive_bonus=2.0, posture_weight=2.0 |
 | 2 (locomotion) | 1e-4 | 0.99 | 1M | 4 | forward_vel_weight=2.0 |
-| 3 (bite) | 1e-4 | 0.99 | 1M | 4 | bite_bonus=1000, bite_approach_weight=3.0 |
+| 3 (bite) | 1e-4 | 0.99 | 1M | 4 | bite_bonus=75 (rescaled from 1000 — see REWARD_SCALE_REDESIGN.md), bite_approach_weight=3.0 |
 
 ---
 
@@ -147,7 +147,7 @@ Try the defaults first.
 |-------|---------------|-------|-------------|---------------|
 | 1 (balance) | 3e-4 | 0.99 | 300K | alive_bonus=2.0 |
 | 2 (locomotion) | 1e-4 | 0.99 | 1M | gait_symmetry_weight=2.0, forward_vel_weight=4.0 |
-| 3 (food_reach) | 1e-4 | 0.99 | 1M | food_reach_bonus=1000, food_approach_weight=3.0 |
+| 3 (food_reach) | 1e-4 | 0.99 | 1M | food_reach_bonus=100 (rescaled from 1000 — see REWARD_SCALE_REDESIGN.md), food_approach_weight=3.0 |
 
 #### Watch For
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ Legend: `[x]` done | `[-]` in progress | `[ ]` not started
 | Phase | Name | Status | Done | Remaining |
 |-------|------|--------|------|-----------|
 | **0** | Clean Slate (v0.2.0) | **COMPLETE** | 5/5 items | — |
-| **1** | First Steps (v0.3.0) | **In Progress** | 10/12 items | Brachiosaurus Stage 3 (food_reach at 16.7% vs 50% target); Stage 3 terminal-bonus rescale (design debt) |
+| **1** | First Steps (v0.3.0) | **In Progress** | 10/12 items | Brachiosaurus Stage 3 (food_reach at 16.7% vs 50% target); Stage 3 terminal-bonus rescale (configs landed, validation runs pending) |
 | **2** | Into the Wild (v0.4.0) | Not Started | 0/9 items | Blocked on Phase 1 training results |
 | **3** | Evolution (v0.5.0) | Not Started | 0/8 items | Blocked on Phases 1-2 |
 | **4** | The Pack (v0.6.0) | Not Started | 0/6 items | Blocked on Phase 3 species |
@@ -167,13 +167,22 @@ curriculum with published results and reproducible checkpoints.
   - PPO unchanged (on-policy, no replay buffer)
   - _Completed: 2026-04-18_
 
-- [ ] **Stage 3 terminal-bonus rescale (reward design debt)**
-  - Stage 3 `strike_bonus_weight` / `bite_bonus_weight` /
-    `food_reach_bonus_weight` are all `1000`, ~2 orders of magnitude larger
-    than accumulated per-step shaping. This produces a bimodal,
-    non-stationary return distribution that VecNormalize was papering over.
+- [-] **Stage 3 terminal-bonus rescale (reward design debt)**
+  - Stage 3 `strike_bonus` / `bite_bonus` / `food_reach_bonus` were all `1000`,
+    ~2 orders of magnitude larger than accumulated per-step shaping. This
+    produced a bimodal, non-stationary return distribution that VecNormalize
+    was papering over.
   - Likely contributor to Brachiosaurus Stage 3 being stuck at 16.7%
     success (food_reach is the sparsest of the three Stage 3 tasks).
+  - Configs landed: rescaled to `75 / 75 / 100` (Velociraptor / T-Rex /
+    Brachiosaurus), proportionally scaled `min_avg_reward` to `10`, tightened
+    sweep `env_*_bonus` ranges, added reward-scale contract header comments,
+    CHANGELOG entry flagging the breaking reward-landscape change.
+  - **Remaining: validation runs.** One SAC Stage 3 run per species at the
+    new scale to confirm the curriculum gate passes and SAC's auto-entropy
+    coefficient settles; T-Rex SAC naturally doubles as a Phase 1 deliverable
+    here. If success rates regress, walk the bonus up toward `150–200`
+    before retreating to `1000`.
   - Proposed fix, validation plan, open questions, and risks captured in
     [REWARD_SCALE_REDESIGN.md](REWARD_SCALE_REDESIGN.md).
   - Breaking change to reward landscape — no cross-boundary checkpoint


### PR DESCRIPTION
This pull request implements a breaking change to the reward landscape for all Stage 3 tasks (terminal bonus) in the Velociraptor, T-Rex, and Brachiosaurus environments. The main goal is to rescale the terminal bonuses (`strike_bonus`, `bite_bonus`, `food_reach_bonus`) from 1000 to much lower values (75 or 100), making them comparable to accumulated shaping rewards and preventing destabilization of SAC's critic. The change is reflected across configs, sweep ranges, documentation, and changelogs, and introduces a clear "reward scale contract" in each Stage 3 config.

**Reward Rescaling and Contract Documentation**

- Rescaled terminal bonuses for Stage 3 tasks: `strike_bonus` and `bite_bonus` reduced from 1000 to 75, and `food_reach_bonus` from 1000 to 100, to align with accumulated shaping rewards and stabilize learning. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R26) [[2]](diffhunk://#diff-4cc43134c17bc65fc2eca0e88ecfb686b13291469e366960655cc247f79c0108L19-R30) [[3]](diffhunk://#diff-4359aeb7ba409e51982c906de9be105d58651f643f6d09460397100120405bcdL17-R26) [[4]](diffhunk://#diff-431203f2f192c9a1e59eb121925d78f0ae324e2dbc093fc86fe4dba7561ea2cdL17-R29)
- Added detailed "reward scale contract" comments to each Stage 3 config file, explaining the rationale and bounds for per-step and terminal rewards, with references to `docs/REWARD_SCALE_REDESIGN.md`. [[1]](diffhunk://#diff-4cc43134c17bc65fc2eca0e88ecfb686b13291469e366960655cc247f79c0108R1-R9) [[2]](diffhunk://#diff-4359aeb7ba409e51982c906de9be105d58651f643f6d09460397100120405bcdR1-R9) [[3]](diffhunk://#diff-431203f2f192c9a1e59eb121925d78f0ae324e2dbc093fc86fe4dba7561ea2cdR1-R12)

**Sweep and Curriculum Adjustments**

- Tightened sweep ranges for terminal bonuses in all Stage 3 sweep config files to match new defaults: e.g., `env_strike_bonus` and `env_bite_bonus` now sweep from 40/50 to 150/200 instead of 500–2000. [[1]](diffhunk://#diff-7c4d10ab8d7d35b9f658dbd979d34b396486fb99ff6a83e321f5c46c1e3a1ac9L74-R74) [[2]](diffhunk://#diff-94a165af14cff92d6c88a122164ef14b4470fe08b5122401be6799636741712bL73-R73) [[3]](diffhunk://#diff-1d5f42f03d7abe25eacbcc46bdab72e64beef37464698489f0f8cbcd65627c7aL76-R76) [[4]](diffhunk://#diff-a0429c561cfbebc59308db6652a77de4547d7bda782ba1526dc508f7b52c5c71L76-R76) [[5]](diffhunk://#diff-3de7a53cc205cf3f689ecfaa65f262a32f94916b7bd1e652f68d7f35b568e03dL83-R83) [[6]](diffhunk://#diff-112e578edd2f27d172959eb694735e533e67a81af00df8236fa3b467f7976357L74-R74)
- Scaled down `min_avg_reward` curriculum thresholds from 100 to 10 in all Stage 3 configs to match the new bonus scale, ensuring graduation criteria remain meaningful. [[1]](diffhunk://#diff-4cc43134c17bc65fc2eca0e88ecfb686b13291469e366960655cc247f79c0108L87-R97) [[2]](diffhunk://#diff-4359aeb7ba409e51982c906de9be105d58651f643f6d09460397100120405bcdL83-R94) [[3]](diffhunk://#diff-431203f2f192c9a1e59eb121925d78f0ae324e2dbc093fc86fe4dba7561ea2cdL85-R99)

**Documentation and Project Tracking**

- Updated `CHANGELOG.md` to document the breaking reward rescale, rationale, and implications for training results and checkpoint compatibility.
- Updated `docs/RL_TRAINING_PLAN.md` to reflect new default bonus values in all relevant tables and notes. [[1]](diffhunk://#diff-2d23d5911a4f887f3fa325573a0e0143f93ee9c1e32441e96f543e22bcac904fL73-R73) [[2]](diffhunk://#diff-2d23d5911a4f887f3fa325573a0e0143f93ee9c1e32441e96f543e22bcac904fL150-R150)
- Updated `docs/ROADMAP.md` to note that Stage 3 terminal-bonus rescale configs have landed, with validation runs pending.

**SAC and PPO Hyperparameter Notes**

- Updated comments in SAC sections of configs to clarify the relationship between the new bonus values, gamma, and shaping rewards, ensuring that the bonus remains net-positive but not destabilizing. [[1]](diffhunk://#diff-4cc43134c17bc65fc2eca0e88ecfb686b13291469e366960655cc247f79c0108L44-R56) [[2]](diffhunk://#diff-4359aeb7ba409e51982c906de9be105d58651f643f6d09460397100120405bcdL41-R53) [[3]](diffhunk://#diff-431203f2f192c9a1e59eb121925d78f0ae324e2dbc093fc86fe4dba7561ea2cdL43-R58)

These changes are critical for stable and interpretable RL training, especially with SAC, and will introduce a discontinuity in historical reward curves and checkpoint compatibility.