### PR TITLE
Fix lost [ppo.policy_kwargs] headers (trex crash), enable trex stage-2 recipe, add config-structure tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   code terminal mock-up intentionally stays dark in both themes.
 
 ### Fixed
+- **Trex/brachio stage TOMLs: restored `[ppo.policy_kwargs]` headers lost
+  in the entropy-decay staging** (PR #436): the dropped headers put
+  `net_arch` into the top-level `[ppo]` table, crashing `PPO.__init__()`
+  at stage start (trex run `20260712_185931`). New config regression
+  tests now pin the structure for every species/stage: `net_arch` only
+  under `policy_kwargs`, `[ppo]` keys validated against the PPO
+  constructor signature plus harness schedule keys, and `[env]` keys
+  validated against each species' env constructor signature.
 - **JAX pipeline correctness** (July 2026 review, PR #426): curriculum gate
   now compares episode-level return against the TOML threshold (it compared
   per-step reward and never advanced past stage 1); observation-normalization

--- a/configs/brachiosaurus/stage1_balance.toml
+++ b/configs/brachiosaurus/stage1_balance.toml
@@ -43,6 +43,8 @@ ent_coef = 0.01
                                         # 5x decay mirrors velociraptor's 0.005 -> 0.001. Velociraptor stages
                                         # 1 & 2 both destabilized late under constant ent_coef; decay fixed
                                         # stage 2. See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
+
+[ppo.policy_kwargs]
 net_arch = [512, 256]
 
 [sac]

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -38,11 +38,12 @@ gamma = 0.98                            # Setting 4 sweep: 0.9797. Previous 0.99
 gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.005
-# ent_coef_end = 0.001                  # Uncomment to decay entropy over the stage (EntCoefDecayCallback).
-                                        # Velociraptor stages 1 & 2 both destabilized late under constant
-                                        # ent_coef (bimodal falls, action std growth); decay fixed stage 2
-                                        # and is enabled for its stage 1. Recommended for the next trex run
-                                        # on the 1.5x-kp plant. See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
+ent_coef_end = 0.001                    # Decay entropy over the stage (EntCoefDecayCallback). Velociraptor
+                                        # stages 1 & 2 both destabilized late under constant ent_coef
+                                        # (bimodal falls, action std growth); decay fixed its stage 2 and is
+                                        # enabled for its stage 1. See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
+
+[ppo.policy_kwargs]
 net_arch = [512, 256]
 
 [sac]

--- a/configs/trex/stage2_locomotion.toml
+++ b/configs/trex/stage2_locomotion.toml
@@ -7,7 +7,13 @@ forward_vel_weight = 2.0               # Match raptor: was 0.8, far too low. Pri
                                        # At 2.0, forward velocity dominates the reward landscape and
                                        # pushes the agent past the slow-walking local optimum.
 alive_bonus = 0.5                      # Keep: already reduced from Stage 1
-fall_penalty = -50.0                   # Keep: reasonable risk/reward balance
+fall_penalty = -150.0                  # Raised from -50: hedge against late-episode falls, which stay cheap
+                                       # in the discounted objective at gamma=0.995 (corrected break-even math
+                                       # in docs/investigations/STAGE2_RECOMMENDATIONS.md section 2.1).
+forward_vel_max = 2.5                  # NEW: was unset (env default 8.0 -> effectively uncapped speed
+                                       # incentive). Saturate just past the 2.0 m/s gate instead of paying
+                                       # for robustness-destroying top speed — the trap that collapsed
+                                       # velociraptor stage 2 (STAGE2_RECOMMENDATIONS.md R4).
 energy_penalty_weight = 0.002          # Increase from 0.001: CoT was near 0, provide some efficiency signal
 tail_stability_weight = 0.05           # Reduce from 0.08 to match raptor: tail oscillation is less
                                        # critical than forward progress at this stage
@@ -35,11 +41,12 @@ gamma = 0.995                           # Increase from 0.99: longer horizon val
 gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.005
-# ent_coef_end = 0.001                  # Uncomment to decay entropy over the stage (EntCoefDecayCallback).
-                                        # This decay (with fall_penalty -150 and forward_vel_max 2.5) is what
-                                        # carried velociraptor stage 2 to 2706 +/- 8 @ 2.75 m/s on the 1.5x-kp
-                                        # plant. Recommended for the next trex stage-2 run.
+ent_coef_end = 0.001                    # Decay entropy over the stage (EntCoefDecayCallback). This decay
+                                        # (with fall_penalty -150 and forward_vel_max 2.5) is what carried
+                                        # velociraptor stage 2 to 2706 +/- 8 @ 2.75 m/s on the 1.5x-kp plant.
                                         # See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
+
+[ppo.policy_kwargs]
 net_arch = [512, 256]                  # Larger first layer for T-Rex's higher-dimensional obs space (83 vs raptor's 67)
 
 [sac]

--- a/environments/shared/tests/test_config.py
+++ b/environments/shared/tests/test_config.py
@@ -69,6 +69,69 @@ class TestLoadStageConfig:
             if key.endswith("_range"):
                 assert isinstance(value, tuple), f"{key} should be a tuple, got {type(value)}"
 
+    @pytest.mark.parametrize("species", SPECIES)
+    @pytest.mark.parametrize("stage", [1, 2, 3])
+    def test_net_arch_only_under_policy_kwargs(self, species, stage):
+        """net_arch must live under [<alg>.policy_kwargs], never in [<alg>].
+
+        A lost [ppo.policy_kwargs] table header silently drops net_arch
+        into [ppo], which is forwarded verbatim to PPO.__init__ and
+        crashes at model construction — hours into a Colab run instead of
+        in CI (run 20260712_185931).
+        """
+        config = load_stage_config(species, stage)
+        for alg_key in ("ppo_kwargs", "sac_kwargs", "jax_kwargs"):
+            kwargs = config[alg_key]
+            assert "net_arch" not in kwargs, (
+                f"{species} stage {stage}: net_arch is a top-level [{alg_key[:-7]}] key — "
+                f"a [{alg_key[:-7]}.policy_kwargs] header is missing in the TOML."
+            )
+        assert "net_arch" in config["ppo_kwargs"].get("policy_kwargs", {}), (
+            f"{species} stage {stage}: [ppo.policy_kwargs] must define net_arch."
+        )
+
+    @pytest.mark.parametrize("species", SPECIES)
+    @pytest.mark.parametrize("stage", [1, 2, 3])
+    def test_ppo_kwargs_accepted_by_sb3(self, species, stage):
+        """Every top-level [ppo] key must be a PPO constructor kwarg or a harness schedule key."""
+        sb3 = pytest.importorskip("stable_baselines3")
+        import inspect
+
+        # Popped by _prepare_alg_kwargs in train_base.py before PPO() is called.
+        harness_keys = {
+            "ent_coef_end",
+            "ent_coef_decay_timesteps",
+            "learning_rate_end",
+            "lr_schedule",
+            "clip_range_end",
+        }
+        accepted = set(inspect.signature(sb3.PPO.__init__).parameters) | harness_keys
+        config = load_stage_config(species, stage)
+        unknown = set(config["ppo_kwargs"]) - accepted
+        assert not unknown, (
+            f"{species} stage {stage}: [ppo] keys {sorted(unknown)} are neither PPO "
+            "constructor kwargs nor harness schedule keys — they would crash "
+            "PPO.__init__ at run time."
+        )
+
+    @pytest.mark.parametrize("species", SPECIES)
+    @pytest.mark.parametrize("stage", [1, 2, 3])
+    def test_env_kwargs_accepted_by_env_constructor(self, species, stage):
+        """[env] is passed verbatim to the species env constructor; unknown keys crash at reset."""
+        import inspect
+
+        from environments.shared.species_registry import get_species_config
+
+        env_class = get_species_config(species).env_class
+        accepted = set(inspect.signature(env_class.__init__).parameters)
+        config = load_stage_config(species, stage)
+        unknown = set(config["env_kwargs"]) - accepted
+        assert not unknown, (
+            f"{species} stage {stage}: [env] keys {sorted(unknown)} are not "
+            f"{env_class.__name__}.__init__ parameters — they would crash env "
+            "construction at run time."
+        )
+
     def test_missing_species_raises(self):
         with pytest.raises(FileNotFoundError):
             load_stage_config("stegosaurus", 1)


### PR DESCRIPTION
## Summary

Fixes the crash that killed trex run `20260712_185931` at stage-1 start:

```
TypeError: PPO.__init__() got an unexpected keyword argument 'net_arch'
```

**Root cause (introduced by #436, my error):** the commented `ent_coef_end` staging blocks accidentally deleted the `[ppo.policy_kwargs]` table header from three TOMLs (trex stage 1, trex stage 2, brachiosaurus stage 1). That silently moved `net_arch` into the top-level `[ppo]` table, which is forwarded verbatim to `PPO.__init__()`. Valid TOML, so nothing failed until model construction at run time. Brachiosaurus stage 2 and all velociraptor TOMLs were unaffected.

### Fixes

- Restored the `[ppo.policy_kwargs]` headers in all three damaged TOMLs.

### Trex stage-2 recipe (the velociraptor-validated formula, as discussed)

- `ent_coef_end = 0.001` enabled for trex stages 1 and 2 (no longer commented).
- Stage 2: `fall_penalty` −50 → **−150**, and `forward_vel_max = 2.5` added — it was previously unset, inheriting the env default of 8.0, i.e. an effectively uncapped speed incentive (the exact trap that collapsed velociraptor stage 2).

### Regression tests (so this class of bug fails in CI, not 4 cells into Colab)

New parametrized tests in `test_config.py` covering every species × stage:

1. `net_arch` must live under `policy_kwargs` and never top-level in `[ppo]`/`[sac]`/`[jax]` — **mutation-verified**: re-introducing the lost header makes exactly this test fail.
2. Every top-level `[ppo]` key must be a `PPO.__init__` parameter or a harness schedule key (`ent_coef_end`, `learning_rate_end`, `lr_schedule`, `clip_range_end`, `ent_coef_decay_timesteps`) — signature-derived; skips when SB3 isn't installed, runs in CI.
3. Every `[env]` key must be a parameter of the species' env constructor (they're passed verbatim).

## Verification

- All config/species/plant test suites pass locally (`test_config.py` 111 incl. the new tests, plus the three species suites and species-integration tests); ruff clean.
- Guard mutation-tested: dropping the header from trex stage 1 fails `test_net_arch_only_under_policy_kwargs[1-trex]`; restoring passes.

## After merge

The crashed trex run left no trained artifacts — just relaunch. Note the notebook **skips cloning if `/content/mesozoic-labs` already exists**, so use a fresh runtime (or delete the directory) to pick up this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYtk5AJ81QbebMzBMGikWp

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYtk5AJ81QbebMzBMGikWp)_