### PR TITLE
Enhance diagnostics: action saturation, grad norm, algo metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded T-Rex reward tests (nosedive, height, heading, spin, drift, backward velocity)
 - Expanded Brachiosaurus reward tests (gait instability, speed penalty, food reach threshold)
 - Consolidated training notebooks into single parameterized `notebooks/training.ipynb`
+- Algorithm-specific training diagnostics persisted to `diagnostics.npz` for **both PPO and SAC** (previously only on TensorBoard): captured SB3 `train/*` metrics (PPO `clip_fraction`/`approx_kl`/`explained_variance`/`entropy_loss`, SAC `critic_loss`/`actor_loss`/`ent_coef`) under `algo_*` keys
+- `diagnostics/action_saturation` and `diagnostics/action_abs_max` — fraction of action components pinned at the control limit and the peak magnitude, computed for both PPO and SAC (SAC previously had no action logging at all)
+- `diagnostics/grad_norm` — PPO post-update (clipped) gradient norm, surfacing when the clip ceiling binds or the policy stalls
+- `explained_variance` in the JAX PPO loss info dict, per-update CSV log, and console output (value-function fit diagnostic)
 
 ### Changed
 - Species training scripts (`train_sb3.py`) are now thin wrappers around shared `train_base.py`
+- `DiagnosticsCallback` plateau detection now averages every episode that completed during a rollout (accumulated per-step) instead of only episodes that happened to end on the rollout's final step — the old sampling was biased and sparse
+- JAX PPO clamps the Gaussian policy's log-std to `[-5, 2]` (applied identically in `sample_action` and `ppo_loss`, preserving the importance ratio) so a collapsing/exploding policy can no longer drive the action std to 0/inf and NaN the log-prob and entropy terms
 - Species test scripts use shared `test_env_base.py` utilities
 - `BaseDinoEnv` now provides concrete helper methods for common reward computations, gait symmetry, and termination checks
 - Raptor, T-Rex, and Brachio reward tests refactored to use shared helpers

--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -38,21 +38,51 @@ def _safe_mean(vals: list) -> float:
     return float("nan")
 
 
+def _global_grad_norm(parameters) -> float | None:
+    """Global L2 norm over the ``.grad`` tensors of *parameters*.
+
+    Returns ``None`` when no parameter carries a gradient yet (e.g. before the
+    first optimizer step).  Used to surface PPO's post-update (clipped)
+    gradient norm: it saturates at ``max_grad_norm`` when clipping binds — a
+    useful "is the clip ceiling always active?" signal — and collapses toward
+    0 if the policy stops learning.
+    """
+    total_sq = 0.0
+    found = False
+    for p in parameters:
+        grad = getattr(p, "grad", None)
+        if grad is None:
+            continue
+        total_sq += float((grad.detach() ** 2).sum().item())
+        found = True
+    if not found:
+        return None
+    return total_sq**0.5
+
+
 class DiagnosticsCallback(_BaseCallback):
     """Logs per-component reward breakdowns and training diagnostics to TensorBoard.
 
     Tracked metrics (under ``diagnostics/`` in TensorBoard):
       - Per-component rewards: reward_forward, reward_alive, reward_energy, etc.
       - Environment state: forward_vel, prey_distance, pelvis_height, tilt_angle
-      - Observation statistics: mean, std, max absolute value
-      - Action statistics: mean, std
+      - Observation statistics: mean, std, max absolute value (PPO)
+      - Action statistics: mean, std, abs_max, and saturation fraction
+        (fraction of action components pinned at the control limit) — for
+        both PPO and SAC
+      - PPO post-update gradient norm
+      - Algorithm-specific train/* metrics captured from SB3's logger
+        (PPO: clip_fraction, approx_kl, explained_variance, …; SAC:
+        critic_loss, actor_loss, ent_coef, …)
       - VecNormalize running variance for observations and returns
       - Termination reason breakdown (fraction per reason)
       - Reward plateau detection with console warnings
 
-    When *log_dir* is provided, per-rollout averages of INFO_KEYS are also
-    saved to ``diagnostics.npz`` so they can be plotted alongside the
-    evaluation curves produced by the notebook's ``plot_training_curves``.
+    When *log_dir* is provided, per-rollout averages of INFO_KEYS, the
+    captured algorithm metrics (under ``algo_*`` keys, on their own
+    ``algo_timesteps`` axis), and termination fractions are saved to
+    ``diagnostics.npz`` so they can be plotted alongside the evaluation curves
+    produced by the notebook's ``plot_training_curves``.
     """
 
     REWARD_KEYS = [
@@ -114,7 +144,14 @@ class DiagnosticsCallback(_BaseCallback):
         "jaw_distance",  # T-Rex
     ]
 
-    def __init__(self, plateau_window=10, plateau_threshold=1.0, log_dir=None, verbose=0):
+    def __init__(
+        self,
+        plateau_window=10,
+        plateau_threshold=1.0,
+        log_dir=None,
+        verbose=0,
+        action_saturation_threshold=0.99,
+    ):
         if _SB3_AVAILABLE:
             super().__init__(verbose)
         else:
