### PR TITLE
Fix brachiosaurus load-bearing; bound actuator forces; implicitfast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — RL/GCP Review Fixes & Model Physics (v0.3.2)
+
+### Fixed
+- **JAX pipeline correctness** (July 2026 review, PR #426): curriculum gate
+  now compares episode-level return against the TOML threshold (it compared
+  per-step reward and never advanced past stage 1); observation-normalization
+  stats carry across curriculum stages; `MJXDinoEnv` no longer mutates the
+  live species registry (stage config leaked across stages); trex TOML
+  `approach_weight` was shadowed by a legacy registry key; `vf_clip_range`
+  now reaches the fused PPO update; CPU evaluation observes the real target
+  body (was hardcoded to the world origin) and its reward includes the same
+  approach/proximity/success/fall components as training; eval records
+  per-episode success and gates on TOML `min_avg_forward_vel` /
+  `min_success_rate`
+- **SB3 pipeline**: eval-collapse callback re-read `evaluations.npz` every
+  training step (a GCS network read on Vertex); `diagnostics.npz` was fully
+  rewritten up to 3× per rollout-end (O(n²) I/O, severe for SAC); final
+  model now saved before the post-training eval; `time_to_target` no longer
+  averages a `-1` sentinel into the mean
+- **Sweeps / Google Cloud**: sweep resume no longer submits duplicate Vertex
+  HPT jobs after a swallowed timeout; Ray Tune stage-2/3 curriculum gates no
+  longer fail unconditionally (metric-alias mismatch; NaN treated as
+  missing); `--wandb` with a missing API key no longer kills headless
+  training and relaunches resume the same W&B run; TensorBoard events sync
+  to GCS periodically (spot-VM preemption no longer loses a stage's logs);
+  `_wait_for_job` honors `--stage-timeout` during persistent API failures;
+  effective per-trial seed and run identity recorded in `metrics.json`
+- `ray_tune_sweep.ipynb` shipped with a `SyntaxError` in the
+  save-search-space cell
+- Broken sweep commands in `vertex-ai.md`; stale `configs/sweep_*.json`
+  paths; nonexistent `wandb_project`/`WandbHook` in `jax.md`
+
+### Changed
+- **Brachiosaurus model physics (breaking for trained policies)**: leg
+  springs now reference stance angles with stronger, force-bounded servos —
+  the model can now statically stand at torso z≈1.13 (previously collapsed
+  to z≈0.70, below the z=1.0 alive floor, even when commanded straight).
+  Pre-existing brachiosaurus checkpoints will not transfer.
+- All three models use `integrator="implicitfast"` and bounded `forcerange`
+  on position actuators (raptor/trex bounds sized to leave settle behavior
+  unchanged)
+- Headless JAX runs with `--checkpoint-dir` now produce a per-update
+  training CSV, rotating + final checkpoints, and a best-episode-return
+  snapshot; `--curriculum` forwards the checkpoint dir per stage; the
+  single-stage CLI passes previously-dropped TOML `[jax]` keys
+  (`minibatch_size`, `warmup_*`, `ramp_*`, `num_envs`, `vf_coef`)
+- New `gcp` extra (`google-cloud-aiplatform`, `google-cloud-storage`),
+  installed in the Docker image
+- Code reviews consolidated: `docs/KNOWN_ISSUES.md` is the living list of
+  open findings; dated reviews archived under `docs/reviews/`
+
 ## [Unreleased] — Codebase Consolidation & Training Results (v0.3.0)
 
 ### Added

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -108,6 +108,43 @@ would pin these down and catch regressions. (June §6.8)
 6. Sweep CSV rows lack a run timestamp / `resume_run` id, so rows merged
    across resume cycles are indistinguishable. (July §4)
 
+## MuJoCo models (July 2026 model review)
+
+Fixed on this branch: the brachiosaurus could not physically hold any torso
+height in its alive region (passive settle z≈0.68, straight-leg command
+z≈0.70, vs `healthy_z_range` floor 1.0 and height target 1.2) — leg springs
+now reference the stance angles and the leg servos are stronger with
+bounded force, giving a static stand at z≈1.13, level, all four feet
+grounded. All three models now use `integrator="implicitfast"` and bounded
+`forcerange` on position actuators (sized to clip impact/reset spikes only
+for raptor/trex, whose settle behavior is unchanged).
+
+> **Note:** these changes alter the physics plant. Brachiosaurus policies
+> trained before this change will NOT transfer; raptor/trex plants changed
+> only marginally (integrator + rarely-binding force caps) but expect small
+> behavioral differences.
+
+Still open:
+
+- **MEDIUM** — the T-Rex home keyframe (pitch 0) is ~35° from its passive
+  equilibrium (settles to forward_z −0.583), which is *past* the stage-1
+  nosedive termination line (−0.519 with the TOML's 0.35 threshold): every
+  episode opens with a dive the policy must catch, and pure passivity is
+  death. Move the passive equilibrium near the intended ~10° natural pitch
+  (tail `springref`, neck stiffness, or hip `ref`/keyframe lean).
+- **LOW** — scene boilerplate (skybox/grid/floor/option) is copy-pasted
+  across the three XMLs → extract a shared `scene.xml` include; limbs are
+  hand-mirrored sign-flips → generate via script/PyMJCF or add a left/right
+  symmetry test.
+- **LOW** — raptor claw `motor gear="50"` on a 0.05 kg claw (huge
+  torque-to-inertia; slams its limits); trex passive ball-joint arms are
+  8 of 37 DOF doing nothing (weld to cut MJX cost ~20%); contype-0 neck
+  geoms can visually clip the floor; no `<light>`/`<visual>` block for
+  nicer renders; brachio food has no collision partner (distance-only
+  success) unlike raptor/trex weapon geoms — fine, but undocumented.
+- **Experiment** — with `implicitfast`, a `timestep` 0.002→0.004 A/B is
+  worth running (halves sim cost if stable).
+
 ## Configs, docs & website
 
 - Website hyperparameter/dimension tables are stale (old single-stage runs,

--- a/environments/brachiosaurus/assets/brachiosaurus.xml
+++ b/environments/brachiosaurus/assets/brachiosaurus.xml
@@ -1,7 +1,7 @@
 <mujoco model="brachiosaurus">
   <compiler angle="degree" autolimits="true"/>
 
-  <option timestep="0.002" gravity="0 0 -9.81">
+  <option timestep="0.002" gravity="0 0 -9.81" integrator="implicitfast">
     <flag warmstart="enable"/>
   </option>
 
@@ -10,16 +10,20 @@
     <geom contype="1" conaffinity="1" friction="1.2 0.005 0.0001"/>
     <motor ctrllimited="true" ctrlrange="-1 1"/>
 
-    <!-- Leg joints: high damping + passive stiffness for heavy quadruped.
-         Stiffness pulls joints toward 0 (straight), preventing crouch exploits
-         and reducing actuator burden during stance phase. -->
+    <!-- Leg joints: high damping + strong passive stiffness for the ~175 kg
+         quadruped.  Springs reference the STANCE angles (per-joint springref
+         below), elephant-style columnar load-bearing: gravity is carried by
+         the springs, actuators modulate around stance.  With the old
+         stiffness=10 (springref 0) the legs collapsed to torso z~0.70 under
+         load -- below the healthy_z floor (1.0) -- even when commanded
+         straight. -->
     <default class="leg_joint">
-      <joint damping="20.0" stiffness="10.0" armature="0.1"/>
+      <joint damping="35.0" stiffness="120.0" armature="0.1"/>
     </default>
 
     <!-- Metatarsal joints: semi-digitigrade stance -->
     <default class="meta_joint">
-      <joint damping="15.0" stiffness="10.0" armature="0.08"/>
+      <joint damping="25.0" stiffness="80.0" armature="0.08"/>
     </default>
 
     <!-- Neck joints: passive stiffness to counteract gravity on heavy neck.
@@ -70,7 +74,7 @@
       Shoulder height: 2.2m (front legs longer)
       Neck length: 2.5m
       Tail length: 1.8m
-      Total mass: ~200kg (scaled)
+      Total mass: ~175kg (scaled)
 
     Brachiosaurus is unique among sauropods:
       - Front legs longer than rear legs (giraffe-like posture)
@@ -175,19 +179,19 @@
               mass="8.0" material="body_mat"/>
 
         <body name="fr_shin" pos="0 0 -0.55">
-          <joint name="fr_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-60 0"/>
+          <joint name="fr_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-60 0" springref="-45"/>
           <geom name="fr_shin_geom" type="capsule" fromto="0 0 0  0 0 -0.45" size="0.09"
                 mass="5.0" material="body_mat"/>
 
           <!-- Metacarpus: short, sub-vertical (sauropod manus was compact) -->
           <body name="fr_meta" pos="0 0 -0.45">
-            <joint name="fr_ankle" class="meta_joint" type="hinge" axis="0 1 0" range="-20 40"/>
+            <joint name="fr_ankle" class="meta_joint" type="hinge" axis="0 1 0" range="-20 40" springref="20"/>
             <geom name="fr_meta_geom" type="capsule" fromto="0 0 0  0.03 0 -0.12" size="0.07"
                   mass="1.5" material="body_mat"/>
 
             <!-- Foot pad: fleshy digital pad at ground contact -->
             <body name="fr_foot" pos="0.03 0 -0.12">
-              <joint name="fr_toe" class="meta_joint" type="hinge" axis="0 1 0" range="-15 25"/>
+              <joint name="fr_toe" class="meta_joint" type="hinge" axis="0 1 0" range="-15 25" springref="5.7"/>
               <geom name="fr_foot_geom" type="ellipsoid" pos="0.03 0 -0.03" size="0.12 0.1 0.04"
                     mass="1.5" material="foot_mat"/>
               <site name="fr_foot_contact" pos="0.03 0 -0.06" size="0.03"/>
@@ -205,17 +209,17 @@
               mass="8.0" material="body_mat"/>
 
         <body name="fl_shin" pos="0 0 -0.55">
-          <joint name="fl_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-60 0"/>
+          <joint name="fl_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-60 0" springref="-45"/>
           <geom name="fl_shin_geom" type="capsule" fromto="0 0 0  0 0 -0.45" size="0.09"
                 mass="5.0" material="body_mat"/>
 
           <body name="fl_meta" pos="0 0 -0.45">
-            <joint name="fl_ankle" class="meta_joint" type="hinge" axis="0 1 0" range="-20 40"/>
+            <joint name="fl_ankle" class="meta_joint" type="hinge" axis="0 1 0" range="-20 40" springref="20"/>
             <geom name="fl_meta_geom" type="capsule" fromto="0 0 0  0.03 0 -0.12" size="0.07"
                   mass="1.5" material="body_mat"/>
 
             <body name="fl_foot" pos="0.03 0 -0.12">
-              <joint name="fl_toe" class="meta_joint" type="hinge" axis="0 1 0" range="-15 25"/>
+              <joint name="fl_toe" class="meta_joint" type="hinge" axis="0 1 0" range="-15 25" springref="5.7"/>
               <geom name="fl_foot_geom" type="ellipsoid" pos="0.03 0 -0.03" size="0.12 0.1 0.04"
                     mass="1.5" material="foot_mat"/>
               <site name="fl_foot_contact" pos="0.03 0 -0.06" size="0.03"/>
@@ -235,18 +239,18 @@
               mass="7.0" material="body_mat"/>
 
         <body name="rr_shin" pos="0 0 -0.45">
-          <joint name="rr_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-60 0"/>
+          <joint name="rr_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-60 0" springref="-10"/>
           <geom name="rr_shin_geom" type="capsule" fromto="0 0 0  0 0 -0.35" size="0.09"
                 mass="4.0" material="body_mat"/>
 
           <!-- Metatarsus: longer than front metacarpus (hind foot digitigrade) -->
           <body name="rr_meta" pos="0 0 -0.35">
-            <joint name="rr_ankle" class="meta_joint" type="hinge" axis="0 1 0" range="-20 40"/>
+            <joint name="rr_ankle" class="meta_joint" type="hinge" axis="0 1 0" range="-20 40" springref="20"/>
             <geom name="rr_meta_geom" type="capsule" fromto="0 0 0  0.04 0 -0.15" size="0.065"
                   mass="1.5" material="body_mat"/>
 
             <body name="rr_foot" pos="0.04 0 -0.15">
-              <joint name="rr_toe" class="meta_joint" type="hinge" axis="0 1 0" range="-15 25"/>
+              <joint name="rr_toe" class="meta_joint" type="hinge" axis="0 1 0" range="-15 25" springref="5.7"/>
               <geom name="rr_foot_geom" type="ellipsoid" pos="0.03 0 -0.03" size="0.12 0.1 0.04"
                     mass="1.5" material="foot_mat"/>
               <site name="rr_foot_contact" pos="0.03 0 -0.06" size="0.03"/>
@@ -264,17 +268,17 @@
               mass="7.0" material="body_mat"/>
 
         <body name="rl_shin" pos="0 0 -0.45">
-          <joint name="rl_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-60 0"/>
+          <joint name="rl_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-60 0" springref="-10"/>
           <geom name="rl_shin_geom" type="capsule" fromto="0 0 0  0 0 -0.35" size="0.09"
                 mass="4.0" material="body_mat"/>
 
           <body name="rl_meta" pos="0 0 -0.35">
-            <joint name="rl_ankle" class="meta_joint" type="hinge" axis="0 1 0" range="-20 40"/>
+            <joint name="rl_ankle" class="meta_joint" type="hinge" axis="0 1 0" range="-20 40" springref="20"/>
             <geom name="rl_meta_geom" type="capsule" fromto="0 0 0  0.04 0 -0.15" size="0.065"
                   mass="1.5" material="body_mat"/>
 
             <body name="rl_foot" pos="0.04 0 -0.15">
-              <joint name="rl_toe" class="meta_joint" type="hinge" axis="0 1 0" range="-15 25"/>
+              <joint name="rl_toe" class="meta_joint" type="hinge" axis="0 1 0" range="-15 25" springref="5.7"/>
               <geom name="rl_foot_geom" type="ellipsoid" pos="0.03 0 -0.03" size="0.12 0.1 0.04"
                     mass="1.5" material="foot_mat"/>
               <site name="rl_foot_contact" pos="0.03 0 -0.06" size="0.03"/>
@@ -294,52 +298,55 @@
          does NOT convert actuator attributes, only joint attributes. -->
 
     <!-- Neck control (5 joints: 4 pitch + 1 yaw on base) -->
-    <position name="neck_1_pitch_act" joint="neck_1_pitch" kp="240" ctrlrange="-0.3491 0.5236"/>
-    <position name="neck_1_yaw_act" joint="neck_1_yaw" kp="160" ctrlrange="-0.2618 0.2618"/>
-    <position name="neck_2_pitch_act" joint="neck_2_pitch" kp="200" ctrlrange="-0.3491 0.4363"/>
-    <position name="neck_3_pitch_act" joint="neck_3_pitch" kp="160" ctrlrange="-0.4363 0.4363"/>
-    <position name="neck_4_pitch_act" joint="neck_4_pitch" kp="120" ctrlrange="-0.5236 0.5236"/>
-    <position name="head_pitch_act" joint="head_pitch" kp="80" ctrlrange="-0.6981 0.6981"/>
+    <position name="neck_1_pitch_act" joint="neck_1_pitch" kp="240" forcerange="-160 160" ctrlrange="-0.3491 0.5236"/>
+    <position name="neck_1_yaw_act" joint="neck_1_yaw" kp="160" forcerange="-110 110" ctrlrange="-0.2618 0.2618"/>
+    <position name="neck_2_pitch_act" joint="neck_2_pitch" kp="200" forcerange="-140 140" ctrlrange="-0.3491 0.4363"/>
+    <position name="neck_3_pitch_act" joint="neck_3_pitch" kp="160" forcerange="-110 110" ctrlrange="-0.4363 0.4363"/>
+    <position name="neck_4_pitch_act" joint="neck_4_pitch" kp="120" forcerange="-80 80" ctrlrange="-0.5236 0.5236"/>
+    <position name="head_pitch_act" joint="head_pitch" kp="80" forcerange="-55 55" ctrlrange="-0.6981 0.6981"/>
 
     <!-- Front right leg (5 actuators: hip pitch/roll, knee, ankle, toe) -->
-    <position name="fr_hip_pitch_act" joint="fr_hip_pitch" kp="200" ctrlrange="-0.6981 0.8727"/>
-    <position name="fr_hip_roll_act" joint="fr_hip_roll" kp="150" ctrlrange="-0.1745 0.1745"/>
-    <position name="fr_knee_act" joint="fr_knee" kp="250" ctrlrange="-1.0472 0"/>
-    <position name="fr_ankle_act" joint="fr_ankle" kp="120" ctrlrange="-0.3491 0.6981"/>
-    <position name="fr_toe_act" joint="fr_toe" kp="80" ctrlrange="-0.2618 0.4363"/>
+    <position name="fr_hip_pitch_act" joint="fr_hip_pitch" kp="600" forcerange="-400 400" ctrlrange="-0.6981 0.8727"/>
+    <position name="fr_hip_roll_act" joint="fr_hip_roll" kp="300" forcerange="-200 200" ctrlrange="-0.1745 0.1745"/>
+    <position name="fr_knee_act" joint="fr_knee" kp="800" forcerange="-500 500" ctrlrange="-1.0472 0"/>
+    <position name="fr_ankle_act" joint="fr_ankle" kp="350" forcerange="-250 250" ctrlrange="-0.3491 0.6981"/>
+    <position name="fr_toe_act" joint="fr_toe" kp="150" forcerange="-100 100" ctrlrange="-0.2618 0.4363"/>
 
     <!-- Front left leg -->
-    <position name="fl_hip_pitch_act" joint="fl_hip_pitch" kp="200" ctrlrange="-0.6981 0.8727"/>
-    <position name="fl_hip_roll_act" joint="fl_hip_roll" kp="150" ctrlrange="-0.1745 0.1745"/>
-    <position name="fl_knee_act" joint="fl_knee" kp="250" ctrlrange="-1.0472 0"/>
-    <position name="fl_ankle_act" joint="fl_ankle" kp="120" ctrlrange="-0.3491 0.6981"/>
-    <position name="fl_toe_act" joint="fl_toe" kp="80" ctrlrange="-0.2618 0.4363"/>
+    <position name="fl_hip_pitch_act" joint="fl_hip_pitch" kp="600" forcerange="-400 400" ctrlrange="-0.6981 0.8727"/>
+    <position name="fl_hip_roll_act" joint="fl_hip_roll" kp="300" forcerange="-200 200" ctrlrange="-0.1745 0.1745"/>
+    <position name="fl_knee_act" joint="fl_knee" kp="800" forcerange="-500 500" ctrlrange="-1.0472 0"/>
+    <position name="fl_ankle_act" joint="fl_ankle" kp="350" forcerange="-250 250" ctrlrange="-0.3491 0.6981"/>
+    <position name="fl_toe_act" joint="fl_toe" kp="150" forcerange="-100 100" ctrlrange="-0.2618 0.4363"/>
 
     <!-- Rear right leg -->
-    <position name="rr_hip_pitch_act" joint="rr_hip_pitch" kp="180" ctrlrange="-0.6981 0.8727"/>
-    <position name="rr_hip_roll_act" joint="rr_hip_roll" kp="130" ctrlrange="-0.1745 0.1745"/>
-    <position name="rr_knee_act" joint="rr_knee" kp="220" ctrlrange="-1.0472 0"/>
-    <position name="rr_ankle_act" joint="rr_ankle" kp="100" ctrlrange="-0.3491 0.6981"/>
-    <position name="rr_toe_act" joint="rr_toe" kp="80" ctrlrange="-0.2618 0.4363"/>
+    <position name="rr_hip_pitch_act" joint="rr_hip_pitch" kp="550" forcerange="-350 350" ctrlrange="-0.6981 0.8727"/>
+    <position name="rr_hip_roll_act" joint="rr_hip_roll" kp="260" forcerange="-180 180" ctrlrange="-0.1745 0.1745"/>
+    <position name="rr_knee_act" joint="rr_knee" kp="700" forcerange="-450 450" ctrlrange="-1.0472 0"/>
+    <position name="rr_ankle_act" joint="rr_ankle" kp="300" forcerange="-220 220" ctrlrange="-0.3491 0.6981"/>
+    <position name="rr_toe_act" joint="rr_toe" kp="150" forcerange="-100 100" ctrlrange="-0.2618 0.4363"/>
 
     <!-- Rear left leg -->
-    <position name="rl_hip_pitch_act" joint="rl_hip_pitch" kp="180" ctrlrange="-0.6981 0.8727"/>
-    <position name="rl_hip_roll_act" joint="rl_hip_roll" kp="130" ctrlrange="-0.1745 0.1745"/>
-    <position name="rl_knee_act" joint="rl_knee" kp="220" ctrlrange="-1.0472 0"/>
-    <position name="rl_ankle_act" joint="rl_ankle" kp="100" ctrlrange="-0.3491 0.6981"/>
-    <position name="rl_toe_act" joint="rl_toe" kp="80" ctrlrange="-0.2618 0.4363"/>
+    <position name="rl_hip_pitch_act" joint="rl_hip_pitch" kp="550" forcerange="-350 350" ctrlrange="-0.6981 0.8727"/>
+    <position name="rl_hip_roll_act" joint="rl_hip_roll" kp="260" forcerange="-180 180" ctrlrange="-0.1745 0.1745"/>
+    <position name="rl_knee_act" joint="rl_knee" kp="700" forcerange="-450 450" ctrlrange="-1.0472 0"/>
+    <position name="rl_ankle_act" joint="rl_ankle" kp="300" forcerange="-220 220" ctrlrange="-0.3491 0.6981"/>
+    <position name="rl_toe_act" joint="rl_toe" kp="150" forcerange="-100 100" ctrlrange="-0.2618 0.4363"/>
 
     <!-- Tail actuators for active balance control (match T-Rex/Raptor pattern:
          actuate proximal segments, leave distal tail_4 passive) -->
-    <position name="tail_1_pitch_act" joint="tail_1_pitch" kp="100" ctrlrange="-0.2618 0.4363"/>
-    <position name="tail_1_yaw_act" joint="tail_1_yaw" kp="80" ctrlrange="-0.1745 0.1745"/>
-    <position name="tail_2_pitch_act" joint="tail_2_pitch" kp="80" ctrlrange="-0.2618 0.4363"/>
-    <position name="tail_3_pitch_act" joint="tail_3_pitch" kp="60" ctrlrange="-0.2618 0.4363"/>
+    <position name="tail_1_pitch_act" joint="tail_1_pitch" kp="100" forcerange="-70 70" ctrlrange="-0.2618 0.4363"/>
+    <position name="tail_1_yaw_act" joint="tail_1_yaw" kp="80" forcerange="-55 55" ctrlrange="-0.1745 0.1745"/>
+    <position name="tail_2_pitch_act" joint="tail_2_pitch" kp="80" forcerange="-55 55" ctrlrange="-0.2618 0.4363"/>
+    <position name="tail_3_pitch_act" joint="tail_3_pitch" kp="60" forcerange="-40 40" ctrlrange="-0.2618 0.4363"/>
   </actuator>
 
   <!-- ==================== SENSORS ==================== -->
 
   <sensor>
+    <!-- WARNING: the Python envs index sensordata by POSITION (gyro 0-2,
+         accel 3-5, quat 6-9, touch 10-13, ...).  Do not reorder or insert
+         sensors without updating mjx_config.py / obs_functions.py. -->
     <!-- IMU-like sensors on torso -->
     <gyro name="torso_gyro" site="imu"/>
     <accelerometer name="torso_accel" site="imu"/>

--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -1,7 +1,7 @@
 <mujoco model="tyrannosaurus_rex">
   <compiler angle="degree" autolimits="true"/>
 
-  <option timestep="0.002" gravity="0 0 -9.81">
+  <option timestep="0.002" gravity="0 0 -9.81" integrator="implicitfast">
     <flag warmstart="enable"/>
   </option>
 
@@ -295,38 +295,41 @@
          does NOT convert actuator attributes, only joint attributes. -->
 
     <!-- Head/neck control -->
-    <position name="neck_pitch_act" joint="neck_pitch" kp="200" ctrlrange="-0.5236 0.6981"/>
-    <position name="neck_yaw_act" joint="neck_yaw" kp="100" ctrlrange="-0.3491 0.3491"/>
-    <position name="head_pitch_act" joint="head_pitch" kp="80" ctrlrange="-0.4363 0.6109"/>
+    <position name="neck_pitch_act" joint="neck_pitch" kp="200" forcerange="-160 160" ctrlrange="-0.5236 0.6981"/>
+    <position name="neck_yaw_act" joint="neck_yaw" kp="100" forcerange="-80 80" ctrlrange="-0.3491 0.3491"/>
+    <position name="head_pitch_act" joint="head_pitch" kp="80" forcerange="-65 65" ctrlrange="-0.4363 0.6109"/>
 
     <!-- Right leg -->
-    <position name="r_hip_pitch_act" joint="r_hip_pitch" kp="200" ctrlrange="-0.8727 1.3963"/>
-    <position name="r_hip_roll_act" joint="r_hip_roll" kp="150" ctrlrange="-0.4363 0.4363"/>
-    <position name="r_knee_act" joint="r_knee" kp="250" ctrlrange="-1.9199 -0.1745"/>
-    <position name="r_ankle_act" joint="r_ankle" kp="150" ctrlrange="0.8727 2.6180"/>
-    <position name="r_toe_d2_act" joint="r_toe_d2_joint" kp="60" ctrlrange="-0.4363 0.8727"/>
-    <position name="r_toe_d3_act" joint="r_toe_d3_joint" kp="60" ctrlrange="-0.4363 0.8727"/>
-    <position name="r_toe_d4_act" joint="r_toe_d4_joint" kp="60" ctrlrange="-0.4363 0.8727"/>
+    <position name="r_hip_pitch_act" joint="r_hip_pitch" kp="200" forcerange="-160 160" ctrlrange="-0.8727 1.3963"/>
+    <position name="r_hip_roll_act" joint="r_hip_roll" kp="150" forcerange="-120 120" ctrlrange="-0.4363 0.4363"/>
+    <position name="r_knee_act" joint="r_knee" kp="250" forcerange="-200 200" ctrlrange="-1.9199 -0.1745"/>
+    <position name="r_ankle_act" joint="r_ankle" kp="150" forcerange="-120 120" ctrlrange="0.8727 2.6180"/>
+    <position name="r_toe_d2_act" joint="r_toe_d2_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
+    <position name="r_toe_d3_act" joint="r_toe_d3_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
+    <position name="r_toe_d4_act" joint="r_toe_d4_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
 
     <!-- Left leg -->
-    <position name="l_hip_pitch_act" joint="l_hip_pitch" kp="200" ctrlrange="-0.8727 1.3963"/>
-    <position name="l_hip_roll_act" joint="l_hip_roll" kp="150" ctrlrange="-0.4363 0.4363"/>
-    <position name="l_knee_act" joint="l_knee" kp="250" ctrlrange="-1.9199 -0.1745"/>
-    <position name="l_ankle_act" joint="l_ankle" kp="150" ctrlrange="0.8727 2.6180"/>
-    <position name="l_toe_d2_act" joint="l_toe_d2_joint" kp="60" ctrlrange="-0.4363 0.8727"/>
-    <position name="l_toe_d3_act" joint="l_toe_d3_joint" kp="60" ctrlrange="-0.4363 0.8727"/>
-    <position name="l_toe_d4_act" joint="l_toe_d4_joint" kp="60" ctrlrange="-0.4363 0.8727"/>
+    <position name="l_hip_pitch_act" joint="l_hip_pitch" kp="200" forcerange="-160 160" ctrlrange="-0.8727 1.3963"/>
+    <position name="l_hip_roll_act" joint="l_hip_roll" kp="150" forcerange="-120 120" ctrlrange="-0.4363 0.4363"/>
+    <position name="l_knee_act" joint="l_knee" kp="250" forcerange="-200 200" ctrlrange="-1.9199 -0.1745"/>
+    <position name="l_ankle_act" joint="l_ankle" kp="150" forcerange="-120 120" ctrlrange="0.8727 2.6180"/>
+    <position name="l_toe_d2_act" joint="l_toe_d2_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
+    <position name="l_toe_d3_act" joint="l_toe_d3_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
+    <position name="l_toe_d4_act" joint="l_toe_d4_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
 
     <!-- Tail actuators for active balance control (counterbalance to massive skull) -->
-    <position name="tail_1_pitch_act" joint="tail_1_pitch" kp="100" ctrlrange="-0.2094 0.2094"/>
-    <position name="tail_1_yaw_act" joint="tail_1_yaw" kp="80" ctrlrange="-0.1396 0.1396"/>
-    <position name="tail_2_pitch_act" joint="tail_2_pitch" kp="80" ctrlrange="-0.2094 0.2094"/>
-    <position name="tail_3_pitch_act" joint="tail_3_pitch" kp="60" ctrlrange="-0.2094 0.2094"/>
+    <position name="tail_1_pitch_act" joint="tail_1_pitch" kp="100" forcerange="-80 80" ctrlrange="-0.2094 0.2094"/>
+    <position name="tail_1_yaw_act" joint="tail_1_yaw" kp="80" forcerange="-65 65" ctrlrange="-0.1396 0.1396"/>
+    <position name="tail_2_pitch_act" joint="tail_2_pitch" kp="80" forcerange="-65 65" ctrlrange="-0.2094 0.2094"/>
+    <position name="tail_3_pitch_act" joint="tail_3_pitch" kp="60" forcerange="-50 50" ctrlrange="-0.2094 0.2094"/>
   </actuator>
 
   <!-- ==================== SENSORS ==================== -->
 
   <sensor>
+    <!-- WARNING: the Python envs index sensordata by POSITION (gyro 0-2,
+         accel 3-5, quat 6-9, touch 10-11, ...).  Do not reorder or insert
+         sensors without updating mjx_config.py / obs_functions.py. -->
     <!-- IMU-like sensors on pelvis -->
     <gyro name="pelvis_gyro" site="imu"/>
     <accelerometer name="pelvis_accel" site="imu"/>

--- a/environments/velociraptor/assets/raptor.xml
+++ b/environments/velociraptor/assets/raptor.xml
@@ -1,7 +1,7 @@
 <mujoco model="velociraptor">
   <compiler angle="degree" autolimits="true"/>
 
-  <option timestep="0.002" gravity="0 0 -9.81">
+  <option timestep="0.002" gravity="0 0 -9.81" integrator="implicitfast">
     <flag warmstart="enable"/>
   </option>
 
@@ -55,7 +55,7 @@
       Body length: 0.6m
       Hip height: 0.5m (in neutral crouch)
       Tail length: 0.8m
-      Total mass: ~15kg
+      Total mass: ~13.5kg
     -->
 
     <body name="pelvis" pos="0 0 0.50">
@@ -234,39 +234,42 @@
          does NOT convert actuator attributes, only joint attributes. -->
 
     <!-- Right leg -->
-    <position name="r_hip_pitch_act" joint="r_hip_pitch" kp="150" ctrlrange="-1.0472 1.5708"/>
-    <position name="r_hip_roll_act" joint="r_hip_roll" kp="100" ctrlrange="-0.5236 0.5236"/>
-    <position name="r_knee_act" joint="r_knee" kp="180" ctrlrange="-2.0944 -0.0872"/>
-    <position name="r_ankle_act" joint="r_ankle" kp="100" ctrlrange="1.0472 2.7925"/>
-    <position name="r_toe_d3_act" joint="r_toe_d3_joint" kp="50" ctrlrange="-0.5236 1.0472"/>
-    <position name="r_toe_d4_act" joint="r_toe_d4_joint" kp="50" ctrlrange="-0.5236 1.0472"/>
+    <position name="r_hip_pitch_act" joint="r_hip_pitch" kp="150" forcerange="-120 120" ctrlrange="-1.0472 1.5708"/>
+    <position name="r_hip_roll_act" joint="r_hip_roll" kp="100" forcerange="-80 80" ctrlrange="-0.5236 0.5236"/>
+    <position name="r_knee_act" joint="r_knee" kp="180" forcerange="-145 145" ctrlrange="-2.0944 -0.0872"/>
+    <position name="r_ankle_act" joint="r_ankle" kp="100" forcerange="-80 80" ctrlrange="1.0472 2.7925"/>
+    <position name="r_toe_d3_act" joint="r_toe_d3_joint" kp="50" forcerange="-40 40" ctrlrange="-0.5236 1.0472"/>
+    <position name="r_toe_d4_act" joint="r_toe_d4_joint" kp="50" forcerange="-40 40" ctrlrange="-0.5236 1.0472"/>
     <motor name="r_claw_act" joint="r_claw" gear="50" ctrlrange="-1 1"/>
 
     <!-- Left leg -->
-    <position name="l_hip_pitch_act" joint="l_hip_pitch" kp="150" ctrlrange="-1.0472 1.5708"/>
-    <position name="l_hip_roll_act" joint="l_hip_roll" kp="100" ctrlrange="-0.5236 0.5236"/>
-    <position name="l_knee_act" joint="l_knee" kp="180" ctrlrange="-2.0944 -0.0872"/>
-    <position name="l_ankle_act" joint="l_ankle" kp="100" ctrlrange="1.0472 2.7925"/>
-    <position name="l_toe_d3_act" joint="l_toe_d3_joint" kp="50" ctrlrange="-0.5236 1.0472"/>
-    <position name="l_toe_d4_act" joint="l_toe_d4_joint" kp="50" ctrlrange="-0.5236 1.0472"/>
+    <position name="l_hip_pitch_act" joint="l_hip_pitch" kp="150" forcerange="-120 120" ctrlrange="-1.0472 1.5708"/>
+    <position name="l_hip_roll_act" joint="l_hip_roll" kp="100" forcerange="-80 80" ctrlrange="-0.5236 0.5236"/>
+    <position name="l_knee_act" joint="l_knee" kp="180" forcerange="-145 145" ctrlrange="-2.0944 -0.0872"/>
+    <position name="l_ankle_act" joint="l_ankle" kp="100" forcerange="-80 80" ctrlrange="1.0472 2.7925"/>
+    <position name="l_toe_d3_act" joint="l_toe_d3_joint" kp="50" forcerange="-40 40" ctrlrange="-0.5236 1.0472"/>
+    <position name="l_toe_d4_act" joint="l_toe_d4_joint" kp="50" forcerange="-40 40" ctrlrange="-0.5236 1.0472"/>
     <motor name="l_claw_act" joint="l_claw" gear="50" ctrlrange="-1 1"/>
 
     <!-- Tail actuators for active balance control -->
-    <position name="tail_1_pitch_act" joint="tail_1_pitch" kp="60" ctrlrange="-0.2618 0.2618"/>
-    <position name="tail_1_yaw_act" joint="tail_1_yaw" kp="50" ctrlrange="-0.1745 0.1745"/>
-    <position name="tail_2_pitch_act" joint="tail_2_pitch" kp="50" ctrlrange="-0.2618 0.2618"/>
-    <position name="tail_3_pitch_act" joint="tail_3_pitch" kp="40" ctrlrange="-0.2618 0.2618"/>
+    <position name="tail_1_pitch_act" joint="tail_1_pitch" kp="60" forcerange="-50 50" ctrlrange="-0.2618 0.2618"/>
+    <position name="tail_1_yaw_act" joint="tail_1_yaw" kp="50" forcerange="-40 40" ctrlrange="-0.1745 0.1745"/>
+    <position name="tail_2_pitch_act" joint="tail_2_pitch" kp="50" forcerange="-40 40" ctrlrange="-0.2618 0.2618"/>
+    <position name="tail_3_pitch_act" joint="tail_3_pitch" kp="40" forcerange="-32 32" ctrlrange="-0.2618 0.2618"/>
 
     <!-- Forelimb actuators (lightweight — for grappling/balance assist) -->
-    <position name="r_shoulder_pitch_act" joint="r_shoulder_pitch" kp="15" ctrlrange="-0.5236 0.7854"/>
-    <position name="r_shoulder_roll_act" joint="r_shoulder_roll" kp="15" ctrlrange="-0.3491 0.3491"/>
-    <position name="l_shoulder_pitch_act" joint="l_shoulder_pitch" kp="15" ctrlrange="-0.5236 0.7854"/>
-    <position name="l_shoulder_roll_act" joint="l_shoulder_roll" kp="15" ctrlrange="-0.3491 0.3491"/>
+    <position name="r_shoulder_pitch_act" joint="r_shoulder_pitch" kp="15" forcerange="-12 12" ctrlrange="-0.5236 0.7854"/>
+    <position name="r_shoulder_roll_act" joint="r_shoulder_roll" kp="15" forcerange="-12 12" ctrlrange="-0.3491 0.3491"/>
+    <position name="l_shoulder_pitch_act" joint="l_shoulder_pitch" kp="15" forcerange="-12 12" ctrlrange="-0.5236 0.7854"/>
+    <position name="l_shoulder_roll_act" joint="l_shoulder_roll" kp="15" forcerange="-12 12" ctrlrange="-0.3491 0.3491"/>
   </actuator>
 
   <!-- ==================== SENSORS ==================== -->
 
   <sensor>
+    <!-- WARNING: the Python envs index sensordata by POSITION (gyro 0-2,
+         accel 3-5, quat 6-9, touch 10-11, ...).  Do not reorder or insert
+         sensors without updating mjx_config.py / obs_functions.py. -->
     <!-- IMU-like sensors -->
     <gyro name="pelvis_gyro" site="imu"/>
     <accelerometer name="pelvis_accel" site="imu"/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mesozoic-labs"
-version = "0.3.1.dev0"
+version = "0.3.2.dev0"
 description = "Robotic dinosaur locomotion environments for MuJoCo + Gymnasium"
 requires-python = ">=3.10"
 license = {text = "MIT"}


### PR DESCRIPTION
MuJoCo model review follow-up (findings recorded in docs/KNOWN_ISSUES.md):

Brachiosaurus could not physically hold any torso height in its alive region: from the home keyframe it sagged to z~0.68 within 3 s, and even with all legs commanded straight it equilibrated at z~0.70 with 14-26 deg of steady-state knee error -- below the healthy_z_range floor (1.0) and far below the height-reward target (1.2). The position servos (kp 180-250, unbounded) were 2-4x too weak for the ~175 kg body.

- Leg/metatarsal springs now reference the STANCE angles (per-joint springref: front knees -45, rear knees -10, ankles 20, toes 5.7 deg) with stiffness 120/80 and higher damping -- elephant-style columnar load-bearing where gravity is carried by the springs and the actuators modulate around stance
- Leg servos strengthened (hips 200->600/550, knees 250->800/700, ankles 120->350/300, toes 80->150) with bounding forcerange
- Measured result: static stand at z=1.14, tilt 1.8 deg, all four feet grounded (10 s settle converges to ~1.13)

All three models:
- integrator="implicitfast" (correct choice for this damping/stiffness/kp regime; also opens the door to a timestep 0.002->0.004 A/B)
- forcerange on all position actuators; for raptor/trex sized to ~0.8*kp so they only clip impact/reset spikes -- settle behavior verified unchanged (raptor z=0.493/24.1deg, trex z=0.783/35.6deg)
- Sensor-order warning comment (the Python envs index sensordata by position); mass comments corrected to the actual sums

NOTE: this changes the physics plant. Brachiosaurus policies trained before this commit will not transfer; raptor/trex change only marginally.

Verified: keyframes within joint limits and all 73 actuator ctrlranges still match joint ranges; settle sims for all three; MJX loads and steps with implicitfast; species suites 126 passed; shared suite all tests passing at 100%.