### PR TITLE
Make training diagnostics evaluation- and stage-aware

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -198,6 +198,7 @@ jobs:
             environments/shared/tests/test_config.py \
             environments/shared/tests/test_curriculum.py \
             environments/shared/tests/test_diagnostics.py \
+            environments/shared/tests/test_eval_diagnostics.py \
             environments/shared/tests/test_evaluation.py \
             environments/shared/tests/test_train_base.py \
             environments/shared/tests/test_wandb_integration.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] — RL/GCP Review Fixes & Model Physics (v0.3.2)
 
 ### Changed
+- **Plateau diagnostics now follow deterministic stage-gate evaluations**:
+  rollout return warnings (which fired at different rates for PPO and SAC and
+  repeated every rollout) are replaced by a warn-once/re-arm state machine.
+  It monitors the currently blocking configured gate — balance duration,
+  forward velocity, task success, then reward — and explains that training
+  continues independently. SB3 evaluation now reports task success as `N/A`
+  when the current stage has no success-rate gate, while preserving genuine
+  Stage 3 `0%` results and success arrays.
 - **Trex and brachiosaurus gait actuator headroom raised to 1.5×kp**
   (breaking — plant change): the same static-only forcerange sizing that
   broke velociraptor stage-2 measured 44–50 % hip / ~31 % ankle / 10–14 %

--- a/environments/shared/curriculum.py
+++ b/environments/shared/curriculum.py
@@ -133,6 +133,12 @@ class CurriculumManager:
         return self._current_stage
 
     @property
+    def current_threshold(self) -> StageThreshold:
+        """Effective threshold for the current stage, including overrides."""
+
+        return self._thresholds[self._current_stage]
+
+    @property
     def is_final_stage(self) -> bool:
         """Whether the manager is on the last stage."""
         return self._current_stage >= self.total_stages
@@ -341,9 +347,10 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
 
     When an ``eval_callback`` is provided, this callback piggybacks on
     its evaluation results (reward / episode length) instead of running
-    a redundant full eval pass.  A small supplementary eval still runs
-    to collect forward velocity and success rate from the info dicts,
-    which ``EvalCallback`` does not capture.
+    a redundant full eval pass. ``StageAwareEvalCallback`` also supplies
+    per-episode forward velocity and task success from that same sample.
+    A small supplementary eval remains for the richer locomotion report and
+    as a compatibility fallback for a plain SB3 ``EvalCallback``.
 
     Args:
         curriculum_manager: The manager tracking stage progress.
@@ -354,13 +361,11 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
         eval_callback: Optional ``EvalCallback`` to read results from.
             When set, the callback reads reward/length (and per-episode
             successes, when the env reports ``info["is_success"]``) from
-            the evaluations.npz and only runs a short supplementary eval
-            for forward velocity and locomotion metrics.
+            evaluations.npz. A ``StageAwareEvalCallback`` additionally
+            provides forward velocity in memory.
         supplementary_episodes: Number of episodes for the supplementary
             eval when *eval_callback* is provided (default 10).  Drives the
