### PR TITLE
Extend the stage-2 plant fix to trex and brachiosaurus; enable stage-1 entropy decay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] — RL/GCP Review Fixes & Model Physics (v0.3.2)
 
 ### Changed
+- **Trex and brachiosaurus gait actuator headroom raised to 1.5×kp**
+  (breaking — plant change): the same static-only forcerange sizing that
+  broke velociraptor stage-2 measured 44–50 % hip / ~31 % ankle / 10–14 %
+  knee gait-cycle clipping on trex (2.5 Hz) and 20–33 % hip clipping on
+  brachiosaurus *at a 1.5 Hz walk*. Raised the clipped groups only (trex
+  hip pitch/knee/ankle; brachio's four hip pitches) — post-fix clipping
+  ≤0.5 %, root-z divergence vs an unbounded plant ≤2 mm. New
+  `test_actuator_bounds.py` for both species pins the contract, built on
+  shared helpers (`environments/shared/tests/actuator_bounds_helpers.py`);
+  the velociraptor test now uses the same helpers. A species-generic
+  saturation report lives at
+  `environments/shared/scripts/actuator_saturation_report.py` (the
+  velociraptor script delegates to it). Policies trained on the old caps
+  will not transfer.
+- **Entropy decay enabled for velociraptor stage 1** (`ent_coef_end =
+  0.001`): run `20260711_235303` — which cleared stages 1–3 and set the
+  stage-2 record (2705.93 ± 7.84 @ 2.75 m/s) — showed stage 1 destabilizing
+  late (peak 1524 @ 2.45M → 385 @ 3.95M, bimodal falls) under constant
+  `ent_coef`, the same pathology entropy decay fixed in stage 2. Staged
+  (commented) `ent_coef_end` suggestions added to the trex and
+  brachiosaurus stage 1/2 TOMLs for their next runs.
 - **Raptor hip-pitch/ankle actuator headroom raised to 1.5×kp** (breaking —
   plant change): the blanket 0.8×kp `forcerange` from the July 9 model
   hardening clipped 34–40 % of hip and 22–25 % of ankle torque during a

--- a/configs/brachiosaurus/stage1_balance.toml
+++ b/configs/brachiosaurus/stage1_balance.toml
@@ -39,8 +39,10 @@ gamma = 0.98                            # Sweep result: 0.9797 — slightly shor
 gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.01
-
-[ppo.policy_kwargs]
+# ent_coef_end = 0.002                  # Uncomment to decay entropy over the stage (EntCoefDecayCallback);
+                                        # 5x decay mirrors velociraptor's 0.005 -> 0.001. Velociraptor stages
+                                        # 1 & 2 both destabilized late under constant ent_coef; decay fixed
+                                        # stage 2. See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
 net_arch = [512, 256]
 
 [sac]

--- a/configs/brachiosaurus/stage2_locomotion.toml
+++ b/configs/brachiosaurus/stage2_locomotion.toml
@@ -37,6 +37,12 @@ gamma = 0.993                           # Sweep winner: 0.9929 — all top-3 tri
 gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.01                         # Sweep winner: 0.0104 — reduced from 0.015. Less entropy lets policy commit to discovered gaits sooner.
+# ent_coef_end = 0.002                  # Uncomment to decay entropy over the stage (EntCoefDecayCallback);
+                                        # 5x decay mirrors velociraptor's 0.005 -> 0.001, which (with
+                                        # fall_penalty -150, forward_vel_max 2.5) carried its stage 2 to
+                                        # 2706 +/- 8 @ 2.75 m/s on the 1.5x-kp plant. Sweep-winner caveat:
+                                        # the 0.0104 constant was tuned on the old plant, so re-validate.
+                                        # See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
 
 [ppo.policy_kwargs]
 net_arch = [512, 256]                  # Larger first layer to match Stage 1 setting 4 architecture

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -38,8 +38,11 @@ gamma = 0.98                            # Setting 4 sweep: 0.9797. Previous 0.99
 gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.005
-
-[ppo.policy_kwargs]
+# ent_coef_end = 0.001                  # Uncomment to decay entropy over the stage (EntCoefDecayCallback).
+                                        # Velociraptor stages 1 & 2 both destabilized late under constant
+                                        # ent_coef (bimodal falls, action std growth); decay fixed stage 2
+                                        # and is enabled for its stage 1. Recommended for the next trex run
+                                        # on the 1.5x-kp plant. See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
 net_arch = [512, 256]
 
 [sac]

--- a/configs/trex/stage2_locomotion.toml
+++ b/configs/trex/stage2_locomotion.toml
@@ -35,8 +35,11 @@ gamma = 0.995                           # Increase from 0.99: longer horizon val
 gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.005
-
-[ppo.policy_kwargs]
+# ent_coef_end = 0.001                  # Uncomment to decay entropy over the stage (EntCoefDecayCallback).
+                                        # This decay (with fall_penalty -150 and forward_vel_max 2.5) is what
+                                        # carried velociraptor stage 2 to 2706 +/- 8 @ 2.75 m/s on the 1.5x-kp
+                                        # plant. Recommended for the next trex stage-2 run.
+                                        # See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
 net_arch = [512, 256]                  # Larger first layer for T-Rex's higher-dimensional obs space (83 vs raptor's 67)
 
 [sac]

--- a/configs/velociraptor/stage1_balance.toml
+++ b/configs/velociraptor/stage1_balance.toml
@@ -34,6 +34,11 @@ gamma = 0.98                                     # Setting 4 sweep: 0.9797. Slig
 gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.005
+ent_coef_end = 0.001                             # Decay entropy over the stage (EntCoefDecayCallback). Run 20260711_235303
+                                                 # stage 1 collapsed late (peak 1524 @ 2.45M -> 385 @ 3.95M, bimodal falls)
+                                                 # under constant ent_coef on the 1.5x-kp plant — the same late-training
+                                                 # entropy pathology that broke stage 2, where this decay fixed it.
+                                                 # See docs/investigations/STAGE2_RECOMMENDATIONS.md section 5.
 
 [ppo.policy_kwargs]
 net_arch = [512, 256]

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -116,15 +116,15 @@ z≈0.70, vs `healthy_z_range` floor 1.0 and height target 1.2) — leg springs
 now reference the stance angles and the leg servos are stronger with
 bounded force, giving a static stand at z≈1.13, level, all four feet
 grounded. All three models now use `integrator="implicitfast"` and bounded
