### PR TITLE
Center Velociraptor actions on the XML home pose

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Swift Bipedal Predator. **Specialty:** Sickle-claw contact attacks.
 | Action dimension / actuators | 22 |
 | Generalized coordinates / velocities | nq=31, nv=30 |
 | Compiled dynamic model mass | 13.5 kg |
-| Plant contract revisions | policy r1; physics r1; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r2; physics r1; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/velociraptor/assets/raptor.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |

--- a/configs/plant_manifest.generated.json
+++ b/configs/plant_manifest.generated.json
@@ -84,7 +84,7 @@
       }
     },
     "velociraptor": {
-      "bundle_sha256": "sha256:9eb173725d5a57cb0f30a6805dc83b26101b003c3654b9e51cd767b5c1e18862",
+      "bundle_sha256": "sha256:da93c4707c1eb7fed54295b5fdfd8f005f7e2b2c0d2d2fe37527f6d114dfdc8d",
       "env_entrypoint": "environments.velociraptor.envs.raptor_env:RaptorEnv",
       "model_path": "environments/velociraptor/assets/raptor.xml",
       "physics": {
@@ -99,9 +99,9 @@
         "action_dim": 22,
         "observation_dim": 67,
         "observation_schema": "bipedal-target/v1",
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:e4873d6f6c4a8316cdba7941fc1a78a1a8ec3c441a7c3b60be42646904ac8fe1"
+        "sha256": "sha256:38e9edbb4330492b9daa81523440ea5a38c643c94f5079723e24644fa6915225"
       },
       "source": {
         "closure_sha256": "sha256:852bbf54cea4e451380ed6b175f001ab0e11dac8e1c3632ea299e0a11f1ff38f",

--- a/configs/plant_versions.toml
+++ b/configs/plant_versions.toml
@@ -12,7 +12,7 @@ canonical_mujoco_version = "3.10.0"
 
 [plants.velociraptor]
 physics_revision = 1
-policy_interface_revision = 1
+policy_interface_revision = 2
 visual_revision = 1
 observation_schema = "bipedal-target/v1"
 

--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -808,9 +808,14 @@ class BaseDinoEnv(gym.Env, ABC):
         """Reset environment to initial state."""
         super().reset(seed=seed)
 
-        # Reset MuJoCo state using keyframe if available, otherwise default
+        # Reset MuJoCo state using the species-selected keyframe if available,
+        # otherwise the historical first keyframe. Species with a named
+        # nominal pose can cache its ID during initialization.
         if self.model.nkey > 0:
-            mujoco.mj_resetDataKeyframe(self.model, self.data, 0)
+            reset_keyframe_id = int(getattr(self, "_reset_keyframe_id", 0))
+            if not 0 <= reset_keyframe_id < self.model.nkey:
+                raise ValueError("reset keyframe ID is outside the model keyframe range")
+            mujoco.mj_resetDataKeyframe(self.model, self.data, reset_keyframe_id)
         else:
             mujoco.mj_resetData(self.model, self.data)
 

--- a/environments/shared/data/plant_manifest.generated.json
+++ b/environments/shared/data/plant_manifest.generated.json
@@ -84,7 +84,7 @@
       }
     },
     "velociraptor": {
-      "bundle_sha256": "sha256:9eb173725d5a57cb0f30a6805dc83b26101b003c3654b9e51cd767b5c1e18862",
+      "bundle_sha256": "sha256:da93c4707c1eb7fed54295b5fdfd8f005f7e2b2c0d2d2fe37527f6d114dfdc8d",
       "env_entrypoint": "environments.velociraptor.envs.raptor_env:RaptorEnv",
       "model_path": "environments/velociraptor/assets/raptor.xml",
       "physics": {
@@ -99,9 +99,9 @@
         "action_dim": 22,
         "observation_dim": 67,
         "observation_schema": "bipedal-target/v1",
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:e4873d6f6c4a8316cdba7941fc1a78a1a8ec3c441a7c3b60be42646904ac8fe1"
+        "sha256": "sha256:38e9edbb4330492b9daa81523440ea5a38c643c94f5079723e24644fa6915225"
       },
       "source": {
         "closure_sha256": "sha256:852bbf54cea4e451380ed6b175f001ab0e11dac8e1c3632ea299e0a11f1ff38f",

--- a/environments/shared/jax_eval.py
+++ b/environments/shared/jax_eval.py
@@ -43,6 +43,7 @@ class EvalConfig:
     root_body_id: int = 1
     sensor_gyro_start: int = 0
     sensor_quat_start: int = 6
+    action_mapping: str = "midpoint/v1"
     reset_noise_scale: float = 0.01
     forward_vel_max: float = 8.0
     # Success bonus added to the reward when a success site reaches the
@@ -167,6 +168,9 @@ def evaluate_policy_cpu(
     import mujoco
     import mujoco.mjx as mjx
 
+    from .mjx_env import ACTION_MAPPING_HOME_KEYFRAME_RESIDUAL, ACTION_MAPPING_MIDPOINT
+    from .mjx_utils import reset_mujoco_data_to_home
+
     mj_data = mujoco.MjData(mj_model)
     act_dim = mj_model.nu
     results = EvalResults()
@@ -199,7 +203,12 @@ def evaluate_policy_cpu(
         _target_body_id = mujoco.mj_name2id(mj_model, mujoco.mjtObj.mjOBJ_BODY, config.target_body)
 
     for ep in range(config.n_episodes):
-        mujoco.mj_resetData(mj_model, mj_data)
+        if config.action_mapping == ACTION_MAPPING_HOME_KEYFRAME_RESIDUAL:
+            reset_mujoco_data_to_home(mj_model, mj_data)
+        elif config.action_mapping == ACTION_MAPPING_MIDPOINT:
+            mujoco.mj_resetData(mj_model, mj_data)
+        else:
+            raise ValueError(f"unknown JAX action mapping {config.action_mapping!r}")
         mj_data.qpos[7:] += reset_rng.uniform(
             -config.reset_noise_scale,
             config.reset_noise_scale,

--- a/environments/shared/jax_setup.py
+++ b/environments/shared/jax_setup.py
@@ -97,6 +97,7 @@ class SpeciesContext:
     obs_dim: int = 0
     act_dim: int = 0
     ctrl_range: Any = None  # jnp.ndarray
+    action_mapping: str = "midpoint/v1"
 
     # Display / video
     camera_track_body: str = "pelvis"
@@ -221,7 +222,7 @@ def setup_species(species: str, stage: int = 1) -> SpeciesContext:
     floor_geom_id = mujoco.mj_name2id(mj_model, mujoco.mjtObj.mjOBJ_GEOM, "floor")
 
     # Resolve termination checks
-    from .mjx_env import _SPECIES_CONFIGS
+    from .mjx_env import _SPECIES_CONFIGS, ACTION_MAPPING_MIDPOINT
 
     species_kw = _SPECIES_CONFIGS.get(species, {})
 
@@ -286,6 +287,7 @@ def setup_species(species: str, stage: int = 1) -> SpeciesContext:
         obs_dim=int(test_obs.shape[0]),
         act_dim=mj_model.nu,
         ctrl_range=jnp.array(mj_model.actuator_ctrlrange),
+        action_mapping=species_kw.get("action_mapping", ACTION_MAPPING_MIDPOINT),
         camera_track_body=cam.get("camera_track_body", root_body_name),
         camera_distance=cam.get("camera_distance", 3.0),
         stage_name=stage_name,
@@ -457,14 +459,35 @@ def make_obs_fn(ctx: SpeciesContext):
 
 def make_scale_action_fn(ctx: SpeciesContext):
     """Create an action scaling function bound to the species context."""
-    from .mjx_utils import scale_action_jax
+    import jax.numpy as jnp
+    import mujoco
+
+    from .mjx_env import ACTION_MAPPING_HOME_KEYFRAME_RESIDUAL, ACTION_MAPPING_MIDPOINT
+    from .mjx_utils import scale_action_around_nominal_jax, scale_action_jax
 
     ctrl_range = ctx.ctrl_range
+    action_mapping = ctx.action_mapping
 
-    def scale_action(action):
+    if action_mapping == ACTION_MAPPING_HOME_KEYFRAME_RESIDUAL:
+        home_keyframe_id = mujoco.mj_name2id(ctx.mj_model, mujoco.mjtObj.mjOBJ_KEY, "home")
+        if home_keyframe_id < 0:
+            raise ValueError("home-keyframe residual action mapping requires a keyframe named 'home'")
+        nominal_ctrl = jnp.array(ctx.mj_model.key_ctrl[home_keyframe_id])
+        if bool(jnp.any((nominal_ctrl < ctrl_range[:, 0]) | (nominal_ctrl > ctrl_range[:, 1]))):
+            raise ValueError("home keyframe controls must lie inside every actuator control range")
+
+        def scale_home_residual_action(action):
+            return scale_action_around_nominal_jax(action, ctrl_range, nominal_ctrl)
+
+        return scale_home_residual_action
+
+    if action_mapping != ACTION_MAPPING_MIDPOINT:
+        raise ValueError(f"unknown JAX action mapping {action_mapping!r}")
+
+    def scale_midpoint_action(action):
         return scale_action_jax(action, ctrl_range)
 
-    return scale_action
+    return scale_midpoint_action
 
 
 def make_reward_fns(ctx: SpeciesContext):
@@ -614,6 +637,7 @@ def run_stage_evaluation(
         root_body_id=ctx.root_body_id,
         sensor_quat_start=ctx.sensor_layout.quat_start,
         sensor_gyro_start=ctx.sensor_layout.gyro_start,
+        action_mapping=ctx.action_mapping,
         reset_noise_scale=0.01,
         forward_vel_max=ctx.forward_vel_max,
         target_standing_z=(ctx.target_standing_z if ctx.target_standing_z is not None else 0.90),

--- a/environments/shared/jax_viz.py
+++ b/environments/shared/jax_viz.py
@@ -542,6 +542,7 @@ def record_training_video(
     success_threshold: float = 0.3,
     target_body: str | None = None,
     sensor_quat_start: int = 6,
+    action_mapping: str = "midpoint/v1",
     output_path: str | Path | None = None,
     fps: int = 50,
     height: int = 480,
@@ -578,6 +579,8 @@ def record_training_video(
             extremity termination. Episode ends if any site drops below
             its threshold (more precise than body checks for tips).
         sensor_quat_start: Index into sensordata where root quaternion starts.
+        action_mapping: Versioned action mapping used by the policy. Home-
+            residual policies also start video rollouts from the home keyframe.
         output_path: If provided, save video to this path (requires mediapy).
         fps: Frames per second for the video.
         height: Render height in pixels.
@@ -595,6 +598,9 @@ def record_training_video(
     import mujoco
     import mujoco.mjx as mjx
 
+    from .mjx_env import ACTION_MAPPING_HOME_KEYFRAME_RESIDUAL, ACTION_MAPPING_MIDPOINT
+    from .mjx_utils import reset_mujoco_data_to_home
+
     mj_data = mujoco.MjData(mj_model)
     renderer = mujoco.Renderer(mj_model, height=height, width=width)
 
@@ -607,7 +613,12 @@ def record_training_video(
     camera.azimuth = camera_azimuth
     camera.elevation = camera_elevation
 
-    mujoco.mj_resetData(mj_model, mj_data)
+    if action_mapping == ACTION_MAPPING_HOME_KEYFRAME_RESIDUAL:
+        reset_mujoco_data_to_home(mj_model, mj_data)
+    elif action_mapping == ACTION_MAPPING_MIDPOINT:
+        mujoco.mj_resetData(mj_model, mj_data)
+    else:
+        raise ValueError(f"unknown JAX action mapping {action_mapping!r}")
     mujoco.mj_forward(mj_model, mj_data)
 
     # Resolve body-height termination checks

--- a/environments/shared/mjx_env.py
+++ b/environments/shared/mjx_env.py
@@ -33,6 +33,9 @@ from .mjx_utils import check_jax
 
 _logger = logging.getLogger(__name__)
 
+ACTION_MAPPING_MIDPOINT = "midpoint/v1"
+ACTION_MAPPING_HOME_KEYFRAME_RESIDUAL = "home-keyframe-residual/v1"
+
 # ---------------------------------------------------------------------------
 # TOML [env] key translation
 # ---------------------------------------------------------------------------
@@ -143,6 +146,7 @@ class MJXEnvConfig:
     sensor_gyro_start: int = 0
     sensor_accel_start: int = 3
     sensor_quat_start: int = 6
+    action_mapping: str = ACTION_MAPPING_MIDPOINT
     natural_forward_z: float = 0.0
     forward_vel_max: float = 8.0
     fall_penalty: float = -100.0
@@ -241,6 +245,7 @@ _PLANT_INTERFACE_CONFIG_FIELDS = frozenset(
         "sensor_gyro_start",
         "sensor_accel_start",
         "sensor_quat_start",
+        "action_mapping",
     }
 )
 
@@ -420,8 +425,28 @@ class MJXDinoEnv:
             if mujoco.mj_name2id(self.mj_model, mujoco.mjtObj.mjOBJ_SITE, name) >= 0
         )
 
-        # Cache default MJX data once (avoids mjx.make_data per env per step)
-        self._default_data = mjx.make_data(self.mjx_model)
+        # Cache reset data once (avoids constructing data per env per reset).
+        # The home-residual action interface must start from the same complete
+        # keyframed state that defines action zero: qpos, qvel, act, ctrl, and
+        # mocap state.  Other species intentionally retain the historical MJX
+        # default reset and midpoint action mapping.
+        self.nominal_ctrl = None
+        if self.config.action_mapping == ACTION_MAPPING_HOME_KEYFRAME_RESIDUAL:
+            from .mjx_utils import reset_mujoco_data_to_home
+
+            home_data = mujoco.MjData(self.mj_model)
+            reset_mujoco_data_to_home(self.mj_model, home_data)
+            nominal_ctrl = home_data.ctrl.copy()
+            ctrl_range = self.mj_model.actuator_ctrlrange
+            if ((nominal_ctrl < ctrl_range[:, 0]) | (nominal_ctrl > ctrl_range[:, 1])).any():
+                raise ValueError("home keyframe controls must lie inside every actuator control range")
+            self.nominal_ctrl = jnp.array(nominal_ctrl)
+            mujoco.mj_forward(self.mj_model, home_data)
+            self._default_data = mjx.put_data(self.mj_model, home_data)
+        elif self.config.action_mapping == ACTION_MAPPING_MIDPOINT:
+            self._default_data = mjx.make_data(self.mjx_model)
+        else:
+            raise ValueError(f"unknown MJX action mapping {self.config.action_mapping!r}")
 
         # Pre-compile step and reset functions.  ``forward_vel_scale`` is
         # passed as a JAX scalar (broadcast via in_axes=None) so the reward
@@ -442,7 +467,7 @@ class MJXDinoEnv:
         import jax.numpy as jnp
         import mujoco.mjx as mjx
 
-        from .mjx_utils import scale_action_jax
+        from .mjx_utils import scale_action_around_nominal_jax, scale_action_jax
         from .reward_functions import (
             check_nosedive_termination,
             quat_to_forward_2d,
@@ -466,6 +491,7 @@ class MJXDinoEnv:
         model = self.mjx_model
         config = self.config
         ctrl_range = self.ctrl_range
+        nominal_ctrl = self.nominal_ctrl
         frame_skip = config.frame_skip
         dt = float(self.mj_model.opt.timestep) * frame_skip
         # Pre-resolved body-height termination pairs (body_id, z_threshold)
@@ -485,7 +511,10 @@ class MJXDinoEnv:
             ramp it without retracing this kernel.
             """
             # Scale action
-            ctrl = scale_action_jax(action, ctrl_range)
+            if nominal_ctrl is None:
+                ctrl = scale_action_jax(action, ctrl_range)
+            else:
+                ctrl = scale_action_around_nominal_jax(action, ctrl_range, nominal_ctrl)
             data = state.data.replace(ctrl=ctrl)
 
             # Physics step with frame skip

--- a/environments/shared/mjx_utils.py
+++ b/environments/shared/mjx_utils.py
@@ -36,9 +36,56 @@ def scale_action_jax(action, ctrl_range):
     return ctrl_min + (action + 1.0) * 0.5 * (ctrl_max - ctrl_min)
 
 
+def scale_action_around_nominal_jax(action, ctrl_range, nominal_ctrl):
+    """Scale normalized actions around a non-midpoint nominal control.
+
+    ``action == 0`` maps exactly to ``nominal_ctrl`` while ``-1`` and ``+1``
+    retain access to the actuator's minimum and maximum controls.  The two
+    halves are scaled independently because a biomechanically useful nominal
+    pose is not generally the midpoint of an actuator's control range.
+
+    Args:
+        action: JAX array of shape ``(n_actuators,)`` in ``[-1, 1]``.
+        ctrl_range: JAX array of shape ``(n_actuators, 2)`` with
+            ``[min, max]`` per actuator.
+        nominal_ctrl: JAX array of shape ``(n_actuators,)`` containing the
+            control targets for the nominal pose.
+
+    Returns:
+        Scaled control array.
+    """
+    import jax.numpy as jnp
+
+    action = jnp.clip(action, -1.0, 1.0)
+    ctrl_min = ctrl_range[:, 0]
+    ctrl_max = ctrl_range[:, 1]
+    below_nominal = nominal_ctrl + action * (nominal_ctrl - ctrl_min)
+    above_nominal = nominal_ctrl + action * (ctrl_max - nominal_ctrl)
+    return jnp.where(action < 0.0, below_nominal, above_nominal)
+
+
 def unscale_action_jax(ctrl, ctrl_range):
     """Inverse of :func:`scale_action_jax`: control range → [-1, 1]."""
 
     ctrl_min = ctrl_range[:, 0]
     ctrl_max = ctrl_range[:, 1]
     return 2.0 * (ctrl - ctrl_min) / (ctrl_max - ctrl_min + 1e-8) - 1.0
+
+
+def reset_mujoco_data_to_home(mj_model, mj_data) -> None:
+    """Reset CPU MuJoCo data to the named ``home`` keyframe.
+
+    ``mj_resetDataKeyframe`` restores the complete keyframed state: qpos,
+    qvel, actuator state, controls, mocap bodies, time, and user data.  This
+    helper keeps home-residual MJX training, CPU evaluation, and visualization
+    aligned with the Gymnasium environment's reset semantics.
+
+    Raises:
+        ValueError: If the model does not define a keyframe named ``home``.
+    """
+    import mujoco
+
+    home_keyframe_id = mujoco.mj_name2id(mj_model, mujoco.mjtObj.mjOBJ_KEY, "home")
+    if home_keyframe_id < 0:
+        raise ValueError("home-keyframe residual action mapping requires a keyframe named 'home'")
+    mujoco.mj_resetDataKeyframe(mj_model, mj_data, home_keyframe_id)

--- a/environments/shared/plant_contract.py
+++ b/environments/shared/plant_contract.py
@@ -53,6 +53,10 @@ PORTABLE_FLOAT_SIGNIFICANT_DIGITS = 12
 MODEL_IDENTITY_ATTRIBUTE = "_mesozoic_plant_identity"
 _MISSING_IDENTITY = object()
 
+_ACTION_MAPPING_MIDPOINT = "midpoint/v1"
+_ACTION_MAPPING_HOME_KEYFRAME_RESIDUAL = "home-keyframe-residual/v1"
+_MIDPOINT_ACTION_MAPPING_DESCRIPTION = "clip[-1,1]-then-affine-to-ordered-ctrlrange/v1"
+
 _logger = logging.getLogger(__name__)
 
 
@@ -330,6 +334,45 @@ def _module_function_semantics(module_name: str, function_names: Sequence[str]) 
     if missing:
         raise PlantContractError(f"{module_name} is missing policy-interface functions: {missing}")
     return {name: _callable_semantics(functions[name])["tokens_sha256"] for name in function_names}
+
+
+def _action_mapping_contract(
+    model: mujoco.MjModel,
+    env: Any,
+) -> tuple[str | dict[str, Any], tuple[str, ...]]:
+    """Describe the species' normalized-action mapping and JAX implementation."""
+    mode = str(getattr(env, "action_mapping", _ACTION_MAPPING_MIDPOINT))
+    if mode == _ACTION_MAPPING_MIDPOINT:
+        return _MIDPOINT_ACTION_MAPPING_DESCRIPTION, ("scale_action_jax",)
+    if mode != _ACTION_MAPPING_HOME_KEYFRAME_RESIDUAL:
+        raise PlantContractError(f"unsupported action mapping mode: {mode!r}")
+
+    home_keyframe_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "home")
+    if home_keyframe_id < 0:
+        raise PlantContractError("home-keyframe residual mapping requires a named 'home' keyframe")
+    nominal_ctrl = np.asarray(model.key_ctrl[home_keyframe_id], dtype=np.float64)
+    ctrl_range = np.asarray(model.actuator_ctrlrange, dtype=np.float64)
+    if nominal_ctrl.shape != (model.nu,) or not np.all(np.isfinite(nominal_ctrl)):
+        raise PlantContractError("home keyframe controls must be finite and match the actuator dimension")
+    if np.any(nominal_ctrl < ctrl_range[:, 0]) or np.any(nominal_ctrl > ctrl_range[:, 1]):
+        raise PlantContractError("home keyframe controls must remain inside every actuator control range")
+
+    return (
+        {
+            "schema": "mesozoic.action-mapping/v1",
+            "mode": mode,
+            "input_clip": [-1.0, 1.0],
+            "negative_endpoint": "ordered-ctrlrange-minimum",
+            "origin": {
+                "keyframe": "home",
+                "keyframe_id": home_keyframe_id,
+                "ctrl": nominal_ctrl,
+            },
+            "positive_endpoint": "ordered-ctrlrange-maximum",
+            "interpolation": "piecewise-affine/v1",
+        },
+        ("scale_action_around_nominal_jax",),
+    )
 
 
 def _array_digest(schema: str, array: np.ndarray) -> dict[str, Any]:
@@ -722,6 +765,13 @@ def _jax_policy_interface_payload(
     registered_frame_skip = int(raw_config.get("frame_skip", -1))
     if registered_frame_skip <= 0:
         raise PlantContractError(f"MJX frame_skip must be positive for {version.species}")
+    registered_action_mapping = str(raw_config.get("action_mapping", _ACTION_MAPPING_MIDPOINT))
+    sb3_action_mapping = str(getattr(env, "action_mapping", _ACTION_MAPPING_MIDPOINT))
+    if registered_action_mapping != sb3_action_mapping:
+        raise PlantContractError(
+            f"SB3 and MJX action mappings diverge for {version.species}: "
+            f"sb3={sb3_action_mapping!r}, mjx={registered_action_mapping!r}"
+        )
 
     probe_data = _deterministic_probe_data(model)
     target_pos = probe_data.mocap_pos[0] if model.nmocap else np.array([1.25, -0.45, 0.8])
@@ -745,7 +795,7 @@ def _jax_policy_interface_payload(
             f"MJX observation probe produced invalid output: shape={observation.shape}, expected={expected_shape}"
         )
 
-    return {
+    payload = {
         "registration_module": module_name,
         "frame_skip": registered_frame_skip,
         "control_timestep": model.opt.timestep * registered_frame_skip,
@@ -767,6 +817,9 @@ def _jax_policy_interface_payload(
             "values": _portable_probe_values(observation),
         },
     }
+    if registered_action_mapping != _ACTION_MAPPING_MIDPOINT:
+        payload["action_mapping"] = registered_action_mapping
+    return payload
 
 
 def _policy_interface_payload(
@@ -802,6 +855,7 @@ def _policy_interface_payload(
     collision_ids = np.flatnonzero((model.geom_contype != 0) | (model.geom_conaffinity != 0))
     sb3_observation_probe = _observation_probe(model, env)
     jax_interface = _jax_policy_interface_payload(model, env, version)
+    action_mapping, jax_action_functions = _action_mapping_contract(model, env)
     mjx_env_module = importlib.import_module("environments.shared.mjx_env")
     jax_setup_module = importlib.import_module("environments.shared.jax_setup")
     backend_observation_equal = np.array_equal(
@@ -813,32 +867,41 @@ def _policy_interface_payload(
             f"SB3 and MJX observation probes diverge for {version.species}; "
             "check cached body IDs, sensor offsets, and observation builders"
         )
+    interface_implementations = {
+        "sb3_observation": _callable_semantics(env._get_obs),
+        "sb3_action_mapping": _callable_semantics(env._scale_action),
+        "backend_neutral_observation": _module_function_semantics(
+            "environments.shared.obs_functions",
+            observation_functions,
+        ),
+        "jax_action_mapping": _module_function_semantics(
+            "environments.shared.mjx_utils",
+            jax_action_functions,
+        ),
+        # These are intentionally production observation callables, not a
+        # parallel test implementation. Reward/termination code stays out
+        # of the interface fingerprint.
+        "jax_observation_callers": {
+            "training_reset_and_step": _callable_semantics(mjx_env_module.build_mjx_observation),
+            "cpu_evaluation": _callable_semantics(jax_setup_module.make_obs_fn),
+        },
+    }
+    if str(getattr(env, "action_mapping", _ACTION_MAPPING_MIDPOINT)) == _ACTION_MAPPING_HOME_KEYFRAME_RESIDUAL:
+        interface_implementations["home_reset"] = {
+            "sb3": _callable_semantics(env.reset),
+            "jax": _module_function_semantics(
+                "environments.shared.mjx_utils",
+                ("reset_mujoco_data_to_home",),
+            ),
+        }
     return {
         "observation_schema": version.observation_schema,
         "observation": _space_payload(env.observation_space),
         "observation_probe": sb3_observation_probe,
         "observation_segments": observation_segments,
         "action": _space_payload(env.action_space),
-        "action_mapping": "clip[-1,1]-then-affine-to-ordered-ctrlrange/v1",
-        "interface_implementations": {
-            "sb3_observation": _callable_semantics(env._get_obs),
-            "sb3_action_mapping": _callable_semantics(env._scale_action),
-            "backend_neutral_observation": _module_function_semantics(
-                "environments.shared.obs_functions",
-                observation_functions,
-            ),
-            "jax_action_mapping": _module_function_semantics(
-                "environments.shared.mjx_utils",
-                ("scale_action_jax",),
-            ),
-            # These are intentionally production observation callables, not a
-            # parallel test implementation. Reward/termination code stays out
-            # of the interface fingerprint.
-            "jax_observation_callers": {
-                "training_reset_and_step": _callable_semantics(mjx_env_module.build_mjx_observation),
-                "cpu_evaluation": _callable_semantics(jax_setup_module.make_obs_fn),
-            },
-        },
+        "action_mapping": action_mapping,
+        "interface_implementations": interface_implementations,
         "jax_interface": jax_interface,
         "backend_observation_equal": backend_observation_equal,
         "frame_skip": int(env.frame_skip),
@@ -1617,13 +1680,18 @@ def validate_mjx_environment_plant(
         "sensor_gyro_start",
         "sensor_accel_start",
         "sensor_quat_start",
+        "action_mapping",
     )
     errors = []
     if str(getattr(config, "species", "")) != current.species:
         errors.append(f"species: runtime={getattr(config, 'species', None)!r}, current={current.species!r}")
     for field_name in fields:
         actual_value = getattr(config, field_name, None)
-        expected_value = expected.get(field_name)
+        expected_value = (
+            expected.get(field_name, _ACTION_MAPPING_MIDPOINT)
+            if field_name == "action_mapping"
+            else expected.get(field_name)
+        )
         if actual_value != expected_value:
             errors.append(f"{field_name}: runtime={actual_value!r}, registered={expected_value!r}")
     action_dim = int(getattr(env, "action_dim", -1))

--- a/environments/shared/tests/static_balance_helpers.py
+++ b/environments/shared/tests/static_balance_helpers.py
@@ -4,10 +4,11 @@ Species-specific test files inherit from these bases, overriding only
 the configuration (body names, thresholds, joint lists).
 
 ``env.step(np.zeros(...))`` is deliberately described as a *neutral action*,
-not zero torque: :class:`~environments.shared.base_env.BaseDinoEnv` maps it to
-the midpoint of every actuator control range, so position servos remain active.
-True passive characterization uses MuJoCo's ``mjDSBL_ACTUATION`` flag and
-checks that both actuator-space and generalized actuator forces stay zero.
+not zero torque: it maps to active position-servo controls (the shared base
+mapping uses range midpoints, while species may provide a nominal-pose
+mapping). True passive characterization uses MuJoCo's ``mjDSBL_ACTUATION``
+flag and checks that both actuator-space and generalized actuator forces stay
+zero.
 """
 
 from contextlib import contextmanager

--- a/environments/shared/tests/test_base_env.py
+++ b/environments/shared/tests/test_base_env.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from environments.brachiosaurus.envs.brachio_env import BrachioEnv
 from environments.shared.base_env import BaseDinoEnv
 from environments.velociraptor.envs.raptor_env import RaptorEnv
 
@@ -165,11 +166,11 @@ class TestTruncation:
 
 
 class TestActionScaling:
-    """Test action normalization from [-1, 1] to actuator ranges."""
+    """Test the shared midpoint action mapping retained by other species."""
 
     @pytest.fixture
     def env(self):
-        e = RaptorEnv()
+        e = BrachioEnv()
         yield e
         e.close()
 

--- a/environments/shared/tests/test_jax_eval.py
+++ b/environments/shared/tests/test_jax_eval.py
@@ -18,6 +18,7 @@ class TestEvalConfig:
         assert cfg.max_tilt_angle == pytest.approx(1.047)
         assert cfg.root_body_id == 1
         assert cfg.sensor_quat_start == 6
+        assert cfg.action_mapping == "midpoint/v1"
         assert cfg.reset_noise_scale == pytest.approx(0.01)
         assert cfg.forward_vel_max == pytest.approx(8.0)
 
@@ -171,3 +172,64 @@ class TestSuccessAndVelGates:
         # No forward_vels/successes recorded at all -- gates must not fire.
         passed, failures = check_stage_gate(results)
         assert passed
+
+
+def test_cpu_evaluation_noise_free_reset_restores_complete_home_state():
+    jax = pytest.importorskip("jax")
+    pytest.importorskip("mujoco.mjx")
+    import jax.numpy as jnp
+    import mujoco
+
+    from environments.shared.jax_eval import evaluate_policy_cpu
+    from environments.shared.mjx_env import _get_model_path
+    from environments.shared.mjx_utils import reset_mujoco_data_to_home
+
+    model = mujoco.MjModel.from_xml_path(_get_model_path("velociraptor"))
+    home_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "home")
+    captured: dict[str, np.ndarray] = {}
+
+    def get_obs(data):
+        if not captured:
+            for field in ("qpos", "qvel", "act", "ctrl", "mocap_pos", "mocap_quat"):
+                captured[field] = np.asarray(jax.device_get(getattr(data, field)))
+        return jnp.zeros(1)
+
+    class ZeroNetwork:
+        def apply(self, _params, _obs):
+            return jnp.zeros(model.nu), jnp.zeros(model.nu), jnp.float32(0.0)
+
+    evaluate_policy_cpu(
+        model,
+        {},
+        ZeroNetwork(),
+        None,
+        get_obs_fn=get_obs,
+        normalize_obs_fn=lambda obs, _stats: obs,
+        scale_action_fn=lambda _action: jnp.asarray(model.key_ctrl[home_id]),
+        reward_fn=lambda _data, _action, _cfg, **_kwargs: jnp.float32(0.0),
+        reward_cfg={},
+        config=EvalConfig(
+            n_episodes=1,
+            max_episode_steps=1,
+            healthy_z_range=(0.0, 10.0),
+            max_tilt_angle=np.pi,
+            natural_forward_z=-1.0,
+            nosedive_threshold=10.0,
+            root_body_id=2,
+            sensor_quat_start=6,
+            action_mapping="home-keyframe-residual/v1",
+            reset_noise_scale=0.0,
+        ),
+    )
+
+    expected = mujoco.MjData(model)
+    reset_mujoco_data_to_home(model, expected)
+    mujoco.mj_forward(model, expected)
+    for field, actual in captured.items():
+        np.testing.assert_allclose(
+            actual,
+            np.asarray(getattr(expected, field)),
+            rtol=0,
+            atol=1e-7,
+            err_msg=f"CPU evaluation reset field {field} diverged from the XML home keyframe",
+        )

--- a/environments/shared/tests/test_mjx_env.py
+++ b/environments/shared/tests/test_mjx_env.py
@@ -5,6 +5,7 @@ These tests are skipped when JAX/MJX is not installed.
 
 import inspect
 
+import numpy as np
 import pytest
 
 _has_jax = False
@@ -61,6 +62,13 @@ class TestMJXDinoEnv:
 
         with pytest.raises(ValueError, match="versioned plant interface"):
             MJXDinoEnv("trex", stage=1, num_envs=1, env_kwargs={"frame_skip": 4})
+        with pytest.raises(ValueError, match="versioned plant interface"):
+            MJXDinoEnv(
+                "trex",
+                stage=1,
+                num_envs=1,
+                env_kwargs={"action_mapping": "home-keyframe-residual/v1"},
+            )
 
     def test_reset_returns_state(self):
         """Reset returns an EnvState with correct shapes."""
@@ -102,6 +110,129 @@ class TestMJXUtils:
         assert float(scale_action_jax(jnp.array([1.0]), ctrl_range)[0]) == pytest.approx(2.0)
         # -1 → min
         assert float(scale_action_jax(jnp.array([-1.0]), ctrl_range)[0]) == pytest.approx(-2.0)
+
+    def test_scale_action_around_nominal_preserves_zero_and_endpoints(self):
+        import jax.numpy as jnp
+
+        from environments.shared.mjx_utils import scale_action_around_nominal_jax
+
+        ctrl_range = jnp.array([[-2.0, 4.0], [-1.0, 3.0]])
+        nominal_ctrl = jnp.array([1.0, 0.5])
+
+        assert np.allclose(
+            np.asarray(scale_action_around_nominal_jax(jnp.zeros(2), ctrl_range, nominal_ctrl)),
+            np.asarray(nominal_ctrl),
+        )
+        assert np.allclose(
+            np.asarray(scale_action_around_nominal_jax(jnp.full(2, -1.0), ctrl_range, nominal_ctrl)),
+            np.asarray(ctrl_range[:, 0]),
+        )
+        assert np.allclose(
+            np.asarray(scale_action_around_nominal_jax(jnp.full(2, 1.0), ctrl_range, nominal_ctrl)),
+            np.asarray(ctrl_range[:, 1]),
+        )
+
+    def test_scale_action_around_nominal_clips_direct_callers(self):
+        import jax.numpy as jnp
+
+        from environments.shared.mjx_utils import scale_action_around_nominal_jax
+
+        ctrl_range = jnp.array([[-2.0, 4.0], [-1.0, 3.0]])
+        nominal_ctrl = jnp.array([1.0, 0.5])
+        scaled = scale_action_around_nominal_jax(jnp.array([-5.0, 5.0]), ctrl_range, nominal_ctrl)
+        assert np.allclose(np.asarray(scaled), np.array([-2.0, 3.0]))
+
+
+@pytest.mark.skipif(not _has_jax, reason="JAX/MJX not installed")
+class TestHomeKeyframeActionMapping:
+    def test_setup_species_raptor_zero_action_maps_to_xml_home(self):
+        import jax.numpy as jnp
+        import mujoco
+
+        from environments.shared.jax_setup import make_scale_action_fn, setup_species
+
+        ctx = setup_species("velociraptor", stage=1)
+        scale_action = make_scale_action_fn(ctx)
+        home_id = mujoco.mj_name2id(ctx.mj_model, mujoco.mjtObj.mjOBJ_KEY, "home")
+
+        assert ctx.action_mapping == "home-keyframe-residual/v1"
+        assert home_id >= 0
+        np.testing.assert_allclose(
+            np.asarray(scale_action(jnp.zeros(ctx.act_dim))),
+            ctx.mj_model.key_ctrl[home_id],
+            rtol=0,
+            atol=1e-7,
+        )
+
+    def test_raptor_jax_mapping_matches_gymnasium_mapping(self):
+        import jax.numpy as jnp
+
+        from environments.shared.jax_setup import make_scale_action_fn, setup_species
+        from environments.velociraptor.envs.raptor_env import RaptorEnv
+
+        ctx = setup_species("velociraptor", stage=1)
+        scale_action = make_scale_action_fn(ctx)
+        env = RaptorEnv()
+        try:
+            action = np.linspace(-1.5, 1.5, ctx.act_dim, dtype=np.float32)
+            np.testing.assert_allclose(
+                np.asarray(scale_action(jnp.asarray(action))),
+                env._scale_action(action),
+                rtol=0,
+                atol=1e-7,
+            )
+        finally:
+            env.close()
+
+    def test_setup_species_trex_retains_midpoint_mapping(self):
+        import jax.numpy as jnp
+
+        from environments.shared.jax_setup import make_scale_action_fn, setup_species
+
+        ctx = setup_species("trex", stage=1)
+        scale_action = make_scale_action_fn(ctx)
+
+        assert ctx.action_mapping == "midpoint/v1"
+        np.testing.assert_allclose(
+            np.asarray(scale_action(jnp.zeros(ctx.act_dim))),
+            np.mean(ctx.mj_model.actuator_ctrlrange, axis=1),
+            rtol=0,
+            atol=1e-7,
+        )
+
+    def test_noise_free_raptor_mjx_reset_restores_complete_home_state(self):
+        import jax
+        import mujoco
+
+        import environments.velociraptor.mjx_config  # noqa: F401
+        from environments.shared.mjx_env import MJXDinoEnv
+        from environments.shared.mjx_utils import reset_mujoco_data_to_home
+
+        env = MJXDinoEnv("velociraptor", stage=1, num_envs=1)
+        states = env.reset(jax.random.PRNGKey(17))
+
+        expected = mujoco.MjData(env.mj_model)
+        reset_mujoco_data_to_home(env.mj_model, expected)
+        mujoco.mj_forward(env.mj_model, expected)
+
+        for field in ("qpos", "qvel", "act", "ctrl", "mocap_pos", "mocap_quat"):
+            np.testing.assert_allclose(
+                np.asarray(getattr(states.data, field)[0]),
+                np.asarray(getattr(expected, field)),
+                rtol=0,
+                atol=1e-7,
+                err_msg=f"MJX reset field {field} diverged from the XML home keyframe",
+            )
+
+    def test_home_reset_requires_named_home_keyframe(self):
+        import mujoco
+
+        from environments.shared.mjx_utils import reset_mujoco_data_to_home
+
+        model = mujoco.MjModel.from_xml_string("<mujoco/>")
+        data = mujoco.MjData(model)
+        with pytest.raises(ValueError, match="keyframe named 'home'"):
+            reset_mujoco_data_to_home(model, data)
 
 
 # ---------------------------------------------------------------------------

--- a/environments/shared/tests/test_plant_contract.py
+++ b/environments/shared/tests/test_plant_contract.py
@@ -183,6 +183,19 @@ def test_mass_change_changes_physics_without_changing_interface(raptor_layers):
     assert changed["physics_sha256"] != original["physics_sha256"]
 
 
+def test_home_control_change_updates_policy_and_physics_fingerprints(raptor_layers):
+    source, interface, version, original = raptor_layers
+    changed_source = source.replace('ctrl="0.663225', 'ctrl="0.650000', 1)
+    assert changed_source != source
+    changed_model = mujoco.MjModel.from_xml_string(changed_source)
+
+    changed = fingerprint_model_layers(changed_model, interface, version)
+
+    assert changed["policy_interface_sha256"] != original["policy_interface_sha256"]
+    assert changed["physics_sha256"] != original["physics_sha256"]
+    assert changed["visual_sha256"] == original["visual_sha256"]
+
+
 def test_joint_actuator_force_cap_changes_physics_fingerprint(raptor_layers):
     source, interface, version, original = raptor_layers
     changed_source = source.replace(
@@ -373,6 +386,33 @@ def test_cached_observation_body_mapping_changes_interface_fingerprint(raptor_la
     assert changed["visual_sha256"] == original["visual_sha256"]
 
 
+def test_raptor_policy_contract_records_home_residual_action_mapping(raptor_layers):
+    _source, env, version, _original = raptor_layers
+
+    payload = plant_contract._policy_interface_payload(env.model, env, version, require_backend_parity=True)
+    mapping = payload["action_mapping"]
+
+    assert mapping["mode"] == "home-keyframe-residual/v1"
+    assert mapping["origin"]["keyframe"] == "home"
+    np.testing.assert_allclose(mapping["origin"]["ctrl"], env.model.key_ctrl[env.home_keyframe_id])
+    assert set(payload["interface_implementations"]["jax_action_mapping"]) == {"scale_action_around_nominal_jax"}
+    assert set(payload["interface_implementations"]["home_reset"]["jax"]) == {"reset_mujoco_data_to_home"}
+    assert payload["jax_interface"]["action_mapping"] == "home-keyframe-residual/v1"
+
+
+def test_other_species_retain_midpoint_action_mapping_contract():
+    env = BrachioEnv(reset_noise_scale=0.0)
+    try:
+        version = load_plant_versions()[1]["brachiosaurus"]
+        payload = plant_contract._policy_interface_payload(env.model, env, version, require_backend_parity=True)
+    finally:
+        env.close()
+
+    assert payload["action_mapping"] == "clip[-1,1]-then-affine-to-ordered-ctrlrange/v1"
+    assert set(payload["interface_implementations"]["jax_action_mapping"]) == {"scale_action_jax"}
+    assert "action_mapping" not in payload["jax_interface"]
+
+
 def test_runtime_environment_binding_rejects_control_cadence_override():
     current = current_plant_identity("velociraptor", verify_generated=False)
     env = RaptorEnv(frame_skip=4, reset_noise_scale=0.0)
@@ -403,12 +443,18 @@ def test_mjx_runtime_binding_rejects_interface_override(raptor_layers):
         sensor_gyro_start=0,
         sensor_accel_start=3,
         sensor_quat_start=6,
+        action_mapping="home-keyframe-residual/v1",
     )
     runtime_env = SimpleNamespace(mj_model=interface.model, config=config, action_dim=22)
     validate_mjx_environment_plant(runtime_env, current)
 
     config.frame_skip = 4
     with pytest.raises(PlantCompatibilityError, match="frame_skip"):
+        validate_mjx_environment_plant(runtime_env, current)
+
+    config.frame_skip = 5
+    config.action_mapping = "midpoint/v1"
+    with pytest.raises(PlantCompatibilityError, match="action_mapping"):
         validate_mjx_environment_plant(runtime_env, current)
 
 

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -68,12 +68,13 @@ def test_catalog_publishes_layered_plant_contract() -> None:
         "trex": "bipedal-target/v1",
         "brachiosaurus": "quadrupedal-target/v1",
     }
+    expected_policy_revisions = {"velociraptor": 2, "trex": 1, "brachiosaurus": 1}
     digest_pattern = re.compile(r"sha256:[0-9a-f]{64}")
     for species in catalog["species"]:
         plant = species["model"]["plant_contract"]
         assert digest_pattern.fullmatch(plant["bundle_sha256"])
         assert digest_pattern.fullmatch(plant["source_closure_sha256"])
-        assert plant["policy_interface"]["revision"] == 1
+        assert plant["policy_interface"]["revision"] == expected_policy_revisions[species["id"]]
         assert plant["policy_interface"]["observation_schema"] == expected_observation_schemas[species["id"]]
         assert plant["physics"]["revision"] == 1
         assert plant["visual"]["revision"] == 1

--- a/environments/velociraptor/README.md
+++ b/environments/velociraptor/README.md
@@ -93,7 +93,9 @@ python scripts/train_sb3.py eval logs/<run_dir>/models/stage3_final.zip
 ## Environment Details
 
 Observation and action totals are generated in the catalog entry linked above. The source of the observation layout and
-action-to-actuator mapping is `envs/raptor_env.py`; actions are normalized to [-1, 1] and scaled to actuator ranges.
+action-to-actuator mapping is `envs/raptor_env.py`. Actions are normalized residuals around the named XML `home`
+keyframe: zero commands the standing pose, while -1 and +1 still reach each actuator's lower and upper limits through
+piecewise-linear interpolation.
 
 ### Reward Components
 

--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -15,6 +15,8 @@ Observation space (total dimension is generated in the public species catalog):
     - Prey distance (scalar) — 1
 
 Action space (total dimension is generated in the public species catalog):
+    - Actions are residuals around the named XML ``home`` keyframe controls
+    - Zero commands home; -1/+1 command each actuator's lower/upper limit
     - Right leg: hip pitch/roll, knee, ankle, toe d3/d4 (6)
     - Right sickle claw (1)
     - Left leg: hip pitch/roll, knee, ankle, toe d3/d4 (6)
@@ -60,6 +62,7 @@ from environments.shared.base_env import BaseDinoEnv
 class RaptorEnv(BaseDinoEnv):
     """Velociraptor locomotion and strike environment."""
 
+    action_mapping = "home-keyframe-residual/v1"
     _camera_distance = 2.0
     _camera_azimuth = 135
     _camera_elevation = -20
@@ -165,6 +168,16 @@ class RaptorEnv(BaseDinoEnv):
 
     def _cache_ids(self):
         """Cache MuJoCo IDs for bodies, geoms, and sites."""
+        # The raptor policy commands residuals around the biomechanically
+        # balanced XML home pose.  Cache the controls once so action zero can
+        # preserve that pose without a keyframe lookup on every environment
+        # step.
+        self.home_keyframe_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_KEY, "home")
+        if self.home_keyframe_id < 0:
+            raise ValueError("Velociraptor model must define a named 'home' keyframe")
+        self._reset_keyframe_id = self.home_keyframe_id
+        self._home_ctrl = self.model.key_ctrl[self.home_keyframe_id].copy()
+
         # Body IDs
         self.pelvis_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, "pelvis")
 
@@ -211,6 +224,30 @@ class RaptorEnv(BaseDinoEnv):
         # are inherited from BaseDinoEnv (0, 3, 6 respectively).
         self._sensor_r_foot = 10
         self._sensor_l_foot = 11
+
+    def _scale_action(self, action: np.ndarray) -> np.ndarray:
+        """Map normalized residual actions around the XML home controls.
+
+        The home pose is not generally the midpoint of an actuator's control
+        range.  A piecewise-linear mapping therefore preserves all three
+        policy-interface anchors:
+
+        * ``-1`` maps to the actuator minimum,
+        * ``0`` maps exactly to the home-keyframe control, and
+        * ``+1`` maps to the actuator maximum.
+
+        Reward terms continue to receive the normalized residual ``action``
+        from :meth:`step`; only the command sent to MuJoCo is transformed.
+        """
+        residual = np.clip(action, -1.0, 1.0)
+        ctrl_range = self.model.actuator_ctrlrange
+        ctrl_min = ctrl_range[:, 0]
+        ctrl_max = ctrl_range[:, 1]
+
+        below_home = residual * (self._home_ctrl - ctrl_min)
+        above_home = residual * (ctrl_max - self._home_ctrl)
+        scaled = self._home_ctrl + np.where(residual < 0.0, below_home, above_home)
+        return np.asarray(scaled)
 
     def _get_obs(self) -> np.ndarray:
         """Construct observation vector."""

--- a/environments/velociraptor/mjx_config.py
+++ b/environments/velociraptor/mjx_config.py
@@ -18,6 +18,7 @@ _SENSOR_TAIL_GYRO_START = 24
 
 register_species_mjx(
     species="velociraptor",
+    action_mapping="home-keyframe-residual/v1",
     frame_skip=5,
     max_episode_steps=1000,
     healthy_z_range=(0.3, 1.0),

--- a/environments/velociraptor/tests/test_raptor_env.py
+++ b/environments/velociraptor/tests/test_raptor_env.py
@@ -97,3 +97,55 @@ class TestStrikeTerminationGating:
         # The gating condition (self.strike_bonus > 0) should prevent
         # strike_success termination even if contact occurs
         env.close()
+
+
+class TestNominalPoseActionScaling:
+    """Raptor actions are residuals around the XML home controls."""
+
+    def test_reset_and_action_origin_use_same_named_home_keyframe(self, env):
+        assert env._reset_keyframe_id == env.home_keyframe_id
+
+    def test_zero_action_maps_exactly_to_home_controls(self, env):
+        action = np.zeros(env.action_space.shape, dtype=np.float32)
+        scaled = env._scale_action(action)
+        home_ctrl = env.model.key_ctrl[env.home_keyframe_id]
+
+        np.testing.assert_array_equal(scaled, home_ctrl)
+
+    def test_action_endpoints_retain_full_control_range(self, env):
+        ctrl_range = env.model.actuator_ctrlrange
+
+        np.testing.assert_allclose(
+            env._scale_action(-np.ones(env.action_space.shape, dtype=np.float32)),
+            ctrl_range[:, 0],
+            atol=1e-12,
+        )
+        np.testing.assert_allclose(
+            env._scale_action(np.ones(env.action_space.shape, dtype=np.float32)),
+            ctrl_range[:, 1],
+            atol=1e-12,
+        )
+
+    def test_piecewise_mapping_interpolates_on_each_side_of_home(self, env):
+        ctrl_range = env.model.actuator_ctrlrange
+        home_ctrl = env.model.key_ctrl[env.home_keyframe_id]
+
+        below = env._scale_action(np.full(env.action_space.shape, -0.5, dtype=np.float32))
+        above = env._scale_action(np.full(env.action_space.shape, 0.5, dtype=np.float32))
+
+        np.testing.assert_allclose(below, (ctrl_range[:, 0] + home_ctrl) / 2.0, atol=1e-12)
+        np.testing.assert_allclose(above, (home_ctrl + ctrl_range[:, 1]) / 2.0, atol=1e-12)
+
+    def test_zero_residual_keeps_energy_and_smoothness_penalties_zero(self, env):
+        env.reset(seed=42)
+        action = np.zeros(env.action_space.shape, dtype=np.float32)
+
+        _, _, terminated, truncated, first_info = env.step(action)
+        assert not terminated
+        assert not truncated
+        _, _, _, _, second_info = env.step(action)
+
+        assert first_info["reward_energy"] == pytest.approx(0.0, abs=1e-12)
+        assert second_info["reward_energy"] == pytest.approx(0.0, abs=1e-12)
+        assert second_info["reward_smoothness"] == pytest.approx(0.0, abs=1e-12)
+        assert second_info["action_delta"] == pytest.approx(0.0, abs=1e-12)

--- a/environments/velociraptor/tests/test_static_balance.py
+++ b/environments/velociraptor/tests/test_static_balance.py
@@ -10,6 +10,7 @@ digitigrade feet, matching dromaeosaurid biomechanics. The tilt tests account
 for this natural lean.
 """
 
+import numpy as np
 import pytest
 
 from environments.shared.tests.static_balance_helpers import (
@@ -54,6 +55,19 @@ class TestNeutralActionStability(NeutralActionStabilityBase):
     root_body_id_attr = "pelvis_id"
     max_height_drop = 0.10
     max_tilt_increase = 0.53  # 30 degrees
+
+    def test_survives_full_noise_free_episode(self, env):
+        """The home-centered zero residual must remain viable for 1,000 Gym steps."""
+        env.reset(seed=0)
+        neutral_action = np.zeros(env.action_space.shape, dtype=np.float32)
+
+        for step in range(1, env.max_episode_steps + 1):
+            _, _, terminated, truncated, info = env.step(neutral_action)
+            assert not terminated, (
+                f"Raptor terminated at step {step}/{env.max_episode_steps} "
+                f"under the XML home command: {info.get('termination_reason', 'unknown')}"
+            )
+            assert truncated is (step == env.max_episode_steps)
 
 
 class TestActuatorDisabledPassive(ActuatorDisabledPassiveBase):

--- a/notebooks/jax_training.ipynb
+++ b/notebooks/jax_training.ipynb
@@ -1105,6 +1105,7 @@
     "        success_threshold=ctx.success_threshold,\n",
     "        target_body=\"prey\",\n",
     "        sensor_quat_start=ctx.sensor_layout.quat_start,\n",
+    "        action_mapping=ctx.action_mapping,\n",
     "        output_path=video_path,\n",
     "        fps=50,\n",
     "        camera_track_body=ctx.camera_track_body,\n",

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -80,13 +80,13 @@
         "nu": 22,
         "dynamic_mass_kg": 13.5,
         "plant_contract": {
-          "bundle_sha256": "sha256:9eb173725d5a57cb0f30a6805dc83b26101b003c3654b9e51cd767b5c1e18862",
+          "bundle_sha256": "sha256:da93c4707c1eb7fed54295b5fdfd8f005f7e2b2c0d2d2fe37527f6d114dfdc8d",
           "source_closure_sha256": "sha256:852bbf54cea4e451380ed6b175f001ab0e11dac8e1c3632ea299e0a11f1ff38f",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 1,
+            "revision": 2,
             "observation_schema": "bipedal-target/v1",
-            "sha256": "sha256:e4873d6f6c4a8316cdba7941fc1a78a1a8ec3c441a7c3b60be42646904ac8fe1"
+            "sha256": "sha256:38e9edbb4330492b9daa81523440ea5a38c643c94f5079723e24644fa6915225"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",


### PR DESCRIPTION
## Summary

- center Velociraptor normalized actions on the named XML `home` controls with a piecewise residual mapping
- preserve the full actuator range: `-1 → minimum`, `0 → home`, and `+1 → maximum`
- align Gymnasium, JAX/MJX training, CPU evaluation, and video rollouts on the same action origin and named-home reset
- version and fingerprint the mapping/reset contract, including the numerical home controls
- add SB3/JAX parity, endpoint, clipping, reset-state, provenance, and 1,000-step stability coverage

## Why

The previous neutral action mapped to actuator-range midpoints, but those midpoints are not the raptor's balanced standing controls. Newly initialized policies produce actions near zero, so the old interface pulled the model away from its viable home pose and into the observed backward-drift/fall basin before useful locomotion learning could begin.

This change makes a zero policy command mechanically meaningful without restricting exploration or changing the reward.

## Compatibility

This is a Velociraptor policy-interface change:

- policy interface revision increases from 1 to 2
- revision-1 Velociraptor PPO, SAC, JAX, and matching normalization artifacts must not be resumed under this interface
- the XML, physics fingerprint, and visual fingerprint are unchanged
- T. rex and Brachiosaurus retain their existing midpoint mapping and plant identities
- lean-aware posture reward and reset-noise tuning are intentionally deferred so training can isolate this fix

## Validation

- `.venv/bin/pytest` — **1,549 passed, 30 skipped**
- Ruff lint and formatting checks
- mypy checks for the changed environment/JAX/contract modules
- plant manifest and species catalog regeneration/currentness checks
- repository and bundled plant manifests are byte-identical
- notebook JSON validation
- noise-free zero residual survives the full 1,000-step Velociraptor episode