-            forward-velocity gate sample (and the success gate only when
-            the npz has no ``successes`` array), so keep it >= 10 when
-            ``min_avg_forward_vel`` gating is enabled.
+            locomotion report and the compatibility fallback samples.
         verbose: Verbosity level.
     """
 
@@ -388,6 +393,31 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
         self.ready_to_advance = False
         self._last_eval_step = 0
         self._last_seen_n_evals = 0
+
+    def _success_rates_for_stage(
+        self,
+        preferred: list[float] | None,
+        fallback: list[float] | None,
+    ) -> list[float] | None:
+        """Select success samples only when the current stage gates on them."""
+
+        if self.curriculum_manager.current_threshold.min_success_rate <= 0.0:
+            return None
+        return preferred if preferred else fallback
+
+    def _forward_velocities_for_eval(
+        self,
+        n_evals: int,
+        fallback: list[float] | None,
+    ) -> list[float] | None:
+        """Use the main evaluation sample for gating, with legacy fallback."""
+
+        histories = getattr(self.eval_callback, "evaluations_forward_velocities", None)
+        if histories is not None and n_evals > 0 and len(histories) >= n_evals:
+            latest = [float(value) for value in histories[n_evals - 1] if np.isfinite(value)]
+            if latest:
+                return latest
+        return fallback
 
     def _on_step(self) -> bool:
         if (self.num_timesteps - self._last_eval_step) < self.eval_freq:
@@ -538,7 +568,7 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
 
     def _on_step_with_eval_callback(self) -> bool:
         """Advancement check using EvalCallback results + supplementary eval."""
-        rewards, lengths, npz_successes, _n_evals = self._read_latest_eval()
+        rewards, lengths, npz_successes, n_evals = self._read_latest_eval()
         if rewards is None:
             return True  # EvalCallback hasn't produced new results yet
 
@@ -546,13 +576,12 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
         forward_vels, success_flags, episode_reports = self._run_supplementary_eval()
         self._log_locomotion_metrics(episode_reports)
 
-        fwd_vel_arg = forward_vels if forward_vels else None
+        fwd_vel_arg = self._forward_velocities_for_eval(n_evals, forward_vels or None)
         # Prefer the EvalCallback's per-episode successes (full
-        # n_eval_episodes sample) over the small supplementary eval.
-        if npz_successes is not None:
-            success_arg = npz_successes
-        else:
-            success_arg = success_flags if success_flags else None
+        # n_eval_episodes sample) over the small supplementary eval, but only
+        # when task success is an active gate for this stage.  Incidental
+        # target contacts in balance/locomotion are not stage success.
+        success_arg = self._success_rates_for_stage(npz_successes, success_flags or None)
         if self.curriculum_manager.should_advance(rewards, lengths, fwd_vel_arg, success_arg):
             self.ready_to_advance = True
             logger.info(
@@ -624,7 +653,7 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
         self._log_locomotion_metrics(episode_reports)
 
         fwd_vel_arg = forward_vels if forward_vels else None
-        success_arg = success_flags if success_flags else None
+        success_arg = self._success_rates_for_stage(None, success_flags or None)
         if self.curriculum_manager.should_advance(rewards, lengths, fwd_vel_arg, success_arg):
             self.ready_to_advance = True
             logger.info(

--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -77,7 +77,6 @@ class DiagnosticsCallback(_BaseCallback):
         critic_loss, actor_loss, ent_coef, …)
       - VecNormalize running variance for observations and returns
       - Termination reason breakdown (fraction per reason)
-      - Reward plateau detection with console warnings
 
     When *log_dir* is provided, per-rollout averages of INFO_KEYS, the
     captured algorithm metrics (under ``algo_*`` keys, on their own
@@ -147,8 +146,8 @@ class DiagnosticsCallback(_BaseCallback):
 
     def __init__(
         self,
-        plateau_window=10,
-        plateau_threshold=1.0,
+        plateau_window=None,
+        plateau_threshold=None,
         log_dir=None,
         verbose=0,
         action_saturation_threshold=0.99,
@@ -164,18 +163,16 @@ class DiagnosticsCallback(_BaseCallback):
             self.logger = None
             self.num_timesteps = 0
             self.training_env = None
-        self.plateau_window = plateau_window
-        self.plateau_threshold = plateau_threshold
+        if plateau_window is not None or plateau_threshold is not None:
+            logger.warning(
+                "DiagnosticsCallback plateau_window/plateau_threshold are deprecated and ignored; "
+                "plateau detection now uses deterministic stage-gate evaluations."
+            )
         # |action| at/above this (in the normalized [-1, 1] control space) counts
         # as "saturated" for the diagnostics/action_saturation metric.
         self.action_saturation_threshold = action_saturation_threshold
         self._log_dir = Path(log_dir) if log_dir is not None else None
         self._step_infos = {k: [] for k in self.REWARD_KEYS + self.INFO_KEYS}
-        self._rollout_ep_rewards: list[float] = []
-        # Episode returns + actions seen during the CURRENT rollout (flushed at
-        # rollout end).  Accumulating per-step avoids the old bias of only
-        # sampling episodes that ended on the rollout's final step.
-        self._rollout_ep_returns: list[float] = []
         self._step_actions: list = []
         self._rollout_terminations: Counter = Counter()
         self._history_timesteps: list[int] = []
@@ -207,11 +204,6 @@ class DiagnosticsCallback(_BaseCallback):
                     self._step_infos[key].append(float(info[key]))
             if "termination_reason" in info:
                 self._rollout_terminations[info["termination_reason"]] += 1
-            # Capture EVERY completed episode's return, not just those ending on
-            # the rollout's final step (Monitor sets info["episode"] on done).
-            if "episode" in info and "r" in info["episode"]:
-                self._rollout_ep_returns.append(float(info["episode"]["r"]))
-
         # Accumulate the actions taken this step. self.locals["actions"] is
         # populated by both the on-policy (PPO) and off-policy (SAC) collection
         # loops, so this works uniformly for both algorithms.
@@ -297,24 +289,6 @@ class DiagnosticsCallback(_BaseCallback):
             self.logger.record("diagnostics/vecnorm_obs_var_mean", _sanitize(float(_np.mean(env.obs_rms.var))))
         if hasattr(env, "ret_rms"):
             self.logger.record("diagnostics/vecnorm_ret_var", _sanitize(float(_np.mean(env.ret_rms.var))))
-
-        # Plateau detection over the mean episode return of each rollout.  Uses
-        # ALL episodes that completed during the rollout (accumulated in
-        # _on_step), not just those ending on the final step.
-        if self._rollout_ep_returns:
-            self._rollout_ep_rewards.append(float(_np.mean(self._rollout_ep_returns)))
-            self._rollout_ep_returns = []
-            if len(self._rollout_ep_rewards) >= self.plateau_window:
-                recent = self._rollout_ep_rewards[-self.plateau_window :]
-                variation = max(recent) - min(recent)
-                self.logger.record("diagnostics/reward_variation", _sanitize(variation))
-                if variation < self.plateau_threshold:
-                    logger.warning(
-                        "PLATEAU WARNING: Reward variation over last %d rollouts is only %.4f. "
-                        "Consider adjusting learning rate or stopping.",
-                        self.plateau_window,
-                        variation,
-                    )
 
         # Persist once per rollout-end, throttled: _save_diagnostics rewrites
         # the ENTIRE accumulated history, and SAC fires on_rollout_end every

--- a/environments/shared/eval_diagnostics.py
+++ b/environments/shared/eval_diagnostics.py
@@ -1,0 +1,396 @@
+"""Stage-aware Stable-Baselines3 evaluation diagnostics.
+
+The rollout diagnostics in :mod:`environments.shared.diagnostics` describe
+what the training workers are doing.  Plateau decisions belong here instead:
+they use deterministic evaluation episodes and the same configured metrics
+that define each curriculum stage.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+try:
+    from stable_baselines3.common.callbacks import BaseCallback as _BaseCallback
+    from stable_baselines3.common.callbacks import EvalCallback as _EvalCallback
+
+    _SB3_AVAILABLE = True
+except ImportError:
+    _BaseCallback = object  # type: ignore[misc,assignment]
+    _EvalCallback = object  # type: ignore[misc,assignment]
+    _SB3_AVAILABLE = False
+
+
+def success_metric_applicable(stage_config: dict[str, Any]) -> bool:
+    """Return whether task success is an active gate for *stage_config*.
+
+    Stage number alone is deliberately not used: the TOML curriculum config
+    is the authority, and a genuine zero remains meaningful whenever a
+    positive success-rate threshold is configured.
+    """
+
+    curriculum = stage_config.get("curriculum_kwargs", {})
+    return float(curriculum.get("min_success_rate", 0.0)) > 0.0
+
+
+class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
+    """SB3 ``EvalCallback`` with stage-aware success and velocity capture.
+
+    Stable-Baselines3 prints a success rate whenever an environment emits
+    terminal ``info["is_success"]``.  The dinosaur environments intentionally
+    keep emitting that standard field, but success is only an evaluation
+    metric in stages whose config has a positive success-rate gate.  This
+    callback suppresses collection in other stages and prints an explicit
+    ``N/A`` instead of a misleading ``0.00%``.
+
+    Mean forward velocity is also captured for every evaluation episode so
+    the plateau diagnostic can follow the Stage 2 locomotion gate without
+    launching another evaluation pass.
+    """
+
+    def __init__(
+        self,
+        eval_env: Any,
+        *,
+        stage: int,
+        success_applicable: bool,
+        **kwargs: Any,
+    ) -> None:
+        if not _SB3_AVAILABLE:
+            raise ImportError(
+                "stable-baselines3 is required for StageAwareEvalCallback. Install with: pip install stable-baselines3"
+            )
+        super().__init__(eval_env, **kwargs)
+        self.stage = stage
+        self.success_applicable = success_applicable
+        self.evaluations_forward_velocities: list[list[float]] = []
+        self._episode_forward_sums: dict[int, float] = {}
+        self._episode_forward_counts: dict[int, int] = {}
+        self._current_eval_forward_velocities: list[float] = []
+
+    def _reset_forward_velocity_capture(self) -> None:
+        self._episode_forward_sums.clear()
+        self._episode_forward_counts.clear()
+        self._current_eval_forward_velocities = []
+
+    def _log_success_callback(self, locals_: dict[str, Any], globals_: dict[str, Any]) -> None:
+        """Capture evaluation velocity and conditionally delegate success."""
+
+        info = locals_["info"]
+        env_index = int(locals_.get("i", 0))
+        forward_vel = info.get("forward_vel")
+        if forward_vel is not None:
+            value = float(forward_vel)
+            if math.isfinite(value):
+                self._episode_forward_sums[env_index] = self._episode_forward_sums.get(env_index, 0.0) + value
+                self._episode_forward_counts[env_index] = self._episode_forward_counts.get(env_index, 0) + 1
+
+        if locals_["done"]:
+            count = self._episode_forward_counts.pop(env_index, 0)
+            total = self._episode_forward_sums.pop(env_index, 0.0)
+            self._current_eval_forward_velocities.append(total / count if count else float("nan"))
+
+        if self.success_applicable:
+            super()._log_success_callback(locals_, globals_)
+
+    def _on_step(self) -> bool:
+        evaluation_due = self.eval_freq > 0 and self.n_calls % self.eval_freq == 0
+        if evaluation_due:
+            self._reset_forward_velocity_capture()
+
+        continue_training = super()._on_step()
+
+        if evaluation_due:
+            self.evaluations_forward_velocities.append(list(self._current_eval_forward_velocities))
+            if not self.success_applicable and self.verbose >= 1:
+                print(f"Success rate: N/A (not an active Stage {self.stage} gate)")
+
+        return bool(continue_training)
+
+
+@dataclass(frozen=True)
+class _GateMetric:
+    key: str
+    label: str
+    threshold: float
+    value: float | None
+    sample_count: int
+    percent: bool = False
+
+
+class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
+    """Warn once when the currently blocking evaluation gate stops moving.
+
+    A plateau is a small range over the latest ``plateau_window`` deterministic
+    evaluations, normalized by that metric's configured gate.  The callback
+    follows the most behaviorally specific failing gate: task success, forward
+    velocity, episode length, then reward.  It disarms after meaningful
+    movement or a gate pass and can warn again only after a later plateau.
+
+    This callback is diagnostic only.  It never stops training and is separate
+    from both curriculum advancement and collapse early stopping.
+    """
+
+    _METRIC_PRIORITY = (
+        "mean_success_rate",
+        "mean_forward_vel",
+        "mean_episode_length",
+        "mean_reward",
+    )
+
+    _GUIDANCE = {
+        "mean_success_rate": (
+            "Inspect target reachability, contact/proximity signals, and the Stage 3 reward ramp before tuning the optimizer."
+        ),
+        "mean_forward_vel": (
+            "Inspect gait stability, actuator saturation, and locomotion reward balance before tuning the optimizer."
+        ),
+        "mean_episode_length": (
+            "Inspect termination reasons, posture, and balance stability before tuning the optimizer."
+        ),
+        "mean_reward": (
+            "Inspect reward components and policy diagnostics to identify which behavior has stopped improving."
+        ),
+    }
+
+    def __init__(
+        self,
+        eval_callback: StageAwareEvalCallback,
+        *,
+        stage: int,
+        curriculum_kwargs: dict[str, Any],
+        plateau_window: int = 5,
+        min_relative_variation: float = 0.05,
+        verbose: int = 0,
+    ) -> None:
+        if not _SB3_AVAILABLE:
+            raise ImportError(
+                "stable-baselines3 is required for StageGatePlateauCallback. "
+                "Install with: pip install stable-baselines3"
+            )
+        if plateau_window < 2:
+            raise ValueError("plateau_window must be at least 2 evaluations")
+        if min_relative_variation < 0.0:
+            raise ValueError("min_relative_variation must be non-negative")
+        super().__init__(verbose)
+        self.eval_callback = eval_callback
+        self.stage = stage
+        self.curriculum_kwargs = dict(curriculum_kwargs)
+        self.plateau_window = plateau_window
+        self.min_relative_variation = min_relative_variation
+        self._last_seen_n_evals = 0
+        self._histories: dict[str, list[float]] = {key: [] for key in self._METRIC_PRIORITY}
+        self._plateau_active = False
+        self._plateau_metric: str | None = None
+
+    @staticmethod
+    def _finite_mean(values: Any) -> float | None:
+        array = np.asarray(values, dtype=float).reshape(-1)
+        finite = array[np.isfinite(array)]
+        if finite.size == 0:
+            return None
+        return float(np.mean(finite))
+
+    @staticmethod
+    def _finite_count(values: Any) -> int:
+        array = np.asarray(values, dtype=float).reshape(-1)
+        return int(np.count_nonzero(np.isfinite(array)))
+
+    def _metrics_for_evaluation(self, index: int) -> list[_GateMetric]:
+        rewards = self.eval_callback.evaluations_results
+        lengths = self.eval_callback.evaluations_length
+        velocities = self.eval_callback.evaluations_forward_velocities
+        successes = self.eval_callback.evaluations_successes
+
+        samples: dict[str, Any | None] = {
+            "mean_reward": rewards[index] if index < len(rewards) else None,
+            "mean_episode_length": lengths[index] if index < len(lengths) else None,
+            "mean_forward_vel": velocities[index] if index < len(velocities) else None,
+            "mean_success_rate": successes[index] if index < len(successes) else None,
+        }
+        values = {key: self._finite_mean(sample) if sample is not None else None for key, sample in samples.items()}
+        counts = {key: self._finite_count(sample) if sample is not None else 0 for key, sample in samples.items()}
+
+        configured = (
+            _GateMetric(
+                "mean_success_rate",
+                "success rate",
+                float(self.curriculum_kwargs.get("min_success_rate", 0.0)),
+                values["mean_success_rate"],
+                counts["mean_success_rate"],
+                percent=True,
+            ),
+            _GateMetric(
+                "mean_forward_vel",
+                "forward velocity",
+                float(self.curriculum_kwargs.get("min_avg_forward_vel", 0.0)),
+                values["mean_forward_vel"],
+                counts["mean_forward_vel"],
+            ),
+            _GateMetric(
+                "mean_episode_length",
+                "episode length",
+                float(self.curriculum_kwargs.get("min_avg_episode_length", 0.0)),
+                values["mean_episode_length"],
+                counts["mean_episode_length"],
+            ),
+            _GateMetric(
+                "mean_reward",
+                "mean reward",
+                float(self.curriculum_kwargs.get("min_avg_reward", -math.inf)),
+                values["mean_reward"],
+                counts["mean_reward"],
+            ),
+        )
+        return [
+            metric
+            for metric in configured
+            if math.isfinite(metric.threshold) and (metric.key == "mean_reward" or metric.threshold > 0.0)
+        ]
+
+    def _clear_plateau(self, reason: str) -> None:
+        if self._plateau_active:
+            logger.info(
+                "Stage %d evaluation plateau cleared at step %d: %s.",
+                self.stage,
+                self.num_timesteps,
+                reason,
+            )
+        self._plateau_active = False
+        self._plateau_metric = None
+
+    @staticmethod
+    def _format_value(metric: _GateMetric, value: float) -> str:
+        if metric.percent:
+            return f"{value:.1%}"
+        if metric.key == "mean_forward_vel":
+            return f"{value:.3f} m/s"
+        if metric.key == "mean_episode_length":
+            return f"{value:.1f} steps"
+        return f"{value:.3f}"
+
+    @staticmethod
+    def _gate_scale(threshold: float) -> float:
+        """Return the gate magnitude, with a stable scale for a zero gate."""
+
+        return abs(threshold) if threshold != 0.0 else 1.0
+
+    def _process_evaluation(self, index: int) -> None:
+        metrics = self._metrics_for_evaluation(index)
+        if not metrics:
+            return
+
+        min_eval_episodes = int(self.curriculum_kwargs.get("min_eval_episodes", 10))
+        reward_metric = next((metric for metric in metrics if metric.key == "mean_reward"), None)
+        if reward_metric is not None:
+            self.logger.record("diagnostics/eval_episode_count", reward_metric.sample_count)
+        if any(metric.value is None or metric.sample_count < min_eval_episodes for metric in metrics):
+            self.logger.record("diagnostics/eval_gate_data_complete", 0.0)
+            return
+
+        self.logger.record("diagnostics/eval_gate_data_complete", 1.0)
+        for metric in metrics:
+            assert metric.value is not None
+            self._histories[metric.key].append(metric.value)
+
+        failing = [metric for metric in metrics if metric.value is not None and metric.value < metric.threshold]
+        if not failing:
+            self.logger.record("diagnostics/eval_gate_met", 1.0)
+            self.logger.record("diagnostics/eval_plateau_active", 0.0)
+            self._clear_plateau("all active stage gates are currently met")
+            return
+
+        self.logger.record("diagnostics/eval_gate_met", 0.0)
+        blocking = next(metric for key in self._METRIC_PRIORITY for metric in failing if metric.key == key)
+        assert blocking.value is not None
+
+        if self._plateau_metric is not None and self._plateau_metric != blocking.key:
+            self._clear_plateau(f"the blocking gate changed to {blocking.label}")
+        self._plateau_metric = blocking.key
+
+        history = self._histories[blocking.key]
+        if len(history) < self.plateau_window:
+            self.logger.record("diagnostics/eval_plateau_active", 0.0)
+            return
+
+        recent = history[-self.plateau_window :]
+        absolute_range = max(recent) - min(recent)
+        gate_scale = self._gate_scale(blocking.threshold)
+        relative_range = absolute_range / gate_scale
+        self.logger.record("diagnostics/eval_plateau_relative_range", relative_range)
+        relative_margin = (blocking.value - blocking.threshold) / gate_scale
+        self.logger.record("diagnostics/eval_gate_relative_margin", relative_margin)
+
+        if relative_range >= self.min_relative_variation:
+            self._clear_plateau(
+                f"{blocking.label} moved by {relative_range:.1%} of its gate over the evaluation window"
+            )
+        elif not self._plateau_active:
+            logger.warning(
+                "STAGE %d EVALUATION PLATEAU: %s stayed within a %s range (%s of its gate) "
+                "across the last %d evaluations; latest %s, required %s, step %d. %s "
+                "Training continues; this diagnostic is not the curriculum gate or collapse early-stop.",
+                self.stage,
+                blocking.label,
+                self._format_value(blocking, absolute_range),
+                f"{relative_range:.1%}",
+                self.plateau_window,
+                self._format_value(blocking, blocking.value),
+                self._format_value(blocking, blocking.threshold),
+                self.num_timesteps,
+                self._GUIDANCE[blocking.key],
+            )
+            self._plateau_active = True
+
+        self.logger.record("diagnostics/eval_plateau_active", float(self._plateau_active))
+
+    def _on_step(self) -> bool:
+        results = getattr(self.eval_callback, "evaluations_results", None)
+        if results is None:
+            return True
+
+        n_evals = len(results)
+        if n_evals < self._last_seen_n_evals:
+            self._last_seen_n_evals = 0
+            self._histories = {key: [] for key in self._METRIC_PRIORITY}
+            self._clear_plateau("evaluation history was reset")
+
+        for index in range(self._last_seen_n_evals, n_evals):
+            self._process_evaluation(index)
+        self._last_seen_n_evals = n_evals
+        return True
+
+
+def build_stage_evaluation_callbacks(
+    eval_env: Any,
+    *,
+    stage: int,
+    stage_config: dict[str, Any],
+    diagnostics_verbose: int = 0,
+    **eval_callback_kwargs: Any,
+) -> tuple[StageAwareEvalCallback, StageGatePlateauCallback]:
+    """Build the paired evaluation and stage-gate diagnostic callbacks."""
+
+    curriculum_kwargs = stage_config.get("curriculum_kwargs", {})
+    eval_callback = StageAwareEvalCallback(
+        eval_env,
+        stage=stage,
+        success_applicable=success_metric_applicable(stage_config),
+        **eval_callback_kwargs,
+    )
+    plateau_callback = StageGatePlateauCallback(
+        eval_callback,
+        stage=stage,
+        curriculum_kwargs=curriculum_kwargs,
+        plateau_window=int(curriculum_kwargs.get("diagnostics_plateau_window", 5)),
+        min_relative_variation=float(curriculum_kwargs.get("diagnostics_plateau_min_relative_variation", 0.05)),
+        verbose=diagnostics_verbose,
+    )
+    return eval_callback, plateau_callback