-`forcerange` on position actuators, sized to clip impact/reset spikes only:
-0.8×kp by default, with the raptor's gait-critical hip pitch and ankle
-servos at 1.5×kp. (The original blanket 0.8×kp sizing clipped 34–40 % of
-the hip and 22–25 % of the ankle gait cycle and collapsed stage-2
-locomotion twice — see
-[investigations/STAGE2_RECOMMENDATIONS.md](investigations/STAGE2_RECOMMENDATIONS.md);
-at 1.5×kp the same excitation measures 0 % clipping and zero divergence
-from an unbounded plant, pinned by
-`environments/velociraptor/tests/test_actuator_bounds.py`.)
+`forcerange` on position actuators, sized to clip impact/reset spikes only,
+with gait-critical actuators at 1.5×kp on every species (raptor hip
+pitch/ankle; trex hip pitch/knee/ankle; brachiosaurus all four hip
+pitches). The original static-only sizing clipped 20–50 % of gait-cycle
+torque per species and collapsed velociraptor stage-2 twice — see
+[investigations/STAGE2_RECOMMENDATIONS.md](investigations/STAGE2_RECOMMENDATIONS.md)
+§5. Post-fix gait clipping is ≤0.5 % everywhere, pinned by each species'
+`tests/test_actuator_bounds.py`; re-measure any re-sizing with
+`environments/shared/scripts/actuator_saturation_report.py`.
 
 > **Note:** these changes alter the physics plant. Brachiosaurus policies
 > trained before this change will NOT transfer; raptor/trex plants changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ than rewrite.
 | [REWARD_DISCREPANCY_INVESTIGATION.md](investigations/REWARD_DISCREPANCY_INVESTIGATION.md) | 2026-04-02 | T-Rex stage-1 reward vs episode-length inconsistency root cause |
 | [REWARD_SCALE_REDESIGN.md](investigations/REWARD_SCALE_REDESIGN.md) | 2026-04-18 | Stage-3 terminal-bonus rescale analysis (implementation deferred) |
 | [STAGE2_INVESTIGATION.md](investigations/STAGE2_INVESTIGATION.md) | 2026-07-09 | Root cause of the velociraptor stage-2 locomotion collapse (bounded-plant actuator clipping) |
-| [STAGE2_RECOMMENDATIONS.md](investigations/STAGE2_RECOMMENDATIONS.md) | 2026-07-11 | Replication review of run 20260711_165924, corrected fall-penalty math, ranked plan (plant fix + config changes implemented) |
+| [STAGE2_RECOMMENDATIONS.md](investigations/STAGE2_RECOMMENDATIONS.md) | 2026-07-11 | Replication review of run 20260711_165924, corrected fall-penalty math, ranked plan — validated 2026-07-12 by run 20260711_235303 (stages 1–3 cleared, stage-2 record); §5 has the outcome and cross-species lessons |
 
 ## Code & repo reviews
 

--- a/docs/investigations/STAGE2_RECOMMENDATIONS.md
+++ b/docs/investigations/STAGE2_RECOMMENDATIONS.md
@@ -40,6 +40,11 @@ To get past stage 2, in order of leverage:
 > `forward_vel_max = 2.5`, `fall_penalty = -150`. R1 remains a run-time
 > notebook step; R3 (gate) is deliberately untouched pending the first run
 > on the fixed plant; R5/R6 are open.
+>
+> **Outcome (2026-07-12):** run `20260711_235303` validated the plan — stage 2
+> passed with the best result on record and stage 3 passed too. See §5 for the
+> results and the cross-species lessons (trex/brachiosaurus carried the same
+> plant defect and are fixed alongside).
 
 ---
 
@@ -307,3 +312,61 @@ Artifacts referenced: Drive run folder
 evaluations/diagnostics npz, videos), `logs/runs_summary.csv` and per-species
 summaries (2026-07-11 export), repo state `da89959` on
 `claude/stage-2-recommendations-un9fxn`.
+
+---
+
+## 5. Outcome (2026-07-12) and cross-species lessons
+
+Run `20260711_235303` — the first on the 1.5×kp plant with the R4 config —
+**validated the plan end-to-end**:
+
+- **Stage 2 PASSED** at the full 8M budget: final eval **2705.93 ± 7.84**
+  (best on record, vs 2679 March best on the unbounded plant), 2.75 ± 0.07 m/s
+  vs the 2.0 gate, episode length 1000 ± 0. Zero catastrophic eval episodes
+  after 4.65M steps; worst single episode in the last 3.35M scored 2562. The
+  bimodal scissor is gone. The run wobbled in the old kill zone (0.75–1.05M,
+  up to 7/30 failures, eval mean within ~2% of the collapse early-stop
+  threshold) and recovered — supporting R5's "don't judge collapse mid-ramp".
+- **Stage 3 PASSED** (96.7% strike success vs the 0.5 gate) — first recorded
+  PPO run to clear all three stages.
+- **R3 is moot**: 2.75 m/s cruise means the 2.0 gate needs no recalibration
+  on the fixed plant.
+- **New follow-up: stage 1 destabilized late** on the new plant (peak
+  1524 ± 422 @ 2.45M → bimodal falls → 385 ± 136 @ 3.95M early stop). The
+  robust-best checkpoint from the healthy phase seeded stage 2 successfully,
+  but the late-training entropy pathology is evidently **generic across
+  stages**, not stage-2-specific → `ent_coef_end` is now enabled for
+  velociraptor stage 1 as well.
+- The npz `np.load` defect (§R7) did not recur in this run's artifacts.
+
+### Cross-species lessons (measured, and fixed alongside this section)
+
+1. **Trex and brachiosaurus carried the same latent plant defect.** The July
+   2026 hardening sized their forcerange caps statically too. Measured with
+   the same scripted-gait excitation (shared report:
+   `environments/shared/scripts/actuator_saturation_report.py`):
+   trex @ 2.5 Hz — hips **44–50%**, ankles ~31%, knees 10–14% clipped;
+   brachiosaurus — hips **20–33% even at a 1.5 Hz walk** (44–51% @ 2.5 Hz),
+   and its only stage-2 pass ever was a 1.12 m/s walk. Fixed to 1.5×kp on
+   the clipped groups only (trex hips/knees/ankles; brachio's four hip
+   pitches — its knees/ankles measured 0% and keep their spike caps).
+   Post-fix: worst gait clipping ≤0.5% (trex) / ~0% (brachio), root-z
+   divergence vs an unbounded plant ≤2 mm. Pinned by new
+   `test_actuator_bounds.py` in both species' test suites.
+2. **Validate every plant change dynamically, not just statically** — a cap
+   that never binds while standing can dominate the gait regime. The shared
+   saturation report + per-species bounds tests now make that check one
+   command / one CI run.
+3. **Decay entropy on long stages.** Constant `ent_coef` produced late-run
+   bimodal collapse in velociraptor stages 1 and 2; decay fixed stage 2 and
+   is enabled for its stage 1. Commented-in suggestions (with species-scaled
+   end values) are staged in the trex and brachiosaurus stage TOMLs — enable
+   on their next runs.
+4. **Trust the safety nets, and keep them:** the collapse early-stop +
+   risk-adjusted (`mean − std`) checkpointing turned the stage-1 wobble into
+   a non-event — training stopped, the healthy checkpoint advanced, stage 2
+   set a record from it.
+5. **Gate sanity:** brachiosaurus's 0.75 m/s gate matches its measured
+   walking regime; trex's stage-2 TOML still gates at 2.0 m/s, which its
+   March passes (3.47 m/s, old plant) support, but the first bounded-plant
+   trex run should re-confirm headroom the way velociraptor's did.