@@ -127,9 +164,17 @@ class DiagnosticsCallback(_BaseCallback):
             self.training_env = None
         self.plateau_window = plateau_window
         self.plateau_threshold = plateau_threshold
+        # |action| at/above this (in the normalized [-1, 1] control space) counts
+        # as "saturated" for the diagnostics/action_saturation metric.
+        self.action_saturation_threshold = action_saturation_threshold
         self._log_dir = Path(log_dir) if log_dir is not None else None
         self._step_infos = {k: [] for k in self.REWARD_KEYS + self.INFO_KEYS}
         self._rollout_ep_rewards: list[float] = []
+        # Episode returns + actions seen during the CURRENT rollout (flushed at
+        # rollout end).  Accumulating per-step avoids the old bias of only
+        # sampling episodes that ended on the rollout's final step.
+        self._rollout_ep_returns: list[float] = []
+        self._step_actions: list = []
         self._rollout_terminations: Counter = Counter()
         self._history_timesteps: list[int] = []
         self._history = {k: [] for k in self.INFO_KEYS}
@@ -137,6 +182,10 @@ class DiagnosticsCallback(_BaseCallback):
         self._history_heading_std: list[float] = []
         self._history_terminations: dict[str, list[float]] = {}
         self._history_term_timesteps: list[int] = []
+        # Algorithm-specific metrics (PPO clip_fraction/approx_kl/…,
+        # SAC critic_loss/ent_coef/…) captured from SB3's logger.
+        self._history_algo_timesteps: list[int] = []
+        self._history_algo: dict[str, list[float]] = {}
 
     if not _SB3_AVAILABLE:
 
@@ -153,6 +202,17 @@ class DiagnosticsCallback(_BaseCallback):
                     self._step_infos[key].append(float(info[key]))
             if "termination_reason" in info:
                 self._rollout_terminations[info["termination_reason"]] += 1
+            # Capture EVERY completed episode's return, not just those ending on
+            # the rollout's final step (Monitor sets info["episode"] on done).
+            if "episode" in info and "r" in info["episode"]:
+                self._rollout_ep_returns.append(float(info["episode"]["r"]))
+
+        # Accumulate the actions taken this step. self.locals["actions"] is
+        # populated by both the on-policy (PPO) and off-policy (SAC) collection
+        # loops, so this works uniformly for both algorithms.
+        actions = self.locals.get("actions")
+        if actions is not None and _np is not None:
+            self._step_actions.append(_np.asarray(actions, dtype=float).reshape(-1))
         return True
 
     def _on_rollout_end(self) -> None:
@@ -193,10 +253,32 @@ class DiagnosticsCallback(_BaseCallback):
             self.logger.record("diagnostics/obs_std", _sanitize(float(_np.std(obs))))
             self.logger.record("diagnostics/obs_max_abs", _sanitize(float(_np.max(_np.abs(obs)))))
 
-        if hasattr(self.model, "rollout_buffer") and self.model.rollout_buffer.actions is not None:
-            acts = self.model.rollout_buffer.actions
+        # Action statistics + saturation from the actions actually taken this
+        # rollout (covers PPO and SAC alike — SAC has no rollout_buffer, so the
+        # old buffer-based path logged nothing for it).  Saturation is the
+        # fraction of action components pinned at the control limit, the key
+        # early-warning of a degenerate bang-bang policy in continuous control.
+        if self._step_actions and _np is not None:
+            acts = _np.concatenate(self._step_actions)
             self.logger.record("diagnostics/action_mean", _sanitize(float(_np.mean(acts))))
             self.logger.record("diagnostics/action_std", _sanitize(float(_np.std(acts))))
+            self.logger.record("diagnostics/action_abs_max", _sanitize(float(_np.max(_np.abs(acts)))))
+            saturation = float(_np.mean(_np.abs(acts) >= self.action_saturation_threshold))
+            self.logger.record("diagnostics/action_saturation", _sanitize(saturation))
+        self._step_actions = []
+
+        # PPO post-update (clipped) gradient norm.  Scoped to PPO: SAC runs
+        # several separate optimizers, so a single global norm is meaningless.
+        if hasattr(self.model, "rollout_buffer") and hasattr(self.model, "policy"):
+            try:
+                gn = _global_grad_norm(self.model.policy.parameters())
+                if gn is not None:
+                    self.logger.record("diagnostics/grad_norm", _sanitize(gn))
+            except (TypeError, AttributeError):
+                logger.debug("grad_norm logging skipped (parameters unavailable)", exc_info=True)
+
+        # Algorithm-specific train/* metrics → durable diagnostics.npz.
+        self._record_algo_metrics()
 
         env = self.training_env
         if hasattr(env, "obs_rms"):
