### PR TITLE
Configurable collapse early-stop for locomotion + run reproducibility (git commit / provenance)

### DIFF
--- a/configs/brachiosaurus/stage2_locomotion.toml
+++ b/configs/brachiosaurus/stage2_locomotion.toml
@@ -43,7 +43,7 @@ ent_coef_end = 0.002                    # Enabled: 5x entropy decay (EntCoefDeca
 ent_coef_decay_timesteps = 6000000      # post-peak collapse, previously disabled only on Brachiosaurus. Anchored to 6M (~the
                                         # gait-consolidation point, just after the 4M ramp) rather than the padded 16M budget,
                                         # so entropy reaches its floor before the late drift. See STAGE2_RECOMMENDATIONS.md §5.
-target_kl = 0.03                        # Cap destabilising late PPO updates (early-stop epochs on high approx-KL).
+target_kl = 0.05                        # Loosened from 0.03: locomotion learns fast early, so a tight KL cap early-stops epochs and throttles gait development. 0.05 matches the JAX path.
 
 [ppo.policy_kwargs]
 net_arch = [512, 256]                  # Larger first layer to match Stage 1 setting 4 architecture
@@ -98,6 +98,9 @@ min_avg_reward = 100.0
 min_avg_episode_length = 750
 min_avg_forward_vel = 0.75             # Gate on actual locomotion; without this, a standing-still policy passes on alive_bonus alone. Realistic walking speed for a heavy sauropod.
 required_consecutive = 3
+collapse_min_evals = 20                 # Backstop early-stop (EvalCollapseEarlyStopCallback): wait ~1M steps (20 evals x 50k) before it can fire.
+collapse_patience = 10                  # Require 10 consecutive sub-threshold evals (~500k steps) so a transient dip won't abort the stage.
+collapse_drop_fraction = 0.5            # Only a >50% drop from peak counts, so the normal early-locomotion dip survives until entropy decay (floor ~6M) stabilises the gait.
 warmup_timesteps = 1000000              # Sweep winner: 1M — 3x longer warmup was the biggest signal. Gives critic much more time to adapt to new reward landscape before policy changes accelerate.
 warmup_clip_range = 0.035               # Sweep winner: 0.0335 — more clip room during warmup lets policy adjust faster once critic is ready.
 warmup_ent_coef = 0.018                 # Sweep winner: 0.0175 — slightly lower than 0.02, less random during warmup since critic has longer to stabilize.

--- a/configs/trex/stage2_locomotion.toml
+++ b/configs/trex/stage2_locomotion.toml
@@ -46,7 +46,7 @@ ent_coef_end = 0.001                    # Decay entropy over the stage (EntCoefD
                                         # velociraptor stage 2 to 2706 +/- 8 @ 2.75 m/s on the 1.5x-kp plant.
                                         # See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
 
-target_kl = 0.03                        # Cap destabilising late PPO updates (early-stop epochs on high approx-KL); mirrors the JAX target_kl guard.
+target_kl = 0.05                        # Loosened from 0.03 for the locomotion stage (fast early learning); matches the JAX path's value.
 
 [ppo.policy_kwargs]
 net_arch = [512, 256]                  # Larger first layer for T-Rex's higher-dimensional obs space (83 vs raptor's 67)
@@ -100,6 +100,9 @@ min_avg_reward = 100.0
 min_avg_episode_length = 750            # Reduce from 800: T-Rex best run reached 682, 800 is too strict
 min_avg_forward_vel = 2.0               # Gate on sustained running (matches raptor stage 2 gate)
 required_consecutive = 3
+collapse_min_evals = 20                 # Backstop early-stop (EvalCollapseEarlyStopCallback): wait ~1M steps before it can fire.
+collapse_patience = 10                  # Require 10 consecutive sub-threshold evals so a transient dip won't abort the stage.
+collapse_drop_fraction = 0.5            # Only a >50% drop from peak counts, so the normal early-locomotion dip survives.
 warmup_timesteps = 300000               # Increased from 100k: give critic more time to adapt to new reward landscape (matches raptor stage 2 proportional warmup)
 warmup_clip_range = 0.02                # Small clip range during warm-up to limit policy change
 warmup_ent_coef = 0.02                  # Higher entropy during warm-up to maintain exploration

--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -44,7 +44,7 @@ ent_coef_end = 0.001                # Linearly decay the entropy bonus over the 
                                     # still rising at the early stop.
                                     # See docs/investigations/STAGE2_RECOMMENDATIONS.md R4.
 