--- a/environments/brachiosaurus/assets/brachiosaurus.xml
+++ b/environments/brachiosaurus/assets/brachiosaurus.xml
@@ -306,28 +306,32 @@
     <position name="head_pitch_act" joint="head_pitch" kp="80" forcerange="-55 55" ctrlrange="-0.6981 0.6981"/>
 
     <!-- Front right leg (5 actuators: hip pitch/roll, knee, ankle, toe) -->
-    <position name="fr_hip_pitch_act" joint="fr_hip_pitch" kp="600" forcerange="-400 400" ctrlrange="-0.6981 0.8727"/>
+    <!-- Hip-pitch forcerange sized at 1.5x kp (was ~0.65x): the tighter caps clipped
+         20-33% of a slow 1.5 Hz walk cycle on all four hips -- same defect class that
+         broke velociraptor stage-2. Knees/ankles/toes measured 0% and keep their
+         original sizing. See docs/investigations/STAGE2_RECOMMENDATIONS.md. -->
+    <position name="fr_hip_pitch_act" joint="fr_hip_pitch" kp="600" forcerange="-900 900" ctrlrange="-0.6981 0.8727"/>
     <position name="fr_hip_roll_act" joint="fr_hip_roll" kp="300" forcerange="-200 200" ctrlrange="-0.1745 0.1745"/>
     <position name="fr_knee_act" joint="fr_knee" kp="800" forcerange="-500 500" ctrlrange="-1.0472 0"/>
     <position name="fr_ankle_act" joint="fr_ankle" kp="350" forcerange="-250 250" ctrlrange="-0.3491 0.6981"/>
     <position name="fr_toe_act" joint="fr_toe" kp="150" forcerange="-100 100" ctrlrange="-0.2618 0.4363"/>
 
     <!-- Front left leg -->
-    <position name="fl_hip_pitch_act" joint="fl_hip_pitch" kp="600" forcerange="-400 400" ctrlrange="-0.6981 0.8727"/>
+    <position name="fl_hip_pitch_act" joint="fl_hip_pitch" kp="600" forcerange="-900 900" ctrlrange="-0.6981 0.8727"/>
     <position name="fl_hip_roll_act" joint="fl_hip_roll" kp="300" forcerange="-200 200" ctrlrange="-0.1745 0.1745"/>
     <position name="fl_knee_act" joint="fl_knee" kp="800" forcerange="-500 500" ctrlrange="-1.0472 0"/>
     <position name="fl_ankle_act" joint="fl_ankle" kp="350" forcerange="-250 250" ctrlrange="-0.3491 0.6981"/>
     <position name="fl_toe_act" joint="fl_toe" kp="150" forcerange="-100 100" ctrlrange="-0.2618 0.4363"/>
 
     <!-- Rear right leg -->
-    <position name="rr_hip_pitch_act" joint="rr_hip_pitch" kp="550" forcerange="-350 350" ctrlrange="-0.6981 0.8727"/>
+    <position name="rr_hip_pitch_act" joint="rr_hip_pitch" kp="550" forcerange="-825 825" ctrlrange="-0.6981 0.8727"/>
     <position name="rr_hip_roll_act" joint="rr_hip_roll" kp="260" forcerange="-180 180" ctrlrange="-0.1745 0.1745"/>
     <position name="rr_knee_act" joint="rr_knee" kp="700" forcerange="-450 450" ctrlrange="-1.0472 0"/>
     <position name="rr_ankle_act" joint="rr_ankle" kp="300" forcerange="-220 220" ctrlrange="-0.3491 0.6981"/>
     <position name="rr_toe_act" joint="rr_toe" kp="150" forcerange="-100 100" ctrlrange="-0.2618 0.4363"/>
 
     <!-- Rear left leg -->
-    <position name="rl_hip_pitch_act" joint="rl_hip_pitch" kp="550" forcerange="-350 350" ctrlrange="-0.6981 0.8727"/>
+    <position name="rl_hip_pitch_act" joint="rl_hip_pitch" kp="550" forcerange="-825 825" ctrlrange="-0.6981 0.8727"/>
     <position name="rl_hip_roll_act" joint="rl_hip_roll" kp="260" forcerange="-180 180" ctrlrange="-0.1745 0.1745"/>
     <position name="rl_knee_act" joint="rl_knee" kp="700" forcerange="-450 450" ctrlrange="-1.0472 0"/>
     <position name="rl_ankle_act" joint="rl_ankle" kp="300" forcerange="-220 220" ctrlrange="-0.3491 0.6981"/>