@@ -204,9 +286,12 @@ class DiagnosticsCallback(_BaseCallback):
         if hasattr(env, "ret_rms"):
             self.logger.record("diagnostics/vecnorm_ret_var", _sanitize(float(_np.mean(env.ret_rms.var))))
 
-        ep_rewards = [info["episode"]["r"] for info in self.locals.get("infos", []) if "episode" in info]
-        if ep_rewards:
-            self._rollout_ep_rewards.append(_np.mean(ep_rewards))
+        # Plateau detection over the mean episode return of each rollout.  Uses
+        # ALL episodes that completed during the rollout (accumulated in
+        # _on_step), not just those ending on the final step.
+        if self._rollout_ep_returns:
+            self._rollout_ep_rewards.append(float(_np.mean(self._rollout_ep_returns)))
+            self._rollout_ep_returns = []
             if len(self._rollout_ep_rewards) >= self.plateau_window:
                 recent = self._rollout_ep_rewards[-self.plateau_window :]
                 variation = max(recent) - min(recent)
@@ -218,6 +303,59 @@ class DiagnosticsCallback(_BaseCallback):
                         self.plateau_window,
                         variation,
                     )
+
+    def _collect_algo_metrics(self) -> dict:
+        """Snapshot SB3's algorithm-specific ``train/*`` metrics.
+
+        SB3 PPO writes ``train/clip_fraction``, ``train/approx_kl``,
+        ``train/explained_variance``, ``train/entropy_loss`` … and SAC writes
+        ``train/critic_loss``, ``train/actor_loss``, ``train/ent_coef`` … into
+        the logger's ``name_to_value`` dict during ``train()``.  These reach
+        TensorBoard but never the durable ``diagnostics.npz``; capturing them
+        here gives BOTH algorithms first-class, offline-plottable diagnostics.
+
+        Returns the ``train/``-prefixed keys (prefix stripped) that currently
+        hold a finite scalar.  Empty when the logger is unavailable (before the
+        first update, or under a test mock where ``name_to_value`` is not a
+        real dict).
+        """
+        logger_obj = getattr(self.model, "logger", None)
+        name_to_value = getattr(logger_obj, "name_to_value", None)
+        if not isinstance(name_to_value, dict):
+            return {}
+        out: dict[str, float] = {}
+        for key, value in name_to_value.items():
+            if not isinstance(key, str) or not key.startswith("train/"):
+                continue
+            # Skip bools (isinstance(True, int) is True) and anything that is
+            # not a real scalar.  float() coerces numpy float32/float64 scalars,
+            # which SB3 commonly stores, while rejecting strings/arrays/None.
+            if isinstance(value, bool):
+                continue
+            try:
+                fval = float(value)
+            except (TypeError, ValueError):
+                continue
+            if _np is not None and not _np.isfinite(fval):
+                continue
+            out[key[len("train/") :]] = fval
+        return out
+
+    def _record_algo_metrics(self) -> None:
+        """Append the latest algorithm ``train/*`` metrics to the npz history."""
+        metrics = self._collect_algo_metrics()
+        if not metrics:
+            return
+        self._history_algo_timesteps.append(self.num_timesteps)
+        n = len(self._history_algo_timesteps)
+        # Back-fill any newly-seen key with NaN for prior rollouts so every
+        # series stays length-aligned with algo_timesteps.
+        for key in metrics:
+            if key not in self._history_algo:
+                self._history_algo[key] = [float("nan")] * (n - 1)
+        for key, series in self._history_algo.items():
+            series.append(float(metrics[key]) if key in metrics else float("nan"))
+        self._save_diagnostics()
 
     def _save_diagnostics(self) -> None:
         """Persist accumulated diagnostics to an npz file in the stage dir."""
@@ -236,4 +374,9 @@ class DiagnosticsCallback(_BaseCallback):
             save_dict["term_timesteps"] = _np.array(self._history_term_timesteps)
             for reason, fracs in self._history_terminations.items():
                 save_dict[f"term_{reason}"] = _np.array(fracs)
+        if self._history_algo_timesteps:
+            save_dict["algo_timesteps"] = _np.array(self._history_algo_timesteps)
+            for key, series in self._history_algo.items():
+                if len(series) == len(self._history_algo_timesteps):
+                    save_dict[f"algo_{key}"] = _np.array(series)
         _np.savez(str(self._log_dir / "diagnostics.npz"), **save_dict)  # type: ignore[arg-type]

