### PR TITLE
Stabilize PPO curriculum: enable/anchor entropy decay, cosine LR, target_kl, brachio fall-floor

### DIFF
--- a/configs/brachiosaurus/stage1_balance.toml
+++ b/configs/brachiosaurus/stage1_balance.toml
@@ -31,7 +31,8 @@ reset_noise_scale = 0.05                  # Increased from 0.01 default to impro
 
 [ppo]
 learning_rate = 3e-5                    # Sweep result: 3.23e-5 — 10x lower than 3e-4. All successful S1 runs used this; higher LR likely caused instability.
-learning_rate_end = 1e-5
+learning_rate_end = 5e-6                # Lowered from 1e-5 so the cosine schedule settles to a gentler late-stage floor.
+lr_schedule = "cosine"                  # Cosine decays faster mid-training than linear, protecting the converged policy from late destabilisation.
 n_steps = 2048
 batch_size = 128                        # Sweep result: doubled from 64. More stable gradient estimates for the large observation space.
 n_epochs = 10
@@ -39,10 +40,12 @@ gamma = 0.98                            # Sweep result: 0.9797 — slightly shor
 gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.01
-# ent_coef_end = 0.002                  # Uncomment to decay entropy over the stage (EntCoefDecayCallback);
-                                        # 5x decay mirrors velociraptor's 0.005 -> 0.001. Velociraptor stages
-                                        # 1 & 2 both destabilized late under constant ent_coef; decay fixed
-                                        # stage 2. See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
+ent_coef_end = 0.002                    # Enabled: 5x entropy decay (EntCoefDecayCallback). Brachiosaurus was the only
+ent_coef_decay_timesteps = 2500000      # species with this disabled; the bipeds destabilised late under a constant ent_coef
+                                        # and this decay fixed them. Anchored to ~40% of the 6M budget so entropy reaches its
+                                        # floor once balance has converged. See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
+target_kl = 0.03                        # Early-stop PPO epochs on high approx-KL — caps destabilising late updates on the
+                                        # thin 4-env rollouts (mirrors the JAX path's target_kl guard).
 
 [ppo.policy_kwargs]
 net_arch = [512, 256]

--- a/configs/brachiosaurus/stage2_locomotion.toml
+++ b/configs/brachiosaurus/stage2_locomotion.toml
@@ -26,10 +26,12 @@ food_head_proximity_weight = 0.0
 food_distance_range = [8.0, 12.0]
 food_height_range = [2.0, 3.0]
 max_episode_steps = 1000
+healthy_z_range = [0.85, 3.5]          # Lowered fall floor from the env default 1.0: settled stance is ~1.13 m and normal gait bob dips to ~1.10 m, so a 1.0 floor fired spurious "fallen" terminations mid-gait (short 642/1000-step episodes, high variance). 0.85 keeps real falls detectable while letting the gait breathe.
 
 [ppo]
 learning_rate = 6e-5                    # Sweep winner: 6.03e-5 — slightly higher than 5e-5, better gradient signal without catastrophic forgetting.
-learning_rate_end = 1e-5
+learning_rate_end = 5e-6                # Lowered from 1e-5 for a gentler late-stage cosine floor.
+lr_schedule = "cosine"                  # Cosine LR protects the converged gait from the post-peak collapse (best 6625 @3.8M -> final 3495).
 n_steps = 2048                          # Sweep winner: 2048 — smaller rollout buffer performed better; faster policy updates.
 batch_size = 512                        # Sweep winner: 512 — larger minibatches gave more stable gradients. Key differentiator of the top trial.
 n_epochs = 10
@@ -37,12 +39,11 @@ gamma = 0.993                           # Sweep winner: 0.9929 — all top-3 tri
 gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.01                         # Sweep winner: 0.0104 — reduced from 0.015. Less entropy lets policy commit to discovered gaits sooner.
-# ent_coef_end = 0.002                  # Uncomment to decay entropy over the stage (EntCoefDecayCallback);
-                                        # 5x decay mirrors velociraptor's 0.005 -> 0.001, which (with
-                                        # fall_penalty -150, forward_vel_max 2.5) carried its stage 2 to
-                                        # 2706 +/- 8 @ 2.75 m/s on the 1.5x-kp plant. Sweep-winner caveat:
-                                        # the 0.0104 constant was tuned on the old plant, so re-validate.
-                                        # See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
+ent_coef_end = 0.002                    # Enabled: 5x entropy decay (EntCoefDecayCallback) — the documented fix for this exact
+ent_coef_decay_timesteps = 6000000      # post-peak collapse, previously disabled only on Brachiosaurus. Anchored to 6M (~the
+                                        # gait-consolidation point, just after the 4M ramp) rather than the padded 16M budget,
+                                        # so entropy reaches its floor before the late drift. See STAGE2_RECOMMENDATIONS.md §5.
+target_kl = 0.03                        # Cap destabilising late PPO updates (early-stop epochs on high approx-KL).
 
 [ppo.policy_kwargs]
 net_arch = [512, 256]                  # Larger first layer to match Stage 1 setting 4 architecture

