### PR TITLE
Center Velociraptor posture reward on natural lean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — Reproducible Runs & Velociraptor Stage-1 Diagnosis (v0.3.3)
+
+### Added
+- **Canonical result bundles for Colab/Google Drive training**: schema-v2
+  summaries, runtime-captured provenance, immutable completed bundles,
+  selected/terminal evaluation evidence, plant/config/model/VecNormalize
+  hashes, partial-versus-promotion validation, idempotent manifests, and
+  strict exporter tests now make failed runs auditable without presenting
+  them as publishable results.
+- **Velociraptor Stage-1 basin investigation**: records the pre-training
+  50-seed physics probe, Commit A's A-only PPO run (`20260720_203454`), the
+  natural-lean diagnosis, Commit B's reward geometry, targeted backend-routing
+  lessons, and the falsifiable next-run plan.
+
+### Changed
+- **Velociraptor actions are residuals around the XML `home` controls**:
+  `-1`/`0`/`+1` map to actuator minimum/home/maximum through a piecewise-linear
+  transform. This is a breaking policy-interface revision (1 → 2); older PPO,
+  SAC, and JAX checkpoints remain historical and cannot be resumed as current
+  policies. XML physics and actuator reach are unchanged.
+- **Velociraptor posture shaping targets its natural forward pitch** (0.35
+  rad) instead of world vertical. The yaw-invariant, direction- and roll-aware
+  squared-chord formulation keeps finite JAX gradients at the exact target;
+  T-Rex and Brachiosaurus retain vertical posture targets.
+
+### Fixed
+- **Targeted natural-posture consistency across training and evaluation
+  paths**: the shared NumPy/JAX primitive, direct MJX, JAX total and detailed
+  reward paths, CPU evaluation, diagnostics, and runtime `natural_pitch`
+  overrides resolve the same reward-only target. Absolute-tilt termination and
+  the existing nosedive boundary remain unchanged, and the JAX notebook now
+  binds reward functions only after environment creation. Comprehensive
+  fixed-state, all-component SB3↔JAX parity remains open.
+
 ## [Unreleased] — RL/GCP Review Fixes & Model Physics (v0.3.2)
 
 ### Changed

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -38,9 +38,12 @@ robustness, **LOW** = cosmetic / QoL.
 - **PPO advantage normalization** — per-minibatch in JAX vs per-batch in
   SB3; acceptable, documented in `jax_ppo.py`. (June §2.7)
 
-An SB3↔JAX per-component reward **parity test** (one fixed state, assert
-components match within tolerance) is the standing recommendation that
-would pin these down and catch regressions. (June §6.8)
+Targeted tests now pin the shared NumPy/JAX Velociraptor natural-lean posture
+primitive and its per-path runtime routing. A comprehensive per-component
+SB3↔JAX reward **parity test** (one fixed state, assert every component within
+tolerance) remains the standing recommendation for the divergences above.
+(June §6.8; see the
+[Stage-1 basin investigation](investigations/VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md))
 
 ## Training / RL
 