-target_kl = 0.03                        # Cap destabilising late PPO updates (early-stop epochs on high approx-KL); mirrors the JAX target_kl guard.
+target_kl = 0.05                        # Loosened from 0.03 for the locomotion stage (fast early learning); matches the JAX path's value.
 
 [ppo.policy_kwargs]
 net_arch = [512, 256]
@@ -96,6 +96,9 @@ min_avg_reward = 100.0
 min_avg_episode_length = 750
 min_avg_forward_vel = 2.0
 required_consecutive = 3
+collapse_min_evals = 20                 # Backstop early-stop (EvalCollapseEarlyStopCallback): wait ~1M steps before it can fire.
+collapse_patience = 10                  # Require 10 consecutive sub-threshold evals so a transient dip won't abort the stage.
+collapse_drop_fraction = 0.5            # Only a >50% drop from peak counts, so the normal early-locomotion dip survives.
 warmup_timesteps = 300000               # Increase from 100k: give critic more time to adapt to new reward landscape
 warmup_clip_range = 0.02
 warmup_ent_coef = 0.02

--- a/environments/shared/config.py
+++ b/environments/shared/config.py
@@ -53,6 +53,33 @@ def get_library_version() -> str:
     return "unknown"
 
 
+def get_git_commit() -> str:
+    """Return the repository's current git commit hash, or ``"unknown"``.
+
+    Runs ``git rev-parse HEAD`` from the repository root so it works even when
+    the process working directory is elsewhere (e.g. a Colab notebook whose CWD
+    is ``/content``). Falls back to the ``GITHUB_SHA`` environment variable (set
+    in CI) before giving up, so a saved stage config records the exact code
+    revision that produced the run for reproducibility.
+    """
+    import os
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return os.environ.get("GITHUB_SHA", "unknown")
+
+
 # Known GPU short-names extracted from full device strings.
 _GPU_SHORT_NAMES = ("A100", "H100", "L4", "L40", "T4", "V100", "A10G", "A10", "RTX")
 