--- a/configs/brachiosaurus/stage3_food_reach.toml
+++ b/configs/brachiosaurus/stage3_food_reach.toml
@@ -22,10 +22,12 @@ food_distance_range = [1.5, 4.0]       # Tightened from [2.0, 6.0]: closer food 
 food_lateral_range = [-1.5, 1.5]
 food_height_range = [2.0, 3.5]         # Lowered from [2.5, 4.0]: slightly lower food reduces coordination demand on neck extension
 max_episode_steps = 1000
+healthy_z_range = [0.85, 3.5]          # Lowered fall floor from the env default 1.0 so the reach motion isn't cut short by spurious "fallen" terminations when the torso bobs during approach (settled stance ~1.13 m).
 
 [ppo]
 learning_rate = 5e-5
-learning_rate_end = 1e-5
+learning_rate_end = 5e-6                # Lowered from 1e-5 for a gentler late-stage cosine floor.
+lr_schedule = "cosine"                 # Cosine LR protects against the post-peak decline (best @1.65M then long drift).
 n_steps = 4096
 batch_size = 256
 n_epochs = 10
@@ -33,6 +35,9 @@ gamma = 0.995
 gae_lambda = 0.95
 clip_range = 0.2                       # Widened from 0.15: tighter clip likely caused reward collapse after 4M. Match Stage 2 value for stability.
 ent_coef = 0.01                        # Doubled from 0.005: more exploration needed to discover neck-extension behavior for food reach
+ent_coef_end = 0.002                   # Enabled: decay entropy to its floor after the reach behaviour is discovered (~1.65M),
+ent_coef_decay_timesteps = 4000000     # so the policy consolidates instead of drifting. Anchored well below the 12M budget.
+target_kl = 0.03                       # Cap destabilising late PPO updates (early-stop epochs on high approx-KL).
 
 [ppo.policy_kwargs]
 net_arch = [512, 256]                  # Match Stage 1 setting 4 architecture to avoid weight truncation on checkpoint load

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -43,6 +43,8 @@ ent_coef_end = 0.001                    # Decay entropy over the stage (EntCoefD
                                         # (bimodal falls, action std growth); decay fixed its stage 2 and is
                                         # enabled for its stage 1. See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
 
+target_kl = 0.03                        # Cap destabilising late PPO updates (early-stop epochs on high approx-KL); mirrors the JAX target_kl guard.
+
 [ppo.policy_kwargs]
 net_arch = [512, 256]
 

--- a/configs/trex/stage2_locomotion.toml
+++ b/configs/trex/stage2_locomotion.toml
@@ -46,6 +46,8 @@ ent_coef_end = 0.001                    # Decay entropy over the stage (EntCoefD
                                         # velociraptor stage 2 to 2706 +/- 8 @ 2.75 m/s on the 1.5x-kp plant.
                                         # See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
 
+target_kl = 0.03                        # Cap destabilising late PPO updates (early-stop epochs on high approx-KL); mirrors the JAX target_kl guard.
+
 [ppo.policy_kwargs]
 net_arch = [512, 256]                  # Larger first layer for T-Rex's higher-dimensional obs space (83 vs raptor's 67)
 

--- a/configs/trex/stage3_bite.toml
+++ b/configs/trex/stage3_bite.toml
@@ -23,7 +23,8 @@ max_episode_steps = 1000
 
 [ppo]
 learning_rate = 5e-5
-learning_rate_end = 1e-5
+learning_rate_end = 5e-6                # Lowered from 1e-5 for a gentler late-stage cosine floor.
+lr_schedule = "cosine"                 # Cosine LR reduces the post-peak decline (best 1726 @5.5M -> final 1316).
 n_steps = 4096
 batch_size = 256
 n_epochs = 10
@@ -31,6 +32,9 @@ gamma = 0.995
 gae_lambda = 0.95
 clip_range = 0.15                      # Widened from 0.1: allow larger policy updates to escape local optimum (survival-only behavior)
 ent_coef = 0.005                       # 5x increase from 0.001: more exploration needed to discover sparse bite reward
+ent_coef_end = 0.001                   # Enabled: decay entropy to a low floor once the bite behaviour is discovered, so the
+ent_coef_decay_timesteps = 3000000     # policy consolidates instead of drifting late (best @5.5M then decline). Anchored below the 8M budget.
+target_kl = 0.03                       # Cap destabilising late PPO updates (early-stop epochs on high approx-KL).
 
 [ppo.policy_kwargs]
 net_arch = [512, 256]

--- a/configs/velociraptor/stage1_balance.toml
+++ b/configs/velociraptor/stage1_balance.toml
@@ -26,7 +26,8 @@ reset_noise_scale = 0.05                  # Increased from 0.01 default to impro
 
 [ppo]
 learning_rate = 3e-5                             # Setting 4 sweep: 3.23e-5 — 10x lower. Old 3e-4 produced inconsistent results (512–1702 range). Lower LR gives stable ~1500–2400.