--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -5,6 +5,7 @@ self-contained and depends only on NumPy and the SB3 BaseCallback interface.
 """
 
 import logging
+import math
 from collections import Counter
 from pathlib import Path
 
@@ -57,7 +58,7 @@ def _global_grad_norm(parameters) -> float | None:
         found = True
     if not found:
         return None
-    return total_sq**0.5
+    return math.sqrt(total_sq)
 
 
 class DiagnosticsCallback(_BaseCallback):

--- a/environments/shared/jax_hooks.py
+++ b/environments/shared/jax_hooks.py
@@ -172,6 +172,7 @@ class CSVLoggingHook:
             "total_loss": f"{metrics.get('total_loss', 0.0):.4f}",
             "policy_loss": f"{metrics.get('policy_loss', 0.0):.4f}",
             "value_loss": f"{metrics.get('value_loss', 0.0):.4f}",
+            "explained_variance": f"{metrics.get('explained_variance', float('nan')):.4f}",
             "entropy": f"{metrics.get('entropy', 0.0):.4f}",
             "approx_kl": f"{metrics.get('approx_kl', 0.0):.6f}",
             "clip_fraction": f"{metrics.get('clip_fraction', 0.0):.4f}",

--- a/environments/shared/jax_ppo.py
+++ b/environments/shared/jax_ppo.py
@@ -22,6 +22,15 @@ from typing import Any, NamedTuple
 
 from .mjx_utils import check_jax
 
+# Safe range for the Gaussian policy's log-std.  Clamping keeps the action
+# std in roughly [6.7e-3, 7.4] so a degenerate (collapsing or exploding)
+# policy cannot drive the log-prob denominator to 0 (NaN) or push the entropy
+# term to ±inf.  The clamp is applied identically in ``sample_action`` and
+# ``ppo_loss`` so the stored and recomputed log-probs stay consistent — i.e.
+# the PPO importance ratio is exactly 1 on the first epoch.
+LOG_STD_MIN = -5.0
+LOG_STD_MAX = 2.0
+
 
 class PPOConfig(NamedTuple):
     """Hyperparameters for a PPO training run."""
@@ -115,6 +124,8 @@ def sample_action(params, network, obs, rng):
     import jax.numpy as jnp
 
     action_mean, action_log_std, value = network.apply(params, obs)
+    # Floor/ceil the log-std before exponentiating (see LOG_STD_MIN/MAX).
+    action_log_std = jnp.clip(action_log_std, LOG_STD_MIN, LOG_STD_MAX)
     action_std = jnp.exp(action_log_std)
 
     # Sample from Gaussian
@@ -192,6 +203,8 @@ def ppo_loss(params, network, batch, config: PPOConfig):
     import jax.numpy as jnp
 
     action_mean, action_log_std, value = network.apply(params, batch["obs"])
+    # Same clamp as sample_action so old/new log-probs stay consistent.
+    action_log_std = jnp.clip(action_log_std, LOG_STD_MIN, LOG_STD_MAX)
     action_std = jnp.exp(action_log_std)
 
     # New log probability
@@ -230,6 +243,17 @@ def ppo_loss(params, network, batch, config: PPOConfig):
 
     total_loss = policy_loss + config.vf_coef * value_loss + config.ent_coef * entropy_loss
 
+    # Explained variance — diagnostic only (not part of the loss).  Measures
+    # how much of the return variance the value head captures: 1.0 is perfect,
+    # 0.0 is no better than predicting the mean, <0 is worse.  NaN when returns
+    # have ~zero variance (matches SB3's ``explained_variance``).
+    var_returns = jnp.var(batch["return_"])
+    explained_variance = jnp.where(
+        var_returns > 1e-8,
+        1.0 - jnp.var(batch["return_"] - value) / (var_returns + 1e-8),
+        jnp.nan,
+    )
+
     info = {
         "policy_loss": policy_loss,
         "value_loss": value_loss,
@@ -237,6 +261,7 @@ def ppo_loss(params, network, batch, config: PPOConfig):
         "approx_kl": jnp.mean((ratio - 1) - jnp.log(ratio)),
         "clip_fraction": jnp.mean((jnp.abs(ratio - 1.0) > config.clip_range).astype(jnp.float32)),
         "mean_std": jnp.mean(action_std),
+        "explained_variance": explained_variance,
     }
 
     return total_loss, info

--- a/environments/shared/jax_trainer.py
+++ b/environments/shared/jax_trainer.py
@@ -716,6 +716,7 @@ def train(
                     "total_loss": f"{avg_loss:.4f}",
                     "policy_loss": f"{avg_aux['policy_loss']:.4f}",
                     "value_loss": f"{avg_aux['value_loss']:.4f}",
+                    "explained_variance": f"{avg_aux['explained_variance']:.4f}",
                     "entropy": f"{avg_aux['entropy']:.4f}",
                     "approx_kl": f"{avg_aux['approx_kl']:.6f}",
                     "clip_fraction": f"{avg_aux['clip_fraction']:.4f}",
@@ -745,6 +746,7 @@ def train(
                     f"r/step={avg_reward:+.3f}  {ep_ret_str}  "
                     f"loss={avg_loss:.4f}  "
                     f"pi={avg_aux['policy_loss']:.3f}  v={avg_aux['value_loss']:.3f}  "
+                    f"ev={avg_aux['explained_variance']:+.2f}  "
                     f"ent={avg_aux['entropy']:.3f}  kl={avg_aux['approx_kl']:.4f}  "
                     f"grad={avg_grad_norm:.3f}  falls={fall_rate:.1%}  "
                     f"SPS={sps:,.0f}  ETA={eta_str}  "

--- a/environments/shared/jax_training_utils.py
+++ b/environments/shared/jax_training_utils.py
@@ -197,6 +197,7 @@ DEFAULT_CSV_FIELDS: list[str] = [
     "total_loss",
     "policy_loss",
     "value_loss",
+    "explained_variance",
     "entropy",
     "approx_kl",
     "clip_fraction",

--- a/environments/shared/tests/test_diagnostics.py
+++ b/environments/shared/tests/test_diagnostics.py
@@ -170,7 +170,8 @@ class TestOnRolloutEnd:
         cb.logger.record.assert_any_call("diagnostics/obs_mean", 2.5)
         cb.logger.record.assert_any_call("diagnostics/obs_std", pytest.approx(np.std([[1, 2], [3, 4]])))
         cb.logger.record.assert_any_call("diagnostics/obs_max_abs", 4.0)
-        cb.logger.record.assert_any_call("diagnostics/action_mean", 0.0)
+        # Action stats now come from the per-step accumulator (see
+        # TestActionStats), not the rollout buffer — works for SAC too.
 
     def test_logs_vecnorm_stats(self, tmp_path):
         cb = DiagnosticsCallback(log_dir=str(tmp_path), verbose=0)
@@ -184,9 +185,14 @@ class TestOnRolloutEnd:
 
 
 class TestPlateauDetection:
+    """Episode returns are captured in _on_step (every completed episode), then
+    the per-rollout mean is appended in _on_rollout_end.  This avoids the old
+    bias of only sampling episodes that ended on the rollout's final step."""
+
     def test_no_warning_below_window(self, callback):
         callback._rollout_ep_rewards = [1.0] * 5
         callback.locals = {"infos": [{"episode": {"r": 1.0}}]}