--- a/environments/brachiosaurus/tests/test_actuator_bounds.py
+++ b/environments/brachiosaurus/tests/test_actuator_bounds.py
@@ -1,0 +1,105 @@
+"""Plant-characterization tests for the brachiosaurus's bounded actuators.
+
+The July 2026 hardening sized position-actuator ``forcerange`` at
+~0.62-0.73x kp against *static* settling only. Under a diagonal-pair
+trot that clipped 20-33% of hip-pitch torque even at a slow 1.5 Hz walk
+cycle — the same plant defect that collapsed velociraptor stage-2 twice
+(see docs/investigations/STAGE2_RECOMMENDATIONS.md), and this species'
+only stage-2 pass was a 1.12 m/s walk. The four hip-pitch actuators were
+re-sized to 1.5x kp, which measures ~0% gait clipping; knees, ankles,
+and toes measured 0% at their original sizing and keep it. These tests
+pin that contract.
+
+Run ``environments/shared/scripts/actuator_saturation_report.py
+brachiosaurus`` for the full per-actuator numbers on the current model.
+"""
+
+import mujoco
+import pytest
+
+from environments.brachiosaurus.envs.brachio_env import BrachioEnv
+from environments.shared.tests.actuator_bounds_helpers import (
+    clip_fraction,
+    measure_clip_fractions,
+    position_actuator_ids,
+)
+
+# Non-raised actuators keep the July 2026 spike-cap sizing, which varies
+# ~0.62-0.73x kp across the model rather than a single documented ratio.
+SPIKE_CAP_RATIO_RANGE = (0.55, 0.85)
+GAIT_HEADROOM_RATIO = 1.5
+GAIT_HEADROOM_ACTUATORS = frozenset({"fr_hip_pitch_act", "fl_hip_pitch_act", "rr_hip_pitch_act", "rl_hip_pitch_act"})
+LEG_PREFIXES = ("fr_", "fl_", "rr_", "rl_")
+
+
+@pytest.fixture(scope="module")
+def model():
+    env = BrachioEnv()
+    try:
+        yield env.model
+    finally:
+        env.close()
+
+
+class TestForceBoundsConfiguration:
+    def test_integrator_is_implicitfast(self, model):
+        assert model.opt.integrator == mujoco.mjtIntegrator.mjINT_IMPLICITFAST
+
+    def test_all_position_actuators_have_forcerange(self, model):
+        for i in position_actuator_ids(model):
+            fr = model.actuator_forcerange[i]
+            name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i)
+            assert fr[1] > 0, f"{name} has no forcerange upper bound"
+            assert fr[0] == -fr[1], f"{name} forcerange is not symmetric"
+
+    def test_forcerange_matches_documented_sizing(self, model):
+        """Hip pitches carry 1.5x-kp gait headroom; everything else stays a spike cap."""
+        lo, hi = SPIKE_CAP_RATIO_RANGE
+        for i in position_actuator_ids(model):
+            kp = model.actuator_gainprm[i, 0]
+            fr = model.actuator_forcerange[i, 1]
+            name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i)
+            ratio = fr / kp
+            if name in GAIT_HEADROOM_ACTUATORS:
+                assert ratio == pytest.approx(GAIT_HEADROOM_RATIO, abs=0.05), (
+                    f"{name}: forcerange/kp = {ratio:.2f}, expected ~{GAIT_HEADROOM_RATIO}. "
+                    "If this changed intentionally, update the ratios here and the "
+                    "saturation numbers in docs/investigations/STAGE2_RECOMMENDATIONS.md."
+                )
+            else:
+                assert lo <= ratio <= hi, (
+                    f"{name}: forcerange/kp = {ratio:.2f}, outside the documented spike-cap band [{lo}, {hi}]."
+                )
+
+
+class TestStaticSaturation:
+    def test_no_saturation_during_settle(self):
+        """Settling from home never clips forces (the caps are for spikes, not posture)."""
+        env = BrachioEnv()
+        try:
+            frac = measure_clip_fractions(env, gait=False, steps=1000)
+            worst = max(frac[i] for i in position_actuator_ids(env.model))
+            assert worst < 0.01, f"static settle saturates a position actuator {worst:.1%} of the time"
+        finally:
+            env.close()
+
+
+class TestDynamicSaturation:
+    def test_trot_excitation_stays_unclipped(self):
+        """Guards the hip headroom that stage-2 locomotion depends on.
+
+        At ~0.65x kp the hip caps clipped 20-33% of a slow 1.5 Hz walk
+        and 44-51% of a 2.5 Hz trot; at 1.5x kp both measure ~0%. Knees
+        keep their spike caps and may graze them (~1% at 1.5 Hz). If hip
+        saturation rises past the ceiling, the plant lost gait headroom —
+        see docs/investigations/STAGE2_RECOMMENDATIONS.md before
+        re-sizing.
+        """
+        env = BrachioEnv()
+        try:
+            model = env.model
+            frac = measure_clip_fractions(env, gait=True, steps=2000)
+            hip = max(clip_fraction(frac, model, f"{p}hip_pitch_act") for p in LEG_PREFIXES)
+            assert hip < 0.10, f"hip saturation {hip:.1%} — plant lost gait headroom, stage 2 will clip"
+        finally:
+            env.close()

