### PR TITLE
Homepage motion polish: crisper reveals, staggered cards, chevron fix

### DIFF
--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -24,7 +24,7 @@
    ============================================================================= */
 
 .scrollReveal {
-  transition: opacity 0.7s ease-out, transform 0.7s ease-out;
+  transition: opacity 0.45s ease-out, transform 0.45s ease-out;
 }
 
 /* Hidden state — added by JS after first paint, and only for sections
@@ -32,7 +32,7 @@
    always see the content. */
 .scrollRevealPending {
   opacity: 0;
-  transform: translateY(30px);
+  transform: translateY(24px);
 }
 
 .revealed {
@@ -388,6 +388,13 @@
   z-index: 10;
 }
 
+/* On short laptop viewports the chevron overlapped the hero stats */
+@media (max-height: 750px) {
+  .heroScrollIndicator {
+    display: none;
+  }
+}
+
 .scrollChevron {
   display: block;
   width: 20px;
@@ -437,13 +444,43 @@
 }
 
 .revealed .featureCard {
-  animation: cardSlideUp 0.5s ease-out both;
+  animation: cardSlideUp 0.45s ease-out both;
 }
 
 @keyframes cardSlideUp {
-  from { opacity: 0; transform: translateY(20px); }
+  from { opacity: 0; transform: translateY(16px); }
   to { opacity: 1; transform: translateY(0); }
 }
+
+/* Staggered entrances — animation-delay only, so hover transitions stay
+   instant.  Same rhythm across features, pipeline, videos, roadmap. */
+.revealed .featureCard:nth-child(2) { animation-delay: 0.08s; }
+.revealed .featureCard:nth-child(3) { animation-delay: 0.16s; }
+.revealed .featureCard:nth-child(4) { animation-delay: 0.24s; }
+
+.revealed .pipelineStep {
+  animation: cardSlideUp 0.45s ease-out both;
+}
+
+.revealed .pipelineStep:nth-child(3) { animation-delay: 0.1s; }
+.revealed .pipelineStep:nth-child(4) { animation-delay: 0.2s; }
+
+.revealed .speciesVideoCard {
+  animation: cardSlideUp 0.45s ease-out both;
+}
+
+.revealed .speciesVideoCard:nth-child(2) { animation-delay: 0.08s; }
+.revealed .speciesVideoCard:nth-child(3) { animation-delay: 0.16s; }
+
+.revealed .timelineCard {
+  animation: cardSlideUp 0.45s ease-out both;
+}
+
+.revealed article.timelineItem:nth-of-type(2) .timelineCard { animation-delay: 0.06s; }
+.revealed article.timelineItem:nth-of-type(3) .timelineCard { animation-delay: 0.12s; }
+.revealed article.timelineItem:nth-of-type(4) .timelineCard { animation-delay: 0.18s; }
+.revealed article.timelineItem:nth-of-type(5) .timelineCard { animation-delay: 0.24s; }
+.revealed article.timelineItem:nth-of-type(6) .timelineCard { animation-delay: 0.3s; }
 
 .featureCardBorder {
   position: absolute;

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -234,12 +234,7 @@ function FeaturesSection() {
       </div>
       <div className={styles.featuresGrid} role="list">
         {features.map((feature, idx) => (
-          <div
-            className={styles.featureCard}
-            key={idx}
-            role="listitem"
-            style={{ transitionDelay: `${idx * 0.1}s` }}
-          >
+          <div className={styles.featureCard} key={idx} role="listitem">
             <div className={styles.featureCardBorder} aria-hidden="true"></div>
             <div className={styles.featureIcon} aria-hidden="true">{feature.icon}</div>
             <h3 className={styles.featureTitle}>{feature.title}</h3>


### PR DESCRIPTION
- Shorten the scroll-reveal transition from 0.7s/30px to 0.45s/24px so sections snap in without the drawn-out fade.
- Stagger card children with CSS animation-delay (feature cards, pipeline steps, species video cards, roadmap timeline cards) instead of a uniform simultaneous reveal.
- Move the feature-card stagger from an inline transition-delay to animation-delay, fixing delayed hover feedback (the inline delay leaked into the card's hover transition).
- Hide the hero scroll chevron below 750px viewport height where it overlapped the hero stats.