+        callback._on_step()
         callback._on_rollout_end()
         # Not enough history for plateau detection, no warning printed
 
@@ -194,6 +200,7 @@ class TestPlateauDetection:
         # Fill the history to reach the plateau window
         callback._rollout_ep_rewards = [50.0] * 9  # 9 entries, need 10
         callback.locals = {"infos": [{"episode": {"r": 50.0}}]}
+        callback._on_step()
         with caplog.at_level("WARNING", logger="environments.shared.diagnostics"):
             callback._on_rollout_end()
         assert "PLATEAU WARNING" in caplog.text
@@ -202,6 +209,7 @@ class TestPlateauDetection:
         # Rewards with enough variation to avoid plateau
         callback._rollout_ep_rewards = list(range(9))  # 0-8
         callback.locals = {"infos": [{"episode": {"r": 100.0}}]}
+        callback._on_step()
         with caplog.at_level("WARNING", logger="environments.shared.diagnostics"):
             callback._on_rollout_end()
         assert "PLATEAU WARNING" not in caplog.text
@@ -209,8 +217,22 @@ class TestPlateauDetection:
     def test_logs_reward_variation(self, callback):
         callback._rollout_ep_rewards = [50.0] * 9
         callback.locals = {"infos": [{"episode": {"r": 50.0}}]}
+        callback._on_step()
         callback._on_rollout_end()
         callback.logger.record.assert_any_call("diagnostics/reward_variation", 0.0)
+
+    def test_captures_all_episodes_not_just_final_step(self, callback):
+        """Every episode completing mid-rollout must count — the whole point of
+        the fix.  Three episodes across two steps → mean over all three."""
+        callback._rollout_ep_rewards = []
+        callback.locals = {"infos": [{"episode": {"r": 10.0}}, {"episode": {"r": 20.0}}]}
+        callback._on_step()
+        callback.locals = {"infos": [{"episode": {"r": 30.0}}]}
+        callback._on_step()
+        assert callback._rollout_ep_returns == [10.0, 20.0, 30.0]
+        callback._on_rollout_end()
+        assert callback._rollout_ep_rewards[-1] == pytest.approx(20.0)  # mean(10,20,30)
+        assert callback._rollout_ep_returns == []  # buffer flushed
 
 
 class TestSaveDiagnostics:
@@ -279,6 +301,143 @@ class TestSaveDiagnostics:
         assert data["timesteps"][1] == 200
         assert data["forward_vel"][0] == pytest.approx(1.0)
         assert data["forward_vel"][1] == pytest.approx(2.0)