@@ -279,6 +306,7 @@ def save_stage_config(
         "description": stage_config.get("description", ""),
         "algorithm": algorithm.upper(),
         "library_version": get_library_version(),
+        "git_commit": get_git_commit(),
         "reward_weights": env_kwargs,
         "hyperparameters": stage_config.get(algo_key, {}),
         "curriculum": stage_config.get("curriculum_kwargs", {}),

--- a/environments/shared/reporting.py
+++ b/environments/shared/reporting.py
@@ -441,6 +441,49 @@ def write_training_summary(
     return summary_path
 
 
+def _backend_name(algorithm: str) -> str:
+    """Training-backend identifier for a summary's ``backend`` field."""
+    return "jax" if algorithm.upper().startswith("JAX") else "stable-baselines3"
+
+
+def _backend_version(algorithm: str) -> "str | None":
+    """Installed version of the training backend, or ``None`` if undetectable."""
+    package = "jax" if algorithm.upper().startswith("JAX") else "stable_baselines3"
+    try:
+        from importlib.metadata import version
+
+        return version(package)
+    except Exception:
+        return None
+
+
+def _run_provenance(overrides: "Mapping[str, Any] | None" = None) -> dict[str, Any]:
+    """Build a summary ``provenance`` block, recording the repository commit.
+
+    Defaults are conservative: a freshly generated summary is ``historical`` /
+    ``unverified``. Per the results contract, ``current`` or ``verified`` may
+    only be claimed once the model hash, config hash, backend version, and
+    evaluation-episode count are all recorded. The repository commit is filled
+    automatically so a generated summary ties back to the exact code revision;
+    callers with full identity can pass ``overrides`` to complete and certify it.
+    """
+    from .config import get_git_commit
+
+    provenance: dict[str, Any] = {
+        "model_revision_status": "historical",
+        "verification_status": "unverified",
+        "evaluation_episodes": None,
+        "repository_commit": get_git_commit(),
+        "model_hash": None,
+        "config_hash": None,
+    }
+    if overrides:
+        for key, value in overrides.items():
+            if key in provenance:
+                provenance[key] = value
+    return provenance
+
+
 def save_results_json(
     stage_results_list: list[dict[str, Any]],
     species: str,
@@ -448,6 +491,7 @@ def save_results_json(
     seed: int,
     results_dir: "str | Path",
     hardware: str = "Google Colab T4 GPU",
+    provenance: "Mapping[str, Any] | None" = None,
 ) -> Path:
     """Save a ``summary.json`` to *results_dir*.
 
@@ -458,6 +502,10 @@ def save_results_json(
         hardware: Description of the training hardware (e.g.
             ``"Vertex AI n1-standard-8 + T4"``).  Defaults to
             ``"Google Colab T4 GPU"`` for notebook usage.
+        provenance: Optional overrides for the ``provenance`` block (e.g.
+            ``model_hash``, ``config_hash``, ``evaluation_episodes``, or a
+            ``current`` / ``verified`` status once the run is fully
+            identified).  ``repository_commit`` is filled automatically.
 
     Returns the path to the written JSON file.
     """
@@ -485,6 +533,8 @@ def save_results_json(
     summary = {
         "species": species,
         "algorithm": algorithm,
+        "backend": _backend_name(algorithm),
+        "backend_version": _backend_version(algorithm),
         "hardware": hardware,
         "seed": seed,
         "date": datetime.now().strftime("%Y-%m-%d"),
@@ -493,6 +543,7 @@ def save_results_json(
         "total_training_time_seconds": round(total_duration, 1),
         "total_training_time": format_duration_hms(total_duration),
         "final_avg_reward": round(final_result["mean_reward"], 2),
+        "provenance": _run_provenance(provenance),
     }
     plant_identity = final_result.get("plant_identity")
     if isinstance(plant_identity, Mapping):

--- a/environments/shared/tests/test_config.py
+++ b/environments/shared/tests/test_config.py
@@ -13,6 +13,7 @@ from environments.shared.config import (
     _find_stage_file,
     _upload_to_gcs,
     append_stage_result_csv,
+    get_git_commit,
     load_all_stages,
     load_stage_config,
     save_stage_config,
@@ -503,6 +504,30 @@ class TestDetectGpuInfo:
         with patch("subprocess.run", side_effect=FileNotFoundError):
             result = _detect_gpu_info_nvidia_smi()
         assert result == {}
+
+
+class TestGetGitCommit:
+    """Git-commit capture for stage-config reproducibility."""
+
+    def test_returns_commit_hash(self):
+        import subprocess
+
+        fake = subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123def456\n", stderr="")
+        with patch("subprocess.run", return_value=fake):
+            assert get_git_commit() == "abc123def456"
+
+    def test_falls_back_to_github_sha(self, monkeypatch):
+        import subprocess
+
+        monkeypatch.setenv("GITHUB_SHA", "ci-sha-789")
+        fake = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="not a git repo")
+        with patch("subprocess.run", return_value=fake):
+            assert get_git_commit() == "ci-sha-789"
+
+    def test_unknown_when_no_git_and_no_env(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_SHA", raising=False)
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert get_git_commit() == "unknown"
 
 
 class TestAppendStageResultCsv:

--- a/environments/shared/tests/test_reporting.py
+++ b/environments/shared/tests/test_reporting.py
@@ -573,9 +573,7 @@ class TestSaveResultsJson:
             "model_revision_status": "current",
             "verification_status": "verified",
         }
-        path = save_results_json(
-            results, "velociraptor", "PPO", seed=42, results_dir=tmp_path, provenance=override
-        )
+        path = save_results_json(results, "velociraptor", "PPO", seed=42, results_dir=tmp_path, provenance=override)
         prov = json.loads(path.read_text())["provenance"]
         assert prov["model_hash"] == "sha256:abc"
         assert prov["config_hash"] == "sha256:def"
@@ -586,9 +584,7 @@ class TestSaveResultsJson:
 
     def test_backend_fields_present(self, tmp_path):
         results = [_make_stage_result(1)]
-        data = json.loads(
-            save_results_json(results, "velociraptor", "PPO", seed=42, results_dir=tmp_path).read_text()
-        )
+        data = json.loads(save_results_json(results, "velociraptor", "PPO", seed=42, results_dir=tmp_path).read_text())
         assert data["backend"] == "stable-baselines3"
         assert "backend_version" in data
 

--- a/environments/shared/tests/test_reporting.py
+++ b/environments/shared/tests/test_reporting.py
@@ -547,6 +547,51 @@ class TestSaveResultsJson:
         data = json.loads(path.read_text())
         assert data["final_avg_reward"] == 75.12
 
+    def test_provenance_records_repository_commit(self, tmp_path):
+        results = [_make_stage_result(1)]
+        path = save_results_json(results, "velociraptor", "PPO", seed=42, results_dir=tmp_path)
+        prov = json.loads(path.read_text())["provenance"]
+        assert set(prov) == {
+            "model_revision_status",
+            "verification_status",
+            "evaluation_episodes",
+            "repository_commit",
+            "model_hash",
+            "config_hash",
+        }
+        # Repository commit is auto-populated; a fresh run stays conservatively uncertified.
+        assert isinstance(prov["repository_commit"], str) and prov["repository_commit"]
+        assert prov["model_revision_status"] == "historical"
+        assert prov["verification_status"] == "unverified"
+
+    def test_provenance_overrides_are_applied(self, tmp_path):
+        results = [_make_stage_result(1)]
+        override = {
+            "model_hash": "sha256:abc",
+            "config_hash": "sha256:def",
+            "evaluation_episodes": 30,
+            "model_revision_status": "current",
+            "verification_status": "verified",
+        }
+        path = save_results_json(
+            results, "velociraptor", "PPO", seed=42, results_dir=tmp_path, provenance=override
+        )
+        prov = json.loads(path.read_text())["provenance"]
+        assert prov["model_hash"] == "sha256:abc"
+        assert prov["config_hash"] == "sha256:def"
+        assert prov["evaluation_episodes"] == 30
+        assert prov["model_revision_status"] == "current"
+        assert prov["verification_status"] == "verified"
+        assert prov["repository_commit"]  # still auto-filled when not overridden
+
+    def test_backend_fields_present(self, tmp_path):
+        results = [_make_stage_result(1)]
+        data = json.loads(
+            save_results_json(results, "velociraptor", "PPO", seed=42, results_dir=tmp_path).read_text()
+        )
+        assert data["backend"] == "stable-baselines3"
+        assert "backend_version" in data
+
     def test_forward_vel_in_stage_data(self, tmp_path):
         results = [_make_stage_result(1, mean_forward_vel=1.5)]
         path = save_results_json(results, "velociraptor", "PPO", seed=42, results_dir=tmp_path)

--- a/environments/shared/tests/test_train_base.py
+++ b/environments/shared/tests/test_train_base.py
@@ -216,6 +216,56 @@ class TestBuildCoreCallbacks:
         assert plateau_callback.min_relative_variation == 0.02
         eval_env.close()
 
+    def test_collapse_early_stop_params_are_configurable(self, tmp_path):
+        gym = pytest.importorskip("gymnasium")
+        pytest.importorskip("stable_baselines3")
+        from stable_baselines3.common.callbacks import CheckpointCallback
+        from stable_baselines3.common.vec_env import DummyVecEnv
+
+        from environments.shared.curriculum import EvalCollapseEarlyStopCallback
+
+        class TinyEnv(gym.Env):
+            observation_space = gym.spaces.Box(-1.0, 1.0, (1,), dtype=np.float32)
+            action_space = gym.spaces.Box(-1.0, 1.0, (1,), dtype=np.float32)
+
+            def reset(self, *, seed=None, options=None):
+                super().reset(seed=seed)
+                return np.zeros(1, dtype=np.float32), {}
+
+            def step(self, action):
+                return np.zeros(1, dtype=np.float32), 0.0, False, False, {"forward_vel": 0.0}
+
+        def _build_collapse_cb(curriculum_kwargs):
+            eval_env = DummyVecEnv([TinyEnv])
+            callbacks, _, _ = _build_core_callbacks(
+                {"CheckpointCallback": CheckpointCallback},
+                eval_env,
+                tmp_path / "models",
+                tmp_path / "logs",
+                2,
+                1,
+                100,
+                100,
+                0,
+                {"curriculum_kwargs": curriculum_kwargs},
+            )
+            eval_env.close()
+            return next(cb for cb in callbacks if isinstance(cb, EvalCollapseEarlyStopCallback))
+
+        # Explicit [curriculum] overrides are honoured.
+        cb = _build_collapse_cb(
+            {"min_avg_reward": 100.0, "collapse_min_evals": 20, "collapse_patience": 10, "collapse_drop_fraction": 0.5}
+        )
+        assert cb.min_evals == 20
+        assert cb.patience == 10
+        assert cb.drop_fraction == 0.5
+
+        # Defaults are lenient (looser than the old hardcoded 8 / 5 / 0.3).
+        cb_default = _build_collapse_cb({"min_avg_reward": 100.0})
+        assert cb_default.min_evals == 12
+        assert cb_default.patience == 8
+        assert cb_default.drop_fraction == 0.4
+
 
 # ── cosine_schedule ─────────────────────────────────────────────────────
 

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -435,8 +435,20 @@ def _build_core_callbacks(
 
     callbacks.append(_DiagCB(log_dir=str(log_path), verbose=verbose))
 
+    # Collapse early-stop is a backstop against a genuinely diverging stage.
+    # Its thresholds are configurable via the stage's [curriculum] section;
+    # defaults are lenient (looser than the former hardcoded 8 / 5 / 0.3) so a
+    # normal early-training dip does not abort a stage before entropy decay /
+    # LR annealing have had a chance to engage.
+    collapse_cfg = stage_config.get("curriculum_kwargs", {})
     callbacks.append(
-        EvalCollapseEarlyStopCallback(eval_callback=eval_callback, min_evals=8, patience=5, verbose=verbose)
+        EvalCollapseEarlyStopCallback(
+            eval_callback=eval_callback,
+            min_evals=int(collapse_cfg.get("collapse_min_evals", 12)),
+            patience=int(collapse_cfg.get("collapse_patience", 8)),
+            drop_fraction=float(collapse_cfg.get("collapse_drop_fraction", 0.4)),
+            verbose=verbose,
+        )
     )
 
     if use_wandb:


### PR DESCRIPTION
## Why

The latest Brachiosaurus run stopped in **Stage 2 at 2.95M of 16M** steps and never reached Stage 3. Root cause: `EvalCollapseEarlyStopCallback` had **hardcoded** thresholds (`min_evals=8, patience=5, drop_fraction=0.3`) and fired during the *normal* early-locomotion dip — **before** the recently-added stabilizers (entropy decay, which reaches its floor at 6M, and cosine LR annealing) could engage. The collapse backstop was effectively fighting the fix it is meant to complement.

## Commit 1 — configurable collapse early-stop

Make the collapse early-stop thresholds configurable from the stage `[curriculum]` section (same plumbing as the existing plateau-diagnostic keys — `_build_core_callbacks` already receives the full `stage_config`, and it reaches the callback in `train()`, `train_curriculum()`, and the notebook).

| param | old (hardcoded) | new default | Stage 2 override |
|---|---|---|---|
| `collapse_min_evals` | 8 | 12 | **20** (~1M steps before it can fire) |
| `collapse_patience` | 5 | 8 | **10** (~500k of sustained drop) |
| `collapse_drop_fraction` | 0.3 | 0.4 | **0.5** (only a >50% drop counts) |

- `drop_fraction` is now threaded through (the builder previously left it at the callback default).
- **Stage 2 `target_kl` 0.03 → 0.05** (matches the JAX path): the tighter cap early-stopped PPO epochs and throttled fast early gait learning.

Under the new Stage-2 settings the prior run's stop (peak ~2200 → final 1478, a 33% dip) would **not** trigger — the early dip now survives to the ≥6M window where entropy decay stabilizes the policy. The backstop still catches a genuinely catastrophic (>50%) divergence, and `robust_best_model` continues to capture the best checkpoint regardless.

## Commit 2 — git commit in `stage_config.json`

`stage_config.json` recorded `library_version` but not the code revision. Add `get_git_commit()` (runs `git rev-parse HEAD` from the repo root so it works when the Colab notebook CWD is `/content`; falls back to `GITHUB_SHA`, then `"unknown"`) and record it as `git_commit`. No notebook change needed — `save_stage_config` already runs on the notebook path.

## Commit 3 — repository_commit in `summary.json` provenance

`save_results_json` now emits a schema-shaped `provenance` block (plus top-level `backend` / `backend_version`) with `repository_commit` auto-populated. Defaults are conservative — a fresh summary is `historical` / `unverified`, since the results contract reserves `current` / `verified` for runs whose model hash, config hash, backend version, and evaluation-episode count are all recorded. Callers with full identity can pass `provenance=` overrides to complete and certify the block. Existing curated `results/` summaries are unchanged.

## Notes / trade-offs

- With `drop_fraction=0.5` the Stage-2 backstop is deliberately permissive — entropy decay is now the primary anti-collapse mechanism, so the callback only aborts on true divergence.
- The separate sweep path (`ray_tune.py`) already exposed `collapse_min_evals` / `collapse_patience` and is untouched.

## Verification

- All 9 stages load; Stage 2 resolves to `(20, 10, 0.5)` + `target_kl=0.05`, Stage 1/3 inherit the lenient `(12, 8, 0.4)` defaults.
- Collapse param traced to the callback across all three entry paths; no test pins the old `8/5` values, a `[curriculum]` allowlist, or the `stage_config.json` / `summary.json` key sets.
- Integration-verified in a sandbox: `git_commit == HEAD` written into `stage_config.json`, and `provenance.repository_commit == HEAD` in `save_results_json` output.
- Added tests: collapse overrides/defaults; `get_git_commit()` success + fallback branches; summary `provenance` defaults, overrides, and backend fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)