--- a/environments/shared/scripts/actuator_saturation_report.py
+++ b/environments/shared/scripts/actuator_saturation_report.py
@@ -1,0 +1,102 @@
+"""Report per-actuator force saturation for any species plant.
+
+Measures what fraction of simulation steps each position actuator spends
+at its ``forcerange`` cap, under (a) static settling and (b) scripted
+gait excitation (alternating legs for bipeds, diagonal-pair trot for the
+brachiosaurus), and how much the bounded plant diverges from an
+unbounded copy under identical commands. Written for the stage-2
+locomotion investigation (docs/investigations/STAGE2_RECOMMENDATIONS.md):
+spike-cap ``forcerange`` sizing validated only against static settling
+clipped a large fraction of gait torque on every species. Re-run this
+after any actuator re-sizing, before spending GPU hours.
+
+Usage::
+
+    python environments/shared/scripts/actuator_saturation_report.py [species[:hz] ...]
+
+    # e.g. all species at their default cadence:
+    python environments/shared/scripts/actuator_saturation_report.py \\
+        velociraptor trex brachiosaurus:1.5
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import mujoco
+import numpy as np
+
+# Add repo root to path
+_repo_root = str(Path(__file__).resolve().parents[3])
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+# The scripted excitation is shared with the per-species plant tests so the
+# report and the CI pins always measure the same thing.
+from environments.shared.tests.actuator_bounds_helpers import (
+    CLIP_EPS,
+    GAIT_AMPLITUDE,
+    GAIT_HZ,
+    gait_commands,
+)
+
+_ROOT = Path(__file__).resolve().parents[2]
+XML_PATHS = {
+    "velociraptor": _ROOT / "velociraptor" / "assets" / "raptor.xml",
+    "trex": _ROOT / "trex" / "assets" / "trex.xml",
+    "brachiosaurus": _ROOT / "brachiosaurus" / "assets" / "brachiosaurus.xml",
+}
+
+
+def _run(xml_str, gait, steps, hz, amplitude):
+    model = mujoco.MjModel.from_xml_string(xml_str)
+    data = mujoco.MjData(model)
+    if model.nkey:
+        mujoco.mj_resetDataKeyframe(model, data, 0)
+    fr = model.actuator_forcerange[:, 1]
+    clip_hits = np.zeros(model.nu)
+    zs = []
+    for t in range(steps):
+        if gait:
+            data.ctrl[:] = gait_commands(model, t, hz=hz, amplitude=amplitude)
+        mujoco.mj_step(model, data)
+        clip_hits += np.abs(data.actuator_force) >= CLIP_EPS * np.maximum(fr, 1e-9)
+        zs.append(data.qpos[2])
+    return model, clip_hits / steps, np.array(zs)
+
+
+def report(species, hz=GAIT_HZ, amplitude=GAIT_AMPLITUDE, steps=2500):
+    xml = XML_PATHS[species].read_text()
+    xml_unbounded = re.sub(r' forcerange="[^"]*"', "", xml)
+
+    model, clip_settle, _ = _run(xml, gait=False, steps=steps, hz=hz, amplitude=amplitude)
+    _, clip_gait, z_bounded = _run(xml, gait=True, steps=steps, hz=hz, amplitude=amplitude)
+    _, _, z_unbounded = _run(xml_unbounded, gait=True, steps=steps, hz=hz, amplitude=amplitude)
+
+    names = [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i) for i in range(model.nu)]
+    is_position = model.actuator_biasprm[:, 1] < 0
+
+    print(f"\n{species} actuator saturation over {steps} steps ({hz} Hz, {amplitude:.0%} amplitude gait excitation)")
+    print(f"{'actuator':26s} {'kp':>6s} {'forcerange':>10s} {'settle':>8s} {'gait':>8s}")
+    for i in np.argsort(-clip_gait):
+        if not is_position[i]:
+            continue  # motors (claw) pin their gear force by construction
+        kp = model.actuator_gainprm[i, 0]
+        fr = model.actuator_forcerange[i, 1]
+        print(f"{names[i]:26s} {kp:6.0f} {fr:10.0f} {clip_settle[i]:8.1%} {clip_gait[i]:8.1%}")
+
+    rms = float(np.sqrt(np.mean((z_bounded - z_unbounded) ** 2)))
+    print(f"root-z RMS divergence, bounded vs unbounded plant under identical commands: {rms:.4f} m")
+
+
+def main(argv):
+    targets = argv or ["velociraptor", "trex", "brachiosaurus"]
+    for arg in targets:
+        species, _, hz = arg.partition(":")
+        if species not in XML_PATHS:
+            raise SystemExit(f"unknown species {species!r}; choose from {sorted(XML_PATHS)}")
+        report(species, hz=float(hz) if hz else GAIT_HZ)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/environments/shared/tests/actuator_bounds_helpers.py
+++ b/environments/shared/tests/actuator_bounds_helpers.py
@@ -1,0 +1,92 @@
+"""Shared helpers for per-species actuator force-bound tests.
+
+The July 2026 model hardening added ``forcerange`` caps sized against
+*static* settling only; under gait-like excitation the caps clipped a
+large fraction of leg torque and collapsed velociraptor stage-2 twice
+(docs/investigations/STAGE2_RECOMMENDATIONS.md). Gait-critical actuators
+now carry 1.5x-kp headroom on every species, and each species pins that
+contract with a test built on these helpers:
+
+* scripted gait excitation (alternating legs for bipeds, diagonal-pair
+  trot for quadrupeds), and
+* per-actuator clip-fraction measurement under settle and gait regimes.
+
+Run ``environments/shared/scripts/actuator_saturation_report.py`` for the
+full per-actuator numbers on any species' current model.
+"""
+
+import mujoco
+import numpy as np
+
+CLIP_EPS = 0.999
+GAIT_HZ = 2.5
+GAIT_AMPLITUDE = 0.8
+
+# Quadruped diagonal-pair trot: FR+RL in phase, FL+RR antiphase.
+_QUAD_PHASES = {"fr_": 0.0, "rl_": 0.0, "fl_": np.pi, "rr_": np.pi}
+
+
+def position_actuator_ids(model):
+    """IDs of position servos (gaintype fixed, biastype affine) with kp > 0."""
+    ids = []
+    for i in range(model.nu):
+        kp = model.actuator_gainprm[i, 0]
+        # Motors (e.g. claw) have gainprm[0] == gear and no position bias.
+        if model.actuator_biasprm[i, 1] < 0 and kp > 0:
+            ids.append(i)
+    return ids
+
+
+def _leg_phase(name):
+    """Gait phase for a leg actuator name, or None for non-leg actuators."""
+    for prefix, phase in _QUAD_PHASES.items():
+        if name.startswith(prefix):
+            return phase
+    if name.startswith("r_"):
+        return 0.0
+    if name.startswith("l_"):
+        return np.pi
+    return None
+
+
+def gait_commands(model, t, hz=GAIT_HZ, amplitude=GAIT_AMPLITUDE):
+    """Scripted sinusoidal gait ctrl vector at step ``t``.
+
+    Leg actuators (by name prefix) run full-amplitude alternating/trot
+    sinusoids; everything else gets a 0.4x-amplitude wiggle.
+    """
+    lo = model.actuator_ctrlrange[:, 0]
+    hi = model.actuator_ctrlrange[:, 1]
+    mid, amp = (lo + hi) / 2, (hi - lo) / 2
+    phase = 2 * np.pi * hz * t * model.opt.timestep
+    ctrl = mid.copy()
+    for i in range(model.nu):
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i)
+        leg = _leg_phase(name)
+        s = np.sin(phase + leg) if leg is not None else 0.4 * np.sin(phase)
+        ctrl[i] = mid[i] + amplitude * amp[i] * s
+    return ctrl
+
+
+def measure_clip_fractions(env, gait, steps, hz=GAIT_HZ, amplitude=GAIT_AMPLITUDE):
+    """Per-actuator fraction of ``steps`` spent at the forcerange cap.
+
+    ``gait=False`` measures passive settling from the reset pose;
+    ``gait=True`` drives the scripted gait.
+    """
+    env.reset(seed=0)
+    model, data = env.model, env.data
+    fr = model.actuator_forcerange[:, 1]
+    clip_hits = np.zeros(model.nu)
+    for t in range(steps):
+        if gait:
+            data.ctrl[:] = gait_commands(model, t, hz=hz, amplitude=amplitude)
+        mujoco.mj_step(model, data)
+        clip_hits += np.abs(data.actuator_force) >= CLIP_EPS * np.maximum(fr, 1e-9)
+    return clip_hits / steps
+
+
+def clip_fraction(frac, model, name):
+    """Clip fraction for a named actuator from a measure_clip_fractions result."""
+    i = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, name)
+    return frac[i]

--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -300,19 +300,23 @@
     <position name="head_pitch_act" joint="head_pitch" kp="80" forcerange="-65 65" ctrlrange="-0.4363 0.6109"/>
 
     <!-- Right leg -->
-    <position name="r_hip_pitch_act" joint="r_hip_pitch" kp="200" forcerange="-160 160" ctrlrange="-0.8727 1.3963"/>
+    <!-- Hip pitch, knee, and ankle forcerange sized at 1.5x kp (was 0.8x): the 0.8x
+         caps clipped 44-50% (hips), 10-14% (knees), and ~31% (ankles) of a moderate
+         gait cycle -- the same plant defect that broke velociraptor stage-2 before
+         commit fd3ffbc fixed it. See docs/investigations/STAGE2_RECOMMENDATIONS.md. -->
+    <position name="r_hip_pitch_act" joint="r_hip_pitch" kp="200" forcerange="-300 300" ctrlrange="-0.8727 1.3963"/>
     <position name="r_hip_roll_act" joint="r_hip_roll" kp="150" forcerange="-120 120" ctrlrange="-0.4363 0.4363"/>
-    <position name="r_knee_act" joint="r_knee" kp="250" forcerange="-200 200" ctrlrange="-1.9199 -0.1745"/>
-    <position name="r_ankle_act" joint="r_ankle" kp="150" forcerange="-120 120" ctrlrange="0.8727 2.6180"/>
+    <position name="r_knee_act" joint="r_knee" kp="250" forcerange="-375 375" ctrlrange="-1.9199 -0.1745"/>
+    <position name="r_ankle_act" joint="r_ankle" kp="150" forcerange="-225 225" ctrlrange="0.8727 2.6180"/>
     <position name="r_toe_d2_act" joint="r_toe_d2_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
     <position name="r_toe_d3_act" joint="r_toe_d3_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
     <position name="r_toe_d4_act" joint="r_toe_d4_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
 
     <!-- Left leg -->
-    <position name="l_hip_pitch_act" joint="l_hip_pitch" kp="200" forcerange="-160 160" ctrlrange="-0.8727 1.3963"/>
+    <position name="l_hip_pitch_act" joint="l_hip_pitch" kp="200" forcerange="-300 300" ctrlrange="-0.8727 1.3963"/>
     <position name="l_hip_roll_act" joint="l_hip_roll" kp="150" forcerange="-120 120" ctrlrange="-0.4363 0.4363"/>
-    <position name="l_knee_act" joint="l_knee" kp="250" forcerange="-200 200" ctrlrange="-1.9199 -0.1745"/>
-    <position name="l_ankle_act" joint="l_ankle" kp="150" forcerange="-120 120" ctrlrange="0.8727 2.6180"/>
+    <position name="l_knee_act" joint="l_knee" kp="250" forcerange="-375 375" ctrlrange="-1.9199 -0.1745"/>
+    <position name="l_ankle_act" joint="l_ankle" kp="150" forcerange="-225 225" ctrlrange="0.8727 2.6180"/>
     <position name="l_toe_d2_act" joint="l_toe_d2_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
     <position name="l_toe_d3_act" joint="l_toe_d3_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
     <position name="l_toe_d4_act" joint="l_toe_d4_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>

--- a/environments/trex/tests/test_actuator_bounds.py
+++ b/environments/trex/tests/test_actuator_bounds.py
@@ -1,23 +1,15 @@
-"""Plant-characterization tests for the raptor's bounded actuators.
+"""Plant-characterization tests for the T-Rex's bounded actuators.
 
-Commit 156a933 added ``forcerange`` (~0.8x kp) to every position actuator
-and switched to the implicitfast integrator, verifying only *static*
-settling. That sizing clipped 34-40% of hip-pitch and 22-25% of ankle
-torque during a moderate gait cycle and broke stage-2 locomotion twice
-(runs 20260709_185946 and 20260711_165924, bitwise-identical collapses).
-The hip-pitch and ankle caps were re-sized to 1.5x kp, which measures 0%
-gait-cycle clipping and zero pelvis-z divergence from an unbounded plant
-under identical commands (see docs/investigations/STAGE2_RECOMMENDATIONS.md
-R2). These tests pin the resulting contract:
+The July 2026 hardening sized every position actuator's ``forcerange`` at
+~0.8x kp against *static* settling only. Under gait-like excitation that
+clipped 44-50% of hip-pitch, 10-14% of knee, and ~31% of ankle torque —
+the same plant defect that collapsed velociraptor stage-2 twice (see
+docs/investigations/STAGE2_RECOMMENDATIONS.md). Hip pitch, knee, and
+ankle were re-sized to 1.5x kp, which measures <1% gait-cycle clipping
+and ~0 pelvis-z divergence from an unbounded plant. These tests pin that
+contract before the next trex stage-2 run trains against the plant.
 
-* the static no-saturation claim stays true (regression guard),
-* every position actuator keeps a symmetric forcerange at its documented
-  kp ratio (0.8x default, 1.5x for the gait-critical hip pitch/ankle), and
-* the dynamic regime stays unclipped: gait-like excitation must not
-  saturate the leg actuators, so the force caps bound impact/reset spikes
-  rather than learnable gaits.
-
-Run ``environments/velociraptor/scripts/actuator_saturation_report.py``
+Run ``environments/shared/scripts/actuator_saturation_report.py trex``
 for the full per-actuator numbers on the current model.
 """
 