+
+
+class TestActionStats:
+    """Action stats + saturation come from the actions actually taken each step
+    (self.locals["actions"]), so they work for PPO and SAC alike."""
+
+    def test_logs_action_stats_and_saturation(self, callback):
+        # 4 components; 2 saturated at |a| >= 0.99 (1.0 and -0.995).
+        callback.locals = {"infos": [], "actions": np.array([[1.0, 0.5], [-0.995, 0.0]])}
+        callback._on_step()
+        callback._on_rollout_end()
+        callback.logger.record.assert_any_call("diagnostics/action_saturation", pytest.approx(0.5))
+        callback.logger.record.assert_any_call("diagnostics/action_abs_max", pytest.approx(1.0))
+        callback.logger.record.assert_any_call(
+            "diagnostics/action_mean", pytest.approx(float(np.mean([1.0, 0.5, -0.995, 0.0])))
+        )
+
+    def test_accumulates_actions_across_steps_then_clears(self, callback):
+        callback.locals = {"infos": [], "actions": np.array([[0.1, 0.2]])}
+        callback._on_step()
+        callback.locals = {"infos": [], "actions": np.array([[0.3, 0.4]])}
+        callback._on_step()
+        assert len(callback._step_actions) == 2
+        callback._on_rollout_end()
+        assert callback._step_actions == []  # flushed after rollout
+
+    def test_no_actions_no_record(self, callback):
+        callback.locals = {"infos": []}  # no "actions" key
+        callback._on_step()
+        callback._on_rollout_end()
+        recorded = {c.args[0] for c in callback.logger.record.call_args_list}
+        assert "diagnostics/action_saturation" not in recorded
+
+    def test_custom_saturation_threshold(self):
+        cb = DiagnosticsCallback(action_saturation_threshold=0.5)
+        assert cb.action_saturation_threshold == 0.5
+
+
+class TestGradNorm:
+    def test_global_grad_norm_none_without_grads(self):
+        from environments.shared.diagnostics import _global_grad_norm
+
+        class _P:
+            grad = None
+
+        assert _global_grad_norm([]) is None
+        assert _global_grad_norm([_P(), _P()]) is None
+
+    def test_global_grad_norm_value(self):
+        torch = pytest.importorskip("torch")
+        from environments.shared.diagnostics import _global_grad_norm
+
+        p1 = torch.nn.Parameter(torch.zeros(2))
+        p1.grad = torch.tensor([3.0, 0.0])
+        p2 = torch.nn.Parameter(torch.zeros(1))
+        p2.grad = torch.tensor([4.0])
+        assert _global_grad_norm([p1, p2]) == pytest.approx(5.0)  # sqrt(9 + 16)
+
+    def test_logs_grad_norm_for_ppo(self, tmp_path):
+        torch = pytest.importorskip("torch")
+        cb = DiagnosticsCallback(log_dir=str(tmp_path), verbose=0)
+        model = _make_mock_model()
+        buffer = MagicMock()
+        buffer.observations = np.array([[1.0]])
+        buffer.actions = np.array([[0.5]])
+        model.rollout_buffer = buffer  # PPO-like
+        p1 = torch.nn.Parameter(torch.zeros(1))
+        p1.grad = torch.tensor([3.0])
+        p2 = torch.nn.Parameter(torch.zeros(1))
+        p2.grad = torch.tensor([4.0])
+        model.policy.parameters.return_value = [p1, p2]
+        cb.init_callback(model)
+        cb.num_timesteps = 100
+        cb.locals = {"infos": []}
+        cb._on_rollout_end()
+        cb.logger.record.assert_any_call("diagnostics/grad_norm", pytest.approx(5.0))
+
+    def test_no_grad_norm_for_sac(self, callback):
+        # Default fixture model has no rollout_buffer (SAC-like) → grad norm skipped.
+        callback.locals = {"infos": []}
+        callback._on_rollout_end()
+        recorded = {c.args[0] for c in callback.logger.record.call_args_list}
+        assert "diagnostics/grad_norm" not in recorded
+
+
+class TestAlgoMetrics:
+    """SB3's algorithm-specific train/* metrics (PPO clip_fraction/
+    explained_variance, SAC critic_loss/ent_coef) are captured into the
+    durable diagnostics.npz, not just TensorBoard."""
+
+    def test_collect_filters_train_keys(self, callback):
+        callback.model.logger.name_to_value = {
+            "train/clip_fraction": 0.1,
+            "train/explained_variance": 0.8,
+            "train/n_updates": 12,
+            "train/some_flag": True,  # bool → skipped
+            "rollout/ep_rew_mean": 5.0,  # not train/ → skipped
+        }
+        m = callback._collect_algo_metrics()
+        assert m == {"clip_fraction": 0.1, "explained_variance": 0.8, "n_updates": 12.0}
+
+    def test_collect_handles_non_dict_logger(self, callback):
+        # The default MagicMock name_to_value is not a real dict → empty.
+        assert callback._collect_algo_metrics() == {}
+
+    def test_saves_algo_metrics_to_npz(self, tmp_path):
+        cb = DiagnosticsCallback(log_dir=str(tmp_path), verbose=0)
+        model = _make_mock_model()
+        model.logger.name_to_value = {
+            "train/clip_fraction": 0.1,
+            "train/explained_variance": 0.8,
+            "rollout/x": 1.0,
+        }
+        cb.init_callback(model)
+        cb.num_timesteps = 100
+        cb.locals = {"infos": []}
+        cb._on_rollout_end()
+        data = np.load(str(tmp_path / "diagnostics.npz"))
+        assert "algo_timesteps" in data and data["algo_timesteps"][0] == 100
+        assert data["algo_clip_fraction"][0] == pytest.approx(0.1)
+        assert data["algo_explained_variance"][0] == pytest.approx(0.8)
+        assert "algo_x" not in data  # non-train/ key excluded
+
+    def test_algo_history_backfills_new_keys(self):
+        cb = DiagnosticsCallback(log_dir=None, verbose=0)
+        model = _make_mock_model()
+        cb.init_callback(model)
+        cb.num_timesteps = 100
+        model.logger.name_to_value = {"train/clip_fraction": 0.1}
+        cb._record_algo_metrics()
+        cb.num_timesteps = 200
+        model.logger.name_to_value = {"train/clip_fraction": 0.2, "train/approx_kl": 0.05}
+        cb._record_algo_metrics()
+        assert cb._history_algo["clip_fraction"] == [0.1, 0.2]
+        assert np.isnan(cb._history_algo["approx_kl"][0])  # back-filled for prior rollout
+        assert cb._history_algo["approx_kl"][1] == pytest.approx(0.05)
+        assert all(len(v) == len(cb._history_algo_timesteps) for v in cb._history_algo.values())
 
 
 class TestWithoutSB3:

