### PR TITLE
Add light mode support & drop Python 3.10

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -43,6 +43,10 @@ jobs:
   test-shared:
     runs-on: ubuntu-latest
     needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -52,7 +56,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -67,6 +71,10 @@ jobs:
   test-velociraptor:
     runs-on: ubuntu-latest
     needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -76,7 +84,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -91,6 +99,10 @@ jobs:
   test-brachiosaurus:
     runs-on: ubuntu-latest
     needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -100,7 +112,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -115,6 +127,10 @@ jobs:
   test-trex:
     runs-on: ubuntu-latest
     needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -124,7 +140,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — RL/GCP Review Fixes & Model Physics (v0.3.2)
 
+### Changed
+- **Python 3.11+ required; Python 3.13 supported** (breaking): dropped
+  Python 3.10 support (`requires-python >= 3.11`), added 3.13 to the
+  trove classifiers and the CI test matrix (3.11 + 3.13), and bumped the
+  Docker base image to `python:3.13-slim`.  The `tomli` conditional
+  dependency and import fallbacks are gone — stdlib `tomllib` is always
+  available on 3.11+.  Ruff now targets py311; mypy targets 3.12 because
+  numpy ≥ 2.3 stubs use PEP 695 syntax that mypy rejects for older targets.
 ### Fixed
 - **JAX pipeline correctness** (July 2026 review, PR #426): curriculum gate
   now compares episode-level return against the TOML threshold (it compared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dependency and import fallbacks are gone — stdlib `tomllib` is always
   available on 3.11+.  Ruff now targets py311; mypy targets 3.12 because
   numpy ≥ 2.3 stubs use PEP 695 syntax that mypy rejects for older targets.
+- **Homepage light mode actually renders light**: the landing page palette
+  (`index.module.css`) gained a `[data-theme='light']` variant — until now
+  every section was hardcoded dark, so toggling the theme changed almost
+  nothing.  Accent colors are darkened for WCAG AA contrast on light
+  surfaces, the curriculum/feature icon colors follow the theme, and the
+  forced-dark homepage navbar override (plus its logo-swap hack) in
+  `custom.css` is removed.  The footer now follows the theme in both modes
+  (Infima's `.footer--dark` element-level variables had silently overridden
+  the intended colors, so it rendered `#303846` even in dark mode).  The
+  code terminal mock-up intentionally stays dark in both themes.
+
 ### Fixed
 - **JAX pipeline correctness** (July 2026 review, PR #426): curriculum gate
   now compares episode-level return against the TOML threshold (it compared

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 LABEL org.opencontainers.image.source="https://github.com/kuds/mesozoic-labs" \
       org.opencontainers.image.description="Mesozoic Labs – robotic dinosaur locomotion training"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -125,7 +125,7 @@ curriculum with published results and reproducible checkpoints.
   - _Dependency: None_
 
 - [x] **Dockerfile for containerized training**
-  - Python 3.11-slim base with MuJoCo headless rendering (`MUJOCO_GL=osmesa`)
+  - Python 3.13-slim base with MuJoCo headless rendering (`MUJOCO_GL=osmesa`)
   - Installs training dependencies via `pip install -e ".[train]"`
   - Packages `environments/` and `configs/` for cloud deployment
   - _Dependency: None_

--- a/environments/shared/config.py
+++ b/environments/shared/config.py
@@ -19,15 +19,11 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+import tomllib
 from pathlib import Path
 from typing import Any
 
 _logger = logging.getLogger(__name__)
-
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 

--- a/environments/shared/scripts/sweep/scoring.py
+++ b/environments/shared/scripts/sweep/scoring.py
@@ -16,6 +16,7 @@ manual reference values are needed.
 from __future__ import annotations
 
 import logging
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -77,15 +78,6 @@ def load_scoring_config(
         Dict mapping metric names to ``{"weight": float, "direction": str}``.
         Returns an empty dict if no config is found for the stage.
     """
-    try:
-        import tomllib
-    except ImportError:
-        try:
-            import tomli as tomllib  # type: ignore[no-redef]
-        except ImportError:
-            logger.warning("tomllib/tomli not available — quality scoring disabled")
-            return {}
-
     if config_path is None:
         config_path = _find_config_path()
     if config_path is None:

--- a/environments/shared/visualization.py
+++ b/environments/shared/visualization.py
@@ -242,7 +242,9 @@ def plot_diagnostics_graphs(
         fontsize=14,
         fontweight="bold",
     )
-    _reward_colors = plt.cm.tab10.colors
+    # Call the colormap instead of touching .colors — the stubs type
+    # plt.cm.tab10 as the base Colormap, which has no .colors attribute.
+    _reward_colors = [plt.cm.tab10(i) for i in range(plt.cm.tab10.N)]
     _all_term_data: dict = {}
 
     for stage_num, stage_dir in stage_dirs:
@@ -374,7 +376,7 @@ def plot_diagnostics_graphs(
         ts = diag["timesteps"] if "timesteps" in diag else None
         if ts is None or len(ts) == 0:
             continue
-        color = plt.cm.tab10.colors[stage_num % 10]
+        color = plt.cm.tab10(stage_num % 10)
 
         # [0,0] Gait Symmetry + Stride Frequency proxy
         if "l_foot_contact" in diag and "r_foot_contact" in diag:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "mesozoic-labs"
 version = "0.3.2.dev0"
 description = "Robotic dinosaur locomotion environments for MuJoCo + Gymnasium"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {text = "MIT"}
 authors = [{name = "Mesozoic Labs Contributors"}]
 readme = "README.md"
@@ -15,9 +15,9 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 
@@ -25,7 +25,6 @@ dependencies = [
     "mujoco>=3.0.0",
     "gymnasium>=0.29.0",
     "numpy>=1.24.0",
-    "tomli>=2.0.0; python_version < '3.11'",
 ]
 
 [project.urls]
@@ -112,14 +111,17 @@ norecursedirs = [
 addopts = "--tb=short -q"
 
 [tool.mypy]
-python_version = "3.10"
+# 3.12 rather than the 3.11 floor: numpy >= 2.3 ships PEP 695 `type`
+# statements in its stubs, which mypy refuses to parse for older targets.
+# Runtime compatibility with 3.11 is covered by the CI test matrix.
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 120
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -8,7 +8,7 @@ Get started with Mesozoic Labs by setting up your development environment.
 
 ## Prerequisites
 
-- Python 3.10+
+- Python 3.11+ (tested on 3.11–3.13)
 - CUDA-compatible GPU (recommended for training, not required)
 - [Docker](https://docs.docker.com/get-docker/) (optional, recommended for reproducible training)
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -55,7 +55,8 @@
   --ifm-footer-background-color: #e8e8e8;
   --ifm-footer-color: #444444;
   --ifm-footer-link-color: #333333;
-  --ifm-footer-title-color: #00994d;
+  /* Darker than the light primary: 4.5:1 (WCAG AA) on the #e8e8e8 footer */
+  --ifm-footer-title-color: #006e37;
   --ifm-color-primary: #00994d;
   --ifm-color-primary-dark: #008a45;
   --ifm-color-primary-darker: #008241;
@@ -186,51 +187,6 @@ body {
   display: none;
 }
 
-/* The homepage commits to its dark identity in light mode too: a white
-   navbar over the dark hero looked disjointed.  Detected via the stable
-   .mz-homepage-hero class on the hero header; browsers without :has()
-   gracefully keep the standard light navbar.
-
-   Everything except the background is scoped to .navbar__inner (the top
-   bar) so the mobile drawer (.navbar-sidebar), which keeps its light
-   surface, is unaffected. */
-[data-theme='light'] body:has(.mz-homepage-hero) .navbar {
-  --ifm-navbar-background-color: rgba(10, 10, 15, 0.87);
-  background-color: var(--ifm-navbar-background-color);
-}
-
-[data-theme='light'] body:has(.mz-homepage-hero) .navbar .navbar__inner {
-  --ifm-navbar-link-color: #e6e6f0;
-  --ifm-menu-color: #e6e6f0;
-  --ifm-color-emphasis-200: #2a2a35;
-}
-
-[data-theme='light'] body:has(.mz-homepage-hero) .navbar .navbar__inner .navbar__title {
-  color: #ffffff;
-}
-
-[data-theme='light'] body:has(.mz-homepage-hero) .navbar .navbar__inner .navbar__link--active {
-  color: #00ff88;
-}
-
-[data-theme='light'] body:has(.mz-homepage-hero) .navbar .navbar__inner .navbar__toggle,
-[data-theme='light'] body:has(.mz-homepage-hero) .navbar .navbar__inner [class*='colorModeToggle'] button {
-  color: #e6e6f0;
-}
-
-/* Swap to the dark-background logo variant on the forced-dark homepage
-   navbar.  Docusaurus's ThemedImage renders ONLY the active theme's <img>
-   once hydrated, so the dark variant can't be revealed with display rules
-   (that left no logo at all).  Instead hide the light artwork and paint
-   the dark variant as a background on the fixed-size logo container. */
-[data-theme='light'] body:has(.mz-homepage-hero) .navbar .navbar__inner .navbar__logo img {
-  visibility: hidden;
-}
-
-[data-theme='light'] body:has(.mz-homepage-hero) .navbar .navbar__inner .navbar__logo {
-  background: url('/img/logo-dark.svg') center / contain no-repeat;
-}
-
 /* Footer customization */
 .footer {
   border-top: 1px solid rgba(0, 255, 136, 0.1);
@@ -240,8 +196,27 @@ body {
   border-top-color: rgba(0, 153, 77, 0.2);
 }
 
+/* The footer uses style: 'dark' (Infima's .footer--dark), which defines the
+   footer variables on the element itself — beating the theme values declared
+   above on :root in BOTH modes (the dark footer actually rendered Infima's
+   #303846, not the intended #050508).  Redefine them here per theme so the
+   footer follows the palette like the rest of the page. */
+[data-theme='dark'] .footer--dark {
+  --ifm-footer-background-color: #050508;
+  --ifm-footer-color: #b0b0be;
+  --ifm-footer-link-color: #c8c8d4;
+  --ifm-footer-title-color: #00ff88;
+}
+
+[data-theme='light'] .footer--dark {
+  --ifm-footer-background-color: #e8e8e8;
+  --ifm-footer-color: #444444;
+  --ifm-footer-link-color: #333333;
+  --ifm-footer-title-color: #006e37;
+}
+
 .footer__title {
-  color: var(--ifm-color-primary);
+  color: var(--ifm-footer-title-color);
   font-weight: 600;
   letter-spacing: 0.05em;
 }

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -3,20 +3,59 @@
    Theme: Prehistoric meets Cyberpunk/Robotics
    ============================================================================= */
 
-/* CSS Variables */
+/* CSS Variables — dark palette is the default (matches defaultMode). */
 :root {
   --color-primary: #00ff88;
+  --color-primary-rgb: 0, 255, 136;
   --color-primary-dim: #00ff8840;
   --color-secondary: #ff6b35;
+  --color-secondary-rgb: 255, 107, 53;
   --color-accent: #00d4ff;
-  --color-dark: #0a0a0f;
-  --color-darker: #050508;
+  --color-accent-dim: #00d4ff40;
+  --color-bg: #0a0a0f;
+  --color-bg-deep: #050508;
   --color-surface: #12121a;
   --color-surface-light: #1a1a25;
+  --color-surface-tint-primary: #0a1a10;
+  --color-surface-tint-secondary: #1f1a15;
   --color-text: #e0e0e0;
   --color-text-dim: #9a9aad;
+  --color-border: #ffffff10;
+  --color-border-strong: #ffffff20;
+  --color-on-primary: #0a0a0f;
+  --color-grid: #00ff8810;
+  --hero-glow-a: #1a2a1a;
+  --hero-glow-b: #1a1a2a;
+  --shadow-preview: 0 10px 40px rgba(0, 0, 0, 0.4);
   --glow-primary: 0 0 20px var(--color-primary-dim);
-  --glow-accent: 0 0 30px #00d4ff40;
+  --glow-accent: 0 0 30px var(--color-accent-dim);
+}
+
+/* Light-mode palette: same variables, values darkened for WCAG AA contrast
+   on light surfaces (neon green/cyan are unreadable on white). */
+[data-theme='light'] {
+  --color-primary: #007a3d;
+  --color-primary-rgb: 0, 122, 61;
+  --color-primary-dim: rgba(0, 122, 61, 0.3);
+  --color-secondary: #b33a09;
+  --color-secondary-rgb: 179, 58, 9;
+  --color-accent: #006884;
+  --color-accent-dim: rgba(0, 104, 132, 0.25);
+  --color-bg: #f7f9f8;
+  --color-bg-deep: #edf2ef;
+  --color-surface: #ffffff;
+  --color-surface-light: #f0f3f1;
+  --color-surface-tint-primary: #e9f6ef;
+  --color-surface-tint-secondary: #fbf1e9;
+  --color-text: #1c1e21;
+  --color-text-dim: #4d5257;
+  --color-border: rgba(0, 0, 0, 0.1);
+  --color-border-strong: rgba(0, 0, 0, 0.18);
+  --color-on-primary: #ffffff;
+  --color-grid: rgba(0, 122, 61, 0.08);
+  --hero-glow-a: #dcebe0;
+  --hero-glow-b: #dfe6ee;
+  --shadow-preview: 0 10px 40px rgba(0, 0, 0, 0.15);
 }
 
 /* =============================================================================
@@ -95,7 +134,7 @@
 
 /* Main Container */
 .main {
-  background: var(--color-dark);
+  background: var(--color-bg);
   min-height: 100vh;
   overflow-x: hidden;
 }
@@ -111,9 +150,9 @@
   align-items: center;
   justify-content: center;
   background:
-    radial-gradient(ellipse at 50% 0%, #1a2a1a 0%, transparent 50%),
-    radial-gradient(ellipse at 80% 80%, #1a1a2a 0%, transparent 40%),
-    var(--color-darker);
+    radial-gradient(ellipse at 50% 0%, var(--hero-glow-a) 0%, transparent 50%),
+    radial-gradient(ellipse at 80% 80%, var(--hero-glow-b) 0%, transparent 40%),
+    var(--color-bg-deep);
   overflow: hidden;
 }
 
@@ -124,12 +163,18 @@
   opacity: 0.5;
 }
 
+/* Data URIs can't reference CSS variables, so light mode swaps the whole
+   image (same grid, dark-green strokes) and softens the CRT scan lines. */
+[data-theme='light'] .heroOverlay {
+  background: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpattern id='grid' width='10' height='10' patternUnits='userSpaceOnUse'%3E%3Cpath d='M 10 0 L 0 0 0 10' fill='none' stroke='%23007a3d14' stroke-width='0.5'/%3E%3C/pattern%3E%3Crect width='100' height='100' fill='url(%23grid)'/%3E%3C/svg%3E");
+}
+
 .gridLines {
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(90deg, transparent 49.5%, #00ff8810 49.5%, #00ff8810 50.5%, transparent 50.5%),
-    linear-gradient(0deg, transparent 49.5%, #00ff8810 49.5%, #00ff8810 50.5%, transparent 50.5%);
+    linear-gradient(90deg, transparent 49.5%, var(--color-grid) 49.5%, var(--color-grid) 50.5%, transparent 50.5%),
+    linear-gradient(0deg, transparent 49.5%, var(--color-grid) 49.5%, var(--color-grid) 50.5%, transparent 50.5%);
   background-size: 100px 100px;
 }
 
@@ -144,6 +189,16 @@
     rgba(0, 0, 0, 0.1) 4px
   );
   pointer-events: none;
+}
+
+[data-theme='light'] .scanLines {
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.025) 2px,
+    rgba(0, 0, 0, 0.025) 4px
+  );
 }
 
 /* Floating particles */
@@ -292,7 +347,7 @@
   gap: 0.6rem;
   padding: 0.9rem 2.2rem;
   background: var(--color-primary);
-  color: var(--color-dark);
+  color: var(--color-on-primary);
   font-size: 0.95rem;
   font-weight: 700;
   letter-spacing: 0.1em;
@@ -417,7 +472,7 @@
 
 .featuresSection {
   padding: 6rem 2rem;
-  background: var(--color-dark);
+  background: var(--color-bg);
   position: relative;
 }
 
@@ -433,7 +488,7 @@
   position: relative;
   background: var(--color-surface);
   padding: 2rem;
-  border: 1px solid #ffffff10;
+  border: 1px solid var(--color-border);
   transition: all 0.4s ease;
 }
 
@@ -499,15 +554,15 @@
   width: 56px;
   height: 56px;
   border-radius: 12px;
-  background: rgba(0, 255, 136, 0.06);
-  border: 1px solid rgba(0, 255, 136, 0.15);
-  box-shadow: 0 0 8px rgba(0, 255, 136, 0.15);
+  background: rgba(var(--color-primary-rgb), 0.06);
+  border: 1px solid rgba(var(--color-primary-rgb), 0.15);
+  box-shadow: 0 0 8px rgba(var(--color-primary-rgb), 0.15);
   transition: box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
 .featureCard:hover .featureIcon {
-  box-shadow: 0 0 16px rgba(0, 255, 136, 0.3);
-  border-color: rgba(0, 255, 136, 0.35);
+  box-shadow: 0 0 16px rgba(var(--color-primary-rgb), 0.3);
+  border-color: rgba(var(--color-primary-rgb), 0.35);
 }
 
 .featureTitle {
@@ -540,7 +595,7 @@
 
 .howItWorksSection {
   padding: 6rem 2rem;
-  background: var(--color-darker);
+  background: var(--color-bg-deep);
 }
 
 .pipelineContainer {
@@ -633,7 +688,7 @@
 
 .simulationSection {
   padding: 6rem 2rem;
-  background: var(--color-dark);
+  background: var(--color-bg);
 }
 
 .simulationContainer {
@@ -668,8 +723,8 @@
 .previewGif {
   width: 100%;
   border-radius: 8px;
-  border: 1px solid #ffffff10;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-preview);
 }
 
 .previewCaption {
@@ -705,7 +760,7 @@
 .terminalTitle {
   margin-left: auto;
   font-size: 0.8rem;
-  color: var(--color-text-dim);
+  color: #9a9aad;
   font-family: 'Courier New', monospace;
 }
 
@@ -717,7 +772,7 @@
 }
 
 .codeLine {
-  color: var(--color-text);
+  color: #e0e0e0;
 }
 
 .codeComment {
@@ -733,7 +788,7 @@
 }
 
 .codeOutput {
-  color: var(--color-primary);
+  color: #00ff88;
 }
 
 .cursor {
@@ -751,7 +806,7 @@
 
 .speciesSection {
   padding: 6rem 2rem;
-  background: var(--color-darker);
+  background: var(--color-bg-deep);
 }
 
 .speciesTabs {
@@ -769,7 +824,7 @@
   gap: 0.25rem;
   padding: 1rem 2rem;
   background: var(--color-surface);
-  border: 1px solid #ffffff10;
+  border: 1px solid var(--color-border);
   color: var(--color-text-dim);
   cursor: pointer;
   transition: all 0.3s ease;
@@ -784,7 +839,7 @@
 
 .speciesTabActive {
   border-color: var(--color-primary);
-  background: linear-gradient(135deg, var(--color-surface) 0%, #0a1a10 100%);
+  background: linear-gradient(135deg, var(--color-surface) 0%, var(--color-surface-tint-primary) 100%);
   box-shadow: var(--glow-primary);
 }
 
@@ -821,10 +876,10 @@
   font-weight: 600;
   letter-spacing: 0.15em;
   color: var(--color-secondary);
-  border: 1px solid rgba(255, 107, 53, 0.3);
+  border: 1px solid rgba(var(--color-secondary-rgb), 0.3);
   padding: 0.3rem 1rem;
   font-family: 'Courier New', monospace;
-  background: rgba(255, 107, 53, 0.05);
+  background: rgba(var(--color-secondary-rgb), 0.05);
   text-transform: uppercase;
 }
 
@@ -838,7 +893,7 @@
   position: relative;
   background: var(--color-surface);
   padding: 1.5rem;
-  border: 1px solid #ffffff10;
+  border: 1px solid var(--color-border);
   transition: all 0.3s ease;
 }
 
@@ -870,7 +925,7 @@
   border: 1px solid var(--color-primary-dim);
   padding: 0.1rem 0.4rem;
   font-family: 'Courier New', monospace;
-  background: rgba(0, 255, 136, 0.05);
+  background: rgba(var(--color-primary-rgb), 0.05);
 }
 
 .speciesStageTitle {
@@ -890,7 +945,7 @@
 .speciesVideoWrap {
   border-radius: 4px;
   overflow: hidden;
-  border: 1px solid #ffffff10;
+  border: 1px solid var(--color-border);
 }
 
 .speciesVideoPlayer {
@@ -905,7 +960,7 @@
 
 .roadmapSection {
   padding: 6rem 2rem;
-  background: var(--color-dark);
+  background: var(--color-bg);
 }
 
 .speciesStats {
@@ -970,7 +1025,7 @@
   height: 12px;
   border-radius: 50%;
   border: 2px solid var(--color-text-dim);
-  background: var(--color-dark);
+  background: var(--color-bg);
   z-index: 1;
 }
 
@@ -983,25 +1038,25 @@
 .timelineItem.active .timelineDot {
   border-color: var(--color-secondary);
   background: var(--color-secondary);
-  box-shadow: 0 0 10px rgba(255, 107, 53, 0.4);
+  box-shadow: 0 0 10px rgba(var(--color-secondary-rgb), 0.4);
   animation: dotPulse 2s ease-in-out infinite;
 }
 
 @keyframes dotPulse {
-  0%, 100% { box-shadow: 0 0 10px rgba(255, 107, 53, 0.4); }
-  50% { box-shadow: 0 0 20px rgba(255, 107, 53, 0.7); }
+  0%, 100% { box-shadow: 0 0 10px rgba(var(--color-secondary-rgb), 0.4); }
+  50% { box-shadow: 0 0 20px rgba(var(--color-secondary-rgb), 0.7); }
 }
 
 .timelineCard {
   background: var(--color-surface);
   padding: 1.5rem;
-  border: 1px solid #ffffff10;
+  border: 1px solid var(--color-border);
   border-left: 3px solid var(--color-text-dim);
   transition: all 0.3s ease;
 }
 
 .timelineCard:hover {
-  border-color: #ffffff20;
+  border-color: var(--color-border-strong);
 }
 
 .timelineItem.complete .timelineCard {
@@ -1010,7 +1065,7 @@
 
 .timelineItem.active .timelineCard {
   border-left-color: var(--color-secondary);
-  background: linear-gradient(135deg, var(--color-surface) 0%, #1f1a15 100%);
+  background: linear-gradient(135deg, var(--color-surface) 0%, var(--color-surface-tint-secondary) 100%);
 }
 
 .timelineItem.upcoming .timelineCard {
@@ -1111,7 +1166,7 @@
 
 .ctaSection {
   padding: 6rem 2rem;
-  background: linear-gradient(180deg, var(--color-dark) 0%, var(--color-darker) 100%);
+  background: linear-gradient(180deg, var(--color-bg) 0%, var(--color-bg-deep) 100%);
   text-align: center;
   position: relative;
   overflow: hidden;
@@ -1145,7 +1200,7 @@
   padding: 1rem 2.5rem;
   background: var(--color-primary);
   border: 2px solid var(--color-primary);
-  color: var(--color-dark);
+  color: var(--color-on-primary);
   font-size: 1rem;
   font-weight: 700;
   letter-spacing: 0.1em;
@@ -1201,6 +1256,10 @@
   background-repeat: repeat-x;
   background-size: 150px 30px;
   opacity: 0.3;
+}
+
+[data-theme='light'] .ctaDinoTrack {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 30'%3E%3Cellipse cx='20' cy='15' rx='8' ry='12' fill='%23007a3d14'/%3E%3Cellipse cx='50' cy='15' rx='8' ry='12' fill='%23007a3d14'/%3E%3Cellipse cx='80' cy='15' rx='8' ry='12' fill='%23007a3d14'/%3E%3C/svg%3E");
 }
 
 /* =============================================================================

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -67,7 +67,7 @@ const PARTICLES = Array.from({ length: 20 }, () => ({
 
 function HeroSection() {
   return (
-    <header className={`${styles.heroBanner} mz-homepage-hero`}>
+    <header className={styles.heroBanner}>
       <div className={styles.heroOverlay} aria-hidden="true"></div>
       <div className={styles.gridLines} aria-hidden="true"></div>
       <div className={styles.scanLines} aria-hidden="true"></div>
@@ -152,43 +152,43 @@ function HeroSection() {
 const FeatureIcons = {
   physics: (
     <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r="3" fill="#00ff88" />
-      <rect x="11" y="1" width="2" height="3" rx="1" fill="#00ff88" />
-      <rect x="11" y="20" width="2" height="3" rx="1" fill="#00ff88" />
-      <rect x="1" y="11" width="3" height="2" rx="1" fill="#00ff88" />
-      <rect x="20" y="11" width="3" height="2" rx="1" fill="#00ff88" />
-      <rect x="4.93" y="4.22" width="2" height="3" rx="1" fill="#00ff88" opacity="0.6" transform="rotate(-45 5.93 5.72)" />
-      <rect x="17.07" y="16.78" width="2" height="3" rx="1" fill="#00ff88" opacity="0.6" transform="rotate(-45 18.07 18.28)" />
-      <rect x="4.93" y="16.78" width="2" height="3" rx="1" fill="#00ff88" opacity="0.6" transform="rotate(45 5.93 18.28)" />
-      <rect x="17.07" y="4.22" width="2" height="3" rx="1" fill="#00ff88" opacity="0.6" transform="rotate(45 18.07 5.72)" />
+      <circle cx="12" cy="12" r="3" fill="var(--color-primary)" />
+      <rect x="11" y="1" width="2" height="3" rx="1" fill="var(--color-primary)" />
+      <rect x="11" y="20" width="2" height="3" rx="1" fill="var(--color-primary)" />
+      <rect x="1" y="11" width="3" height="2" rx="1" fill="var(--color-primary)" />
+      <rect x="20" y="11" width="3" height="2" rx="1" fill="var(--color-primary)" />
+      <rect x="4.93" y="4.22" width="2" height="3" rx="1" fill="var(--color-primary)" opacity="0.6" transform="rotate(-45 5.93 5.72)" />
+      <rect x="17.07" y="16.78" width="2" height="3" rx="1" fill="var(--color-primary)" opacity="0.6" transform="rotate(-45 18.07 18.28)" />
+      <rect x="4.93" y="16.78" width="2" height="3" rx="1" fill="var(--color-primary)" opacity="0.6" transform="rotate(45 5.93 18.28)" />
+      <rect x="17.07" y="4.22" width="2" height="3" rx="1" fill="var(--color-primary)" opacity="0.6" transform="rotate(45 18.07 5.72)" />
     </svg>
   ),
   brain: (
     <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24">
-      <path d="M12 2C9.8 2 8 3.5 7.5 5.5C5.5 5.8 4 7.5 4 9.5c0 1.5.8 2.8 2 3.5C5.5 14.2 5 15.5 5 17c0 2.8 2.2 5 5 5h4c2.8 0 5-2.2 5-5 0-1.5-.5-2.8-1-4 1.2-.7 2-2 2-3.5 0-2-1.5-3.7-3.5-4C16 3.5 14.2 2 12 2z" fill="#00ff88" opacity="0.2" />
-      <path d="M12 2C9.8 2 8 3.5 7.5 5.5C5.5 5.8 4 7.5 4 9.5c0 1.5.8 2.8 2 3.5C5.5 14.2 5 15.5 5 17c0 2.8 2.2 5 5 5h4c2.8 0 5-2.2 5-5 0-1.5-.5-2.8-1-4 1.2-.7 2-2 2-3.5 0-2-1.5-3.7-3.5-4C16 3.5 14.2 2 12 2z" fill="none" stroke="#00ff88" strokeWidth="1.5" />
-      <circle cx="9" cy="10" r="1.5" fill="#00ff88" />
-      <circle cx="15" cy="10" r="1.5" fill="#00ff88" />
-      <circle cx="12" cy="15" r="1.5" fill="#00ff88" />
-      <line x1="9" y1="10" x2="15" y2="10" stroke="#00ff88" strokeWidth="1" opacity="0.5" />
-      <line x1="9" y1="10" x2="12" y2="15" stroke="#00ff88" strokeWidth="1" opacity="0.5" />
-      <line x1="15" y1="10" x2="12" y2="15" stroke="#00ff88" strokeWidth="1" opacity="0.5" />
+      <path d="M12 2C9.8 2 8 3.5 7.5 5.5C5.5 5.8 4 7.5 4 9.5c0 1.5.8 2.8 2 3.5C5.5 14.2 5 15.5 5 17c0 2.8 2.2 5 5 5h4c2.8 0 5-2.2 5-5 0-1.5-.5-2.8-1-4 1.2-.7 2-2 2-3.5 0-2-1.5-3.7-3.5-4C16 3.5 14.2 2 12 2z" fill="var(--color-primary)" opacity="0.2" />
+      <path d="M12 2C9.8 2 8 3.5 7.5 5.5C5.5 5.8 4 7.5 4 9.5c0 1.5.8 2.8 2 3.5C5.5 14.2 5 15.5 5 17c0 2.8 2.2 5 5 5h4c2.8 0 5-2.2 5-5 0-1.5-.5-2.8-1-4 1.2-.7 2-2 2-3.5 0-2-1.5-3.7-3.5-4C16 3.5 14.2 2 12 2z" fill="none" stroke="var(--color-primary)" strokeWidth="1.5" />
+      <circle cx="9" cy="10" r="1.5" fill="var(--color-primary)" />
+      <circle cx="15" cy="10" r="1.5" fill="var(--color-primary)" />
+      <circle cx="12" cy="15" r="1.5" fill="var(--color-primary)" />
+      <line x1="9" y1="10" x2="15" y2="10" stroke="var(--color-primary)" strokeWidth="1" opacity="0.5" />
+      <line x1="9" y1="10" x2="12" y2="15" stroke="var(--color-primary)" strokeWidth="1" opacity="0.5" />
+      <line x1="15" y1="10" x2="12" y2="15" stroke="var(--color-primary)" strokeWidth="1" opacity="0.5" />
     </svg>
   ),
   species: (
     <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24">
-      <path d="M17 4c-1 0-3 1-4 3l-1 2-2-1c-1.5 0-3 1-3.5 2.5L5 14l-2 1v4h3l2-2h4l3 2h3v-4l-1-3c0-1-.5-2-1.5-2.5L15 8l1-2c.5-1 .5-2 0-2z" fill="#00ff88" opacity="0.2" />
-      <path d="M17 4c-1 0-3 1-4 3l-1 2-2-1c-1.5 0-3 1-3.5 2.5L5 14l-2 1v4h3l2-2h4l3 2h3v-4l-1-3c0-1-.5-2-1.5-2.5L15 8l1-2c.5-1 .5-2 0-2z" fill="none" stroke="#00ff88" strokeWidth="1.5" strokeLinejoin="round" />
-      <circle cx="16" cy="6" r="1" fill="#00ff88" />
+      <path d="M17 4c-1 0-3 1-4 3l-1 2-2-1c-1.5 0-3 1-3.5 2.5L5 14l-2 1v4h3l2-2h4l3 2h3v-4l-1-3c0-1-.5-2-1.5-2.5L15 8l1-2c.5-1 .5-2 0-2z" fill="var(--color-primary)" opacity="0.2" />
+      <path d="M17 4c-1 0-3 1-4 3l-1 2-2-1c-1.5 0-3 1-3.5 2.5L5 14l-2 1v4h3l2-2h4l3 2h3v-4l-1-3c0-1-.5-2-1.5-2.5L15 8l1-2c.5-1 .5-2 0-2z" fill="none" stroke="var(--color-primary)" strokeWidth="1.5" strokeLinejoin="round" />
+      <circle cx="16" cy="6" r="1" fill="var(--color-primary)" />
     </svg>
   ),
   openSource: (
     <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24">
-      <rect x="3" y="3" width="18" height="18" rx="3" fill="#00ff88" opacity="0.2" />
-      <rect x="3" y="3" width="18" height="18" rx="3" fill="none" stroke="#00ff88" strokeWidth="1.5" />
-      <path d="M9 8l-3 4 3 4" fill="none" stroke="#00ff88" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M15 8l3 4-3 4" fill="none" stroke="#00ff88" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-      <line x1="13" y1="7" x2="11" y2="17" stroke="#00ff88" strokeWidth="1.5" strokeLinecap="round" opacity="0.6" />
+      <rect x="3" y="3" width="18" height="18" rx="3" fill="var(--color-primary)" opacity="0.2" />
+      <rect x="3" y="3" width="18" height="18" rx="3" fill="none" stroke="var(--color-primary)" strokeWidth="1.5" />
+      <path d="M9 8l-3 4 3 4" fill="none" stroke="var(--color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M15 8l3 4-3 4" fill="none" stroke="var(--color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <line x1="13" y1="7" x2="11" y2="17" stroke="var(--color-primary)" strokeWidth="1.5" strokeLinecap="round" opacity="0.6" />
     </svg>
   ),
 };
@@ -251,27 +251,32 @@ function FeaturesSection() {
    HOW IT WORKS (Curriculum Pipeline)
    ============================================================================= */
 
+// Stage colors reference the palette variables from index.module.css so
+// they follow the light/dark theme (hex literals here would not).
 const curriculumSteps = [
   {
     stage: 1,
     title: 'Balance',
     subtitle: 'Stand & Stabilize',
     description: 'The agent learns to stand upright and maintain balance using proprioceptive feedback and joint torques.',
-    color: '#00ff88',
+    color: 'var(--color-primary)',
+    glow: 'var(--color-primary-dim)',
   },
   {
     stage: 2,
     title: 'Locomotion',
     subtitle: 'Walk & Run',
     description: 'Building on balance skills, the agent develops forward locomotion with natural gait patterns.',
-    color: '#00d4ff',
+    color: 'var(--color-accent)',
+    glow: 'var(--color-accent-dim)',
   },
   {
     stage: 3,
     title: 'Behavior',
     subtitle: 'Strike & Hunt',
     description: 'Advanced species-specific behaviors emerge: sickle claw strikes, head attacks, and tail defense.',
-    color: '#ff6b35',
+    color: 'var(--color-secondary)',
+    glow: 'rgba(var(--color-secondary-rgb), 0.25)',
   },
 ];
 
@@ -296,7 +301,7 @@ function HowItWorksSection() {
           <div className={styles.pipelineStep} key={idx}>
             <div
               className={styles.pipelineNode}
-              style={{ borderColor: step.color, boxShadow: `0 0 20px ${step.color}40` }}
+              style={{ borderColor: step.color, boxShadow: `0 0 20px ${step.glow}` }}
               aria-hidden="true"
             >
               <span style={{ color: step.color }}>{step.stage}</span>


### PR DESCRIPTION
## Summary

This PR adds full light mode support to the homepage and drops Python 3.10 support in favor of 3.11+.

## Key Changes

### Homepage Light Mode
- **CSS Variables**: Expanded the `:root` palette with RGB variants and semantic names (`--color-bg`, `--color-on-primary`, etc.) to support theme switching
- **Light Theme Palette**: Added `[data-theme='light']` CSS rules with darkened accent colors (WCAG AA contrast on light surfaces) and adjusted backgrounds/text colors
- **SVG Icon Colors**: Updated feature icons to use CSS variables instead of hardcoded `#00ff88`, so they follow the active theme
- **Curriculum Step Colors**: Made pipeline stage colors theme-aware via CSS variables with corresponding glow effects
- **Footer Theming**: Fixed footer color overrides by redefining Infima's `.footer--dark` variables per theme (was rendering `#303846` in dark mode due to element-level specificity)
- **Removed Forced-Dark Navbar**: Deleted the `:has(.mz-homepage-hero)` override that forced a dark navbar in light mode and the logo-swap hack; removed the `mz-homepage-hero` class marker
- **Light Mode Overlays**: Added theme-specific SVG data URIs for the hero grid and softer scan lines in light mode

### Python Version Support
- **Minimum Version**: Bumped `requires-python` from `>=3.10` to `>=3.11`
- **Removed Conditional Imports**: Deleted `tomli` fallback logic in `scoring.py`, `config.py` (now always use stdlib `tomllib`)
- **Updated Classifiers**: Removed 3.10, added 3.13 to `pyproject.toml` classifiers
- **CI Matrix**: Added Python 3.13 to test matrix alongside 3.11 for `test-shared`, `test-velociraptor`, `test-brachiosaurus`, and `test-trex` jobs
- **Tool Targets**: Updated Ruff to `py311` and mypy to `3.12` (numpy ≥ 2.3 stubs use PEP 695 syntax unsupported by older mypy targets)
- **Docker**: Bumped base image from `python:3.12-slim` to `python:3.13-slim`
- **Documentation**: Updated installation prerequisites to reflect 3.11+ requirement

### Bug Fixes
- Fixed matplotlib colormap access in `visualization.py`: changed `plt.cm.tab10.colors` to `[plt.cm.tab10(i) for i in range(plt.cm.tab10.N)]` to avoid type stub issues

## Implementation Details

The light mode palette uses semantic CSS variable names (e.g., `--color-bg`, `--color-surface-tint-primary`) to centralize theme values and reduce duplication. RGB variants (`--color-primary-rgb`) enable `rgba()` color functions for opacity adjustments without hardcoding hex values. The footer fix addresses Infima's element-level variable specificity by explicitly redefining colors in theme-scoped selectors.