-learning_rate_end = 1e-5
+learning_rate_end = 5e-6                          # Lowered from 1e-5 for a gentler late-stage cosine floor.
+lr_schedule = "cosine"                            # Cosine LR protects the converged balance policy from the late collapse seen on 07-12.
 n_steps = 2048
 batch_size = 128                                 # Setting 4 sweep: halved from 256. All successful Setting 4 runs used 128.
 n_epochs = 10                                    # Setting 4 sweep: restored from 6. With batch=128, minibatch count doubles — 10 epochs is validated by data.
@@ -39,6 +40,8 @@ ent_coef_end = 0.001                             # Decay entropy over the stage 
                                                  # under constant ent_coef on the 1.5x-kp plant — the same late-training
                                                  # entropy pathology that broke stage 2, where this decay fixed it.
                                                  # See docs/investigations/STAGE2_RECOMMENDATIONS.md section 5.
+ent_coef_decay_timesteps = 3000000               # Anchor the decay to ~the observed collapse point (~2.45M) instead of the full 6M budget, so entropy reaches its 0.001 floor before the late drift.
+target_kl = 0.03                                 # Early-stop PPO epochs on high approx-KL — extra guard against the late destabilisation that collapsed the 07-12 run.
 
 [ppo.policy_kwargs]
 net_arch = [512, 256]

--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -44,6 +44,8 @@ ent_coef_end = 0.001                # Linearly decay the entropy bonus over the 
                                     # still rising at the early stop.
                                     # See docs/investigations/STAGE2_RECOMMENDATIONS.md R4.
 
+target_kl = 0.03                        # Cap destabilising late PPO updates (early-stop epochs on high approx-KL); mirrors the JAX target_kl guard.
+
 [ppo.policy_kwargs]
 net_arch = [512, 256]
 

--- a/configs/velociraptor/stage3_strike.toml
+++ b/configs/velociraptor/stage3_strike.toml
@@ -26,7 +26,8 @@ max_episode_steps = 1000
 
 [ppo]
 learning_rate = 5e-5
-learning_rate_end = 1e-5
+learning_rate_end = 5e-6                # Lowered from 1e-5 for a gentler late-stage cosine floor.
+lr_schedule = "cosine"                 # Cosine LR reduces the post-peak decline (best 1351 @5.7M -> final 1283).
 n_steps = 4096
 batch_size = 256
 n_epochs = 10
@@ -34,6 +35,9 @@ gamma = 0.995
 gae_lambda = 0.95
 clip_range = 0.15                      # Widened from 0.1: allow larger policy updates to escape local optimum (survival-only behavior)
 ent_coef = 0.005                       # 5x increase from 0.001: more exploration needed to discover sparse strike reward
+ent_coef_end = 0.001                   # Enabled: decay entropy to a low floor once the strike behaviour is discovered, so the
+ent_coef_decay_timesteps = 3000000     # policy consolidates instead of drifting late. Anchored below the 8M budget.
+target_kl = 0.03                       # Cap destabilising late PPO updates (early-stop epochs on high approx-KL).
 
 [ppo.policy_kwargs]
 net_arch = [512, 256]


### PR DESCRIPTION
Addresses the post-peak eval collapse (final eval far below best) seen in the
latest Colab runs: Brachiosaurus S2 6625->3495 (+/-1335), S3 gate failure at
0.80 success, and Velociraptor S1 1524->424.

Training-stability (root cause = non-decaying exploration on a padded budget):
- Brachiosaurus S1/S2/S3: enable ent_coef decay (the only species with it
  disabled) — the documented fix for this exact late-training pathology.
- Anchor decay to the observed convergence point via explicit
  ent_coef_decay_timesteps instead of the padded 12-16M budget, so entropy
  reaches its floor before the collapse window rather than after run end.
- Switch collapse-prone stages to the already-implemented cosine LR schedule
  and lower learning_rate_end 1e-5 -> 5e-6.
- Add target_kl=0.03 to every SB3 [ppo] section to cap destabilising late
  updates on thin 4-env rollouts (the JAX path already sets target_kl).
  Enable/anchor decay also applied to Velociraptor S1 (catastrophic collapse)
  and the three terminal stage-3 configs, which previously lacked decay.

Model/env:
- Raise Brachiosaurus healthy_z floor 1.0 -> 0.85 on S2/S3: settled stance is
  ~1.13m and normal gait bob dips to ~1.10m, so the 1.0 floor fired spurious
  "fallen" terminations mid-gait (short episodes, high variance).

Config-only. Verified all 9 stages load and every [ppo] key is a valid PPO
constructor kwarg or harness schedule key; cosine schedule and decay math
exercised directly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T6QoQJ5M3VQovtF5VdYQjL