### PR TITLE
Fix reliability checks and optional backend CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -151,3 +151,73 @@ jobs:
         run: pytest environments/trex/tests/ -v --tb=short --cov=environments/trex --cov-report=term-missing
         env:
           MUJOCO_GL: osmesa
+
+  test-sb3:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install OSMesa
+        run: sudo apt-get update && sudo apt-get install -y libosmesa6-dev
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install SB3 dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -e ".[train,test]"
+
+      - name: Verify optional backend imports
+        run: python -c "import stable_baselines3, torch; print(stable_baselines3.__version__, torch.__version__)"
+
+      - name: Run SB3 integration tests
+        run: |
+          pytest \
+            environments/shared/tests/test_config.py \
+            environments/shared/tests/test_curriculum.py \
+            environments/shared/tests/test_diagnostics.py \
+            environments/shared/tests/test_evaluation.py \
+            environments/shared/tests/test_train_base.py \
+            environments/shared/tests/test_wandb_integration.py \
+            -v --tb=short
+        env:
+          MUJOCO_GL: osmesa
+
+  test-jax-cpu:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install OSMesa
+        run: sudo apt-get update && sudo apt-get install -y libosmesa6-dev
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install CPU JAX dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -e ".[jax-cpu,test]"
+
+      - name: Verify optional backend imports
+        run: python -c "import flax, jax, optax; from mujoco import mjx; print(jax.__version__, jax.default_backend())"
+        env:
+          JAX_PLATFORMS: cpu
+
+      - name: Run JAX and MJX tests
+        run: |
+          pytest \
+            environments/shared/tests/test_jax_*.py \
+            environments/shared/tests/test_mjx_env.py \
+            environments/shared/tests/test_reward_functions.py \
+            -v --tb=short
+        env:
+          JAX_PLATFORMS: cpu
+          MUJOCO_GL: osmesa

--- a/environments/brachiosaurus/assets/brachiosaurus.xml
+++ b/environments/brachiosaurus/assets/brachiosaurus.xml
@@ -15,7 +15,7 @@
          below), elephant-style columnar load-bearing: gravity is carried by
          the springs, actuators modulate around stance.  With the old
          stiffness=10 (springref 0) the legs collapsed to torso z~0.70 under
-         load -- below the healthy_z floor (1.0) -- even when commanded
+         load — below the healthy_z floor (1.0) — even when commanded
          straight. -->
     <default class="leg_joint">
       <joint damping="35.0" stiffness="120.0" armature="0.1"/>
@@ -307,7 +307,7 @@
 
     <!-- Front right leg (5 actuators: hip pitch/roll, knee, ankle, toe) -->
     <!-- Hip-pitch forcerange sized at 1.5x kp (was ~0.65x): the tighter caps clipped
-         20-33% of a slow 1.5 Hz walk cycle on all four hips -- same defect class that
+         20-33% of a slow 1.5 Hz walk cycle on all four hips — same defect class that
          broke velociraptor stage-2. Knees/ankles/toes measured 0% and keep their
          original sizing. See docs/investigations/STAGE2_RECOMMENDATIONS.md. -->
     <position name="fr_hip_pitch_act" joint="fr_hip_pitch" kp="600" forcerange="-900 900" ctrlrange="-0.6981 0.8727"/>

--- a/environments/shared/config.py
+++ b/environments/shared/config.py
@@ -71,7 +71,7 @@ def _detect_gpu_info() -> dict[str, Any]:
             return {
                 "gpu_model": short_name,
                 "gpu_full_name": full_name,
-                "gpu_memory_gb": round(props.total_mem / 1e9, 1),
+                "gpu_memory_gb": round(props.total_memory / 1e9, 1),
                 "cuda_version": torch.version.cuda or "",
             }
     except Exception:

--- a/environments/shared/scripts/sweep/trial.py
+++ b/environments/shared/scripts/sweep/trial.py
@@ -63,6 +63,30 @@ def _parse_hpt_extra_args(extra_args: list[str]) -> list[str]:
     return overrides
 
 