@@ -29,18 +21,25 @@ from environments.shared.tests.actuator_bounds_helpers import (
     measure_clip_fractions,
     position_actuator_ids,
 )
-from environments.velociraptor.envs.raptor_env import RaptorEnv
+from environments.trex.envs.trex_env import TRexEnv
 
-# Default sizing from commit 156a933; gait-critical actuators carry extra
-# headroom so the caps only bind on impact/reset spikes, not gait torques.
-FORCERANGE_KP_RATIO = 0.8
+FORCERANGE_KP_RATIO = 0.8  # spike-cap sizing from the July 2026 hardening
 GAIT_HEADROOM_RATIO = 1.5
-GAIT_HEADROOM_ACTUATORS = frozenset({"r_hip_pitch_act", "l_hip_pitch_act", "r_ankle_act", "l_ankle_act"})
+GAIT_HEADROOM_ACTUATORS = frozenset(
+    {
+        "r_hip_pitch_act",
+        "l_hip_pitch_act",
+        "r_knee_act",
+        "l_knee_act",
+        "r_ankle_act",
+        "l_ankle_act",
+    }
+)
 
 
 @pytest.fixture(scope="module")
 def model():
-    env = RaptorEnv()
+    env = TRexEnv()
     try:
         yield env.model
     finally:
