### PR TITLE
Fix sb3_training notebook: pass stage_config to _build_core_callbacks

### DIFF
--- a/notebooks/sb3_training.ipynb
+++ b/notebooks/sb3_training.ipynb
@@ -503,6 +503,7 @@
     "    callbacks, eval_callback, save_vecnorm_cb = _build_core_callbacks(\n",
     "        sb3, eval_env, model_dir, stage_dir, stage, N_ENVS,\n",
     "        eval_freq=50000, save_freq=500000, verbose=VERBOSE,\n",
+    "        stage_config=config,\n",
     "    )\n",
     "    best_vecnorm_path = save_vecnorm_cb.save_path\n",
     "\n",


### PR DESCRIPTION
The notebook's train_stage() called _build_core_callbacks() without the stage_config argument, which became a required positional parameter when the helper started building stage-aware evaluation callbacks. Every run crashed at Stage 1 model setup with:
  TypeError: _build_core_callbacks() missing 1 required positional argument: 'stage_config'

The library callers (train_base.train / train_curriculum) already pass `config`; the notebook was not updated. Pass stage_config=config to match. Verified the notebook remains valid JSON and that the other train_base helper calls in the notebook still match their current signatures.