### PR TITLE
Fix JAX implementation bugs and add regression coverage

### DIFF
--- a/environments/shared/jax_checkpoint.py
+++ b/environments/shared/jax_checkpoint.py
@@ -113,7 +113,23 @@ class CheckpointManager:
         self.directory.mkdir(parents=True, exist_ok=True)
         self.prefix = prefix
         self.max_keep = max_keep
-        self._recent: list[Path] = []
+        # Discover any pre-existing checkpoints (sorted oldest -> newest by
+        # update number) so a resumed run continues to enforce ``max_keep``
+        # instead of silently letting old files accumulate on disk.
+        existing = list(self.directory.glob(f"{prefix}_*.pkl"))
+
+        def _update_idx(p: Path) -> int:
+            stem = p.stem  # e.g. "checkpoint_42"
+            suffix = stem[len(prefix) + 1 :]
+            try:
+                return int(suffix)
+            except ValueError:
+                return -1
+
+        self._recent: list[Path] = sorted(
+            (p for p in existing if _update_idx(p) >= 0),
+            key=_update_idx,
+        )
 
     def save(
         self,

--- a/environments/shared/jax_eval.py
+++ b/environments/shared/jax_eval.py
@@ -302,8 +302,10 @@ def evaluate_policy_cpu(
 
             prev_action = action
 
-            cpu_data = mjx.put_data(mj_model, mj_data)
-            r = float(reward_fn(cpu_data, action, reward_cfg))
+            # Reuse a single mjx.put_data call for the post-step data;
+            # mj_data has already been advanced by frame_skip mj_step calls.
+            post_step_data = mjx.put_data(mj_model, mj_data)
+            r = float(reward_fn(post_step_data, action, reward_cfg))
             ep_reward += r
 
             if body_z < config.healthy_z_range[0] or body_z > config.healthy_z_range[1]:

--- a/environments/shared/jax_ppo.py
+++ b/environments/shared/jax_ppo.py
@@ -247,7 +247,14 @@ def make_optimizer(config: PPOConfig):
 
     When ``config.learning_rate_end`` is set, the learning rate is
     linearly decayed from ``learning_rate`` to ``learning_rate_end``
-    over ``config.total_updates * config.n_epochs`` gradient steps.
+    over ``config.total_updates * config.n_epochs * config.n_minibatches``
+    gradient steps — i.e. one step per minibatch update.
+
+    Note: the schedule is per-run.  In a multi-stage curriculum each
+    call to ``make_optimizer`` builds an independent schedule sized to
+    the stage's ``total_updates``, so the LR decays to
+    ``learning_rate_end`` once per stage rather than once across the
+    whole curriculum.
 
     Returns:
         An ``optax.GradientTransformation``.

--- a/environments/shared/jax_trainer.py
+++ b/environments/shared/jax_trainer.py
@@ -555,9 +555,7 @@ def train(
             # trace doesn't need to be invalidated.
             if _ramp_active and relative_update < config.ramp_updates:
                 ramp_progress = relative_update / config.ramp_updates
-                forward_vel_scale = (
-                    config.ramp_start_fraction + (1.0 - config.ramp_start_fraction) * ramp_progress
-                )
+                forward_vel_scale = config.ramp_start_fraction + (1.0 - config.ramp_start_fraction) * ramp_progress
                 # Mirror the effective weight into reward_cfg so callers
                 # inspecting it (e.g. diagnostics) see the current value.
                 reward_cfg[config.ramp_attr] = _ramp_target_value * forward_vel_scale

--- a/environments/shared/jax_trainer.py
+++ b/environments/shared/jax_trainer.py
@@ -275,10 +275,22 @@ def _build_jit_fns(config: TrainConfig, network, optimizer, reward_detail_fn, en
                 )
 
                 approx_kl = aux["approx_kl"]
-                use_target_kl = TARGET_KL is not None
-                kl_over = use_target_kl & (approx_kl > TARGET_KL)
-                should_skip = kl_exceeded | kl_over
+                # Compare in Python (TARGET_KL is closure-captured) so we
+                # never evaluate ``traced > None`` when target_kl is disabled.
+                if TARGET_KL is not None:
+                    should_skip = kl_exceeded | (approx_kl > TARGET_KL)
+                else:
+                    should_skip = kl_exceeded
 
+                # On KL early-stop we revert BOTH params and the full
+                # opt_state — that includes Optax counters/moments and any
+                # LR-schedule step counter, so the schedule effectively
+                # rewinds to its pre-update value.  This is intentional
+                # (a skipped update consumes no schedule step), but it is
+                # subtle.  Under jit every leaf is a traced array, so the
+                # ``hasattr(new, "shape")`` check is always True and the
+                # ``else`` branch is dead — kept defensively for any
+                # future non-array opt-state field.
                 out_params = jax.tree.map(lambda new, old: jnp.where(should_skip, old, new), new_params, params)
                 out_opt_state = jax.tree.map(
                     lambda new, old: jnp.where(should_skip, old, new) if hasattr(new, "shape") else new,
@@ -313,28 +325,45 @@ def _build_jit_fns(config: TrainConfig, network, optimizer, reward_detail_fn, en
         NUM_ENVS = config.num_envs
 
         @jax.jit
-        def collect_rollout(states, rng, params, obs_rms):
+        def collect_rollout(states, rng, params, obs_rms, forward_vel_scale):
+            """Collect a rollout under the current obs stats.
+
+            Stores RAW (un-normalized) observations and the pre-reset
+            ``final_obs`` for each step.  The caller normalizes once
+            with the same stats — that keeps the PPO importance ratio
+            consistent and lets running stats track raw obs only.
+
+            ``forward_vel_scale`` is a scalar JAX array routed through to
+            the env so the reward ramp can take effect without retracing.
+            """
+
             def step_fn(carry, _):
                 states, rng = carry
                 rng, action_rng, step_rng = jax.random.split(rng, 3)
 
-                obs = normalize_obs(states.obs, obs_rms)
+                raw_obs = states.obs
+                obs_normed = normalize_obs(raw_obs, obs_rms)
                 rngs = jax.random.split(action_rng, NUM_ENVS)
-                raw_actions, log_probs, values = jax.vmap(_sample_action, in_axes=(None, 0, 0))(params, obs, rngs)
+                raw_actions, log_probs, values = jax.vmap(_sample_action, in_axes=(None, 0, 0))(
+                    params, obs_normed, rngs
+                )
 
                 actions = jnp.clip(raw_actions, -1.0, 1.0)
-                new_states, rewards, terminated, truncated = env.step(states, actions, step_rng)
-                dones = terminated | truncated
-                gae_dones = terminated
+                new_states, rewards, terminated, truncated, final_obs = env.step(
+                    states, actions, step_rng, return_final_obs=True, forward_vel_scale=forward_vel_scale
+                )
+                full_done = terminated | truncated
+                gae_done = terminated
 
                 return (new_states, rng), (
-                    obs,
+                    raw_obs,
                     raw_actions,
                     log_probs,
                     values,
                     rewards,
-                    gae_dones.astype(jnp.float32),
-                    dones.astype(jnp.float32),
+                    gae_done.astype(jnp.float32),
+                    full_done.astype(jnp.float32),
+                    final_obs,
                 )
 
             (states, _), rollout = jax.lax.scan(step_fn, (states, rng), None, length=ROLLOUT_LEN)
@@ -455,6 +484,15 @@ def train(
     _warmup_active = config.warmup_updates > 0
     _ramp_active = config.ramp_updates > 0
     _ramp_target_value = reward_cfg.get(config.ramp_attr, 0.0) if _ramp_active else 0.0
+    if _ramp_active and config.ramp_attr != "forward_vel_weight":
+        # The MJX env captures most weights as Python constants at trace
+        # time, so they cannot be ramped without recompilation.  Only
+        # ``forward_vel_weight`` is wired through ``env.step`` as a
+        # runtime scale.  Fail loud rather than silently doing nothing.
+        raise ValueError(
+            f"Reward ramp on attr={config.ramp_attr!r} is not supported by the MJX path; "
+            "only 'forward_vel_weight' is dynamic at runtime."
+        )
 
     # Reset environments
     rng, reset_rng = jax.random.split(rng)
@@ -512,23 +550,34 @@ def train(
                     )
 
             # ---------- Reward ramp ----------
-            if _ramp_active:
-                if relative_update < config.ramp_updates:
-                    ramp_progress = relative_update / config.ramp_updates
-                    ramp_value = _ramp_target_value * (
-                        config.ramp_start_fraction + (1.0 - config.ramp_start_fraction) * ramp_progress
-                    )
-                else:
-                    ramp_value = _ramp_target_value
-                reward_cfg[config.ramp_attr] = ramp_value
+            # The ramp scales forward_vel_weight in [start_fraction, 1.0]
+            # and is passed through to env.step at runtime so the JIT
+            # trace doesn't need to be invalidated.
+            if _ramp_active and relative_update < config.ramp_updates:
+                ramp_progress = relative_update / config.ramp_updates
+                forward_vel_scale = (
+                    config.ramp_start_fraction + (1.0 - config.ramp_start_fraction) * ramp_progress
+                )
+                # Mirror the effective weight into reward_cfg so callers
+                # inspecting it (e.g. diagnostics) see the current value.
+                reward_cfg[config.ramp_attr] = _ramp_target_value * forward_vel_scale
+            else:
+                forward_vel_scale = 1.0
+                if _ramp_active:
+                    reward_cfg[config.ramp_attr] = _ramp_target_value
+            forward_vel_scale_arr = jnp.float32(forward_vel_scale)
 
             # ---------- Collect rollout ----------
             _t_phase = time.time()
             rng, rng_collect = jax.random.split(rng)
-            states, rollout = collect_rollout(states, rng_collect, params, obs_rms)
-            obs_t, act_t, lp_t, val_t, rew_t, done_t, full_done_t = rollout
+            # Snapshot the obs stats used during this rollout — PPO must
+            # see the same normalization, otherwise the importance ratio
+            # is biased.  We update obs_rms only after consuming the batch.
+            rollout_obs_rms = obs_rms
+            states, rollout = collect_rollout(states, rng_collect, params, rollout_obs_rms, forward_vel_scale_arr)
+            obs_t, act_t, lp_t, val_t, rew_t, gae_done_t, full_done_t, final_obs_t = rollout
 
-            jax.block_until_ready(done_t)
+            jax.block_until_ready(full_done_t)
             _t_rollout = time.time() - _t_phase
             _cum_t_rollout += _t_rollout
 
@@ -540,25 +589,35 @@ def train(
             full_done_np = np.array(full_done_t)
             _completed_returns, _completed_lengths = compute_episode_stats(rew_np, full_done_np, _ep_stats_acc)
 
-            # ---------- Update obs normalisation ----------
-            obs_batch_flat = obs_t.reshape(-1, OBS_DIM)
-            obs_rms = update_running_stats(obs_rms, obs_batch_flat)
-
             # ---------- Bootstrap value for GAE ----------
+            # Use the per-step ``final_obs`` (pre-auto-reset) for the last
+            # step so truncations bootstrap their true s_T value.  Natural
+            # terminations are masked out by the GAE done flag anyway.
             rng, rng_bootstrap = jax.random.split(rng)
-            obs_final = normalize_obs(states.obs, obs_rms)
-            _, _, bootstrap_values = batched_sample(params, obs_final, rng_bootstrap)
+            last_final_obs = final_obs_t[-1]
+            bootstrap_obs = normalize_obs(last_final_obs, rollout_obs_rms)
+            _, _, bootstrap_values = batched_sample(params, bootstrap_obs, rng_bootstrap)
             val_t_plus1 = jnp.concatenate([val_t, bootstrap_values[None]], axis=0)
 
             # ---------- Compute advantages ----------
-            advantages, returns = compute_gae(rew_t, val_t_plus1, done_t, GAMMA, GAE_LAMBDA)
+            # gae_done_t masks ONLY natural termination so truncated
+            # rollout steps still bootstrap V(s_{t+1}) correctly.
+            advantages, returns = compute_gae(rew_t, val_t_plus1, gae_done_t, GAMMA, GAE_LAMBDA)
 
-            flat_obs = obs_t.reshape(-1, OBS_DIM)
+            # Normalize PPO inputs with the rollout-time stats so the new
+            # policy sees the same scaled inputs as the behaviour policy.
+            flat_obs_raw = obs_t.reshape(-1, OBS_DIM)
+            flat_obs = normalize_obs(flat_obs_raw, rollout_obs_rms)
             flat_act = act_t.reshape(-1, ACT_DIM)
             flat_lp = lp_t.reshape(-1)
             flat_adv = advantages.reshape(-1)
             flat_ret = returns.reshape(-1)
             flat_val = val_t.reshape(-1)
+
+            # ---------- Update obs normalisation (from RAW obs) ----------
+            # Done after the rollout has been consumed so PPO sees stats
+            # that match what the behaviour policy used.
+            obs_rms = update_running_stats(obs_rms, flat_obs_raw)
 
             # ---------- PPO update ----------
             _t_phase = time.time()
@@ -849,7 +908,21 @@ class JaxTrainer:
                 fn(*args)
 
     def _build_collect_rollout(self):
-        """Build the JIT-compiled rollout collector."""
+        """Build the JIT-compiled rollout collector.
+
+        Returned tuple ordering (per timestep):
+        ``(raw_obs, raw_action, log_prob, value, reward, gae_done, full_done, final_obs)``.
+
+        - ``raw_obs`` is the unnormalized obs at the input to the policy.
+          Callers normalize once on the host with the *same* stats used
+          inside this rollout to keep PPO importance sampling consistent.
+        - ``gae_done`` masks ONLY natural termination — used by GAE so
+          that time-limit truncations still bootstrap their value.
+        - ``full_done`` marks any episode boundary (terminated or
+          truncated) — used for episode tracking and fall-rate stats.
+        - ``final_obs`` is the post-step pre-auto-reset obs, needed to
+          bootstrap value correctly at truncation boundaries.
+        """
         import jax
         import jax.numpy as jnp
 
@@ -867,19 +940,28 @@ class JaxTrainer:
                 states, rng = carry
                 rng, action_rng = jax.random.split(rng)
 
-                obs = normalize_obs(states.obs, obs_stats_arg)
+                # Normalize for the policy but store the RAW obs so the
+                # caller can re-normalize with the exact same stats later.
+                raw_obs = states.obs
+                obs_normed = normalize_obs(raw_obs, obs_stats_arg)
                 raw_action, log_prob, value = jax.vmap(
                     sample_action,
                     in_axes=(None, None, 0, 0),
-                )(params, network, obs, jax.random.split(action_rng, num_envs))
+                )(params, network, obs_normed, jax.random.split(action_rng, num_envs))
 
                 # Clip for env; store raw action for PPO ratio consistency
                 action = jnp.clip(raw_action, -1.0, 1.0)
                 rng, step_rng = jax.random.split(rng)
-                new_states, rewards, terminated, truncated = env.step(states, action, step_rng)
-                dones = (terminated | truncated).astype(jnp.float32)
+                new_states, rewards, terminated, truncated, final_obs = env.step(
+                    states, action, step_rng, return_final_obs=True
+                )
+                gae_done = terminated.astype(jnp.float32)
+                full_done = (terminated | truncated).astype(jnp.float32)
 
-                return (new_states, rng), (states.obs, raw_action, log_prob, value, rewards, dones)
+                return (
+                    (new_states, rng),
+                    (raw_obs, raw_action, log_prob, value, rewards, gae_done, full_done, final_obs),
+                )
 
             return jax.lax.scan(step_fn, (states, rng), None, length=rollout_len)
 
@@ -926,10 +1008,16 @@ class JaxTrainer:
                     )
                     approx_kl = loss_info["approx_kl"]
 
-                    use_target_kl = ppo_config.target_kl is not None
-                    kl_over = use_target_kl & (approx_kl > ppo_config.target_kl)
-                    should_skip = kl_exceeded | kl_over
+                    # Compare in Python so we never evaluate ``traced > None``
+                    # when target_kl is disabled.
+                    if ppo_config.target_kl is not None:
+                        should_skip = kl_exceeded | (approx_kl > ppo_config.target_kl)
+                    else:
+                        should_skip = kl_exceeded
 
+                    # See note in scan_ppo_epochs: skipped updates revert
+                    # the entire opt_state (including LR-schedule step), so
+                    # the schedule effectively pauses on KL early-stop.
                     out_params = jax.tree.map(
                         lambda new, old: jnp.where(should_skip, old, new),
                         new_params,
@@ -987,19 +1075,17 @@ class JaxTrainer:
         _logger.info("num_envs=%d rollout_len=%d num_updates=%d", self.num_envs, self.rollout_len, num_updates)
 
         rng = jax.random.PRNGKey(seed)
-        rng, init_rng = jax.random.split(rng)
+        rng, init_rng, reset_rng = jax.random.split(rng, 3)
 
-        dummy_obs = jnp.zeros(
-            self.env.mj_model.nq - 7 + self.env.mj_model.nv - 6 + 17,
-        )
+        # Derive obs_dim from a real reset rather than reconstructing it from
+        # nq/nv arithmetic — the latter forgets foot-contact channels.
+        states = self.env.reset(reset_rng)
+        obs_dim = int(states.obs.shape[-1])
+        dummy_obs = jnp.zeros((obs_dim,))
         params = self.network.init(init_rng, dummy_obs) if init_params is None else init_params
         opt_state = self.optimizer.init(params)
 
-        obs_dim = dummy_obs.shape[0]
         obs_stats = RunningMeanStd.create(obs_dim)
-
-        rng, reset_rng = jax.random.split(rng)
-        states = self.env.reset(reset_rng)
 
         self._collect_rollout = self._build_collect_rollout()
         self._scan_ppo_update = self._build_scan_ppo_update()
@@ -1040,36 +1126,43 @@ class JaxTrainer:
                 t_rollout_start = time.time()
                 rng, collect_rng = jax.random.split(state.rng)
                 state.rng = rng
+                # Snapshot the obs stats used during this rollout — we'll
+                # normalize all PPO inputs with the SAME stats so the
+                # importance-sampling ratio stays consistent.  Stats are
+                # updated AFTER PPO consumes the rollout.
+                rollout_obs_stats = state.obs_stats
                 (states, _), rollout_data = self._collect_rollout(
                     state.env_states,
                     collect_rng,
                     state.params,
-                    state.obs_stats,
+                    rollout_obs_stats,
                 )
                 state.env_states = states
-                rollout_obs, rollout_actions, rollout_log_probs, rollout_values, rollout_rewards, rollout_dones = (
-                    rollout_data
-                )
+                (
+                    rollout_obs,
+                    rollout_actions,
+                    rollout_log_probs,
+                    rollout_values,
+                    rollout_rewards,
+                    rollout_gae_dones,
+                    rollout_full_dones,
+                    rollout_final_obs,
+                ) = rollout_data
 
-                jax.block_until_ready(rollout_dones)
+                jax.block_until_ready(rollout_full_dones)
                 t_rollout = time.time() - t_rollout_start
                 state.t_rollout_cumulative += t_rollout
                 state.total_steps += self.num_envs * self.rollout_len
-
-                state.obs_stats = update_running_stats(
-                    state.obs_stats,
-                    rollout_obs.reshape(-1, obs_dim),
-                )
 
                 mean_reward = float(jnp.mean(rollout_rewards))
                 elapsed = time.time() - t0
                 fps = state.total_steps / elapsed if elapsed > 0 else 0
 
                 # Compute fall rate on-device; only transfer scalars
-                fall_rate = float(jnp.sum(rollout_dones)) / (self.rollout_len * self.num_envs)
+                fall_rate = float(jnp.sum(rollout_full_dones)) / (self.rollout_len * self.num_envs)
                 # Defer full GPU→CPU transfer for episode tracking
                 rew_np = np.array(rollout_rewards)
-                done_np = np.array(rollout_dones)
+                done_np = np.array(rollout_full_dones)
                 completed_returns, completed_lengths = compute_episode_stats(rew_np, done_np, ep_stats_acc)
                 mean_ep_return = float(np.mean(completed_returns)) if completed_returns else float("nan")
                 mean_ep_length = float(np.mean(completed_lengths)) if completed_lengths else float("nan")
@@ -1085,20 +1178,35 @@ class JaxTrainer:
                 }
                 self._dispatch("on_rollout_end", state, rollout_metrics)
 
-                rollout_obs_norm = normalize_obs(rollout_obs.reshape(-1, obs_dim), state.obs_stats)
+                # Bootstrap value at the end of the rollout.  When the last
+                # step truncated, ``state.env_states.obs`` is the post-reset
+                # obs, so use the per-step ``rollout_final_obs`` for the
+                # last index — that's the true s_T.  When the last step
+                # terminated, the (1 - gae_done) GAE mask zeros it out.
+                last_final_obs = rollout_final_obs[-1]
+
+                # Normalize PPO inputs with the SAME stats used during sampling
+                rollout_obs_norm = normalize_obs(rollout_obs.reshape(-1, obs_dim), rollout_obs_stats)
 
                 rng, bootstrap_rng = jax.random.split(state.rng)
                 state.rng = rng
-                final_obs = normalize_obs(state.env_states.obs, state.obs_stats)
-                bootstrap_value = _batched_bootstrap(state.params, final_obs, bootstrap_rng)
+                bootstrap_obs_norm = normalize_obs(last_final_obs, rollout_obs_stats)
+                bootstrap_value = _batched_bootstrap(state.params, bootstrap_obs_norm, bootstrap_rng)
 
                 rollout_values_arr = jnp.concatenate([rollout_values, bootstrap_value[None]], axis=0)
                 advantages, returns = compute_gae(
                     rollout_rewards,
                     rollout_values_arr,
-                    rollout_dones,
+                    rollout_gae_dones,
                     self.ppo_config.gamma,
                     self.ppo_config.gae_lambda,
+                )
+
+                # Update running obs stats AFTER the rollout has been fully
+                # consumed for normalization, using RAW obs (never normalized).
+                state.obs_stats = update_running_stats(
+                    state.obs_stats,
+                    rollout_obs.reshape(-1, obs_dim),
                 )
 
                 batch = {

--- a/environments/shared/mjx_env.py
+++ b/environments/shared/mjx_env.py
@@ -242,15 +242,18 @@ class MJXDinoEnv:
         # Cache default MJX data once (avoids mjx.make_data per env per step)
         self._default_data = mjx.make_data(self.mjx_model)
 
-        # Pre-compile step and reset functions
+        # Pre-compile step and reset functions.  ``forward_vel_scale`` is
+        # passed as a JAX scalar (broadcast via in_axes=None) so the reward
+        # ramp can adjust the forward-velocity weight at runtime without
+        # forcing a re-trace.
         self._step_single = jax.jit(self._make_step_fn())
         self._reset_single = jax.jit(self._make_reset_fn())
-        self._batched_step = jax.jit(jax.vmap(self._step_single, in_axes=(0, 0, 0)))
+        self._batched_step = jax.jit(jax.vmap(self._step_single, in_axes=(0, 0, 0, None)))
         self._batched_reset = jax.jit(jax.vmap(self._reset_single, in_axes=(0,)))
 
         # Fused step + auto-reset: runs step and reset in a single vmapped
         # kernel, selecting the reset state only where episodes ended.
-        self._batched_step_autoreset = jax.jit(jax.vmap(self._make_fused_step_fn(), in_axes=(0, 0, 0)))
+        self._batched_step_autoreset = jax.jit(jax.vmap(self._make_fused_step_fn(), in_axes=(0, 0, 0, None)))
 
     def _make_step_fn(self):
         """Build the single-env step function as a closure over model/config."""
@@ -301,8 +304,13 @@ class MJXDinoEnv:
             foot_indices=config.sensor_foot_indices,
         )
 
-        def step_fn(state: EnvState, action, rng):
-            """Pure single-environment step function."""
+        def step_fn(state: EnvState, action, rng, forward_vel_scale):
+            """Pure single-environment step function.
+
+            ``forward_vel_scale`` (a scalar JAX array) multiplies the
+            ``forward_vel_weight`` reward at runtime so the trainer can
+            ramp it without retracing this kernel.
+            """
             # Scale action
             ctrl = scale_action_jax(action, ctrl_range)
             data = state.data.replace(ctrl=ctrl)
@@ -335,8 +343,10 @@ class MJXDinoEnv:
             forward_ref = target_rel_2d / (jnp.linalg.norm(target_rel_2d) + 1e-8)
 
             weights = config.reward_weights
+            # Apply runtime ramp scale (default 1.0) to forward_vel_weight.
+            forward_vel_weight = weights.get("forward_vel_weight", 1.0) * forward_vel_scale
             r_forward, fwd_vel = reward_forward_velocity(
-                vel_2d, forward_ref, config.forward_vel_max, weights.get("forward_vel_weight", 1.0)
+                vel_2d, forward_ref, config.forward_vel_max, forward_vel_weight
             )
             # Foot contact: read touch sensors
             foot_contact_threshold = 0.1  # Newtons
@@ -621,6 +631,12 @@ class MJXDinoEnv:
         Fusing step + reset into one function means a single ``vmap`` call
         handles both, avoiding a second batched reset kernel and the
         Python-level ``tree_map`` / ``where`` selection.
+
+        The fused step also returns ``final_obs`` — the post-step obs
+        BEFORE auto-reset.  Callers that need to bootstrap value at a
+        truncation boundary (where the episode ends without termination)
+        must use ``final_obs``, not ``new_state.obs``, since the latter
+        is the reset-episode obs once auto-reset fires.
         """
         step_fn = self._make_step_fn()
         reset_fn = self._make_reset_fn()
@@ -628,10 +644,13 @@ class MJXDinoEnv:
         import jax
         import jax.numpy as jnp
 
-        def fused_step(state: EnvState, action, rng):
+        def fused_step(state: EnvState, action, rng, forward_vel_scale):
             rng_step, rng_reset = jax.random.split(rng)
-            new_state, reward, terminated, truncated = step_fn(state, action, rng_step)
+            new_state, reward, terminated, truncated = step_fn(state, action, rng_step, forward_vel_scale)
             done = terminated | truncated
+
+            # Capture the pre-reset obs so callers can bootstrap at truncation.
+            final_obs = new_state.obs
 
             reset_state = reset_fn(rng_reset)
 
@@ -641,7 +660,7 @@ class MJXDinoEnv:
                 new_state,
                 reset_state,
             )
-            return out_state, reward, terminated, truncated
+            return out_state, reward, terminated, truncated, final_obs
 
         return fused_step
 
@@ -659,7 +678,15 @@ class MJXDinoEnv:
         rngs = jax.random.split(rng, self.num_envs)
         return self._batched_reset(rngs)
 
-    def step(self, states: EnvState, actions, rng):
+    def step(
+        self,
+        states: EnvState,
+        actions,
+        rng,
+        *,
+        return_final_obs: bool = False,
+        forward_vel_scale: Any = None,
+    ):
         """Step all environments with fused auto-reset.
 
         Uses a single vmapped kernel that computes both the physics step
@@ -670,11 +697,28 @@ class MJXDinoEnv:
             states: Batched ``EnvState``.
             actions: Actions array of shape ``(num_envs, action_dim)``.
             rng: JAX PRNGKey (used for step and auto-reset).
+            return_final_obs: When ``True``, also return the pre-reset
+                observation so callers can bootstrap at truncation.
+            forward_vel_scale: Optional scalar (``float`` or 0-d JAX array)
+                that multiplies the ``forward_vel_weight`` reward
+                component at runtime.  ``None`` (default) is treated as
+                ``1.0`` — no scaling.  Use this from a curriculum / ramp
+                so the policy sees a smoothly-changing reward without
+                forcing JIT recompilation.
 
         Returns:
-            (new_states, rewards, terminated, truncated) tuple.
+            ``(new_states, rewards, terminated, truncated)`` by default,
+            or ``(new_states, rewards, terminated, truncated, final_obs)``
+            when ``return_final_obs=True``.
         """
         import jax
+        import jax.numpy as jnp
 
+        scale = jnp.float32(1.0) if forward_vel_scale is None else jnp.asarray(forward_vel_scale, dtype=jnp.float32)
         rngs = jax.random.split(rng, self.num_envs)
-        return self._batched_step_autoreset(states, actions, rngs)
+        new_states, rewards, terminated, truncated, final_obs = self._batched_step_autoreset(
+            states, actions, rngs, scale
+        )
+        if return_final_obs:
+            return new_states, rewards, terminated, truncated, final_obs
+        return new_states, rewards, terminated, truncated

--- a/environments/shared/tests/test_jax_checkpoint.py
+++ b/environments/shared/tests/test_jax_checkpoint.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import pickle
 
-import pytest
-
 from environments.shared.jax_checkpoint import (
     CheckpointManager,
     load_checkpoint,

--- a/environments/shared/tests/test_jax_checkpoint.py
+++ b/environments/shared/tests/test_jax_checkpoint.py
@@ -1,0 +1,89 @@
+"""Tests for jax_checkpoint module."""
+
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+from environments.shared.jax_checkpoint import (
+    CheckpointManager,
+    load_checkpoint,
+    save_checkpoint,
+)
+
+
+class TestSaveLoadCheckpoint:
+    def test_round_trip(self, tmp_path):
+        path = tmp_path / "ckpt.pkl"
+        params = {"w": [1.0, 2.0, 3.0]}
+        save_checkpoint(path, params, update=10)
+        data = load_checkpoint(path)
+        assert data["update"] == 10
+        assert data["params"] == params
+
+    def test_with_obs_rms_and_history(self, tmp_path):
+        path = tmp_path / "ckpt.pkl"
+        save_checkpoint(
+            path,
+            params={"w": 1.0},
+            obs_rms="rms_object",
+            update=5,
+            history={"reward": [1.0, 2.0]},
+            extra={"best_reward": 5.5},
+        )
+        data = load_checkpoint(path)
+        assert data["obs_rms"] == "rms_object"
+        assert data["history"] == {"reward": [1.0, 2.0]}
+        assert data["best_reward"] == 5.5
+
+
+class TestCheckpointManager:
+    def test_save_and_rotate(self, tmp_path):
+        mgr = CheckpointManager(tmp_path, prefix="ckpt", max_keep=2)
+        for u in (1, 2, 3):
+            mgr.save({"w": u}, update=u)
+        # Only the last 2 should remain
+        remaining = sorted(p.name for p in tmp_path.iterdir())
+        assert remaining == ["ckpt_2.pkl", "ckpt_3.pkl"]
+
+    def test_latest_property(self, tmp_path):
+        mgr = CheckpointManager(tmp_path, prefix="ckpt", max_keep=5)
+        assert mgr.latest is None
+        mgr.save({"w": 0}, update=0)
+        assert mgr.latest is not None
+        assert mgr.latest.name == "ckpt_0.pkl"
+
+    def test_rediscovers_existing_files_on_construct(self, tmp_path):
+        """Bug #9 regression: a fresh CheckpointManager pointed at a
+        directory that already has rotated checkpoints must enforce
+        max_keep across the OLD plus NEW files, not start counting
+        from zero and let old files accumulate forever."""
+        # Pre-populate directory with three checkpoints from a prior run
+        for u in (1, 2, 3):
+            with open(tmp_path / f"ckpt_{u}.pkl", "wb") as f:
+                pickle.dump({"params": {"w": u}, "update": u}, f)
+
+        mgr = CheckpointManager(tmp_path, prefix="ckpt", max_keep=2)
+        # Saving one new ckpt should rotate the OLDEST pre-existing one out
+        mgr.save({"w": 4}, update=4)
+        remaining = sorted(p.name for p in tmp_path.iterdir())
+        # max_keep=2 — newest two should survive: ckpt_3 and ckpt_4
+        assert remaining == ["ckpt_3.pkl", "ckpt_4.pkl"]
+
+    def test_ignores_unrelated_files_on_construct(self, tmp_path):
+        """Random other .pkl files in the directory should not corrupt
+        the rotation queue."""
+        (tmp_path / "params.pkl").write_bytes(b"unrelated")
+        (tmp_path / "ckpt_random_other.pkl").write_bytes(b"unrelated")
+        with open(tmp_path / "ckpt_5.pkl", "wb") as f:
+            pickle.dump({"params": {}, "update": 5}, f)
+
+        mgr = CheckpointManager(tmp_path, prefix="ckpt", max_keep=1)
+        mgr.save({"w": 6}, update=6)
+        # ckpt_5 must rotate out, but unrelated files survive untouched
+        names = sorted(p.name for p in tmp_path.iterdir())
+        assert "params.pkl" in names
+        assert "ckpt_random_other.pkl" in names
+        assert "ckpt_5.pkl" not in names
+        assert "ckpt_6.pkl" in names

--- a/environments/shared/tests/test_jax_normalization.py
+++ b/environments/shared/tests/test_jax_normalization.py
@@ -1,0 +1,125 @@
+"""Tests for jax_normalization (RunningMeanStd / Welford updates)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def _jnp():
+    jnp = pytest.importorskip("jax.numpy")
+    return jnp
+
+
+class TestRunningMeanStdCreate:
+    def test_initial_state(self, _jnp):
+        from environments.shared.jax_normalization import RunningMeanStd
+
+        stats = RunningMeanStd.create(5)
+        assert stats.mean.shape == (5,)
+        assert stats.var.shape == (5,)
+        # Initial mean=0, var=1, count=tiny so the first update dominates.
+        assert float(_jnp.max(_jnp.abs(stats.mean))) == pytest.approx(0.0)
+        assert float(_jnp.max(_jnp.abs(stats.var - 1.0))) == pytest.approx(0.0)
+        assert stats.count < 1.0
+
+
+class TestUpdateRunningStats:
+    """Welford updates must converge to the true distribution stats."""
+
+    def test_converges_to_true_mean_and_var(self, _jnp):
+        import numpy as np
+
+        from environments.shared.jax_normalization import RunningMeanStd, update_running_stats
+
+        rng = np.random.default_rng(42)
+        true_mean = np.array([3.0, -2.0, 7.0])
+        true_std = np.array([0.5, 1.5, 2.5])
+
+        stats = RunningMeanStd.create(3)
+        for _ in range(20):
+            batch = rng.normal(true_mean, true_std, size=(512, 3))
+            stats = update_running_stats(stats, _jnp.array(batch))
+
+        # Tolerance: with 20 batches of 512 the Welford estimate should
+        # be within ~1% of the true value.
+        assert float(_jnp.max(_jnp.abs(stats.mean - _jnp.array(true_mean)))) < 0.1
+        assert float(_jnp.max(_jnp.abs(_jnp.sqrt(stats.var) - _jnp.array(true_std)))) < 0.1
+
+    def test_does_not_collapse_when_fed_raw_obs(self, _jnp):
+        """Bug #4 regression: feeding RAW obs to update_running_stats
+        and then normalizing must NOT make the distribution drift
+        toward N(0, 1) — that's the failure mode of feeding back
+        already-normalized obs.  We verify that after several updates,
+        the running mean still tracks the raw distribution mean.
+        """
+        import numpy as np
+
+        from environments.shared.jax_normalization import (
+            RunningMeanStd,
+            update_running_stats,
+        )
+
+        rng = np.random.default_rng(0)
+        # Heavily off-zero distribution
+        stats = RunningMeanStd.create(2)
+        for _ in range(10):
+            batch = rng.normal([10.0, 5.0], 0.3, size=(256, 2))
+            stats = update_running_stats(stats, _jnp.array(batch))
+
+        # Mean should clearly NOT be ~0 — that'd indicate normalized
+        # data was being fed back.
+        assert float(stats.mean[0]) > 5.0
+        assert float(stats.mean[1]) > 2.5
+
+
+class TestNormalizeObs:
+    def test_zero_distribution_normalizes_to_zero(self, _jnp):
+        """An obs equal to the running mean normalizes to 0."""
+        from environments.shared.jax_normalization import (
+            RunningMeanStd,
+            normalize_obs,
+            update_running_stats,
+        )
+
+        # Update with constant data so mean is exactly 5.0 and var is small.
+        stats = RunningMeanStd.create(1)
+        batch = _jnp.full((100, 1), 5.0)
+        stats = update_running_stats(stats, batch)
+
+        normed = normalize_obs(_jnp.array([5.0]), stats)
+        assert float(_jnp.abs(normed[0])) < 1e-3
+
+    def test_clipping(self, _jnp):
+        from environments.shared.jax_normalization import RunningMeanStd, normalize_obs
+
+        stats = RunningMeanStd.create(1)  # mean=0, var=1
+        # Far-out value normalizes to its raw value (since var=1) and
+        # then gets clipped to ±10.
+        normed = normalize_obs(_jnp.array([50.0]), stats, clip=10.0)
+        assert float(normed[0]) == pytest.approx(10.0, abs=1e-5)
+        normed_neg = normalize_obs(_jnp.array([-50.0]), stats, clip=10.0)
+        assert float(normed_neg[0]) == pytest.approx(-10.0, abs=1e-5)
+
+
+class TestDecayRunningStats:
+    """Curriculum stage transitions need to make new data dominate."""
+
+    def test_decay_reduces_count(self, _jnp):
+        from environments.shared.jax_normalization import (
+            RunningMeanStd,
+            decay_running_stats,
+            update_running_stats,
+        )
+
+        stats = RunningMeanStd.create(2)
+        batch = _jnp.ones((1000, 2)) * 3.0
+        stats = update_running_stats(stats, batch)
+        pre_count = stats.count
+        decayed = decay_running_stats(stats, decay_factor=0.01)
+        # Mean/var preserved
+        assert float(_jnp.max(_jnp.abs(decayed.mean - stats.mean))) == pytest.approx(0.0)
+        assert float(_jnp.max(_jnp.abs(decayed.var - stats.var))) == pytest.approx(0.0)
+        # Count reduced
+        assert decayed.count < pre_count
+        assert decayed.count == pytest.approx(pre_count * 0.01, rel=1e-3)

--- a/environments/shared/tests/test_jax_ppo.py
+++ b/environments/shared/tests/test_jax_ppo.py
@@ -136,3 +136,83 @@ class TestMakeOptimizer:
         )
         opt = make_optimizer(cfg)
         assert opt is not None
+
+
+# ---------------------------------------------------------------------------
+# compute_gae: verify done masking distinguishes termination from truncation
+# ---------------------------------------------------------------------------
+
+
+class TestComputeGAE:
+    """The trainer feeds compute_gae a done mask that is 1 ONLY for natural
+    termination — truncation must keep the bootstrap value alive."""
+
+    @pytest.fixture()
+    def _jnp(self):
+        jnp = pytest.importorskip("jax.numpy")
+        return jnp
+
+    def test_terminal_done_zeros_bootstrap(self, _jnp):
+        """When done=1 at step T-1, GAE must not propagate V(s_T)."""
+        from environments.shared.jax_ppo import compute_gae
+
+        jnp = _jnp
+        # 1 env, 3 steps; done at the last step.
+        rewards = jnp.array([[0.0], [0.0], [1.0]])
+        # values = [V(s_0), V(s_1), V(s_2), V(s_3)]; bootstrap at index 3.
+        values = jnp.array([[0.0], [0.0], [0.0], [10.0]])
+        dones = jnp.array([[0.0], [0.0], [1.0]])
+
+        adv, ret = compute_gae(rewards, values, dones, gamma=0.99, gae_lambda=0.95)
+        # Step 2 done=1 → δ_2 = r_2 + 0 - V(s_2) = 1.0; A_2 = 1.0
+        # The bootstrap V(s_3)=10 must NOT enter A_2.
+        assert float(adv[-1, 0]) == pytest.approx(1.0, abs=1e-5)
+        assert float(ret[-1, 0]) == pytest.approx(1.0, abs=1e-5)
+
+    def test_no_done_bootstraps_value(self, _jnp):
+        """When done=0 (truncation, in our convention), bootstrap V(s_T)."""
+        from environments.shared.jax_ppo import compute_gae
+
+        jnp = _jnp
+        rewards = jnp.array([[1.0]])
+        values = jnp.array([[0.0], [10.0]])  # V(s_0)=0, bootstrap V(s_1)=10
+        dones = jnp.array([[0.0]])
+
+        adv, _ = compute_gae(rewards, values, dones, gamma=0.99, gae_lambda=0.95)
+        # δ_0 = r + γ * V(s_1) - V(s_0) = 1 + 0.99*10 - 0 = 10.9; A_0 = 10.9
+        assert float(adv[0, 0]) == pytest.approx(10.9, abs=1e-4)
+
+    def test_truncation_vs_termination_diverge(self, _jnp):
+        """Same trajectory, two done patterns — bootstrap behavior must differ."""
+        from environments.shared.jax_ppo import compute_gae
+
+        jnp = _jnp
+        rewards = jnp.array([[0.0]])
+        values = jnp.array([[0.0], [5.0]])
+
+        adv_truncated, _ = compute_gae(
+            rewards, values, jnp.array([[0.0]]), gamma=1.0, gae_lambda=1.0
+        )
+        adv_terminated, _ = compute_gae(
+            rewards, values, jnp.array([[1.0]]), gamma=1.0, gae_lambda=1.0
+        )
+        # Truncation bootstraps: A_0 = 0 + 5 - 0 = 5
+        # Termination zeros bootstrap: A_0 = 0 + 0 - 0 = 0
+        assert float(adv_truncated[0, 0]) == pytest.approx(5.0, abs=1e-5)
+        assert float(adv_terminated[0, 0]) == pytest.approx(0.0, abs=1e-5)
+
+    def test_chronological_order(self, _jnp):
+        """Output advantages must be in chronological (forward) order."""
+        from environments.shared.jax_ppo import compute_gae
+
+        jnp = _jnp
+        rewards = jnp.array([[1.0], [2.0], [3.0]])
+        values = jnp.array([[0.0], [0.0], [0.0], [0.0]])
+        dones = jnp.array([[0.0], [0.0], [0.0]])
+
+        adv, ret = compute_gae(rewards, values, dones, gamma=1.0, gae_lambda=1.0)
+        # With γ=λ=1, advantage at step t = sum of future rewards.
+        # A_0 = r_0 + r_1 + r_2 = 6; A_1 = 5; A_2 = 3
+        assert float(adv[0, 0]) == pytest.approx(6.0, abs=1e-5)
+        assert float(adv[1, 0]) == pytest.approx(5.0, abs=1e-5)
+        assert float(adv[2, 0]) == pytest.approx(3.0, abs=1e-5)

--- a/environments/shared/tests/test_jax_ppo.py
+++ b/environments/shared/tests/test_jax_ppo.py
@@ -190,12 +190,8 @@ class TestComputeGAE:
         rewards = jnp.array([[0.0]])
         values = jnp.array([[0.0], [5.0]])
 
-        adv_truncated, _ = compute_gae(
-            rewards, values, jnp.array([[0.0]]), gamma=1.0, gae_lambda=1.0
-        )
-        adv_terminated, _ = compute_gae(
-            rewards, values, jnp.array([[1.0]]), gamma=1.0, gae_lambda=1.0
-        )
+        adv_truncated, _ = compute_gae(rewards, values, jnp.array([[0.0]]), gamma=1.0, gae_lambda=1.0)
+        adv_terminated, _ = compute_gae(rewards, values, jnp.array([[1.0]]), gamma=1.0, gae_lambda=1.0)
         # Truncation bootstraps: A_0 = 0 + 5 - 0 = 5
         # Termination zeros bootstrap: A_0 = 0 + 0 - 0 = 0
         assert float(adv_truncated[0, 0]) == pytest.approx(5.0, abs=1e-5)

--- a/environments/shared/tests/test_jax_trainer.py
+++ b/environments/shared/tests/test_jax_trainer.py
@@ -321,19 +321,16 @@ class TestJaxTrainerSmoke:
         import jax
 
         trainer, env = self._build()
-        # Monkeypatch in init so we exercise the build but stop early.
         rng = jax.random.PRNGKey(0)
         states = env.reset(rng)
         collect = trainer._build_collect_rollout()
-        from environments.shared.jax_normalization import RunningMeanStd
 
-        stats = RunningMeanStd.create(int(states.obs.shape[-1]))
         # We need params to actually run the network — re-use trainer.train
-        # to do init then call collect with returned params.
+        # to do init then call collect with the returned params.
         params, _metrics, tstate = trainer.train(num_updates=1, seed=0)
         (_states, _), rollout = collect(tstate.env_states, rng, params, tstate.obs_stats)
         assert len(rollout) == 8
-        raw_obs, raw_action, log_prob, value, reward, gae_done, full_done, final_obs = rollout
+        raw_obs, _raw_action, _log_prob, _value, _reward, gae_done, full_done, final_obs = rollout
         assert raw_obs.shape[-1] == int(states.obs.shape[-1])
         assert final_obs.shape == raw_obs.shape
         # gae_done <= full_done elementwise (truncation cannot fire without
@@ -350,12 +347,11 @@ class TestNotebookTrainRewardRamp:
     ramp targets rather than silently doing nothing."""
 
     def _make_train_inputs(self, *, ramp_attr="forward_vel_weight", ramp_updates=2):
-        import environments.trex.mjx_config  # noqa: F401
         import jax
-        import jax.numpy as jnp  # noqa: F401
 
-        from environments.shared.jax_ppo import PPOConfig, make_actor_critic, make_optimizer
+        import environments.trex.mjx_config  # noqa: F401
         from environments.shared.jax_normalization import RunningMeanStd
+        from environments.shared.jax_ppo import PPOConfig, make_actor_critic, make_optimizer
         from environments.shared.jax_trainer import TrainConfig
         from environments.shared.mjx_env import MJXDinoEnv
 

--- a/environments/shared/tests/test_jax_trainer.py
+++ b/environments/shared/tests/test_jax_trainer.py
@@ -7,6 +7,15 @@ import pytest
 from environments.shared.jax_hooks import BestModelHook, CSVLoggingHook, LoggingHook, StabilityHook
 from environments.shared.jax_trainer import JaxTrainer, StopTraining, TrainerState
 
+_has_jax = False
+try:
+    import jax  # noqa: F401
+    import mujoco.mjx  # noqa: F401
+
+    _has_jax = True
+except ImportError:
+    pass
+
 
 class TestTrainerState:
     def test_defaults(self):
@@ -259,3 +268,192 @@ class TestCSVLoggingHook:
         csv_path = tmp_path / "log2.csv"
         hook = CSVLoggingHook(path=csv_path)
         assert hook.path == csv_path
+
+
+# ---------------------------------------------------------------------------
+# End-to-end JaxTrainer tests — guard the bugs fixed in this review.
+# Skipped when JAX/MJX is not installed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _has_jax, reason="JAX/MJX not installed")
+class TestJaxTrainerSmoke:
+    """One-update smoke run that catches obs-dim and rollout-tuple bugs."""
+
+    def _build(self, num_envs=4, rollout_len=4, n_minibatches=2):
+        import environments.trex.mjx_config  # noqa: F401
+        from environments.shared.jax_ppo import PPOConfig, make_actor_critic, make_optimizer
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        env = MJXDinoEnv("trex", stage=1, num_envs=num_envs)
+        ppo_cfg = PPOConfig(
+            n_epochs=1,
+            n_minibatches=n_minibatches,
+            target_kl=None,  # disable KL early-stop for determinism
+            total_updates=2,
+        )
+        network = make_actor_critic(env.action_dim, hidden_dims=(8,))
+        optimizer = make_optimizer(ppo_cfg)
+        trainer = JaxTrainer(
+            env=env,
+            network=network,
+            optimizer=optimizer,
+            ppo_config=ppo_cfg,
+            num_envs=num_envs,
+            rollout_len=rollout_len,
+        )
+        return trainer, env
+
+    def test_one_update_runs(self):
+        """Bug #1 regression: network init obs_dim must match the env's
+        actual obs (which includes foot contacts).  A wrong dummy_obs
+        size causes a shape error on the first ``apply``."""
+        trainer, _env = self._build()
+        params, metrics, state = trainer.train(num_updates=1, seed=0)
+        assert state.update == 0
+        assert state.total_steps == trainer.num_envs * trainer.rollout_len
+        assert "mean_reward" in metrics
+
+    def test_rollout_unpacks_8_tuple(self):
+        """Bug #2 regression: ``_build_collect_rollout`` returns the
+        new (raw_obs, action, log_prob, value, reward, gae_done,
+        full_done, final_obs) layout — not the old 6-tuple."""
+        import jax
+
+        trainer, env = self._build()
+        # Monkeypatch in init so we exercise the build but stop early.
+        rng = jax.random.PRNGKey(0)
+        states = env.reset(rng)
+        collect = trainer._build_collect_rollout()
+        from environments.shared.jax_normalization import RunningMeanStd
+
+        stats = RunningMeanStd.create(int(states.obs.shape[-1]))
+        # We need params to actually run the network — re-use trainer.train
+        # to do init then call collect with returned params.
+        params, _metrics, tstate = trainer.train(num_updates=1, seed=0)
+        (_states, _), rollout = collect(tstate.env_states, rng, params, tstate.obs_stats)
+        assert len(rollout) == 8
+        raw_obs, raw_action, log_prob, value, reward, gae_done, full_done, final_obs = rollout
+        assert raw_obs.shape[-1] == int(states.obs.shape[-1])
+        assert final_obs.shape == raw_obs.shape
+        # gae_done <= full_done elementwise (truncation cannot fire without
+        # also flipping full_done)
+        import jax.numpy as jnp
+
+        assert bool(jnp.all(gae_done <= full_done))
+
+
+@pytest.mark.skipif(not _has_jax, reason="JAX/MJX not installed")
+class TestNotebookTrainRewardRamp:
+    """Bug #5 regression: the notebook ``train()`` reward ramp must
+    actually affect the env's reward, and must reject unsupported
+    ramp targets rather than silently doing nothing."""
+
+    def _make_train_inputs(self, *, ramp_attr="forward_vel_weight", ramp_updates=2):
+        import environments.trex.mjx_config  # noqa: F401
+        import jax
+        import jax.numpy as jnp  # noqa: F401
+
+        from environments.shared.jax_ppo import PPOConfig, make_actor_critic, make_optimizer
+        from environments.shared.jax_normalization import RunningMeanStd
+        from environments.shared.jax_trainer import TrainConfig
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        num_envs, rollout_len = 4, 4
+        env = MJXDinoEnv(
+            "trex",
+            stage=1,
+            num_envs=num_envs,
+            env_kwargs={"reward_weights": {"forward_vel_weight": 1.0}},
+        )
+        ppo_cfg = PPOConfig(n_epochs=1, n_minibatches=2, target_kl=None, total_updates=2)
+        network = make_actor_critic(env.action_dim, hidden_dims=(8,))
+        optimizer = make_optimizer(ppo_cfg)
+
+        rng = jax.random.PRNGKey(0)
+        rng, init_rng, reset_rng = jax.random.split(rng, 3)
+        states = env.reset(reset_rng)
+        obs_dim = int(states.obs.shape[-1])
+        params = network.init(init_rng, states.obs[0])
+        opt_state = optimizer.init(params)
+        obs_rms = RunningMeanStd.create(obs_dim)
+
+        cfg = TrainConfig(
+            num_envs=num_envs,
+            rollout_len=rollout_len,
+            num_updates=2,
+            ppo_epochs=1,
+            minibatch_size=8,
+            obs_dim=obs_dim,
+            act_dim=env.action_dim,
+            ramp_updates=ramp_updates,
+            ramp_attr=ramp_attr,
+            ramp_start_fraction=0.1,
+            verbose=0,
+            output_dir=".",
+            model_dir=".",
+            checkpoint_freq=10,
+        )
+        return cfg, env, network, params, opt_state, obs_rms, optimizer, rng
+
+    def test_unsupported_ramp_attr_raises(self, tmp_path):
+        from environments.shared.jax_trainer import train
+
+        cfg, env, network, params, opt_state, obs_rms, optimizer, rng = self._make_train_inputs(
+            ramp_attr="energy_penalty_weight"
+        )
+        cfg.output_dir = tmp_path
+        cfg.model_dir = tmp_path
+        with pytest.raises(ValueError, match="forward_vel_weight"):
+            train(
+                cfg,
+                env,
+                network,
+                params,
+                opt_state,
+                obs_rms,
+                reward_cfg={"energy_penalty_weight": 0.5},
+                rng=rng,
+                optimizer=optimizer,
+            )
+
+
+@pytest.mark.skipif(not _has_jax, reason="JAX/MJX not installed")
+class TestJaxTrainerObsStatsRawOnly:
+    """Bug #4 regression: obs_rms must be updated from RAW obs only."""
+
+    def test_running_stats_track_raw_distribution(self):
+        """After several updates, mean and std should reflect the raw
+        obs distribution — NOT collapse toward (0, 1) which would
+        indicate stats were updated using already-normalized obs."""
+        import environments.trex.mjx_config  # noqa: F401
+        from environments.shared.jax_ppo import PPOConfig, make_actor_critic, make_optimizer
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        num_envs, rollout_len = 4, 4
+        env = MJXDinoEnv("trex", stage=1, num_envs=num_envs)
+        ppo_cfg = PPOConfig(n_epochs=1, n_minibatches=2, target_kl=None, total_updates=3)
+        network = make_actor_critic(env.action_dim, hidden_dims=(8,))
+        optimizer = make_optimizer(ppo_cfg)
+        trainer = JaxTrainer(
+            env=env,
+            network=network,
+            optimizer=optimizer,
+            ppo_config=ppo_cfg,
+            num_envs=num_envs,
+            rollout_len=rollout_len,
+        )
+        _params, _metrics, state = trainer.train(num_updates=3, seed=0)
+        # Raw obs include qpos with z-position around standing height
+        # (positive, ~0.6-1.0).  If obs_rms were being fed normalized
+        # obs, the mean would converge toward 0 across updates.  We
+        # check that at least one channel of running mean is clearly
+        # away from zero, indicating raw-obs accumulation is working.
+        import jax.numpy as jnp
+
+        obs_mean = state.obs_stats.mean
+        assert float(jnp.max(jnp.abs(obs_mean))) > 0.05, (
+            f"obs_rms.mean is suspiciously close to zero (max abs = "
+            f"{float(jnp.max(jnp.abs(obs_mean))):.4f}); stats may be "
+            "updated from normalized obs"
+        )

--- a/environments/shared/tests/test_mjx_env.py
+++ b/environments/shared/tests/test_mjx_env.py
@@ -150,9 +150,7 @@ class TestStepReturnFinalObs:
         rng = jax.random.PRNGKey(0)
         states = env.reset(rng)
         actions = jnp.zeros((2, env.action_dim))
-        new_states, _r, terminated, _trunc, final_obs = env.step(
-            states, actions, rng, return_final_obs=True
-        )
+        new_states, _r, terminated, _trunc, final_obs = env.step(states, actions, rng, return_final_obs=True)
         assert bool(terminated[0])
         # After termination + auto-reset, new_states.obs is the freshly
         # reset obs.  final_obs should NOT match the reset state because

--- a/environments/shared/tests/test_mjx_env.py
+++ b/environments/shared/tests/test_mjx_env.py
@@ -86,3 +86,133 @@ class TestMJXUtils:
         assert float(scale_action_jax(jnp.array([1.0]), ctrl_range)[0]) == pytest.approx(2.0)
         # -1 → min
         assert float(scale_action_jax(jnp.array([-1.0]), ctrl_range)[0]) == pytest.approx(-2.0)
+
+
+# ---------------------------------------------------------------------------
+# Bug-fix coverage: env.step exposes final_obs and respects forward_vel_scale
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _has_jax, reason="JAX/MJX not installed")
+class TestStepReturnFinalObs:
+    """``env.step(return_final_obs=True)`` returns the pre-reset obs so
+    callers can bootstrap value at truncation boundaries."""
+
+    def test_default_returns_4_tuple(self):
+        import jax
+
+        import environments.trex.mjx_config  # noqa: F401
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        env = MJXDinoEnv("trex", stage=1, num_envs=2)
+        rng = jax.random.PRNGKey(0)
+        states = env.reset(rng)
+        actions = jax.numpy.zeros((2, env.action_dim))
+        out = env.step(states, actions, rng)
+        assert len(out) == 4
+
+    def test_return_final_obs_returns_5_tuple(self):
+        import jax
+
+        import environments.trex.mjx_config  # noqa: F401
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        env = MJXDinoEnv("trex", stage=1, num_envs=2)
+        rng = jax.random.PRNGKey(0)
+        states = env.reset(rng)
+        actions = jax.numpy.zeros((2, env.action_dim))
+        out = env.step(states, actions, rng, return_final_obs=True)
+        assert len(out) == 5
+        new_states, _rewards, _term, _trunc, final_obs = out
+        # Same shape as the new states' obs
+        assert final_obs.shape == new_states.obs.shape
+
+    def test_final_obs_differs_from_reset_obs_after_termination(self):
+        """Force termination by lowering the healthy z-range floor so the
+        first step terminates on a fresh reset.  ``final_obs`` should
+        track the post-step (pre-reset) obs, while ``new_states.obs``
+        is the post-reset obs.  Even though the policy then acts on the
+        post-reset obs, GAE bootstrap must use the pre-reset value."""
+        import jax
+        import jax.numpy as jnp
+
+        import environments.trex.mjx_config  # noqa: F401
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        # Force termination on the very first step by setting the lower
+        # healthy z-bound above the natural standing height.
+        env = MJXDinoEnv(
+            "trex",
+            stage=1,
+            num_envs=2,
+            env_kwargs={"healthy_z_range": (5.0, 10.0)},
+        )
+        rng = jax.random.PRNGKey(0)
+        states = env.reset(rng)
+        actions = jnp.zeros((2, env.action_dim))
+        new_states, _r, terminated, _trunc, final_obs = env.step(
+            states, actions, rng, return_final_obs=True
+        )
+        assert bool(terminated[0])
+        # After termination + auto-reset, new_states.obs is the freshly
+        # reset obs.  final_obs should NOT match the reset state because
+        # its step_count was advanced inside step_fn.
+        # We can't compare obs directly (reset obs is randomized) but we
+        # can confirm final_obs has the right shape.
+        assert final_obs.shape == new_states.obs.shape
+
+
+@pytest.mark.skipif(not _has_jax, reason="JAX/MJX not installed")
+class TestForwardVelScale:
+    """The reward ramp drives ``forward_vel_scale``; the env must apply
+    it at runtime without recompilation."""
+
+    def test_scale_zero_zeros_forward_reward(self):
+        """With forward_vel_scale=0 the forward-velocity reward must
+        vanish (the difference vs the default scale must equal exactly
+        ``forward_vel_weight * fwd_vel_norm``).  This proves the runtime
+        scale is wired through, not baked into the JIT trace."""
+        import jax
+        import jax.numpy as jnp
+
+        import environments.trex.mjx_config  # noqa: F401
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        # Set a strong forward_vel_weight so the difference is large.
+        env = MJXDinoEnv(
+            "trex",
+            stage=1,
+            num_envs=2,
+            env_kwargs={"reward_weights": {"forward_vel_weight": 10.0}},
+        )
+        rng = jax.random.PRNGKey(7)
+        states = env.reset(rng)
+        # Use a non-zero action so the body actually moves and forward_vel
+        # is non-trivial.  Same seed/state for both calls so physics path
+        # is identical — only the reward scaling differs.
+        actions = jnp.full((2, env.action_dim), 0.1)
+
+        _, r_full, _, _ = env.step(states, actions, rng, forward_vel_scale=1.0)
+        _, r_zero, _, _ = env.step(states, actions, rng, forward_vel_scale=0.0)
+
+        # The two rewards must differ by exactly the forward_vel component
+        # (i.e. they cannot be equal — that would mean the scale was
+        # baked in as a Python constant).
+        diff = float(jnp.max(jnp.abs(r_full - r_zero)))
+        assert diff > 0, "forward_vel_scale had no effect on reward"
+
+    def test_default_scale_is_one(self):
+        """Calling step() without forward_vel_scale must match scale=1.0."""
+        import jax
+        import jax.numpy as jnp
+
+        import environments.trex.mjx_config  # noqa: F401
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        env = MJXDinoEnv("trex", stage=1, num_envs=2)
+        rng = jax.random.PRNGKey(11)
+        states = env.reset(rng)
+        actions = jnp.full((2, env.action_dim), 0.1)
+        _, r_default, _, _ = env.step(states, actions, rng)
+        _, r_one, _, _ = env.step(states, actions, rng, forward_vel_scale=1.0)
+        assert jnp.allclose(r_default, r_one, atol=1e-6)


### PR DESCRIPTION
JaxTrainer / notebook train():
- Derive obs_dim from env reset (was missing foot-contact channels in
  the hardcoded nq/nv arithmetic; first network apply would fail)
- Keep terminated and truncated separate so GAE only zeros the
  bootstrap on natural termination, not on time-limit truncation
- Snapshot obs_rms before the rollout and use the SAME stats for PPO
  loss recomputation, so the importance-sampling ratio stays
  consistent with the behaviour policy
- Update obs_rms from RAW observations only (notebook path was feeding
  already-normalized obs back in, which collapsed running stats to
  N(0,1) over a few updates)
- Use per-step pre-reset final_obs for end-of-rollout value bootstrap,
  so truncated trailing episodes bootstrap their true s_T value
- Wire forward_vel_scale through env.step so the reward ramp actually
  takes effect; raise on unsupported ramp_attr instead of silently
  doing nothing
- Fix latent target_kl=None bug that crashed JIT tracing with
  "traced > None"

MJXDinoEnv:
- env.step(return_final_obs=True) returns the pre-reset obs alongside
  the (auto-reset) new state
- env.step(forward_vel_scale=...) routes a runtime scalar to the
  forward-velocity reward without forcing JIT recompilation

Misc:
- jax_ppo.make_optimizer docstring corrected (LR schedule covers
  total_updates * n_epochs * n_minibatches gradient steps; also
  documents the per-stage scope in curricula)
- CheckpointManager rediscovers existing rotated checkpoints on
  construction so resumed runs continue to enforce max_keep
- jax_eval renames the post-step put_data variable for clarity
- scan_ppo_epochs / scan_ppo_update document the opt_state revert
  semantics on KL early-stop

Tests:
- test_jax_ppo: GAE done-mask correctness (truncation vs termination,
  chronological order)
- test_mjx_env: final_obs return path and forward_vel_scale runtime
  effect
- test_jax_trainer: end-to-end smoke run that catches the obs_dim
  bug, rollout-tuple shape regression, and obs_rms raw-obs invariant;
  unsupported reward-ramp attr error path
- test_jax_normalization (new): Welford convergence, raw-obs
  invariant, normalize/decay behaviour
- test_jax_checkpoint (new): rotation, latest, and existing-file
  rediscovery on construction

https://claude.ai/code/session_01UhgpPF2yi8sDDKAMpSK58V