--- a/docs/PLANT_CONTRACT.md
+++ b/docs/PLANT_CONTRACT.md
@@ -29,6 +29,11 @@ Each semantic layer has an independent positive revision: `policy_interface_revi
 - A visual-only change does not make a policy incompatible.
 - A policy-interface or physics change makes an existing policy incompatible, even when dimensions happen to match.
 
+The Velociraptor home-residual change is an example where tensor dimensions and
+XML physics stayed fixed but action meaning changed, requiring a policy-interface
+revision and fresh checkpoints. See the
+[Stage-1 basin investigation](investigations/VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md).
+
 The generator compares the existing committed manifest with the new one and refuses to write a changed semantic layer
 unless its revision increased. Pull-request CI also compares against the base branch, so deleting or replacing the local
 manifest cannot bypass revision monotonicity.

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,7 @@ than rewrite.
 | [REWARD_SCALE_REDESIGN.md](investigations/REWARD_SCALE_REDESIGN.md) | 2026-04-18 | Stage-3 terminal-bonus rescale analysis (implementation deferred) |
 | [STAGE2_INVESTIGATION.md](investigations/STAGE2_INVESTIGATION.md) | 2026-07-09 | Root cause of the velociraptor stage-2 locomotion collapse (bounded-plant actuator clipping) |
 | [STAGE2_RECOMMENDATIONS.md](investigations/STAGE2_RECOMMENDATIONS.md) | 2026-07-11 | Replication review of run 20260711_165924, corrected fall-penalty math, ranked plan — validated 2026-07-12 by run 20260711_235303 (stages 1–3 cleared, stage-2 record); §5 has the outcome and cross-species lessons |
+| [VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md](investigations/VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md) | 2026-07-20 | Commit A physics probe and A-only PPO run 20260720_203454; natural-lean reward-conflict diagnosis, pending Commit B validation, and fresh-run decision rules |
 
 ## Code & repo reviews
 

--- a/docs/RESULT_BUNDLES.md
+++ b/docs/RESULT_BUNDLES.md
@@ -15,6 +15,9 @@ evidence needed to make that hand-off reproducible.
   a canonical `summary.json`, matching CSV metrics, and valid artifact hashes.
 
 A partial bundle must not be presented as a public three-stage result.
+Run `20260720_203454` is a concrete failed-but-auditable example; its role in
+the Velociraptor diagnosis is documented in the
+[Stage-1 basin investigation](investigations/VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md).
 
 ## Canonical layout
 

--- a/docs/investigations/VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md
+++ b/docs/investigations/VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md
@@ -1,0 +1,407 @@
+# Velociraptor Stage-1 Backward-Drift Basin
+
+- **Date:** 2026-07-20
+- **Scope:** Velociraptor PPO Stage 1, result-bundle integrity, home-keyframe
+  action residuals, and natural-lean posture shaping
+- **Status:** Commit A is implemented and evaluated. Commit B is implemented;
+  its fresh A+B training run is still pending.
+
+This is the append-only investigation record for the Stage-1 balance failure
+that remained after the July model and optimizer work. It records the evidence,
+the two isolated changes, the failed-but-informative run
+`20260720_203454`, and the decision rules for the next experiment.
+
+## Executive summary
+
+The original failure was not one problem:
+
+1. **Action zero did not mean “stand.”** It commanded actuator-range
+   midpoints, even though the XML already defined a stable, non-midpoint
+   `home` control pose. A 50-seed physics probe showed that this interface
+   alone drove the model into a backward-drift/fall basin. Commit A changed
+   Velociraptor actions to residuals around the XML home controls.
+2. **After that correction, the Stage-1 reward still preferred the wrong
+   posture.** The A-only PPO run moved forward instead of backward, but learned
+   to straighten from the supported natural pitch of 0.35 rad (about 20°)
+   toward world vertical. Its posture penalty improved while survival did not.
+   Commit B therefore centres Velociraptor posture shaping on its natural
+   forward lean without changing absolute-tilt safety limits.
+
+The sequence matters. Commit A was evaluated before Commit B so its effect
+could be identified. Reset noise, XML physics, termination thresholds, and
+Stage-1 hyperparameters were held fixed. The next run must likewise be a fresh
+PPO Stage-1 run with A+B and `reset_noise_scale = 0.05`; it must not resume the
+A-only policy or advance to Stage 2 unless the survival gate passes.
+
+## 1. Why evidence integrity came first
+
+The schema, provenance, and exporter work was a prerequisite for interpreting
+this experiment, not bookkeeping after it. The canonical bundle contract is
+documented in [RESULT_BUNDLES.md](../RESULT_BUNDLES.md).
+
+Two validation levels are intentionally different:
+
+- **Drive validation** preserves partial and gate-failed runs as valid
+  evidence.
+- **Promotion validation** accepts only complete, internally consistent,
+  promotable three-stage results.
+
+Run `20260720_203454` demonstrates why that distinction is useful: it failed
+Stage 1, was correctly labelled `failed`, and still retained enough evidence
+to diagnose the next change. It must not be published into `results/`, the
+generated species catalog, or the website.
+
+Runtime provenance binds the evidence to:
+
+- the exact repository commit and dirty/patch state;
+- Python and dependency versions;
+- training and deterministic evaluation seed roles;
+- plant identity and resolved stage configuration;
+- the selected checkpoint and matching SB3 VecNormalize hashes; and
+- separate selected-policy and terminal-policy episode evidence.
+
+Exporter tests protect relationships, not only JSON shape. They verify
+summary/CSV/provenance/manifest identity agreement, frozen-gate recomputation,
+selected and terminal evidence aggregation, mixed-plant rejection, tamper and
+unlisted-artifact detection, write-free idempotence, failure preservation,
+credential sanitization, and non-mutating legacy audits.
+
+### Colab and Google Drive operating rules
+
+For every causal experiment:
+
+1. Start from a clean Colab runtime and install the exact intended commit.
+2. Use a new run ID; never mix stages or artifacts from different code states.
+3. Let the notebook export directly to its unique Drive run directory.
+4. For a complete run, treat `summary.json` as canonical and generated
+   CSV/documentation as derivatives. A partial or failed Stage-1 run correctly
+   has no summary; audit its provenance, manifest, stage config, and raw
+   evaluation evidence without synthesizing missing stages. Never manually
+   copy metrics between formats.
+5. Use `google_drive_summary.ipynb` to audit or migrate the bundle, and run
+   strict promotion validation only after all three stages legitimately pass.
+
+A failed experiment is valuable when it is attributable. A high-scoring run
+without exact code, configuration, seeds, plant identity, and raw evaluation
+episodes is not equivalent evidence.
+
+## 2. Pre-Commit-A physics probe
+
+Before spending another training budget, a 50-seed, 1,000-step physics probe
+compared the old policy-neutral command with the XML standing command.
+
+| Command | Reset noise | 1,000-step survivors | Observation |
+|---|---:|---:|---|
+| Old zero action (actuator midpoints) | 0.00 | 0/50 | Mean failure near step 167; backward drift |
+| XML `home` controls | up to 0.03 | 50/50 | Stable in every seed |
+| XML `home` controls | 0.05 | 48/50 | Stable in 96% of seeds |
+
+This was a local exploratory probe against the pre-Commit-A mapping (the
+parent of `c8af06d`), not a canonical Drive bundle. It used 50 seeded resets
+and a 1,000-command horizon, but its script, exact seed list, per-seed output,
+and explicit fall criterion were not retained. The aggregate is recorded as
+decision evidence, not publication evidence. Any future reliance on the exact
+rates should first reproduce the probe with a checked-in script that captures
+the commit, seeds, command path, reset noise, horizon, and termination rule.
+
+This isolated the action interface from reset noise and learning. Lowering
+`reset_noise_scale` first would have hidden part of the symptom while leaving
+zero action mechanically inconsistent with the standing pose.
+
+The probe also supplied a useful priority rule: test the passive/nominal
+control semantics before changing rewards, optimizer settings, or curriculum
+noise. Cheap physics probes can reject an entire family of expensive training
+experiments.
+
+## 3. Commit A — home-keyframe residual actions
+
+[Commit A (`c8af06d`)](https://github.com/kuds/mesozoic-labs/commit/c8af06deefbf878733dec915fd2051b85163bafe)
+changed only the Velociraptor policy interface. For each actuator, the
+piecewise-linear mapping preserves three anchors:
+
+```text
+action -1  -> actuator minimum
+action  0  -> XML home control
+action +1  -> actuator maximum
+```
+
+A single affine midpoint mapping cannot generally preserve those anchors
+because the standing control is not the midpoint of the actuator range.
+Piecewise residual control is standard in legged-robot learning because the
+policy learns deviations from a viable nominal pose rather than having to
+rediscover the pose while it is also learning balance.
+
+Important compatibility details:
+
+- Energy and smoothness remain defined in normalized residual-action space;
+  zero residual has zero energy cost and no smoothness cost when unchanged.
+- Reset, CPU evaluation, MJX training, JAX CPU evaluation, and video rollout
+  all resolve the same named `home` keyframe.
+- This is a breaking policy-interface change from Velociraptor revision 1 to
+  revision 2. Pre-revision-2 PPO, SAC, and JAX checkpoints are historical and
+  cannot be resumed as current policies even though the action dimension did
+  not change.
+- The XML, compiled physics revision, visual revision, actuator limits, and
+  reset noise did not change.
+
+## 4. A-only PPO run `20260720_203454`
+
+The canonical Drive bundle records a clean run at repository merge commit
+[`3695f4d`](https://github.com/kuds/mesozoic-labs/commit/3695f4d186446d57301c6150cb94c9ba103fb751),
+Velociraptor policy-interface revision 2, result schema 2, and `failed` status.
+It evaluated Commit A without Commit B.
+
+### 4.1 Outcome
+
+| Metric | A-only result | Stage-1 requirement |
+|---|---:|---:|
+| Training steps | 1.1M / 6M (early-stopped) | Up to 6M |
+| Wall time | about 29m 09s | — |
+| Selected eval reward | 149.22 ± 28.76 | mean ≥ 100 |
+| Selected eval episode length | 128.4 ± 19.1 | mean ≥ 750 |
+| Selected eval forward velocity | 0.18 ± 0.15 m/s | diagnostic |
+| Selected eval distance | 0.774 m mean | diagnostic |
+| Episodes reaching 750 steps | 0/30 | survival gate not met |
+| Episode-length range | 88–174 | — |
+
+The reward threshold passed but the balance threshold failed decisively, so
+stopping before Stage 2 was correct.
+
+### 4.2 Why the raw reward peak was misleading
+
+The raw 50k checkpoint peak was `261.79 ± 261.72`, but its robust score
+(`mean - standard deviation`) was only `0.07`. Around 650k and 700k, isolated
+1-of-30 episodes reached 1,000 steps; the other 29 episodes still failed. Those
+rare survivors created variance, not repeatable balance.
+
+For balance tasks, mean reward alone can be dominated by a few long episodes.
+The survival distribution, robust score, and termination mix must be reviewed
+before declaring improvement.
+
+### 4.3 What Commit A improved
+
+Training forward velocity moved from roughly `-0.234 m/s` early to
+`+0.026 m/s` late, and the selected evaluation averaged `+0.18 m/s`. This is
+consistent with making action zero a viable standing command weakening the
+catastrophic backward-drift basin; the within-run trend is not by itself a
+controlled A/B comparison.
+
+Commit A was therefore a partial success, not a failed hypothesis. It fixed
+the action semantics but exposed a separate balance incentive conflict.
+
+### 4.4 Failure anatomy
+
+The raptor's natural pitch is `0.35 rad` (about 20.1°), with a natural
+forward-axis vertical component of `-sin(0.35) ≈ -0.343`. During training:
+
+- mean tilt moved from about 30.6° toward 15.8°, overshooting the supported
+  lean toward world vertical;
+- `forward_z` moved from about `-0.398` to `-0.174`, away from the natural
+  target;
+- posture reward improved from about `-0.457` to `-0.139`; and
+- survival remained near 1.3 seconds.
+
+The old posture term was functioning exactly as coded: it penalized absolute
+tilt from vertical. PPO collected that reward by straightening the torso even
+though the XML's tail-counterbalanced standing geometry was designed around a
+forward lean.
+
+Late termination proportions reinforce the balance diagnosis:
+
+| Termination | Late-run share |
+|---|---:|
+| Fallen | about 39.2% |
+| Tail contact | about 37.0% |
+| Body contact | about 16.4% |
+| Excessive tilt | about 7.1% |
+| Nosedive | about 0.3% |
+
+The failure was not predominantly a nosedive and was not an immediate reset
+failure.
+
+### 4.5 Hypotheses ruled down
+
+**Optimizer instability was not the leading cause.** PPO's late diagnostics
+were healthy: approximate KL was about 0.016, explained variance about 0.96,
+and value loss about 0.063. The policy learned the provided objective; the
+objective's posture geometry was wrong for this morphology.
+
+**Reset noise was not the leading cause.** The XML home command survived
+48/50 physics probes at the unchanged 0.05 noise, and learned-policy failures
+were not concentrated at reset. Noise reduction remains a later controlled
+experiment only if A+B is stable at zero/small noise but not at 0.05.
+
+**More training was not justified.** The policy was becoming more upright
+while the balance distribution remained catastrophic. Continuing the same
+objective would spend compute reinforcing the conflict.
+
+## 5. Commit B — natural-lean posture shaping
+
+Commit B changes the Velociraptor posture reward from deviation from world
+vertical to deviation from its direction-aware natural lean.
+
+### 5.1 Reward geometry
+
+For pelvis quaternion `[w, x, y, z]`, use the world-Z components of the body's
+forward, lateral, and up axes:
+
+```text
+orientation = [2(xz - wy), 2(yz + wx), 1 - 2(x² + y²)]
+target      = [-sin(natural_pitch), 0, cos(natural_pitch)]
+alignment   = dot(orientation, target)
+
+normalized_error = clip(
+    (1 - alignment) / (1 - cos(max_tilt_angle)), 0, 1
+)
+posture_reward = -posture_weight * normalized_error
+```
+
+This construction is:
+
+- **direction-aware** — correct forward pitch differs from backward pitch;
+- **roll-aware** — lateral tilt reduces alignment;
+- **yaw-invariant** — turning on the ground does not change the posture score;
+  and
+- **JAX-safe at the target** — normalized squared chord distance avoids the
+  undefined `acos` gradient at exact alignment while retaining local
+  quadratic behavior.
+
+Penalizing `abs(tilt) - natural_pitch` would not meet the contract: it could
+reward the wrong pitch direction or roll at the same absolute angle.
+
+### 5.2 Safety semantics stay separate
+
+The reward helper still returns absolute tilt relative to world up for
+termination and historical diagnostics. Commit B does not change:
+
+- `raptor.xml` or any physics/visual revision;
+- `reset_noise_scale = 0.05`;
+- the absolute-tilt termination threshold;
+- the existing rounded MJX nosedive baseline (`-0.342`) or termination
+  boundary; or
+- Stage-1 TOML weights and PPO hyperparameters.
+
+It also does not change the action/observation interface or the plant identity;
+Velociraptor remains at policy-interface revision 2. Reward semantics are
+identified by exact repository and resolved-config provenance rather than a
+plant revision, and still require a fresh training run.
+
+The exact reward-only target is kept separate from that rounded nosedive
+baseline, so an isolated reward experiment cannot silently move a safety
+boundary.
+
+With the Stage-1 `posture_weight = 1.5` and `max_tilt_angle = 1.047`, the XML
+home-pose penalty changes from `-0.166729` to approximately zero
+(`-0.0000013` in the numeric probe). A world-upright pose, which formerly
+incurred zero posture penalty, now costs `-0.181944`. This reverses the
+incentive identified in the A-only run without changing the maximum weight or
+gate.
+
+### 5.3 Targeted backend and evaluation consistency
+
+Reward correctness includes every consumer, not only the main training step.
+The natural-lean target is applied consistently in:
+
+- the SB3/Gymnasium environment;
+- direct MJX environment stepping;
+- JAX total-reward and detailed-component functions;
+- JAX CPU evaluation and diagnostics; and
+- custom `natural_pitch` overrides resolved at runtime.
+
+Velociraptor alone opts into the lean-aware target. T-Rex and Brachiosaurus
+retain their vertical posture reward. The JAX notebook binds reward functions
+only after `create_env` has resolved the live MJX configuration; regression
+tests pin this ordering. Binding earlier would capture stale registry defaults
+and make notebook behavior disagree with direct environment creation.
+
+This coverage pins the lean primitive and its routing through the relevant
+paths. It is not yet the comprehensive, fixed-state, all-component SB3↔JAX
+parity test retained in [KNOWN_ISSUES.md](../KNOWN_ISSUES.md).
+
+## 6. Next experiment and decision rules
+
+### Immediate run
+
+After Commit B and the documentation/version follow-up are merged:
+
+1. Start a fresh Colab runtime on the exact merged commit and reinstall the
+   package.
+2. Run `sb3_training.ipynb` with Velociraptor + PPO, Stage 1 from scratch, and
+   a new run ID.
+3. Keep the same Stage-1 TOML, seeds/evaluation protocol, 6M-step budget, and
+   `reset_noise_scale = 0.05`.
+4. Do not resume `20260720_203454`; it was optimized under the old reward and
+   would weaken the A+B comparison.
+5. Review the canonical bundle, not copied headline metrics.
+
+The configured training gate remains mean reward at least 100 and mean episode
+length at least 750 for three consecutive evaluations. A single high-return or
+1,000-step episode is not a pass.
+
+A-only and A+B total rewards are not directly comparable even though the
+numeric weight and gate are unchanged: the home-pose posture baseline moves by
+about 0.167 reward per step. Use episode-length distributions, survival rate,
+and termination causes as the primary causal comparison; reward is the
+configured gate, not an invariant cross-reward score.
+
+### What happens after the run
+
+- **If Stage 1 passes robustly:** continue PPO through Stages 2 and 3 using the
+  new revision-2 Stage-1 checkpoint. Those stages need current checkpoints
+  because revision-1 action semantics are incompatible.
+- **If posture tracks the natural target but survival still fails:** inspect
+  contact/support geometry and the termination distribution before changing
+  optimizer settings.
+- **If A+B is stable at zero or small reset noise but fails at 0.05:** then run
+  an isolated reset-noise curriculum experiment (for example 0.02–0.03). Do
+  not lower noise pre-emptively.
+- **If survival passes but reward fails:** inspect component balance and the
+  frozen gate; do not infer another physics defect from reward alone.
+- **Do not run SAC merely to bypass this test.** Validate the environment and
+  reward geometry with PPO first, then rerun SAC on the current policy
+  interface if a current SAC result is desired.
+- **The JAX natural-lean paths are already updated.** Defer expensive JAX
+  retraining until the SB3 PPO experiment validates the morphology fix; any
+  revision-1 JAX checkpoint remains historical.
+
+## 7. General lessons
+
+1. **Define neutral action semantically.** In a legged robot, zero should map
+   to a viable nominal command, not an arbitrary actuator midpoint.
+2. **Match rewards to morphology.** “Upright” is not synonymous with “world
+   vertical” for a tail-counterbalanced biped.
+3. **Probe physics before training.** A small seeded control test can identify
+   action/reset defects more cheaply and clearly than millions of RL steps.
+4. **Change one causal layer at a time.** Action mapping, reward target, reset
+   noise, XML, termination, and optimizer settings should not move together.
+5. **Use distributions, not seductive peaks.** Robust scores, episode-length
+   distributions, and termination causes expose rare-survivor artifacts.
+6. **Healthy PPO metrics do not prove a healthy objective.** An optimizer can
+   efficiently learn the wrong reward geometry.
+7. **Keep shaping separate from safety.** A reward target may change without
+   moving absolute termination or nosedive boundaries.
+8. **Parity includes evaluation and diagnostics.** A correct training reward
+   is insufficient if checkpoint selection, CPU evaluation, or plots use
+   different semantics.
+9. **Version policy semantics, not just dimensions.** Identical tensor shapes
+   do not make checkpoints compatible after action meaning changes.
+10. **Instrument before experimenting.** A correctly failed, immutable bundle
+    is more actionable than an unverifiable success claim.
+
+## 8. Evidence and artifacts
+
+- [Canonical run bundle](https://drive.google.com/drive/folders/1lH449rXldKQ0Gms0pOY06Map-nAw9a_V)
+- [Stage-1 artifacts](https://drive.google.com/drive/folders/1giECOwZvN8V7F0mLwk3iyEHiemZxzpj4)
+- [Training curves](https://drive.google.com/file/d/1KRF998INQb--RN678eS_c3dbUf0v8QDQ/view?usp=drivesdk)
+- [Locomotion health](https://drive.google.com/file/d/1U3XaCQ_pJYZneiO1zVZ65zd_qbV_5FCF/view?usp=drivesdk)
+- [Behavioral metrics](https://drive.google.com/file/d/1K_w-ZQ1ZfHAhwA3uJ066yPvVWNuR3fvm/view?usp=drivesdk)
+- [Result-bundle contract](../RESULT_BUNDLES.md)
+- [Plant/policy compatibility contract](../PLANT_CONTRACT.md)
+- [Velociraptor Stage-1 config](../../configs/velociraptor/stage1_balance.toml)
+- [Velociraptor environment](../../environments/velociraptor/envs/raptor_env.py)
+
+## 9. Follow-up outcome (append only)
+
+Pending a fresh A+B PPO Stage-1 run. Append its run ID, exact commit, selected
+and terminal evaluation distributions, gate outcome, termination mix, and the
+next decision here. Do not rewrite the A-only evidence above.

--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -35,6 +35,7 @@ from .reward_functions import reward_forward_velocity as _reward_forward_velocit
 from .reward_functions import reward_heading_alignment as _reward_heading_alignment_pure
 from .reward_functions import reward_idle_penalty as _reward_idle_penalty_pure
 from .reward_functions import reward_lateral_velocity_penalty as _reward_lateral_velocity_penalty_pure
+from .reward_functions import reward_lean_aware_posture as _reward_lean_aware_posture_pure
 from .reward_functions import reward_nosedive as _reward_nosedive_pure
 from .reward_functions import reward_posture as _reward_posture_pure
 from .reward_functions import reward_speed_penalty as _reward_speed_penalty_pure
@@ -243,6 +244,24 @@ class BaseDinoEnv(gym.Env, ABC):
             (reward, tilt_angle) tuple.
         """
         return _reward_posture_pure(quat, self.max_tilt_angle, weight)
+
+    def _compute_lean_aware_posture_reward(
+        self,
+        quat: np.ndarray,
+        weight: float,
+        natural_forward_z: float,
+    ) -> tuple[float, float]:
+        """Compute posture penalty relative to a natural forward lean.
+
+        Returns the absolute tilt angle alongside the target-relative reward
+        so termination and diagnostics remain relative to world-up.
+        """
+        return _reward_lean_aware_posture_pure(
+            quat,
+            self.max_tilt_angle,
+            weight,
+            natural_forward_z,
+        )
 
     def _compute_nosedive_penalty(
         self, quat: np.ndarray, weight: float, natural_forward_z: float

--- a/environments/shared/jax_eval.py
+++ b/environments/shared/jax_eval.py
@@ -23,6 +23,8 @@ from typing import Any
 
 import numpy as np
 
+from .reward_functions import reward_lean_aware_posture, reward_posture
+
 
 @dataclass
 class EvalConfig:
@@ -34,6 +36,7 @@ class EvalConfig:
     healthy_z_range: tuple[float, float] = (0.3, 2.0)
     max_tilt_angle: float = 1.047
     natural_forward_z: float = 0.0
+    posture_target_forward_z: float | None = None
     nosedive_threshold: float = 0.5
     termination_body_heights: dict[str, float] | None = None
     termination_site_heights: dict[str, float] | None = None
@@ -57,6 +60,24 @@ class EvalConfig:
     # Seed for reset noise — evaluation is otherwise non-reproducible and
     # curriculum gate decisions would vary run-to-run for borderline policies.
     seed: int = 42
+
+
+def _posture_reward_for_eval(
+    quat: np.ndarray,
+    config: EvalConfig,
+    weight: float,
+) -> float:
+    """Mirror the posture primitive selected by JAX training."""
+    if config.posture_target_forward_z is None:
+        reward, _ = reward_posture(quat, config.max_tilt_angle, weight)
+    else:
+        reward, _ = reward_lean_aware_posture(
+            quat,
+            config.max_tilt_angle,
+            weight,
+            config.posture_target_forward_z,
+        )
+    return float(reward)
 
 
 @dataclass
@@ -271,8 +292,12 @@ def evaluate_policy_cpu(
             results.diag_reward_components["forward"].append(reward_cfg.get("forward_vel_weight", 0.0) * fwd_norm)
             results.diag_reward_components["alive"].append(reward_cfg.get("alive_bonus", 0.0))
             results.diag_reward_components["energy"].append(-reward_cfg.get("energy_penalty_weight", 0.0) * energy)
-            tilt_norm = min(tilt / config.max_tilt_angle, 1.0)
-            results.diag_reward_components["posture"].append(-reward_cfg.get("posture_weight", 0.2) * tilt_norm**2)
+            posture_reward = _posture_reward_for_eval(
+                root_quat,
+                config,
+                reward_cfg.get("posture_weight", 0.2),
+            )
+            results.diag_reward_components["posture"].append(posture_reward)
 
             # Height maintenance
             height_w = reward_cfg.get("height_weight", 0.0)

--- a/environments/shared/jax_reward_termination.py
+++ b/environments/shared/jax_reward_termination.py
@@ -30,6 +30,7 @@ from .reward_functions import (
     reward_heading_alignment,
     reward_height_maintenance,
     reward_lateral_velocity_penalty,
+    reward_lean_aware_posture,
     reward_nosedive,
     reward_posture,
     reward_proximity,
@@ -37,6 +38,23 @@ from .reward_functions import (
 )
 
 Array = Any
+
+
+def _reward_posture_for_target(
+    quat: Array,
+    max_tilt_angle: float,
+    weight: float,
+    posture_target_forward_z: float | None,
+) -> tuple[Array, Array]:
+    """Select vertical or natural-lean posture shaping at trace time."""
+    if posture_target_forward_z is None:
+        return reward_posture(quat, max_tilt_angle, weight)
+    return reward_lean_aware_posture(
+        quat,
+        max_tilt_angle,
+        weight,
+        posture_target_forward_z,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -56,6 +74,7 @@ def compute_total_reward(
     max_tilt_angle: float,
     natural_forward_z: float,
     n_actuators: int,
+    posture_target_forward_z: float | None = None,
     sensor_quat_start: int = 6,
     sensor_gyro_start: int = 0,
     foot_indices: tuple[int, ...] = (10, 11),
@@ -113,7 +132,12 @@ def compute_total_reward(
     r_alive = raw_alive * alive_gate
 
     r_energy = reward_energy(action, n_actuators, reward_cfg.get("energy_penalty_weight", 0.001))
-    r_posture, _ = reward_posture(root_quat, max_tilt_angle, reward_cfg.get("posture_weight", 0.2))
+    r_posture, _ = _reward_posture_for_target(
+        root_quat,
+        max_tilt_angle,
+        reward_cfg.get("posture_weight", 0.2),
+        posture_target_forward_z,
+    )
 
     total = r_forward + r_alive + r_energy + r_posture
 
@@ -236,6 +260,7 @@ def compute_reward_components(
     max_tilt_angle: float,
     natural_forward_z: float,
     n_actuators: int,
+    posture_target_forward_z: float | None = None,
     sensor_quat_start: int = 6,
     sensor_gyro_start: int = 0,
     foot_indices: tuple[int, ...] = (10, 11),
@@ -277,7 +302,12 @@ def compute_reward_components(
     r_alive = raw_alive * alive_gate
 
     r_energy = reward_energy(action, n_actuators, reward_cfg.get("energy_penalty_weight", 0.001))
-    r_posture, _ = reward_posture(root_quat, max_tilt_angle, reward_cfg.get("posture_weight", 0.2))
+    r_posture, _ = _reward_posture_for_target(
+        root_quat,
+        max_tilt_angle,
+        reward_cfg.get("posture_weight", 0.2),
+        posture_target_forward_z,
+    )
 
     components: dict[str, Array] = {
         "forward": r_forward,

--- a/environments/shared/jax_setup.py
+++ b/environments/shared/jax_setup.py
@@ -74,6 +74,7 @@ class SpeciesContext:
 
     # MJXDinoEnv config (from registration + TOML merge)
     # Provides: healthy_z_range, max_tilt_angle, natural_forward_z,
+    # posture_target_forward_z,
     # sensor_*, termination_body_heights, success_sites, etc.
     env_config: Any = None  # MJXEnvConfig
 
@@ -114,7 +115,35 @@ class SpeciesContext:
 
     @property
     def natural_forward_z(self) -> float:
-        return self.env_config.natural_forward_z if self.env_config else 0.0
+        if self.env_config:
+            return float(self.env_config.natural_forward_z)
+        if "natural_forward_z" in self.reward_cfg:
+            return float(self.reward_cfg["natural_forward_z"])
+        from .mjx_env import _SPECIES_CONFIGS
+
+        return float(_SPECIES_CONFIGS.get(self.species, {}).get("natural_forward_z", 0.0))
+
+    @property
+    def posture_target_forward_z(self) -> float | None:
+        """Natural posture target, resolved even before ``create_env``.
+
+        Setup and validation callers may inspect the context before creating
+        the MJX environment, so fall back to the species registry rather than
+        silently selecting the vertical default.
+        """
+        if self.env_config:
+            target = self.env_config.posture_target_forward_z
+            return float(target) if target is not None else None
+        from .mjx_env import _SPECIES_CONFIGS
+
+        if "posture_target_forward_z" in self.reward_cfg:
+            target = self.reward_cfg["posture_target_forward_z"]
+            return float(target) if target is not None else None
+
+        target = _SPECIES_CONFIGS.get(self.species, {}).get("posture_target_forward_z")
+        if target is not None and "natural_forward_z" in self.reward_cfg:
+            target = self.reward_cfg["natural_forward_z"]
+        return float(target) if target is not None else None
 
     @property
     def frame_skip(self) -> int:
@@ -519,6 +548,7 @@ def make_reward_fns(ctx: SpeciesContext):
         target_standing_z=ctx.target_standing_z,
         max_tilt_angle=ctx.max_tilt_angle,
         natural_forward_z=ctx.natural_forward_z,
+        posture_target_forward_z=ctx.posture_target_forward_z,
         n_actuators=ctx.mj_model.nu,
         sensor_quat_start=ctx.sensor_layout.quat_start,
         sensor_gyro_start=ctx.sensor_layout.gyro_start,
@@ -626,6 +656,7 @@ def run_stage_evaluation(
         healthy_z_range=ctx.healthy_z_range,
         max_tilt_angle=ctx.max_tilt_angle,
         natural_forward_z=ctx.natural_forward_z,
+        posture_target_forward_z=ctx.posture_target_forward_z,
         # TOML can tighten the nosedive threshold (e.g. trex stage 1);
         # without this the eval terminated later than training.
         nosedive_threshold=ctx.reward_cfg.get("nosedive_termination_threshold", 0.5),

--- a/environments/shared/mjx_env.py
+++ b/environments/shared/mjx_env.py
@@ -148,6 +148,10 @@ class MJXEnvConfig:
     sensor_quat_start: int = 6
     action_mapping: str = ACTION_MAPPING_MIDPOINT
     natural_forward_z: float = 0.0
+    # Reward-only target.  ``None`` preserves the vertical posture reward;
+    # Velociraptor supplies its natural forward lean.  Absolute-tilt and
+    # nosedive termination remain independent and unchanged.
+    posture_target_forward_z: float | None = None
     forward_vel_max: float = 8.0
     fall_penalty: float = -100.0
     # Target spawning ranges
@@ -365,6 +369,17 @@ class MJXDinoEnv:
         # so the shared SB3/JAX TOMLs actually take effect here.
         if env_kwargs:
             env_kwargs = canonicalize_env_kwargs(env_kwargs)
+            # Velociraptor uses natural pitch for both nosedive semantics and
+            # its reward-only posture target.  Keep a caller-provided
+            # natural_pitch override in parity with RaptorEnv while leaving
+            # upright-target species unchanged.  An explicit posture target
+            # still takes precedence.
+            if (
+                "natural_forward_z" in env_kwargs
+                and species_kwargs.get("posture_target_forward_z") is not None
+                and "posture_target_forward_z" not in env_kwargs
+            ):
+                env_kwargs["posture_target_forward_z"] = env_kwargs["natural_forward_z"]
             for key in sorted(_PLANT_INTERFACE_CONFIG_FIELDS & env_kwargs.keys()):
                 if env_kwargs[key] != species_kwargs.get(key):
                     raise ValueError(
@@ -482,6 +497,7 @@ class MJXDinoEnv:
             reward_heading_alignment,
             reward_height_maintenance,
             reward_lateral_velocity_penalty,
+            reward_lean_aware_posture,
             reward_nosedive,
             reward_posture,
             reward_proximity,
@@ -567,7 +583,19 @@ class MJXDinoEnv:
             r_energy = reward_energy(action, ctrl_range.shape[0], weights.get("energy_penalty_weight", 0.001))
 
             pelvis_quat = data.sensordata[config.sensor_quat_start : config.sensor_quat_start + 4]
-            r_posture, tilt = reward_posture(pelvis_quat, config.max_tilt_angle, weights.get("posture_weight", 0.2))
+            if config.posture_target_forward_z is not None:
+                r_posture, tilt = reward_lean_aware_posture(
+                    pelvis_quat,
+                    config.max_tilt_angle,
+                    weights.get("posture_weight", 0.2),
+                    config.posture_target_forward_z,
+                )
+            else:
+                r_posture, tilt = reward_posture(
+                    pelvis_quat,
+                    config.max_tilt_angle,
+                    weights.get("posture_weight", 0.2),
+                )
 
             target_dist = jnp.linalg.norm(target_pos - pelvis_xpos)
             r_approach, _ = reward_approach_shaping(

--- a/environments/shared/reward_functions.py
+++ b/environments/shared/reward_functions.py
@@ -180,6 +180,49 @@ def reward_posture(
     return reward, tilt_angle
 
 
+def reward_lean_aware_posture(
+    quat: Array,
+    max_tilt_angle: float,
+    weight: float,
+    natural_forward_z: float,
+) -> tuple[Array, Array]:
+    """Penalise deviation from a species' natural forward-leaning posture.
+
+    The world-up vector expressed in body coordinates is compared with a
+    target that has the requested forward-axis Z component, zero lateral
+    lean, and a positive up component.  This makes the reward invariant to
+    yaw while distinguishing correct forward pitch from backward pitch and
+    roll.
+
+    The reward uses a normalised squared chord distance instead of
+    ``acos(alignment) ** 2``.  The chord form has the same local quadratic
+    behaviour but keeps JAX gradients finite at the exact target pose.
+
+    Returns:
+        ``(reward, absolute_tilt_angle)``.  The absolute tilt remains relative
+        to world-up so termination and historical diagnostics keep their
+        existing semantics.
+    """
+    xp = _array_mod(quat)
+    w, x, y, z = quat[0], quat[1], quat[2], quat[3]
+
+    body_forward_z = 2.0 * (x * z - w * y)
+    body_up_z = 1.0 - 2.0 * (x * x + y * y)
+
+    target_forward_z = xp.clip(natural_forward_z, -1.0, 1.0)
+    target_up_z = xp.sqrt(xp.maximum(0.0, 1.0 - target_forward_z**2))
+    # The target's lateral-axis Z component is zero, so its dot-product
+    # contribution vanishes.  Roll is still penalised through body_up_z.
+    alignment = body_forward_z * target_forward_z + body_up_z * target_up_z
+
+    max_chord_error = 1.0 - xp.cos(max_tilt_angle)
+    chord_error_norm = xp.clip((1.0 - alignment) / max_chord_error, 0.0, 1.0)
+    reward = -weight * chord_error_norm
+
+    tilt_angle = xp.arccos(xp.clip(body_up_z, -1.0, 1.0))
+    return reward, tilt_angle
+
+
 def reward_nosedive(
     quat: Array,
     weight: float,

--- a/environments/shared/tests/test_jax_eval.py
+++ b/environments/shared/tests/test_jax_eval.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from environments.shared.jax_eval import EvalConfig, EvalResults, check_stage_gate
+from environments.shared.jax_eval import EvalConfig, EvalResults, _posture_reward_for_eval, check_stage_gate
 
 
 class TestEvalConfig:
@@ -16,6 +16,7 @@ class TestEvalConfig:
         assert cfg.frame_skip == 5
         assert cfg.healthy_z_range == (0.3, 2.0)
         assert cfg.max_tilt_angle == pytest.approx(1.047)
+        assert cfg.posture_target_forward_z is None
         assert cfg.root_body_id == 1
         assert cfg.sensor_quat_start == 6
         assert cfg.action_mapping == "midpoint/v1"
@@ -37,6 +38,18 @@ class TestEvalConfig:
         assert cfg.healthy_z_range == (0.5, 1.5)
         assert cfg.max_tilt_angle == pytest.approx(0.8)
         assert cfg.root_body_id == 2
+
+    def test_lean_aware_posture_decomposition_matches_target(self):
+        natural_pitch = 0.35
+        config = EvalConfig(posture_target_forward_z=-np.sin(natural_pitch))
+        target_quat = np.array([np.cos(natural_pitch / 2.0), 0.0, np.sin(natural_pitch / 2.0), 0.0])
+        upright_quat = np.array([1.0, 0.0, 0.0, 0.0])
+
+        target_reward = _posture_reward_for_eval(target_quat, config, weight=1.5)
+        upright_reward = _posture_reward_for_eval(upright_quat, config, weight=1.5)
+
+        assert target_reward == pytest.approx(0.0, abs=1e-10)
+        assert upright_reward < target_reward
 
 
 class TestEvalResults:

--- a/environments/shared/tests/test_jax_reward_termination.py
+++ b/environments/shared/tests/test_jax_reward_termination.py
@@ -122,6 +122,94 @@ class TestHealthyZMax:
 
 
 # ---------------------------------------------------------------------------
+# Velociraptor natural-pitch posture parity
+# ---------------------------------------------------------------------------
+
+
+class TestLeanAwarePosture:
+    def test_total_and_detailed_rewards_use_natural_posture_target(self):
+        from environments.shared.jax_reward_termination import compute_reward_components, compute_total_reward
+
+        natural_pitch = 0.35
+        target_forward_z = -np.sin(natural_pitch)
+        target_quat = (np.cos(natural_pitch / 2.0), 0.0, np.sin(natural_pitch / 2.0), 0.0)
+        reward_cfg = {
+            "alive_bonus": 0.0,
+            "energy_penalty_weight": 0.0,
+            "forward_vel_weight": 0.0,
+            "posture_weight": 1.5,
+        }
+        action = np.zeros(5)
+
+        target_data = _make_mock_data(quat=target_quat)
+        target_total = compute_total_reward(
+            target_data,
+            action,
+            reward_cfg,
+            root_body_id=1,
+            healthy_z_min=0.3,
+            healthy_z_max=1.5,
+            max_tilt_angle=1.047,
+            natural_forward_z=-0.342,
+            posture_target_forward_z=target_forward_z,
+            n_actuators=5,
+        )
+        target_components = compute_reward_components(
+            target_data,
+            action,
+            reward_cfg,
+            root_body_id=1,
+            healthy_z_min=0.3,
+            healthy_z_max=1.5,
+            max_tilt_angle=1.047,
+            natural_forward_z=-0.342,
+            posture_target_forward_z=target_forward_z,
+            n_actuators=5,
+        )
+
+        upright_data = _make_mock_data(quat=(1.0, 0.0, 0.0, 0.0))
+        upright_components = compute_reward_components(
+            upright_data,
+            action,
+            reward_cfg,
+            root_body_id=1,
+            healthy_z_min=0.3,
+            healthy_z_max=1.5,
+            max_tilt_angle=1.047,
+            natural_forward_z=-0.342,
+            posture_target_forward_z=target_forward_z,
+            n_actuators=5,
+        )
+
+        assert float(target_total) == pytest.approx(float(target_components["posture"]), abs=1e-6)
+        assert float(target_components["posture"]) == pytest.approx(0.0, abs=1e-6)
+        assert float(upright_components["posture"]) < float(target_components["posture"])
+
+    def test_none_target_preserves_upright_posture_reward(self):
+        from environments.shared.jax_reward_termination import compute_reward_components
+
+        components = compute_reward_components(
+            _make_mock_data(quat=(1.0, 0.0, 0.0, 0.0)),
+            np.zeros(5),
+            {
+                "alive_bonus": 0.0,
+                "energy_penalty_weight": 0.0,
+                "forward_vel_weight": 0.0,
+                "posture_weight": 1.5,
+            },
+            root_body_id=1,
+            healthy_z_min=0.3,
+            healthy_z_max=1.5,
+            max_tilt_angle=1.047,
+            natural_forward_z=-0.169,
+            posture_target_forward_z=None,
+            n_actuators=5,
+        )
+
+        assert float(components["posture"]) == pytest.approx(0.0, abs=1e-7)
+
+
+# ---------------------------------------------------------------------------
 # Fix #9: compute_total_reward alignment with mjx_env.step
 # ---------------------------------------------------------------------------
 

--- a/environments/shared/tests/test_mjx_env.py
+++ b/environments/shared/tests/test_mjx_env.py
@@ -37,6 +37,7 @@ class TestMJXDinoEnv:
         env = MJXDinoEnv("trex", stage=1, num_envs=4)
         assert env.action_dim == 21
         assert env.num_envs == 4
+        assert env.config.posture_target_forward_z is None
 
     def test_raptor_creation(self):
         """MJXDinoEnv can be created for Velociraptor."""
@@ -46,6 +47,36 @@ class TestMJXDinoEnv:
         env = MJXDinoEnv("velociraptor", stage=1, num_envs=4)
         assert env.action_dim == 22
         assert env.num_envs == 4
+        assert env.config.natural_forward_z == pytest.approx(-0.342)
+        assert env.config.posture_target_forward_z == pytest.approx(-np.sin(0.35))
+
+    def test_raptor_natural_pitch_override_updates_posture_target(self):
+        import environments.velociraptor.mjx_config  # noqa: F401
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        env = MJXDinoEnv(
+            "velociraptor",
+            stage=1,
+            num_envs=1,
+            env_kwargs={"natural_pitch": 0.5},
+        )
+
+        assert env.config.natural_forward_z == pytest.approx(-np.sin(0.5))
+        assert env.config.posture_target_forward_z == pytest.approx(-np.sin(0.5))
+
+    def test_trex_natural_pitch_override_keeps_vertical_posture_target(self):
+        import environments.trex.mjx_config  # noqa: F401
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        env = MJXDinoEnv(
+            "trex",
+            stage=1,
+            num_envs=1,
+            env_kwargs={"natural_pitch": 0.5},
+        )
+
+        assert env.config.natural_forward_z == pytest.approx(-np.sin(0.5))
+        assert env.config.posture_target_forward_z is None
 
     def test_brachio_creation(self):
         """MJXDinoEnv can be created for Brachiosaurus."""
@@ -55,6 +86,7 @@ class TestMJXDinoEnv:
         env = MJXDinoEnv("brachiosaurus", stage=1, num_envs=4)
         assert env.action_dim == 30
         assert env.num_envs == 4
+        assert env.config.posture_target_forward_z is None
 
     def test_stage_cannot_override_versioned_plant_interface(self):
         import environments.trex.mjx_config  # noqa: F401
@@ -145,6 +177,29 @@ class TestMJXUtils:
 
 @pytest.mark.skipif(not _has_jax, reason="JAX/MJX not installed")
 class TestHomeKeyframeActionMapping:
+    def test_setup_species_resolves_raptor_posture_target_before_env_creation(self):
+        from environments.shared.jax_setup import setup_species
+
+        ctx = setup_species("velociraptor", stage=1)
+
+        assert ctx.env_config is None
+        assert ctx.natural_forward_z == pytest.approx(-0.342)
+        assert ctx.posture_target_forward_z == pytest.approx(-np.sin(0.35))
+
+    def test_pre_env_raptor_natural_pitch_override_updates_posture_target(self):
+        import environments.velociraptor.mjx_config  # noqa: F401
+        from environments.shared.jax_setup import SpeciesContext
+
+        overridden = -np.sin(0.5)
+        ctx = SpeciesContext(
+            species="velociraptor",
+            stage=1,
+            reward_cfg={"natural_forward_z": overridden},
+        )
+
+        assert ctx.natural_forward_z == pytest.approx(overridden)
+        assert ctx.posture_target_forward_z == pytest.approx(overridden)
+
     def test_setup_species_raptor_zero_action_maps_to_xml_home(self):
         import jax.numpy as jnp
         import mujoco

--- a/environments/shared/tests/test_result_bundle.py
+++ b/environments/shared/tests/test_result_bundle.py
@@ -122,7 +122,7 @@ def stable_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
         result_bundle,
         "_dependency_versions",
         lambda: {
-            "mesozoic_labs": "0.3.2.dev0",
+            "mesozoic_labs": "0.3.3.dev0",
             "mujoco": "3.10.0",
             "mujoco_mjx": "3.10.0",
             "gymnasium": "1.2.0",

--- a/environments/shared/tests/test_reward_functions.py
+++ b/environments/shared/tests/test_reward_functions.py
@@ -21,6 +21,7 @@ from environments.shared.reward_functions import (
     reward_forward_velocity,
     reward_height_maintenance,
     reward_idle_penalty,
+    reward_lean_aware_posture,
     reward_posture,
     reward_proximity,
     reward_speed_penalty,
@@ -137,6 +138,81 @@ class TestRewardPosture:
         reward, tilt = reward_posture(quat, 1.047, 1.0)
         assert reward == pytest.approx(0.0, abs=1e-6)
         assert tilt == pytest.approx(0.0, abs=1e-6)
+
+
+class TestRewardLeanAwarePosture:
+    natural_pitch = 0.35
+    natural_forward_z = -np.sin(natural_pitch)
+    max_tilt = 1.047
+
+    @staticmethod
+    def _pitch_quat(angle: float) -> np.ndarray:
+        return np.array([np.cos(angle / 2.0), 0.0, np.sin(angle / 2.0), 0.0])
+
+    @staticmethod
+    def _roll_quat(angle: float) -> np.ndarray:
+        return np.array([np.cos(angle / 2.0), np.sin(angle / 2.0), 0.0, 0.0])
+
+    @staticmethod
+    def _quat_multiply(left: np.ndarray, right: np.ndarray) -> np.ndarray:
+        w1, x1, y1, z1 = left
+        w2, x2, y2, z2 = right
+        return np.array(
+            [
+                w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+                w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+                w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+                w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+            ]
+        )
+
+    def _reward(self, quat: np.ndarray, weight: float = 1.0) -> tuple[float, float]:
+        return reward_lean_aware_posture(
+            quat,
+            self.max_tilt,
+            weight,
+            self.natural_forward_z,
+        )
+
+    def test_natural_forward_pitch_minimizes_penalty(self):
+        reward, tilt = self._reward(self._pitch_quat(self.natural_pitch))
+        assert reward == pytest.approx(0.0, abs=1e-12)
+        assert tilt == pytest.approx(self.natural_pitch, abs=1e-6)
+
+    def test_upright_backward_pitch_and_roll_are_penalized(self):
+        upright_reward, upright_tilt = self._reward(np.array([1.0, 0.0, 0.0, 0.0]))
+        backward_reward, _ = self._reward(self._pitch_quat(-self.natural_pitch))
+        natural_pitch = self._pitch_quat(self.natural_pitch)
+        rolled_natural_pitch = self._quat_multiply(natural_pitch, self._roll_quat(self.natural_pitch))
+        roll_reward, _ = self._reward(rolled_natural_pitch)
+
+        assert upright_reward < 0.0
+        assert backward_reward < upright_reward
+        assert roll_reward < 0.0
+        assert upright_tilt == pytest.approx(0.0, abs=1e-6)
+
+    def test_world_yaw_does_not_change_reward(self):
+        pitch = self._pitch_quat(self.natural_pitch)
+        yaw_angle = 1.2
+        yaw = np.array([np.cos(yaw_angle / 2.0), 0.0, 0.0, np.sin(yaw_angle / 2.0)])
+        yawed_pitch = self._quat_multiply(yaw, pitch)
+
+        reward, _ = self._reward(pitch)
+        yawed_reward, _ = self._reward(yawed_pitch)
+        assert yawed_reward == pytest.approx(reward, abs=1e-12)
+
+    def test_quaternion_sign_does_not_change_reward(self):
+        quat = self._pitch_quat(0.1)
+        reward, tilt = self._reward(quat)
+        negated_reward, negated_tilt = self._reward(-quat)
+        assert negated_reward == pytest.approx(reward, abs=1e-12)
+        assert negated_tilt == pytest.approx(tilt, abs=1e-12)
+
+    def test_reward_is_bounded_and_zero_weight_is_exactly_zero(self):
+        reward, _ = self._reward(self._pitch_quat(np.pi / 2.0), weight=2.0)
+        zero_weight_reward, _ = self._reward(self._pitch_quat(-0.5), weight=0.0)
+        assert -2.0 <= reward <= 0.0
+        assert zero_weight_reward == 0.0
 
 
 class TestRewardProximity:
@@ -256,6 +332,7 @@ class TestDistanceContact:
 
 _has_jax = False
 try:
+    import jax
     import jax.numpy as jnp
 
     _has_jax = True
@@ -290,3 +367,24 @@ class TestNumpyJaxParity:
         r_np = reward_energy(action, 4, 0.01)
         r_jax = reward_energy(jnp.array(action), 4, 0.01)
         assert r_np == pytest.approx(r_jax, abs=1e-6)
+
+    def test_lean_aware_posture_parity(self):
+        natural_pitch = 0.35
+        target = -np.sin(natural_pitch)
+        quat = np.array([np.cos(0.2), 0.0, np.sin(0.2), 0.0])
+        r_np, tilt_np = reward_lean_aware_posture(quat, 1.047, 1.5, target)
+        r_jax, tilt_jax = reward_lean_aware_posture(jnp.array(quat), 1.047, 1.5, target)
+        assert r_np == pytest.approx(r_jax, abs=1e-6)
+        assert tilt_np == pytest.approx(tilt_jax, abs=1e-6)
+
+    def test_lean_aware_posture_gradient_is_finite_at_target(self):
+        natural_pitch = 0.35
+        target = -np.sin(natural_pitch)
+
+        def posture_reward_for_pitch(pitch):
+            quat = jnp.array([jnp.cos(pitch / 2.0), 0.0, jnp.sin(pitch / 2.0), 0.0])
+            reward, _ = reward_lean_aware_posture(quat, 1.047, 1.5, target)
+            return reward
+
+        gradient = jax.grad(posture_reward_for_pitch)(jnp.float32(natural_pitch))
+        assert np.isfinite(float(gradient))

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -328,6 +328,16 @@ def test_training_notebooks_do_not_restore_stale_public_defaults() -> None:
     assert "A100 recommended" not in jax
 
 
+def test_jax_notebook_resolves_env_before_binding_reward_functions() -> None:
+    notebook = json.loads((REPOSITORY_ROOT / "notebooks" / "jax_training.ipynb").read_text(encoding="utf-8"))
+    code = "\n".join("".join(cell.get("source", [])) for cell in notebook["cells"] if cell.get("cell_type") == "code")
+
+    create_index = code.index("env = create_env(ctx")
+    reward_index = code.index("compute_reward, compute_reward_detailed")
+
+    assert create_index < reward_index, "JAX rewards must bind after create_env populates ctx.env_config"
+
+
 def test_sb3_notebook_refuses_a_hybrid_model_and_vecnormalize_checkpoint() -> None:
     notebook = json.loads((REPOSITORY_ROOT / "notebooks" / "sb3_training.ipynb").read_text(encoding="utf-8"))
     chunks: list[str] = []

--- a/environments/velociraptor/README.md
+++ b/environments/velociraptor/README.md
@@ -102,7 +102,9 @@ piecewise-linear interpolation.
 Reward weights vary by stage. The `[env]` section of each
 `configs/velociraptor/stage*.toml` file is authoritative; this README does not
 copy numeric weights. Components include locomotion, survival, posture, energy,
-tail stability, approach shaping, target contact, and fall penalties.
+tail stability, approach shaping, target contact, and fall penalties. Posture
+shaping is direction-aware and centred on the raptor's natural forward lean;
+absolute tilt remains the safety signal for termination.
 
 ### Termination Conditions
 - Pelvis height < 0.25m (fallen)

--- a/environments/velociraptor/README.md
+++ b/environments/velociraptor/README.md
@@ -95,7 +95,8 @@ python scripts/train_sb3.py eval logs/<run_dir>/models/stage3_final.zip
 Observation and action totals are generated in the catalog entry linked above. The source of the observation layout and
 action-to-actuator mapping is `envs/raptor_env.py`. Actions are normalized residuals around the named XML `home`
 keyframe: zero commands the standing pose, while -1 and +1 still reach each actuator's lower and upper limits through
-piecewise-linear interpolation.
+piecewise-linear interpolation. The evidence and compatibility rationale are in the
+[Stage-1 basin investigation](../../docs/investigations/VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md).
 
 ### Reward Components
 
@@ -138,8 +139,9 @@ absolute tilt remains the safety signal for termination.
 - Check that alive_bonus isn't dominating
 
 **If it walks but falls a lot:**
-- Increase `alive_bonus` in early training
-- Add a reward for maintaining upright orientation
+- Inspect the episode-length distribution and termination mix before changing weights
+- Check whether `forward_z` tracks the natural lean; do not reward world-vertical posture for this morphology
+- Lower reset noise only if a controlled probe isolates reset perturbations as the failure source
 
 **If it ignores the prey:**
 - Add proximity reward (bonus for getting closer)

--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -37,7 +37,7 @@ Reward components:
     - Approach shaping (distance to prey)
     - Proximity bonus (continuous reward for being close to prey)
     - Claw proximity shaping (reward for positioning claw tip near prey)
-    - Posture (continuous tilt penalty)
+    - Posture (continuous deviation from the natural forward lean)
     - Nosedive penalty
     - Gait symmetry (alternating foot contacts)
     - Action smoothness (penalize jerky action changes)
@@ -127,9 +127,10 @@ class RaptorEnv(BaseDinoEnv):
         self.idle_penalty_weight = idle_penalty_weight
         self.idle_velocity_threshold = idle_velocity_threshold
 
-        # Natural forward pitch (~20°). The nosedive penalty and termination
-        # are measured relative to this angle so the raptor isn't punished for
-        # its biomechanically correct forward lean.
+        # Natural forward pitch (~20°). Posture shaping, the nosedive penalty,
+        # and nosedive termination are measured relative to this angle so the
+        # raptor is not rewarded for abandoning its biomechanically supported
+        # forward lean.
         self._natural_forward_z = -np.sin(natural_pitch)
 
         # Raptor-specific env settings
@@ -402,9 +403,15 @@ class RaptorEnv(BaseDinoEnv):
         info["claw_proximity"] = claw_proximity
         info["reward_claw_proximity"] = reward_claw_proximity
 
-        # 7. Continuous posture reward
+        # 7. Continuous posture reward centred on the natural forward lean.
+        # The returned tilt remains absolute (relative to world-up) for
+        # diagnostics and termination parity.
         pelvis_quat = self.data.sensordata[self._sensor_quat_start : self._sensor_quat_start + 4]
-        reward_posture, tilt_angle = self._compute_posture_reward(pelvis_quat, self.posture_weight)
+        reward_posture, tilt_angle = self._compute_lean_aware_posture_reward(
+            pelvis_quat,
+            self.posture_weight,
+            self._natural_forward_z,
+        )
         info["tilt_angle"] = tilt_angle
         info["reward_posture"] = reward_posture
 

--- a/environments/velociraptor/mjx_config.py
+++ b/environments/velociraptor/mjx_config.py
@@ -6,6 +6,8 @@ Registers the Velociraptor species with the MJX environment so that
 
 from __future__ import annotations
 
+import math
+
 from environments.shared.mjx_env import register_species_mjx
 
 # Sensor indices match the MJCF sensor definition order:
@@ -15,6 +17,8 @@ _SENSOR_R_FOOT = 10
 _SENSOR_L_FOOT = 11
 # Tail tip gyro starts after: gyro(3)+accel(3)+quat(4)+touch(2)+r_claw_pos(3)+l_claw_pos(3)+tail_pos(3)+tail_linvel(3)=24
 _SENSOR_TAIL_GYRO_START = 24
+_NATURAL_PITCH = 0.35
+_POSTURE_TARGET_FORWARD_Z = -math.sin(_NATURAL_PITCH)
 
 register_species_mjx(
     species="velociraptor",
@@ -27,7 +31,10 @@ register_species_mjx(
     sensor_gyro_start=0,
     sensor_accel_start=3,
     sensor_quat_start=6,
-    natural_forward_z=-0.342,  # -sin(0.35)  ~20° natural pitch
+    # Preserve the existing rounded nosedive baseline so reward shaping does
+    # not move the termination boundary in this isolated experiment.
+    natural_forward_z=-0.342,
+    posture_target_forward_z=_POSTURE_TARGET_FORWARD_Z,
     sensor_tail_gyro_start=_SENSOR_TAIL_GYRO_START,
     forward_vel_max=10.0,
     fall_penalty=-100.0,

--- a/environments/velociraptor/tests/test_raptor_rewards.py
+++ b/environments/velociraptor/tests/test_raptor_rewards.py
@@ -71,6 +71,38 @@ class TestRaptorRewardComponents:
     def test_posture_reward_negative_or_zero(self, env):
         assert_posture_reward_non_positive(env)
 
+    def test_posture_reward_prefers_xml_home_lean_to_vertical(self, env):
+        home_quat = env.model.key_qpos[env.home_keyframe_id, 3:7]
+        home_reward, home_tilt = env._compute_lean_aware_posture_reward(
+            home_quat,
+            1.0,
+            env._natural_forward_z,
+        )
+        upright_reward, upright_tilt = env._compute_lean_aware_posture_reward(
+            np.array([1.0, 0.0, 0.0, 0.0]),
+            1.0,
+            env._natural_forward_z,
+        )
+
+        assert home_reward == pytest.approx(0.0, abs=1e-5)
+        assert home_reward > upright_reward
+        assert home_tilt == pytest.approx(np.deg2rad(20.0), abs=1e-5)
+        assert upright_tilt == pytest.approx(0.0, abs=1e-6)
+
+    def test_step_reports_lean_aware_posture_reward(self, env):
+        env.reset(seed=42)
+        action = np.zeros(env.action_space.shape, dtype=np.float32)
+        _, _, _, _, info = env.step(action)
+        pelvis_quat = env.data.sensordata[env._sensor_quat_start : env._sensor_quat_start + 4]
+        expected, absolute_tilt = env._compute_lean_aware_posture_reward(
+            pelvis_quat,
+            env.posture_weight,
+            env._natural_forward_z,
+        )
+
+        assert info["reward_posture"] == pytest.approx(expected, abs=1e-8)
+        assert info["tilt_angle"] == pytest.approx(absolute_tilt, abs=1e-8)
+
     def test_gait_reward_non_negative(self, env):
         assert_gait_reward_non_negative(env)
 

--- a/notebooks/jax_training.ipynb
+++ b/notebooks/jax_training.ipynb
@@ -411,7 +411,6 @@
     "# Observation and action functions (from library)\n",
     "get_obs = make_obs_fn(ctx)\n",
     "scale_action = make_scale_action_fn(ctx)\n",
-    "compute_reward, compute_reward_detailed, is_terminated = make_reward_fns(ctx)\n",
     "\n",
     "print(f\"Observation dim: {OBS_DIM}\")\n",
     "print(f\"Action dim: {ACT_DIM}\")"
@@ -441,6 +440,9 @@
     "# Create MJXDinoEnv via library helper (applies solver tuning + env_kwargs merge)\n",
     "env = create_env(ctx, num_envs=NUM_ENVS)\n",
     "mjx_model = env.mjx_model\n",
+    "\n",
+    "# Bind rewards only after create_env resolves the stage-specific MJX config.\n",
+    "compute_reward, compute_reward_detailed, is_terminated = make_reward_fns(ctx)\n",
     "\n",
     "print(f\"MJXDinoEnv created: {SPECIES} stage {CURRENT_STAGE}\")\n",
     "print(f\"  num_envs={NUM_ENVS}, action_dim={env.action_dim}, frame_skip={env.config.frame_skip}\")\n",
@@ -655,7 +657,7 @@
    },
    "outputs": [],
    "source": [
-    "# Reward and termination wrappers already created by make_reward_fns() above.\n",
+    "# Reward and termination wrappers were bound after MJXDinoEnv creation above.\n",
     "# compute_reward, compute_reward_detailed, is_terminated are ready to use.\n",
     "print(f\"Active reward components: {[k for k, v in reward_cfg.items() if isinstance(v, (int, float)) and v != 0]}\")"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mesozoic-labs"
-version = "0.3.2.dev0"
+version = "0.3.3.dev0"
 description = "Dinosaur-inspired locomotion environments for MuJoCo and Gymnasium"
 requires-python = ">=3.11"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- center the Velociraptor posture reward on its natural forward pitch instead of world vertical
- use a yaw-invariant, direction- and roll-aware squared-chord error with finite JAX gradients at the target
- route the same reward-only target through SB3, direct MJX, JAX total/component rewards, CPU evaluation, and runtime `natural_pitch` overrides
- keep absolute-tilt diagnostics/termination and the existing nosedive boundary unchanged
- document the Commit A probe, A-only PPO run `20260720_203454`, lessons learned, and the next experiment
- bump the Python library version from `0.3.2.dev0` to `0.3.3.dev0`

## Why

After the home-keyframe residual action change, PPO moved out of the worst backward-drift basin but still failed the Stage-1 survival gate:

- selected evaluation: **149.22 ± 28.76 reward**
- selected episode length: **128.4 ± 19.1 steps**
- **0/30** episodes reached the 750-step gate
- PPO diagnostics remained healthy while the policy straightened away from the XML-supported lean

The old posture component charged the approximately 20° XML home pose `-0.166729` per step and charged upright posture zero. This change makes the home penalty approximately zero and makes upright posture cost `-0.181944` at the Stage-1 weight.

## Compatibility and scope

- no XML or compiled-physics change
- no reset-noise, termination-threshold, stage-weight, or PPO-hyperparameter change
- Velociraptor remains policy-interface revision 2; Commit B changes reward semantics, identified by exact repository/config provenance
- T-Rex and Brachiosaurus retain their vertical posture targets
- the existing rounded MJX nosedive baseline remains separate from the exact reward-only target

A fresh training run is required. A-only and A+B total rewards are not directly comparable because the posture baseline changed.

## Validation

- full `environments/shared/tests` and `environments/velociraptor/tests` suites
- focused T-Rex and Brachiosaurus reward regression tests
- result-bundle tests
- Ruff and mypy
- plant-contract and generated species-catalog checks
- notebook JSON/order regression checks
- wheel/runtime metadata resolves to `0.3.3.dev0`

## Post-merge experiment

Run a fresh Velociraptor PPO Stage 1 from a clean Colab runtime with a new run ID. Keep `reset_noise_scale = 0.05` and the current Stage-1 configuration unchanged; do not resume the A-only policy or proceed to Stage 2 unless the survival gate passes.