@@ -75,8 +74,8 @@ class TestForceBoundsConfiguration:
 
 class TestStaticSaturation:
     def test_no_saturation_during_settle(self):
-        """The commit's static claim: settling from home never clips forces."""
-        env = RaptorEnv()
+        """Settling from home never clips forces (the caps are for spikes, not posture)."""
+        env = TRexEnv()
         try:
             frac = measure_clip_fractions(env, gait=False, steps=1000)
             worst = max(frac[i] for i in position_actuator_ids(env.model))
@@ -87,25 +86,23 @@ class TestStaticSaturation:
 
 class TestDynamicSaturation:
     def test_gait_excitation_stays_unclipped(self):
-        """Guards the actuator headroom the stage-2 fix depends on.
+        """Guards the gait headroom that stage-2 locomotion depends on.
 
-        The 0.8x-kp caps clipped hips 34-40% and ankles 22-25% of a
-        moderate (0.8-amplitude) alternating-leg gait cycle and collapsed
-        stage-2 locomotion twice; at 1.5x kp the same excitation measures
-        0% clipping. If this test starts failing because saturation *rose*,
-        the plant lost gait headroom again — see
+        At 0.8x kp the caps clipped hips 44-50%, knees 10-14%, and ankles
+        ~31% of a moderate 2.5 Hz gait cycle; at 1.5x kp the same
+        excitation measures <1%. If saturation rises past these ceilings,
+        the plant lost gait headroom — see
         docs/investigations/STAGE2_RECOMMENDATIONS.md before re-sizing.
         """
-        env = RaptorEnv()
+        env = TRexEnv()
         try:
             model = env.model
             frac = measure_clip_fractions(env, gait=True, steps=2000)
             hip = max(clip_fraction(frac, model, f"{s}_hip_pitch_act") for s in "rl")
+            knee = max(clip_fraction(frac, model, f"{s}_knee_act") for s in "rl")
             ankle = max(clip_fraction(frac, model, f"{s}_ankle_act") for s in "rl")
-            # Measured at 1.5x kp: 0.0% on both groups (was hips 0.34-0.40,
-            # ankles 0.22-0.25 at 0.8x kp). Thresholds keep margin for
-            # timestep/integrator jitter while catching any real regression.
             assert hip < 0.10, f"hip saturation {hip:.1%} — plant lost gait headroom, stage 2 will clip"
+            assert knee < 0.05, f"knee saturation {knee:.1%} — plant lost gait headroom, stage 2 will clip"
             assert ankle < 0.05, f"ankle saturation {ankle:.1%} — plant lost gait headroom, stage 2 will clip"
         finally:
             env.close()

--- a/environments/velociraptor/scripts/actuator_saturation_report.py
+++ b/environments/velociraptor/scripts/actuator_saturation_report.py
@@ -1,93 +1,26 @@
 """Report per-actuator force saturation on the raptor plant.
 