--- a/environments/shared/tests/test_jax_ppo.py
+++ b/environments/shared/tests/test_jax_ppo.py
@@ -143,6 +143,104 @@ class TestMakeOptimizer:
 # ---------------------------------------------------------------------------
 
 
+class TestExplainedVariance:
+    """ppo_loss exposes explained_variance as a diagnostic (not part of loss)."""
+
+    @pytest.fixture()
+    def _jax(self):
+        jax = pytest.importorskip("jax")
+        jnp = pytest.importorskip("jax.numpy")
+        return jax, jnp
+
+    def test_explained_variance_in_info_and_finite(self, _jax):
+        jax, jnp = _jax
+        from environments.shared.jax_ppo import PPOConfig, make_actor_critic, ppo_loss
+
+        network = make_actor_critic(action_dim=2, hidden_dims=(8,))
+        params = network.init(jax.random.PRNGKey(0), jnp.zeros(3))
+        batch = {
+            "obs": jnp.zeros((4, 3)),
+            "action": jnp.zeros((4, 2)),
+            "old_log_prob": jnp.zeros(4),
+            "advantage": jnp.array([1.0, -1.0, 0.5, -0.5]),
+            "return_": jnp.array([1.0, 2.0, 3.0, 4.0]),
+        }
+        _, info = ppo_loss(params, network, batch, PPOConfig())
+        assert "explained_variance" in info
+        assert np.isfinite(float(info["explained_variance"]))
+        assert float(info["explained_variance"]) <= 1.0 + 1e-6
+
+    def test_explained_variance_nan_for_constant_returns(self, _jax):
+        jax, jnp = _jax
+        from environments.shared.jax_ppo import PPOConfig, make_actor_critic, ppo_loss
+
+        network = make_actor_critic(action_dim=2, hidden_dims=(8,))
+        params = network.init(jax.random.PRNGKey(0), jnp.zeros(3))
+        batch = {
+            "obs": jnp.zeros((4, 3)),
+            "action": jnp.zeros((4, 2)),
+            "old_log_prob": jnp.zeros(4),
+            "advantage": jnp.zeros(4),
+            "return_": jnp.ones(4) * 5.0,  # zero variance → NaN (matches SB3)
+        }
+        _, info = ppo_loss(params, network, batch, PPOConfig())
+        assert np.isnan(float(info["explained_variance"]))
+
+
+class TestLogStdClamp:
+    """A collapsing/exploding policy must not push the Gaussian std to 0/inf
+    and blow up the log-prob and entropy terms — log-std is clamped."""
+
+    @pytest.fixture()
+    def _jax(self):
+        jax = pytest.importorskip("jax")
+        jnp = pytest.importorskip("jax.numpy")
+        return jax, jnp
+
+    def test_clamp_constants_sane(self):
+        from environments.shared.jax_ppo import LOG_STD_MAX, LOG_STD_MIN
+
+        assert LOG_STD_MIN < 0 < LOG_STD_MAX
+
+    def test_extreme_log_std_is_floored(self, _jax):
+        jax, jnp = _jax
+        pytest.importorskip("flax")
+        from flax.core import freeze, unfreeze
+
+        from environments.shared.jax_ppo import (
+            LOG_STD_MIN,
+            PPOConfig,
+            make_actor_critic,
+            ppo_loss,
+            sample_action,
+        )
+
+        network = make_actor_critic(action_dim=3, hidden_dims=(8,))
+        params = network.init(jax.random.PRNGKey(0), jnp.zeros(4))
+        # Force log_std far below the clamp floor (std would otherwise be ~0).
+        try:
+            mp = unfreeze(params)
+            mp["params"]["log_std"] = jnp.full((3,), -100.0)
+            params = freeze(mp)
+        except Exception:
+            pytest.skip("flax param container API changed")
+
+        action, log_prob, _ = sample_action(params, network, jnp.zeros(4), jax.random.PRNGKey(1))
+        assert np.isfinite(float(log_prob)), "log_prob must stay finite despite tiny log_std"
+
+        batch = {
+            "obs": jnp.zeros((1, 4)),
+            "action": action[None],
+            "old_log_prob": log_prob[None],
+            "advantage": jnp.zeros(1),
+            "return_": jnp.zeros(1),
+        }
+        _, info = ppo_loss(params, network, batch, PPOConfig())
+        # std must be floored at exp(LOG_STD_MIN), not exp(-100) ≈ 0.
+        assert float(info["mean_std"]) == pytest.approx(float(jnp.exp(LOG_STD_MIN)), rel=1e-5)
+        assert np.isfinite(float(info["entropy"]))
+
+
 class TestComputeGAE:
     """The trainer feeds compute_gae a done mask that is 1 ONLY for natural
     termination — truncation must keep the bootstrap value alive."""