+def _log_hardware_info() -> None:
+    """Log best-effort hardware details without interrupting a training trial."""
+    try:
+        import multiprocessing
+
+        logger.info("  CPU cores: %d", multiprocessing.cpu_count())
+    except Exception:
+        pass
+
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            logger.info("  GPU: %s (CUDA %s)", torch.cuda.get_device_name(0), torch.version.cuda)
+            memory_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
+            logger.info("  GPU memory: %.1f GB", memory_gb)
+        else:
+            logger.info("  GPU: none (CPU-only training)")
+    except ImportError:
+        logger.info("  GPU: torch not installed (CPU-only training)")
+    except Exception as exc:
+        logger.warning("  GPU diagnostics unavailable; continuing training: %s", exc)
+
+
 def run_trial(args: argparse.Namespace, extra_args: list[str]) -> None:
     """Run a single training trial.
 
@@ -100,22 +124,7 @@ def run_trial(args: argparse.Namespace, extra_args: list[str]) -> None:
         trial_id,
     )
     logger.info("  timesteps=%s  n_envs=%d  seed=%d", f"{args.timesteps:,}", args.n_envs, args.seed)
-    try:
-        import multiprocessing
-
-        logger.info("  CPU cores: %d", multiprocessing.cpu_count())
-    except Exception:
-        pass
-    try:
-        import torch
-
-        if torch.cuda.is_available():
-            logger.info("  GPU: %s (CUDA %s)", torch.cuda.get_device_name(0), torch.version.cuda)
-            logger.info("  GPU memory: %.1f GB", torch.cuda.get_device_properties(0).total_mem / 1e9)
-        else:
-            logger.info("  GPU: none (CPU-only training)")
-    except ImportError:
-        logger.info("  GPU: torch not installed (CPU-only training)")
+    _log_hardware_info()
     logger.info("=" * 60)
 
     overrides = _parse_hpt_extra_args(extra_args)

--- a/environments/shared/tests/test_config.py
+++ b/environments/shared/tests/test_config.py
@@ -2,7 +2,8 @@
 
 import csv
 import json
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -384,6 +385,27 @@ class TestSaveStageConfig:
 class TestDetectGpuInfo:
     """Tests for GPU detection with torch and nvidia-smi fallback."""
 
+    def test_torch_reports_24gb_using_total_memory(self):
+        cuda = MagicMock()
+        cuda.is_available.return_value = True
+        cuda.get_device_name.return_value = "NVIDIA RTX 4090"
+        cuda.get_device_properties.return_value = SimpleNamespace(total_memory=24_000_000_000)
+        fake_torch = SimpleNamespace(cuda=cuda, version=SimpleNamespace(cuda="12.1"))
+
+        with (
+            patch.dict("sys.modules", {"torch": fake_torch}),
+            patch("environments.shared.config._detect_gpu_info_nvidia_smi") as mock_fallback,
+        ):
+            result = _detect_gpu_info()
+
+        assert result == {
+            "gpu_model": "RTX",
+            "gpu_full_name": "NVIDIA RTX 4090",
+            "gpu_memory_gb": 24.0,
+            "cuda_version": "12.1",
+        }
+        mock_fallback.assert_not_called()
+
     def test_falls_back_to_nvidia_smi_when_torch_unavailable(self):
         fake_smi = {
             "gpu_model": "T4",
@@ -398,6 +420,27 @@ class TestDetectGpuInfo:
             result = _detect_gpu_info()
         assert result["gpu_model"] == "T4"
         assert result["gpu_memory_gb"] == 15.0
+
+    def test_device_property_lookup_failure_falls_back_to_nvidia_smi(self):
+        cuda = MagicMock()
+        cuda.is_available.return_value = True
+        cuda.get_device_name.return_value = "NVIDIA RTX 4090"
+        cuda.get_device_properties.side_effect = RuntimeError("CUDA device query failed")
+        fake_torch = SimpleNamespace(cuda=cuda, version=SimpleNamespace(cuda="12.1"))
+        fake_smi = {
+            "gpu_model": "RTX",
+            "gpu_full_name": "NVIDIA RTX 4090",
+            "gpu_memory_gb": 24.0,
+            "driver_version": "555.42",
+        }
+
+        with (
+            patch.dict("sys.modules", {"torch": fake_torch}),
+            patch("environments.shared.config._detect_gpu_info_nvidia_smi", return_value=fake_smi),
+        ):
+            result = _detect_gpu_info()
+
+        assert result == fake_smi
 
     def test_nvidia_smi_parses_output(self):
         import subprocess

--- a/environments/shared/tests/test_diagnostics.py
+++ b/environments/shared/tests/test_diagnostics.py
@@ -480,12 +480,11 @@ class TestSaveThrottle:
         from environments.shared.diagnostics import DiagnosticsCallback
 
         cb = DiagnosticsCallback(log_dir=str(tmp_path), save_interval_seconds=3600.0)
-        cb.logger = MagicMock()
+        model = _make_mock_model()
+        model.rollout_buffer = MagicMock(observations=None)
+        cb.init_callback(model)
         cb.num_timesteps = 100
         cb.locals = {"infos": []}
-        cb.model = MagicMock()
-        cb.model.rollout_buffer.observations = None
-        cb.training_env = None
 
         cb._step_infos["forward_vel"] = [1.0]
         cb._on_rollout_end()  # first save always happens (last_save_time=0)

--- a/environments/shared/tests/test_mjcf_assets.py
+++ b/environments/shared/tests/test_mjcf_assets.py
@@ -1,0 +1,65 @@
+"""Regression tests for the species MJCF assets."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from xml.etree import ElementTree
+
+import mujoco
+import pytest
+
+
+@dataclass(frozen=True)
+class ModelExpectations:
+    """Compiled dimensions and animal mass for a species model."""
+
+    nq: int
+    nv: int
+    nu: int
+    dynamic_mass: float
+
+
+ENVIRONMENTS_DIR = Path(__file__).resolve().parents[2]
+
+EXPECTED_MODELS = {
+    "brachiosaurus/assets/brachiosaurus.xml": ModelExpectations(38, 37, 30, 175.3),
+    "trex/assets/trex.xml": ModelExpectations(40, 37, 21, 85.4),
+    "velociraptor/assets/raptor.xml": ModelExpectations(31, 30, 22, 13.5),
+}
+
+
+def _discover_mjcf_assets() -> tuple[Path, ...]:
+    """Return every species MJCF asset in a deterministic order."""
+    return tuple(sorted(ENVIRONMENTS_DIR.glob("*/assets/*.xml")))
+
+
+MJCF_ASSETS = _discover_mjcf_assets()
+
+
+def _asset_id(asset_path: Path) -> str:
+    return asset_path.relative_to(ENVIRONMENTS_DIR).as_posix()
+
+
+def test_mjcf_inventory_matches_expected_models():
+    """Require new or renamed species assets to add explicit regression pins."""
+    discovered = {_asset_id(asset_path) for asset_path in MJCF_ASSETS}
+    assert discovered == set(EXPECTED_MODELS)
+
+
+@pytest.mark.parametrize("asset_path", MJCF_ASSETS, ids=_asset_id)
+def test_mjcf_is_standard_xml(asset_path: Path):
+    """All MJCF files must also be well-formed, standards-compliant XML."""
+    ElementTree.parse(asset_path)
+
+
+@pytest.mark.parametrize("asset_path", MJCF_ASSETS, ids=_asset_id)
+def test_mjcf_compiled_model_is_unchanged(asset_path: Path):
+    """Pin the compiled interface and dynamic animal mass for every species."""
+    model = mujoco.MjModel.from_xml_path(str(asset_path))
+    expected = EXPECTED_MODELS[_asset_id(asset_path)]
+
+    assert (model.nq, model.nv, model.nu) == (expected.nq, expected.nv, expected.nu)
+
+    # The target is a mocap body, so exclude it (and the massless world body)
+    # from the mass of the dynamic animal.
+    dynamic_mass = float(model.body_mass[model.body_mocapid == -1].sum())
+    assert dynamic_mass == pytest.approx(expected.dynamic_mass)

