### PR TITLE
Bump version to 0.3.1.dev0 and log it in stage_summary.txt

### DIFF
--- a/environments/shared/reporting.py
+++ b/environments/shared/reporting.py
@@ -219,6 +219,8 @@ def write_stage_summary(
 
     Returns the path to the written summary file.
     """
+    from .config import get_library_version
+
     summary_path = Path(stage_dir) / "stage_summary.txt"
     mean_len = results_dict.get("mean_episode_length", 0)
     std_len = results_dict.get("std_episode_length", 0)
@@ -234,6 +236,7 @@ def write_stage_summary(
         f"Stage:          {results_dict['stage']} ({results_dict['name']})",
         f"Description:    {results_dict['description']}",
         f"Algorithm:      {algorithm}",
+        f"Version:        {get_library_version()}",
         f"Date:           {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
         f"Timesteps:      {results_dict['timesteps']:,}",
         f"Duration:       {format_duration(results_dict['duration_seconds'])}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mesozoic-labs"
-version = "0.3.0.dev0"
+version = "0.3.1.dev0"
 description = "Robotic dinosaur locomotion environments for MuJoCo + Gymnasium"
 requires-python = ">=3.10"
 license = {text = "MIT"}


### PR DESCRIPTION
This pull request introduces a minor version bump and enhances the stage summary reporting by including the library version in the output. The changes help improve traceability and reproducibility of results by recording the exact version used.

**Reporting improvements:**

* The `write_stage_summary` function in `environments/shared/reporting.py` now includes the current library version in the generated stage summary, using the `get_library_version` function. [[1]](diffhunk://#diff-564f493ca4e4a318c343d37a71c8ead1909b21a3b0cf017499c3efbe3e58e0f5R222-R223) [[2]](diffhunk://#diff-564f493ca4e4a318c343d37a71c8ead1909b21a3b0cf017499c3efbe3e58e0f5R239)

**Versioning:**

* Bumped the project version from `0.3.0.dev0` to `0.3.1.dev0` in `pyproject.toml` to reflect the new functionality.