--- a/environments/shared/tests/test_jax_training_utils.py
+++ b/environments/shared/tests/test_jax_training_utils.py
@@ -25,6 +25,10 @@ class TestCSVFields:
         """DEFAULT_CSV_FIELDS should include learning_rate."""
         assert "learning_rate" in DEFAULT_CSV_FIELDS
 
+    def test_explained_variance_in_default_fields(self):
+        """DEFAULT_CSV_FIELDS should include explained_variance (value-fn fit)."""
+        assert "explained_variance" in DEFAULT_CSV_FIELDS
+
     def test_csv_logger_writes_learning_rate(self, tmp_path):
         """CSV logger should accept and write a learning_rate column."""
         path = tmp_path / "test.csv"


### PR DESCRIPTION
## Summary
This PR significantly expands the diagnostics and monitoring capabilities for both PPO and SAC training algorithms. It adds action saturation tracking, PPO gradient norm monitoring, and persists algorithm-specific training metrics (like `clip_fraction`, `approx_kl`, `critic_loss`) to the durable `diagnostics.npz` file for offline analysis.

## Key Changes

### Diagnostics Callback Enhancements
- **Action Statistics & Saturation**: Added per-step action accumulation to track action statistics (`mean`, `std`, `abs_max`) and saturation fraction (actions pinned at control limits). This works uniformly for both PPO and SAC, replacing the old rollout-buffer-only approach.
- **PPO Gradient Norm**: Added `_global_grad_norm()` function to compute L2 norm of policy gradients post-update. Useful for detecting when gradient clipping is active (saturates at `max_grad_norm`).
- **Algorithm-Specific Metrics**: Implemented `_collect_algo_metrics()` and `_record_algo_metrics()` to capture SB3's `train/*` metrics (PPO: `clip_fraction`, `approx_kl`, `explained_variance`; SAC: `critic_loss`, `actor_loss`, `ent_coef`) and persist them to `diagnostics.npz` with automatic back-filling for newly-seen keys.
- **Episode Return Tracking**: Fixed plateau detection to capture ALL episodes completing during a rollout (not just those ending on the final step) by accumulating returns in `_on_step()` and flushing in `_on_rollout_end()`.
- **New Constructor Parameter**: Added `action_saturation_threshold` (default 0.99) to customize the saturation detection threshold.

### JAX PPO Improvements
- **Log-Std Clamping**: Added `LOG_STD_MIN` (-5.0) and `LOG_STD_MAX` (2.0) constants to prevent policy collapse/explosion. Clamp is applied identically in both `sample_action()` and `ppo_loss()` to keep importance ratios consistent.
- **Explained Variance Diagnostic**: Added `explained_variance` metric to `ppo_loss()` info dict, measuring how well the value function fits returns (1.0 = perfect, 0.0 = mean prediction, <0 = worse than mean).

### Test Coverage
- Added comprehensive tests for action statistics, saturation, gradient norm, and algorithm metrics collection
- Added tests for explained variance and log-std clamping in JAX PPO
- Updated plateau detection tests to verify all-episode capture behavior

## Notable Implementation Details
- Action accumulation uses `self.locals["actions"]` which is populated by both PPO and SAC collection loops, enabling uniform handling.
- Algorithm metrics are back-filled with NaN when new keys appear mid-training to maintain alignment with the `algo_timesteps` axis.
- Gradient norm logging gracefully skips if parameters are unavailable (e.g., before first update).
- The saturation metric provides an early warning signal for degenerate bang-bang policies in continuous control.

https://claude.ai/code/session_01S2GHFk1NAopgxfd6dK71TL