--- a/environments/shared/scripts/sweep/ray_tune.py
+++ b/environments/shared/scripts/sweep/ray_tune.py
@@ -550,7 +550,6 @@ def train_trial(config: dict[str, Any]) -> None:
     from stable_baselines3.common.callbacks import (
         CallbackList,
         CheckpointCallback,
-        EvalCallback,
     )
 
     from environments.shared.config import load_all_stages, save_stage_config
@@ -561,6 +560,7 @@ def train_trial(config: dict[str, Any]) -> None:
         StageWarmupCallback,
         load_vecnorm_stats,
     )
+    from environments.shared.eval_diagnostics import build_stage_evaluation_callbacks
     from environments.shared.species_registry import get_species_config
     from environments.shared.train_base import (
         cosine_schedule,
@@ -698,13 +698,15 @@ def train_trial(config: dict[str, Any]) -> None:
             model = alg_cls("MlpPolicy", train_env, policy_kwargs=policy_kwargs, **alg_kwargs)
 
         # Callbacks
-        callbacks = []
+        callbacks: list[Any] = []
 
         save_vecnorm_cb = SaveVecNormalizeCallback(
             save_path=str(model_dir / "best_model_vecnorm.pkl"),
         )
-        eval_callback = EvalCallback(
+        eval_callback, plateau_callback = build_stage_evaluation_callbacks(
             eval_env,
+            stage=stage,
+            stage_config=stage_config,
             best_model_save_path=str(model_dir),
             log_path=str(trial_dir),
             eval_freq=eval_freq // n_envs,
@@ -715,6 +717,7 @@ def train_trial(config: dict[str, Any]) -> None:
             callback_on_new_best=save_vecnorm_cb,
         )
         callbacks.append(eval_callback)
+        callbacks.append(plateau_callback)
 
         model_ref = [model]
         callbacks.append(

--- a/environments/shared/tests/test_curriculum.py
+++ b/environments/shared/tests/test_curriculum.py
@@ -74,6 +74,15 @@ class TestCurriculumManager:
         assert "env_kwargs" in config
         assert "ppo_kwargs" in config
 
+    def test_current_threshold_returns_effective_override(self):
+        manager = CurriculumManager(
+            species="velociraptor",
+            stage_thresholds={1: {"min_success_rate": 0.75}},
+            start_stage=1,
+        )
+
+        assert manager.current_threshold.min_success_rate == 0.75
+
     def test_should_not_advance_without_data(self, manager):
         assert not manager.should_advance()
 
@@ -651,6 +660,70 @@ class TestCallbackMethodsMocked:
             cb._log_locomotion_metrics([{"some": "report"}])
 
         mock_log.assert_called_once_with(mock_agg, 1, step=1000)
+
+    def test_success_samples_are_na_when_stage_has_no_success_gate(self):
+        cb = object.__new__(CurriculumCallback)
+        cb.curriculum_manager = MagicMock()
+        cb.curriculum_manager.current_threshold = StageThreshold(min_success_rate=0.0)
+
+        result = cb._success_rates_for_stage([1.0, 0.0], [1.0])
+
+        assert result is None
+
+    def test_success_gate_prefers_full_eval_samples(self):
+        cb = object.__new__(CurriculumCallback)
+        cb.curriculum_manager = MagicMock()
+        cb.curriculum_manager.current_threshold = StageThreshold(min_success_rate=0.5)
+
+        result = cb._success_rates_for_stage([0.0, 0.0], [1.0])
+
+        assert result == [0.0, 0.0]
+
+    def test_success_gate_falls_back_to_supplementary_samples(self):
+        cb = object.__new__(CurriculumCallback)
+        cb.curriculum_manager = MagicMock()
+        cb.curriculum_manager.current_threshold = StageThreshold(min_success_rate=0.5)
+
+        result = cb._success_rates_for_stage(None, [1.0, 0.0])
+
+        assert result == [1.0, 0.0]
+
+    def test_forward_velocity_gate_prefers_main_eval_sample(self):
+        cb = object.__new__(CurriculumCallback)
+        cb.eval_callback = MagicMock()
+        cb.eval_callback.evaluations_forward_velocities = [[1.0, 1.5], [2.0, 2.5]]
+
+        result = cb._forward_velocities_for_eval(2, [9.0])
+
+        assert result == [2.0, 2.5]
+
+    def test_forward_velocity_gate_supports_plain_eval_callback(self):
+        cb = object.__new__(CurriculumCallback)
+        cb.eval_callback = MagicMock(spec=[])
+
+        result = cb._forward_velocities_for_eval(1, [0.5, 0.75])
+
+        assert result == [0.5, 0.75]
+
+    def test_eval_callback_path_gates_on_main_eval_velocity_sample(self):
+        cb = object.__new__(CurriculumCallback)
+        cb.eval_callback = MagicMock()
+        cb.eval_callback.evaluations_forward_velocities = [[1.0, 1.5, 2.0]]
+        cb.curriculum_manager = MagicMock()
+        cb.curriculum_manager.current_threshold = StageThreshold(min_avg_forward_vel=1.0)
+        cb.curriculum_manager.should_advance.return_value = False
+        cb._read_latest_eval = MagicMock(return_value=([100.0] * 3, [1000.0] * 3, None, 1))
+        cb._run_supplementary_eval = MagicMock(return_value=([9.0], [1.0], []))
+        cb._log_locomotion_metrics = MagicMock()
+
+        assert cb._on_step_with_eval_callback() is True
+
+        cb.curriculum_manager.should_advance.assert_called_once_with(
+            [100.0] * 3,
+            [1000.0] * 3,
+            [1.0, 1.5, 2.0],
+            None,
+        )
 
 
 class TestStageWarmupCallbackMocked:

--- a/environments/shared/tests/test_diagnostics.py
+++ b/environments/shared/tests/test_diagnostics.py
@@ -40,18 +40,28 @@ def callback(tmp_path):
 class TestInit:
     def test_default_params(self):
         cb = DiagnosticsCallback()
-        assert cb.plateau_window == 10
-        assert cb.plateau_threshold == 1.0
         assert cb._log_dir is None
 
     def test_custom_params(self, tmp_path):
-        cb = DiagnosticsCallback(plateau_window=20, plateau_threshold=2.0, log_dir=str(tmp_path), verbose=1)
-        assert cb.plateau_window == 20
-        assert cb.plateau_threshold == 2.0
+        cb = DiagnosticsCallback(
+            log_dir=str(tmp_path),
+            verbose=1,
+            action_saturation_threshold=0.95,
+            save_interval_seconds=30.0,
+        )
         assert cb._log_dir == tmp_path
+        assert cb.action_saturation_threshold == 0.95
+        assert cb.save_interval_seconds == 30.0
+
+    def test_legacy_plateau_params_are_accepted_but_ignored(self, caplog):
+        with caplog.at_level("WARNING", logger="environments.shared.diagnostics"):
+            cb = DiagnosticsCallback(plateau_window=20, plateau_threshold=2.0)
+
+        assert not hasattr(cb, "plateau_window")
+        assert not hasattr(cb, "plateau_threshold")
+        assert "deprecated and ignored" in caplog.text
 
     def test_initial_state(self, callback):
-        assert callback._rollout_ep_rewards == []
         assert callback._rollout_terminations == Counter()
         assert callback._history_timesteps == []
 
@@ -183,56 +193,14 @@ class TestOnRolloutEnd:
         cb.logger.record.assert_any_call("diagnostics/vecnorm_obs_var_mean", 1.5)
         cb.logger.record.assert_any_call("diagnostics/vecnorm_ret_var", 0.5)
 
-
-class TestPlateauDetection:
-    """Episode returns are captured in _on_step (every completed episode), then
-    the per-rollout mean is appended in _on_rollout_end.  This avoids the old
-    bias of only sampling episodes that ended on the rollout's final step."""
-
-    def test_no_warning_below_window(self, callback):
-        callback._rollout_ep_rewards = [1.0] * 5
-        callback.locals = {"infos": [{"episode": {"r": 1.0}}]}
-        callback._on_step()
-        callback._on_rollout_end()
-        # Not enough history for plateau detection, no warning printed
-
-    def test_plateau_warning(self, callback, caplog):
-        # Fill the history to reach the plateau window
-        callback._rollout_ep_rewards = [50.0] * 9  # 9 entries, need 10
+    def test_constant_training_episode_returns_do_not_emit_plateau_warning(self, callback, caplog):
         callback.locals = {"infos": [{"episode": {"r": 50.0}}]}
         callback._on_step()
+
         with caplog.at_level("WARNING", logger="environments.shared.diagnostics"):
             callback._on_rollout_end()
-        assert "PLATEAU WARNING" in caplog.text
 
-    def test_no_plateau_when_varying(self, callback, caplog):
-        # Rewards with enough variation to avoid plateau
-        callback._rollout_ep_rewards = list(range(9))  # 0-8
-        callback.locals = {"infos": [{"episode": {"r": 100.0}}]}
-        callback._on_step()
-        with caplog.at_level("WARNING", logger="environments.shared.diagnostics"):
-            callback._on_rollout_end()
-        assert "PLATEAU WARNING" not in caplog.text
-
-    def test_logs_reward_variation(self, callback):
-        callback._rollout_ep_rewards = [50.0] * 9
-        callback.locals = {"infos": [{"episode": {"r": 50.0}}]}
-        callback._on_step()
-        callback._on_rollout_end()
-        callback.logger.record.assert_any_call("diagnostics/reward_variation", 0.0)
-
-    def test_captures_all_episodes_not_just_final_step(self, callback):
-        """Every episode completing mid-rollout must count — the whole point of
-        the fix.  Three episodes across two steps → mean over all three."""
-        callback._rollout_ep_rewards = []
-        callback.locals = {"infos": [{"episode": {"r": 10.0}}, {"episode": {"r": 20.0}}]}
-        callback._on_step()
-        callback.locals = {"infos": [{"episode": {"r": 30.0}}]}
-        callback._on_step()
-        assert callback._rollout_ep_returns == [10.0, 20.0, 30.0]
-        callback._on_rollout_end()
-        assert callback._rollout_ep_rewards[-1] == pytest.approx(20.0)  # mean(10,20,30)
-        assert callback._rollout_ep_returns == []  # buffer flushed
+        assert "PLATEAU" not in caplog.text
 
 
 class TestSaveDiagnostics:

--- a/environments/shared/tests/test_eval_diagnostics.py
+++ b/environments/shared/tests/test_eval_diagnostics.py
@@ -1,0 +1,416 @@
+"""Tests for stage-aware SB3 evaluation diagnostics."""
+
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from environments.shared import eval_diagnostics as eval_diagnostics_module
+from environments.shared.eval_diagnostics import (
+    StageAwareEvalCallback,
+    StageGatePlateauCallback,
+    success_metric_applicable,
+)
+
+
+class TestSuccessMetricApplicable:
+    def test_requires_positive_configured_gate(self):
+        assert success_metric_applicable({"curriculum_kwargs": {"min_success_rate": 0.5}}) is True
+        assert success_metric_applicable({"curriculum_kwargs": {"min_success_rate": 0.0}}) is False
+        assert success_metric_applicable({"curriculum_kwargs": {}}) is False
+        assert success_metric_applicable({}) is False
+
+    @pytest.mark.parametrize("species", ["velociraptor", "trex", "brachiosaurus"])
+    def test_real_configs_enable_success_only_for_stage_three(self, species):
+        from environments.shared.config import load_all_stages
+
+        configs = load_all_stages(species)
+
+        assert success_metric_applicable(configs[1]) is False
+        assert success_metric_applicable(configs[2]) is False
+        assert success_metric_applicable(configs[3]) is True
+
+
+def _bare_stage_aware_callback(*, success_applicable: bool) -> StageAwareEvalCallback:
+    if success_applicable:
+        pytest.importorskip("stable_baselines3")
+    callback = object.__new__(StageAwareEvalCallback)
+    callback.stage = 3 if success_applicable else 1
+    callback.success_applicable = success_applicable
+    callback._is_success_buffer = []
+    callback.evaluations_forward_velocities = []
+    callback._episode_forward_sums = {}
+    callback._episode_forward_counts = {}
+    callback._current_eval_forward_velocities = []
+    return callback
+
+
+class TestStageAwareEvalCallback:
+    def test_inapplicable_success_does_not_populate_sb3_buffer(self):
+        callback = _bare_stage_aware_callback(success_applicable=False)
+
+        callback._log_success_callback(
+            {"i": 0, "done": True, "info": {"is_success": True, "forward_vel": 1.0}},
+            {},
+        )
+
+        assert callback._is_success_buffer == []
+
+    def test_applicable_zero_success_remains_a_real_zero(self):
+        callback = _bare_stage_aware_callback(success_applicable=True)
+
+        callback._log_success_callback(
+            {"i": 0, "done": True, "info": {"is_success": False, "forward_vel": 1.0}},
+            {},
+        )
+
+        assert callback._is_success_buffer == [False]
+
+    def test_captures_per_episode_mean_forward_velocity(self):
+        callback = _bare_stage_aware_callback(success_applicable=False)
+
+        callback._log_success_callback({"i": 0, "done": False, "info": {"forward_vel": 1.0}}, {})
+        callback._log_success_callback({"i": 0, "done": True, "info": {"forward_vel": 3.0}}, {})
+
+        assert callback._current_eval_forward_velocities == [2.0]
+
+    def test_prints_na_for_inapplicable_evaluation(self, capsys):
+        pytest.importorskip("stable_baselines3")
+        callback = _bare_stage_aware_callback(success_applicable=False)
+        callback.eval_freq = 10
+        callback.n_calls = 10
+        callback.verbose = 1
+
+        with patch.object(eval_diagnostics_module._EvalCallback, "_on_step", return_value=True):
+            assert callback._on_step() is True
+
+        assert "Success rate: N/A (not an active Stage 1 gate)" in capsys.readouterr().out
+        assert callback.evaluations_forward_velocities == [[]]
+
+    @pytest.mark.parametrize(
+        ("success_applicable", "expected_successes", "expected_output"),
+        [
+            (False, False, "Success rate: N/A"),
+            (True, True, "Success rate: 0.00%"),
+        ],
+    )
+    def test_npz_schema_and_console_output(
+        self,
+        tmp_path,
+        capsys,
+        success_applicable,
+        expected_successes,
+        expected_output,
+    ):
+        gym = pytest.importorskip("gymnasium")
+        pytest.importorskip("stable_baselines3")
+        from stable_baselines3.common.monitor import Monitor
+        from stable_baselines3.common.vec_env import DummyVecEnv
+
+        class TinyEvalEnv(gym.Env):
+            observation_space = gym.spaces.Box(-1.0, 1.0, (1,), dtype=np.float32)
+            action_space = gym.spaces.Box(-1.0, 1.0, (1,), dtype=np.float32)
+
+            def reset(self, *, seed=None, options=None):
+                super().reset(seed=seed)
+                self.steps = 0
+                return np.zeros(1, dtype=np.float32), {}
+
+            def step(self, action):
+                self.steps += 1
+                done = self.steps >= 2
+                info = {"forward_vel": float(self.steps)}
+                if done:
+                    info["is_success"] = False
+                return np.zeros(1, dtype=np.float32), 1.0, done, False, info
+
+        train_env = DummyVecEnv([lambda: Monitor(TinyEvalEnv())])
+        eval_env = DummyVecEnv([lambda: Monitor(TinyEvalEnv())])
+        model = MagicMock()
+        model.get_env.return_value = train_env
+        model.get_vec_normalize_env.return_value = None
+        model.num_timesteps = 1
+        model.logger = MagicMock()
+        model.predict.side_effect = lambda observations, **kwargs: (
+            np.zeros((observations.shape[0], 1), dtype=np.float32),
+            None,
+        )
+
+        callback = StageAwareEvalCallback(
+            eval_env,
+            stage=3 if success_applicable else 1,
+            success_applicable=success_applicable,
+            log_path=str(tmp_path),
+            eval_freq=1,
+            n_eval_episodes=2,
+            verbose=1,
+        )
+        callback.init_callback(model)
+
+        assert callback.on_step() is True
+
+        data = np.load(tmp_path / "evaluations.npz")
+        assert ("successes" in data.files) is expected_successes
+        if expected_successes:
+            assert data["successes"].shape == (1, 2)
+            assert data["successes"].tolist() == [[False, False]]
+        assert callback.evaluations_forward_velocities == [[1.5, 1.5]]
+        assert expected_output in capsys.readouterr().out
+
+
+def _plateau_callback(
+    curriculum_kwargs: dict,
+    *,
+    stage: int,
+    plateau_window: int = 3,
+    min_relative_variation: float = 0.05,
+):
+    eval_callback = SimpleNamespace(
+        evaluations_results=[],
+        evaluations_length=[],
+        evaluations_forward_velocities=[],
+        evaluations_successes=[],
+    )
+    callback = object.__new__(StageGatePlateauCallback)
+    callback.eval_callback = cast(StageAwareEvalCallback, eval_callback)
+    callback.stage = stage
+    callback.curriculum_kwargs = dict(curriculum_kwargs)
+    callback.plateau_window = plateau_window
+    callback.min_relative_variation = min_relative_variation
+    callback._last_seen_n_evals = 0
+    callback._histories = {key: [] for key in callback._METRIC_PRIORITY}
+    callback._plateau_active = False
+    callback._plateau_metric = None
+    if eval_diagnostics_module._SB3_AVAILABLE:
+        model = MagicMock()
+        model.logger = MagicMock()
+        callback.init_callback(model)
+    else:
+        callback.__dict__["logger"] = MagicMock()
+    callback.num_timesteps = 100_000
+    return callback, eval_callback
+
+
+def _add_evaluation(
+    callback: StageGatePlateauCallback,
+    eval_callback: SimpleNamespace,
+    *,
+    reward: float,
+    length: float,
+    forward_vel: float | None = None,
+    success_rate: float | None = None,
+    n_episodes: int = 10,
+    forward_vel_episodes: int | None = None,
+    success_episodes: int | None = None,
+) -> None:
+    eval_callback.evaluations_results.append([reward] * n_episodes)
+    eval_callback.evaluations_length.append([length] * n_episodes)
+    if forward_vel is not None:
+        count = n_episodes if forward_vel_episodes is None else forward_vel_episodes
+        eval_callback.evaluations_forward_velocities.append([forward_vel] * count)
+    if success_rate is not None:
+        count = n_episodes if success_episodes is None else success_episodes
+        eval_callback.evaluations_successes.append([success_rate] * count)
+    callback.num_timesteps += 50_000
+    assert callback._on_step() is True
+
+
+class TestStageGatePlateauCallback:
+    def test_waits_for_full_evaluation_window(self, caplog):
+        callback, eval_callback = _plateau_callback(
+            {"min_avg_reward": 100.0, "min_success_rate": 0.5},
+            stage=3,
+        )
+
+        for _ in range(2):
+            _add_evaluation(callback, eval_callback, reward=200.0, length=1000.0, success_rate=0.0)
+
+        assert "EVALUATION PLATEAU" not in caplog.text
+
+    def test_warns_once_for_stable_blocking_success_gate(self, caplog):
+        callback, eval_callback = _plateau_callback(
+            {"min_avg_reward": 100.0, "min_success_rate": 0.5},
+            stage=3,
+        )
+
+        with caplog.at_level("WARNING", logger="environments.shared.eval_diagnostics"):
+            for _ in range(4):
+                _add_evaluation(callback, eval_callback, reward=200.0, length=1000.0, success_rate=0.0)
+
+        warnings = [record.message for record in caplog.records if "EVALUATION PLATEAU" in record.message]
+        assert len(warnings) == 1
+        assert "STAGE 3" in warnings[0]
+        assert "success rate" in warnings[0]
+        assert "latest 0.0%, required 50.0%" in warnings[0]
+        assert "Training continues" in warnings[0]
+        assert callback._plateau_active is True
+
+    def test_rearms_only_after_meaningful_movement(self, caplog):
+        callback, eval_callback = _plateau_callback(
+            {"min_avg_reward": 100.0, "min_success_rate": 0.5},
+            stage=3,
+        )
+
+        with caplog.at_level("WARNING", logger="environments.shared.eval_diagnostics"):
+            for _ in range(3):
+                _add_evaluation(callback, eval_callback, reward=200.0, length=1000.0, success_rate=0.0)
+            _add_evaluation(callback, eval_callback, reward=200.0, length=1000.0, success_rate=0.1)
+            for _ in range(3):
+                _add_evaluation(callback, eval_callback, reward=200.0, length=1000.0, success_rate=0.0)
+
+        warnings = [record for record in caplog.records if "EVALUATION PLATEAU" in record.message]
+        assert len(warnings) == 2
+        assert callback._plateau_active is True
+
+    def test_relative_range_uses_actual_success_gate_scale(self):
+        callback, eval_callback = _plateau_callback(
+            {"min_avg_reward": 100.0, "min_success_rate": 0.5},
+            stage=3,
+        )
+
+        for success_rate in (0.0, 0.04, 0.0):
+            _add_evaluation(callback, eval_callback, reward=200.0, length=1000.0, success_rate=success_rate)
+
+        callback.logger.record.assert_any_call("diagnostics/eval_plateau_relative_range", pytest.approx(0.08))
+
+    def test_does_not_warn_when_all_configured_gates_pass(self, caplog):
+        callback, eval_callback = _plateau_callback(
+            {"min_avg_reward": 100.0, "min_success_rate": 0.5},
+            stage=3,
+        )
+
+        with caplog.at_level("WARNING", logger="environments.shared.eval_diagnostics"):
+            for _ in range(3):
+                _add_evaluation(callback, eval_callback, reward=200.0, length=1000.0, success_rate=0.6)
+
+        assert "EVALUATION PLATEAU" not in caplog.text
+        callback.logger.record.assert_any_call("diagnostics/eval_gate_met", 1.0)
+
+    def test_stage_two_follows_forward_velocity_gate(self, caplog):
+        callback, eval_callback = _plateau_callback(
+            {
+                "min_avg_reward": 100.0,
+                "min_avg_episode_length": 750.0,
+                "min_avg_forward_vel": 2.0,
+            },
+            stage=2,
+        )
+
+        with caplog.at_level("WARNING", logger="environments.shared.eval_diagnostics"):
+            for _ in range(3):
+                _add_evaluation(
+                    callback,
+                    eval_callback,
+                    reward=200.0,
+                    length=1000.0,
+                    forward_vel=0.5,
+                )
+
+        assert "forward velocity" in caplog.text
+        assert "required 2.000 m/s" in caplog.text
+
+    def test_stage_one_prefers_balance_duration_over_reward(self, caplog):
+        callback, eval_callback = _plateau_callback(
+            {"min_avg_reward": 100.0, "min_avg_episode_length": 750.0},
+            stage=1,
+        )
+
+        with caplog.at_level("WARNING", logger="environments.shared.eval_diagnostics"):
+            for _ in range(3):
+                _add_evaluation(callback, eval_callback, reward=50.0, length=500.0)
+
+        assert "episode length" in caplog.text
+        assert "required 750.0 steps" in caplog.text
+
+    def test_relative_range_prevents_warning_when_metric_moves(self, caplog):
+        callback, eval_callback = _plateau_callback(
+            {"min_avg_reward": 100.0},
+            stage=1,
+        )
+
+        with caplog.at_level("WARNING", logger="environments.shared.eval_diagnostics"):
+            for reward in (50.0, 53.0, 56.0):
+                _add_evaluation(callback, eval_callback, reward=reward, length=1000.0)
+
+        assert "EVALUATION PLATEAU" not in caplog.text
+
+    def test_zero_reward_gate_is_still_active(self, caplog):
+        callback, eval_callback = _plateau_callback({"min_avg_reward": 0.0}, stage=1)
+
+        with caplog.at_level("WARNING", logger="environments.shared.eval_diagnostics"):
+            for _ in range(3):
+                _add_evaluation(callback, eval_callback, reward=-1.0, length=1000.0)
+
+        assert "mean reward" in caplog.text
+        assert "required 0.000" in caplog.text
+
+    def test_missing_active_gate_metric_skips_safely(self, caplog):
+        callback, eval_callback = _plateau_callback(
+            {"min_avg_reward": 100.0, "min_avg_forward_vel": 2.0},
+            stage=2,
+        )
+
+        with caplog.at_level("WARNING", logger="environments.shared.eval_diagnostics"):
+            for _ in range(3):
+                _add_evaluation(callback, eval_callback, reward=50.0, length=1000.0)
+
+        assert "EVALUATION PLATEAU" not in caplog.text
+        callback.logger.record.assert_any_call("diagnostics/eval_gate_data_complete", 0.0)
+
+    def test_undersized_evaluation_cannot_claim_gate_met(self, caplog):
+        callback, eval_callback = _plateau_callback(
+            {"min_avg_reward": 100.0, "min_eval_episodes": 10},
+            stage=1,
+        )
+
+        for _ in range(3):
+            _add_evaluation(callback, eval_callback, reward=200.0, length=1000.0, n_episodes=5)
+
+        assert "EVALUATION PLATEAU" not in caplog.text
+        callback.logger.record.assert_any_call("diagnostics/eval_gate_data_complete", 0.0)
+        assert not any(
+            call.args == ("diagnostics/eval_gate_met", 1.0) for call in callback.logger.record.call_args_list
+        )
+
+    def test_each_active_gate_requires_minimum_finite_samples(self):
+        callback, eval_callback = _plateau_callback(
+            {"min_avg_reward": 100.0, "min_avg_forward_vel": 2.0, "min_eval_episodes": 10},
+            stage=2,
+        )
+
+        for _ in range(3):
+            _add_evaluation(
+                callback,
+                eval_callback,
+                reward=200.0,
+                length=1000.0,
+                forward_vel=3.0,
+                forward_vel_episodes=5,
+            )
+
+        callback.logger.record.assert_any_call("diagnostics/eval_gate_data_complete", 0.0)
+        assert not any(
+            call.args == ("diagnostics/eval_gate_met", 1.0) for call in callback.logger.record.call_args_list
+        )
+
+    def test_repeated_steps_without_new_eval_do_not_change_history(self):
+        callback, eval_callback = _plateau_callback({"min_avg_reward": 100.0}, stage=1)
+        _add_evaluation(callback, eval_callback, reward=50.0, length=1000.0)
+        before = list(callback._histories["mean_reward"])
+
+        for _ in range(10):
+            assert callback._on_step() is True
+
+        assert callback._histories["mean_reward"] == before
+
+    def test_rejects_invalid_window(self):
+        pytest.importorskip("stable_baselines3")
+        with pytest.raises(ValueError, match="at least 2"):
+            StageGatePlateauCallback(
+                MagicMock(spec=StageAwareEvalCallback),
+                stage=1,
+                curriculum_kwargs={"min_avg_reward": 100.0},
+                plateau_window=1,
+            )

--- a/environments/shared/tests/test_train_base.py
+++ b/environments/shared/tests/test_train_base.py
@@ -5,11 +5,13 @@ import math
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
 from environments.shared.train_base import (
     SpeciesConfig,
     _apply_overrides,
+    _build_core_callbacks,
     _cast_value,
     _create_or_load_model,
     _is_gcs_path,
@@ -118,6 +120,70 @@ class TestSpeciesConfig:
             success_keys=["food_reached"],
         )
         assert cfg.species == "brachiosaurus"
+
+
+class TestBuildCoreCallbacks:
+    @pytest.mark.parametrize(
+        ("stage", "success_threshold", "success_applicable"),
+        [(1, 0.0, False), (3, 0.5, True)],
+    )
+    def test_wires_stage_aware_eval_and_plateau_callbacks(
+        self,
+        tmp_path,
+        stage,
+        success_threshold,
+        success_applicable,
+    ):
+        gym = pytest.importorskip("gymnasium")
+        pytest.importorskip("stable_baselines3")
+        from stable_baselines3.common.callbacks import CheckpointCallback
+        from stable_baselines3.common.vec_env import DummyVecEnv
+
+        from environments.shared.eval_diagnostics import (
+            StageAwareEvalCallback,
+            StageGatePlateauCallback,
+        )
+
+        class TinyEnv(gym.Env):
+            observation_space = gym.spaces.Box(-1.0, 1.0, (1,), dtype=np.float32)
+            action_space = gym.spaces.Box(-1.0, 1.0, (1,), dtype=np.float32)
+
+            def reset(self, *, seed=None, options=None):
+                super().reset(seed=seed)
+                return np.zeros(1, dtype=np.float32), {}
+
+            def step(self, action):
+                return np.zeros(1, dtype=np.float32), 0.0, False, False, {"forward_vel": 0.0}
+
+        eval_env = DummyVecEnv([TinyEnv])
+        stage_config = {
+            "curriculum_kwargs": {
+                "min_avg_reward": 100.0,
+                "min_success_rate": success_threshold,
+                "diagnostics_plateau_window": 7,
+                "diagnostics_plateau_min_relative_variation": 0.02,
+            }
+        }
+
+        callbacks, eval_callback, _ = _build_core_callbacks(
+            {"CheckpointCallback": CheckpointCallback},
+            eval_env,
+            tmp_path / "models",
+            tmp_path / "logs",
+            stage,
+            1,
+            100,
+            100,
+            0,
+            stage_config,
+        )
+
+        assert isinstance(eval_callback, StageAwareEvalCallback)
+        assert eval_callback.success_applicable is success_applicable
+        plateau_callback = next(callback for callback in callbacks if isinstance(callback, StageGatePlateauCallback))
+        assert plateau_callback.plateau_window == 7
+        assert plateau_callback.min_relative_variation == 0.02
+        eval_env.close()
 
 
 # ── cosine_schedule ─────────────────────────────────────────────────────

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -9,6 +9,8 @@ The original monolithic module has been split into focused submodules for
 maintainability:
 
 - :mod:`~environments.shared.diagnostics` -- ``DiagnosticsCallback``
+- :mod:`~environments.shared.eval_diagnostics` -- stage-aware SB3 evaluation
+  and plateau diagnostics
 - :mod:`~environments.shared.evaluation` -- ``eval_policy``, ``evaluate``,
   ``record_stage_video``
 - :mod:`~environments.shared.cli` -- ``main``, ``_apply_overrides``,
@@ -322,6 +324,7 @@ def _build_core_callbacks(
     eval_freq: int,
     save_freq: int,
     verbose: int,
+    stage_config: dict[str, Any],
     use_wandb: bool = False,
     local_tb_dir: Path | None = None,
     gcs_tb_path: Path | None = None,
@@ -338,10 +341,11 @@ def _build_core_callbacks(
         SaveVecNormalizeCallback,
     )
     from .diagnostics import DiagnosticsCallback as _DiagCB
+    from .eval_diagnostics import build_stage_evaluation_callbacks
     from .tb_sync import PeriodicTbSyncCallback
     from .wandb_integration import WandbCallback
 
-    callbacks = []
+    callbacks: list[Any] = []
 
     save_vecnorm_cb = SaveVecNormalizeCallback(
         save_path=str(model_dir / "best_model_vecnorm.pkl"),
@@ -354,8 +358,11 @@ def _build_core_callbacks(
     import tempfile as _tempfile
 
     local_eval_dir = _tempfile.mkdtemp(prefix=f"eval_stage{stage}_")
-    eval_callback = sb3["EvalCallback"](
+    eval_callback, plateau_callback = build_stage_evaluation_callbacks(
         eval_env,
+        stage=stage,
+        stage_config=stage_config,
+        diagnostics_verbose=verbose,
         best_model_save_path=str(model_dir),
         log_path=local_eval_dir,
         eval_freq=eval_freq // n_envs,
@@ -366,6 +373,7 @@ def _build_core_callbacks(
         callback_on_new_best=save_vecnorm_cb,
     )
     callbacks.append(eval_callback)
+    callbacks.append(plateau_callback)
     callbacks.append(PublishEvalArtifactsCallback(eval_callback, publish_dir=log_path))
     # Risk-adjusted (mean - std) checkpoint alongside SB3's mean-reward
     # best_model; next-stage loading prefers it when present.
@@ -572,6 +580,7 @@ def train(
         eval_freq,
         save_freq,
         verbose,
+        config,
         use_wandb,
         local_tb_dir=local_tb_dir,
         gcs_tb_path=gcs_tb_path,
@@ -1001,6 +1010,7 @@ def train_curriculum(
             eval_freq,
             save_freq,
             verbose,
+            config,
             use_wandb,
             local_tb_dir=local_tb_dir,
             gcs_tb_path=gcs_tb_path,


### PR DESCRIPTION
## Summary

- move plateau detection from training-rollout returns to deterministic evaluations and the currently blocking stage gate
- warn once per plateau episode, re-arm only after meaningful movement, and include stage, timestep, measured range, configured gate, and behavior-specific guidance
- report success as N/A when a stage has no success-rate gate while preserving genuine Stage 3 0% results and `evaluations.npz` success arrays
- use the same 30-episode forward-velocity sample for Stage 2 diagnostics and curriculum advancement
- share callback construction between regular training and Ray Tune, and run the new integration tests in the SB3 CI lane

## Root cause

The old warning compared an absolute reward range across training rollouts. That made warning cadence algorithm-dependent, treated a hard-coded range of 1.0 as meaningful at every reward scale, and emitted the same warning on every subsequent rollout. SB3 also printed a success rate whenever terminal `is_success` existed, even when success was not part of the current stage.

## Behavior after this change

The diagnostic waits for five deterministic evaluations by default, follows task success, forward velocity, episode length, or reward in stage-priority order, and requires the configured minimum number of finite samples for every active gate. It never stops training and remains separate from curriculum advancement and collapse early-stop.

The defaults can be overridden per stage with `diagnostics_plateau_window` and `diagnostics_plateau_min_relative_variation`.

## Validation

- `ruff check environments/`
- `ruff format --check environments/`
- `mypy --no-site-packages environments/ --ignore-missing-imports`
- exact SB3 CI test selection, including the new evaluation-diagnostics integration tests
- no-SB3 core-CI simulation for diagnostics/curriculum imports and tests
- full non-JAX/non-MJX test suite
- `git diff --check`
- workflow YAML parse