-Measures what fraction of simulation steps each position actuator spends
-at its ``forcerange`` cap, under (a) static settling and (b) gait-like
-alternating-leg sinusoids, and how much the bounded plant diverges from
-an unbounded copy under identical commands. Written for the stage-2
-locomotion investigation (docs/investigations/STAGE2_INVESTIGATION.md):
-the original ~0.8x kp sizing was validated against *static* behavior
-only, while dynamic gaits lived in the clipped regime; hip pitch and
-ankle now carry 1.5x kp headroom (docs/investigations/
-STAGE2_RECOMMENDATIONS.md R2), which this report measures at 0% gait
-clipping. Re-run after any actuator re-sizing.
+Thin wrapper kept at this documented path; the measurement now lives in
+``environments/shared/scripts/actuator_saturation_report.py`` so every
+species runs the identical excitation (docs/investigations/
+STAGE2_RECOMMENDATIONS.md). Extra CLI args are forwarded, so this also
+accepts a cadence override, e.g. ``... velociraptor:1.5`` style args of
+the shared script.
 
 Usage::
 
     python environments/velociraptor/scripts/actuator_saturation_report.py
 """
 
-import re
+import sys
 from pathlib import Path
 
-import mujoco
-import numpy as np
+# Add repo root to path
+_repo_root = str(Path(__file__).resolve().parents[3])
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
 
-XML_PATH = Path(__file__).resolve().parents[1] / "assets" / "raptor.xml"
-CLIP_EPS = 0.999
-GAIT_HZ = 2.5
-GAIT_AMPLITUDE = 0.8
-
-
-def _gait_ctrl(model, t):
-    lo, hi = model.actuator_ctrlrange[:, 0], model.actuator_ctrlrange[:, 1]
-    mid, amp = (lo + hi) / 2, (hi - lo) / 2
-    phase = 2 * np.pi * GAIT_HZ * t * model.opt.timestep
-    ctrl = mid.copy()
-    for i in range(model.nu):
-        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i)
-        if name.startswith("r_"):
-            s = np.sin(phase)
-        elif name.startswith("l_"):
-            s = np.sin(phase + np.pi)
-        else:
-            s = 0.4 * np.sin(phase)
-        ctrl[i] = mid[i] + GAIT_AMPLITUDE * amp[i] * s
-    return ctrl
-
-
-def _run(xml_str, gait, steps):
-    model = mujoco.MjModel.from_xml_string(xml_str)
-    data = mujoco.MjData(model)
-    if model.nkey:
-        mujoco.mj_resetDataKeyframe(model, data, 0)
-    fr = model.actuator_forcerange[:, 1]
-    clip_hits = np.zeros(model.nu)
-    zs = []
-    for t in range(steps):
-        if gait:
-            data.ctrl[:] = _gait_ctrl(model, t)
-        mujoco.mj_step(model, data)
-        clip_hits += np.abs(data.actuator_force) >= CLIP_EPS * np.maximum(fr, 1e-9)
-        zs.append(data.qpos[2])
-    return model, clip_hits / steps, np.array(zs)
-
-
-def main(steps: int = 2500):
-    xml = XML_PATH.read_text()
-    xml_unbounded = re.sub(r' forcerange="[^"]*"', "", xml)
-
-    model, clip_settle, _ = _run(xml, gait=False, steps=steps)
-    _, clip_gait, z_bounded = _run(xml, gait=True, steps=steps)
-    _, _, z_unbounded = _run(xml_unbounded, gait=True, steps=steps)
-
-    names = [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i) for i in range(model.nu)]
-    is_position = model.actuator_biasprm[:, 1] < 0
-
-    print(
-        f"Raptor actuator saturation over {steps} steps ({GAIT_HZ} Hz, {GAIT_AMPLITUDE:.0%} amplitude gait excitation)"
-    )
-    print(f"{'actuator':26s} {'kp':>6s} {'forcerange':>10s} {'settle':>8s} {'gait':>8s}")
-    order = np.argsort(-clip_gait)
-    for i in order:
-        if not is_position[i]:
-            continue  # motors (claw) pin their gear force by construction
-        kp = model.actuator_gainprm[i, 0]
-        fr = model.actuator_forcerange[i, 1]
-        print(f"{names[i]:26s} {kp:6.0f} {fr:10.0f} {clip_settle[i]:8.1%} {clip_gait[i]:8.1%}")
-
-    rms = float(np.sqrt(np.mean((z_bounded - z_unbounded) ** 2)))
-    print(f"\npelvis-z RMS divergence, bounded vs unbounded plant under identical commands: {rms:.4f} m")
-
+from environments.shared.scripts.actuator_saturation_report import main
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:] or ["velociraptor"])


### PR DESCRIPTION
## Summary

Cross-species follow-up to #435, prompted by run `20260711_235303` validating the velociraptor fix end-to-end (stages 1–3 cleared; stage-2 record **2705.93 ± 7.84 @ 2.75 m/s** vs the 348 ± 511 collapse before). Measuring the other two plants with the same scripted-gait excitation showed they carry the identical latent defect — static-only forcerange sizing that clips gait torque:

| Species (before) | Worst gait-cycle clipping | After 1.5×kp on clipped groups |
|---|---|---|
| Trex @ 2.5 Hz | hips 44–50%, ankles ~31%, knees 10–14% | ≤0.5% |
| Brachiosaurus @ 1.5 Hz walk | hips 20–33% (44–51% @ 2.5 Hz) | ~0% |

### Plants (breaking — policies trained on the old caps won't transfer)

- **Trex**: hip pitch ±160→±300, knee ±200→±375, ankle ±120→±225 (1.5×kp).
- **Brachiosaurus**: all four hip pitches to 1.5×kp (fr/fl ±400→±900, rr/rl ±350→±825). Knees/ankles/toes measured 0% clipping and keep their spike caps.
- Root-z divergence vs an unbounded plant under identical commands drops to ≤2 mm on both.

### Tests & tooling

- New `test_actuator_bounds.py` for trex and brachiosaurus pinning integrator, symmetric forcerange, per-group kp ratios, static no-clip, and dynamic gait-clipping ceilings.
- Shared excitation/measurement helpers (`environments/shared/tests/actuator_bounds_helpers.py`) — biped alternation + quadruped diagonal-pair trot — now used by all three species' tests, so CI and the report measure the same thing.
- Species-generic saturation report at `environments/shared/scripts/actuator_saturation_report.py` (`... trex brachiosaurus:1.5`); the velociraptor script delegates to it.

### Config

- `ent_coef_end = 0.001` **enabled for velociraptor stage 1**: run `20260711_235303` stage 1 destabilized late (peak 1524 @ 2.45M → 385 @ 3.95M, bimodal falls) under constant `ent_coef` — the same pathology entropy decay fixed in stage 2. The robust-best checkpoint contained the damage, but the fix is one line.
- Staged (commented) `ent_coef_end` suggestions in trex and brachiosaurus stage 1/2 TOMLs, scaled to their entropy baselines, following the stage-then-enable pattern used for velociraptor.

### Docs

- `STAGE2_RECOMMENDATIONS.md` §5: run `20260711_235303` outcome + five cross-species lessons (validate plant changes dynamically; decay entropy on long stages; keep the collapse-stop + robust-checkpoint safety nets; per-species gate sanity).
- KNOWN_ISSUES plant paragraph, CHANGELOG, and docs index updated.

## Verification

- Saturation measured before/after per species with the shared report (velociraptor re-measured as control: 0%).
- 342 tests pass locally: all three species suites + shared config/constants/species-integration tests.
- `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYtk5AJ81QbebMzBMGikWp

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYtk5AJ81QbebMzBMGikWp)_