--- a/environments/shared/tests/test_sweep_trial.py
+++ b/environments/shared/tests/test_sweep_trial.py
@@ -1,9 +1,75 @@
 """Tests for sweep trial.py — HPT arg parsing and override conversion."""
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 from environments.shared.scripts.sweep import (
     _hpt_arg_to_override,
     _parse_hpt_extra_args,
 )
+from environments.shared.scripts.sweep.trial import _log_hardware_info
+
+
+class TestLogHardwareInfo:
+    """Hardware logging must remain best-effort so diagnostics cannot abort a trial."""
+
+    def test_cuda_available_logs_24gb_using_total_memory(self):
+        cuda = MagicMock()
+        cuda.is_available.return_value = True
+        cuda.get_device_name.return_value = "NVIDIA RTX 4090"
+        cuda.get_device_properties.return_value = SimpleNamespace(total_memory=24_000_000_000)
+        fake_torch = SimpleNamespace(cuda=cuda, version=SimpleNamespace(cuda="12.1"))
+
+        with (
+            patch.dict("sys.modules", {"torch": fake_torch}),
+            patch("environments.shared.scripts.sweep.trial.logger.info") as mock_info,
+        ):
+            _log_hardware_info()
+
+        mock_info.assert_any_call("  GPU: %s (CUDA %s)", "NVIDIA RTX 4090", "12.1")
+        mock_info.assert_any_call("  GPU memory: %.1f GB", 24.0)
+
+    def test_cuda_unavailable_logs_cpu_only(self):
+        cuda = MagicMock()
+        cuda.is_available.return_value = False
+        fake_torch = SimpleNamespace(cuda=cuda, version=SimpleNamespace(cuda=None))
+
+        with (
+            patch.dict("sys.modules", {"torch": fake_torch}),
+            patch("environments.shared.scripts.sweep.trial.logger.info") as mock_info,
+        ):
+            _log_hardware_info()
+
+        mock_info.assert_any_call("  GPU: none (CPU-only training)")
+        cuda.get_device_properties.assert_not_called()
+
+    def test_torch_unavailable_logs_cpu_only(self):
+        with (
+            patch.dict("sys.modules", {"torch": None}),
+            patch("environments.shared.scripts.sweep.trial.logger.info") as mock_info,
+        ):
+            _log_hardware_info()
+
+        mock_info.assert_any_call("  GPU: torch not installed (CPU-only training)")
+
+    def test_device_property_lookup_failure_does_not_raise(self):
+        cuda = MagicMock()
+        cuda.is_available.return_value = True
+        cuda.get_device_name.return_value = "NVIDIA RTX 4090"
+        cuda.get_device_properties.side_effect = RuntimeError("CUDA device query failed")
+        fake_torch = SimpleNamespace(cuda=cuda, version=SimpleNamespace(cuda="12.1"))
+
+        with (
+            patch.dict("sys.modules", {"torch": fake_torch}),
+            patch("environments.shared.scripts.sweep.trial.logger.warning") as mock_warning,
+        ):
+            _log_hardware_info()
+
+        mock_warning.assert_called_once_with(
+            "  GPU diagnostics unavailable; continuing training: %s",
+            cuda.get_device_properties.side_effect,
+        )
+
 
 # ── _hpt_arg_to_override ────────────────────────────────────────────────────
 

--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -302,7 +302,7 @@
     <!-- Right leg -->
     <!-- Hip pitch, knee, and ankle forcerange sized at 1.5x kp (was 0.8x): the 0.8x
          caps clipped 44-50% (hips), 10-14% (knees), and ~31% (ankles) of a moderate
-         gait cycle -- the same plant defect that broke velociraptor stage-2 before
+         gait cycle — the same plant defect that broke velociraptor stage-2 before
          commit fd3ffbc fixed it. See docs/investigations/STAGE2_RECOMMENDATIONS.md. -->
     <position name="r_hip_pitch_act" joint="r_hip_pitch" kp="200" forcerange="-300 300" ctrlrange="-0.8727 1.3963"/>
     <position name="r_hip_roll_act" joint="r_hip_roll" kp="150" forcerange="-120 120" ctrlrange="-0.4363 0.4363"/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,13 @@ jax = [
     "flax>=0.8.0",
     "optax>=0.1.7",
 ]
+jax-cpu = [
+    # CPU-only JAX stack for development and CI hosts without NVIDIA drivers.
+    "mujoco-mjx>=3.0.0",
+    "jax>=0.4.20",
+    "flax>=0.8.0",
+    "optax>=0.1.7",
+]
 mjlab = [
     # mjlab (GPU-accelerated MuJoCo-Warp + Isaac-Lab-style manager API).
     # Requires an NVIDIA GPU for training; macOS is evaluation-only.


### PR DESCRIPTION
## Summary

- replace Torch's invalid `total_mem` access with `total_memory` and make sweep hardware diagnostics best-effort
- initialize the diagnostics callback test through Stable-Baselines3's public callback API
- make the T-Rex and Brachiosaurus MJCF assets standards-valid XML
- add MJCF inventory, XML parsing, MuJoCo compilation, model-dimension, and dynamic-mass regression tests
- add a CPU-only `jax-cpu` dependency extra
- add dedicated Python 3.12 SB3 and CPU JAX/MJX CI jobs with explicit import gates

## Why

Four reliability gaps were allowing failures to escape the normal test matrix:

1. Current Torch exposes GPU memory as `total_memory`, so `total_mem` could abort sweep startup on CUDA hosts.
2. The default CI extra omitted SB3, Torch, JAX, and MJX, causing optional-backend tests to skip.
3. XML comments in two MJCF assets contained illegal `--` sequences. MuJoCo accepted them, but standards-compliant XML parsers did not.
4. The SB3 test fixture assigned read-only callback properties instead of using `init_callback()`.

## Impact

GPU diagnostics can no longer terminate training when optional hardware probes fail, and both supported training backends now receive routine CI coverage. The XML edits are comment-only; compiled model dimensions and dynamic animal masses remain pinned and unchanged.

## Validation

- repository-wide non-JAX suite: **1,139 passed**
- SB3 CI selection: **336 passed**
- CPU JAX/MJX CI selection: **166 passed**
- MJCF regression suite: **7 passed**
- Ruff lint: passed
- Ruff format check: passed
- CI-equivalent mypy check: passed
- `xmllint` and `git diff --check`: passed
