### PR TITLE
Fix dead raptor foot touch sensors; raise knee forcerange to 1.5x kp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Reproducible Runs & Velociraptor Stage-1 Diagnosis (v0.3.3)
 
+### Changed
+- **Velociraptor knee actuators raised to 1.5×kp** (breaking — plant change,
+  physics revision 1 → 2): the knee measured 0 % clip at the moderate
+  2.5 Hz/0.8-amplitude contract gait but 30–46 % at sprint-like 3–4 Hz
+  full-amplitude excitation while still capped at 0.8×kp (`forcerange`
+  ±145 on kp=180) — the same clipped-torque signature that collapsed
+  stage-2 locomotion at the hips. At ±270 the same sprint excitation
+  measures 0 % knee clip; the moderate-regime contract and the
+  home-control no-saturation guarantee are unchanged, and a new
+  sprint-regime contract test pins the knee headroom.
+
+### Fixed
+- **Velociraptor foot touch sensors were dead during normal stance**
+  (breaking — policy-interface revision 2 → 3, visual revision 1 → 2): the
+  raptor is digitigrade and a lying toe capsule contacts the floor near its
+  ends, but the r=0.02 touch sites sat at the toe midpoint, so both sensors
+  — and the two foot-contact observation dims fed from them — read 0 while
+  standing (verified: six active floor contacts, zero sensor signal). The
+  sites now envelop the whole toe_d3 capsule. Fixing them exposed a second
+  defect: the adjacent toe digits (d3/d4) interpenetrate at rest and the
+  solver held a constant ~300 N phantom repulsion between them, which the
+  enlarged sites would have summed even airborne; new contact excludes
+  remove it. Verified post-fix: ~37 N per foot at settled stance, exactly
+  0 N airborne, 48/50 standing-probe survival unchanged, and regression
+  tests pin stance/airborne sensor behavior. The T-Rex has the same
+  dead-sensor defect (recorded in KNOWN_ISSUES, not yet fixed).
+
 ### Added
 - **Canonical result bundles for Colab/Google Drive training**: schema-v2
   summaries, runtime-captured provenance, immutable completed bundles,

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Swift Bipedal Predator. **Specialty:** Sickle-claw contact attacks.
 | Action dimension / actuators | 22 |
 | Generalized coordinates / velocities | nq=31, nv=30 |
 | Compiled dynamic model mass | 13.5 kg |
-| Plant contract revisions | policy r2; physics r1; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r3; physics r2; visual r2 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/velociraptor/assets/raptor.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |

--- a/configs/plant_manifest.generated.json
+++ b/configs/plant_manifest.generated.json
@@ -84,30 +84,30 @@
       }
     },
     "velociraptor": {
-      "bundle_sha256": "sha256:da93c4707c1eb7fed54295b5fdfd8f005f7e2b2c0d2d2fe37527f6d114dfdc8d",
+      "bundle_sha256": "sha256:a25de61e72daa4cf453b3c3c9284577a7b0a559a0f486eeeae9f69647fa58557",
       "env_entrypoint": "environments.velociraptor.envs.raptor_env:RaptorEnv",
       "model_path": "environments/velociraptor/assets/raptor.xml",
       "physics": {
         "nq": 31,
         "nu": 22,
         "nv": 30,
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:fde764755bd2f688cd6ca957d994a3d2d47087243ba9f06b5821e39a1b1bd4d6"
+        "sha256": "sha256:c10e6102bbe0a5ca0fc4a33e439f8e199704bbf4c27e922796787da736b65352"
       },
       "policy_interface": {
         "action_dim": 22,
         "observation_dim": 67,
         "observation_schema": "bipedal-target/v1",
-        "revision": 2,
+        "revision": 3,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:38e9edbb4330492b9daa81523440ea5a38c643c94f5079723e24644fa6915225"
+        "sha256": "sha256:a1cddb3c11997620980eaa57d2e7ff824695d07d31359cbdd78db2002dd99a2d"
       },
       "source": {
-        "closure_sha256": "sha256:852bbf54cea4e451380ed6b175f001ab0e11dac8e1c3632ea299e0a11f1ff38f",
+        "closure_sha256": "sha256:17c1ed5f2c7f162327cb8b59661564118101cfde331a525d3d3846e53cd660fb",
         "dependencies": [
           {
-            "content_sha256": "sha256:1c815fb4c7005d626dc1c494695cbc70d86a4009f43943888f09d0b7cc4452f5",
+            "content_sha256": "sha256:c3a67f20f311b76a6e363971c30e43d39652df539cb02cb8de315482295b0481",
             "kind": "mjcf",
             "logical_path": "environments/velociraptor/assets/raptor.xml"
           }
@@ -117,9 +117,9 @@
       },
       "species": "velociraptor",
       "visual": {
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.mujoco-visual/v1",
-        "sha256": "sha256:c901ba81e9e810d60f9815d45fd0e6f74b5bdb2f9bb71d5e6aabfed70bc7bc51"
+        "sha256": "sha256:7a9147bf05e193781eb96e95f03614c8263dd6e360f88cbc56a571a2c2a13be6"
       }
     }
   },

--- a/configs/plant_versions.toml
+++ b/configs/plant_versions.toml
@@ -11,9 +11,9 @@ canonical_mujoco_version = "3.10.0"
 # increases. Source-only changes (for example comments) do not require a bump.
 
 [plants.velociraptor]
-physics_revision = 1
-policy_interface_revision = 2
-visual_revision = 1
+physics_revision = 2
+policy_interface_revision = 3
+visual_revision = 2
 observation_schema = "bipedal-target/v1"
 
 [plants.trex]

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -131,8 +131,11 @@ z≈1.13, level, all four feet grounded. All three models now use
 `integrator="implicitfast"` and bounded
 `forcerange` on position actuators, sized to clip impact/reset spikes only,
 with gait-critical actuators at 1.5×kp on every species (raptor hip
-pitch/ankle; trex hip pitch/knee/ankle; brachiosaurus all four hip
-pitches). The original home-control-only sizing clipped 20–50 % of
+pitch/knee/ankle; trex hip pitch/knee/ankle; brachiosaurus all four hip
+pitches — the raptor knee joined the 1.5× set in July 2026 after measuring
+0 % clip at the moderate 2.5 Hz/0.8-amplitude regime but 30–46 % at
+sprint-like 3–4 Hz full-amplitude excitation while still capped at
+0.8×kp). The original home-control-only sizing clipped 20–50 % of
 gait-cycle torque per species and collapsed velociraptor stage-2 twice — see
 [investigations/STAGE2_RECOMMENDATIONS.md](investigations/STAGE2_RECOMMENDATIONS.md)
 §5. Post-fix gait clipping is ≤0.5 % everywhere, pinned by each species'
@@ -149,6 +152,21 @@ are documented in [PLANT_CONTRACT.md](PLANT_CONTRACT.md).
 
 Still open:
 
+- **MEDIUM** — the T-Rex foot touch sensors read 0 during settled stance
+  (verified empirically: both `r/l_foot_contact` are 0.0 after a settle),
+  the same defect fixed on the velociraptor: a lying toe capsule contacts
+  the floor near its ends, and the r=0.06 site at the toe midpoint misses
+  those contact points. The two foot-contact observation dims and any
+  foot-contact reward gating are dead. Fix as on the raptor: enlarge the
+  site to envelop the toe capsule, check for adjacent-digit
+  interpenetration (add contact excludes if the digits overlap at rest),
+  and bump the trex plant revisions.
+- **LOW** — the raptor's toe-clipping margin now sits at the toes: at
+  sprint-like excitation (3–4 Hz, full amplitude) the 0.8×kp toe caps clip
+  10–16 % and the 1.5×kp hip pitch ~11–16 % (its physical envelope); the
+  knee measures 0 % after its 1.5× bump. Re-measure with
+  `environments/shared/scripts/actuator_saturation_report.py` before any
+  faster-gait (stage-3 sprint) work and consider 1.5× toes if they bind.
 - **MEDIUM** — the T-Rex home keyframe (pitch 0) is ~35° from its passive
   equilibrium (settles to forward_z −0.583), which is *past* the stage-1
   nosedive termination line (−0.519 with the TOML's 0.35 threshold): every

--- a/docs/investigations/STAGE2_RECOMMENDATIONS.md
+++ b/docs/investigations/STAGE2_RECOMMENDATIONS.md
@@ -195,6 +195,21 @@ r_hip_pitch_act / l_hip_pitch_act:  kp=150  forcerange="-225 225"   (was ±120, 
 r_ankle_act     / l_ankle_act:      kp=100  forcerange="-150 150"   (was ±80)
 ```
 
+> **July 2026 follow-up:** "knees measure ~0% gait clipping" holds only for
+> the moderate 2.5 Hz/0.8-amplitude regime pinned here. At sprint-like
+> excitation (3–4 Hz, full amplitude) the 0.8×kp knee cap measured 30–46 %
+> clip — the same signature that broke stage 2 at the hips — so the knee was
+> raised to 1.5×kp as well:
+>
+> ```xml
+> r_knee_act / l_knee_act:  kp=180  forcerange="-270 270"   (was ±145, 0.8×kp → 1.5×kp)
+> ```
+>
+> Post-bump the knee measures 0 % at 3.5 Hz/1.0 (pinned by
+> `test_sprint_excitation_keeps_knee_unclipped`). At that regime the
+> remaining clip sits on the 0.8×kp toes (10–16 %) and the 1.5×kp hip pitch
+> (~11–16 %, its physical envelope) — re-measure before stage-3 sprint work.
+
 Operational requirements:
 
 - **Must merge to `main`** — the Colab notebook clones `main` with no branch

--- a/environments/shared/data/plant_manifest.generated.json
+++ b/environments/shared/data/plant_manifest.generated.json
@@ -84,30 +84,30 @@
       }
     },
     "velociraptor": {
-      "bundle_sha256": "sha256:da93c4707c1eb7fed54295b5fdfd8f005f7e2b2c0d2d2fe37527f6d114dfdc8d",
+      "bundle_sha256": "sha256:a25de61e72daa4cf453b3c3c9284577a7b0a559a0f486eeeae9f69647fa58557",
       "env_entrypoint": "environments.velociraptor.envs.raptor_env:RaptorEnv",
       "model_path": "environments/velociraptor/assets/raptor.xml",
       "physics": {
         "nq": 31,
         "nu": 22,
         "nv": 30,
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:fde764755bd2f688cd6ca957d994a3d2d47087243ba9f06b5821e39a1b1bd4d6"
+        "sha256": "sha256:c10e6102bbe0a5ca0fc4a33e439f8e199704bbf4c27e922796787da736b65352"
       },
       "policy_interface": {
         "action_dim": 22,
         "observation_dim": 67,
         "observation_schema": "bipedal-target/v1",
-        "revision": 2,
+        "revision": 3,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:38e9edbb4330492b9daa81523440ea5a38c643c94f5079723e24644fa6915225"
+        "sha256": "sha256:a1cddb3c11997620980eaa57d2e7ff824695d07d31359cbdd78db2002dd99a2d"
       },
       "source": {
-        "closure_sha256": "sha256:852bbf54cea4e451380ed6b175f001ab0e11dac8e1c3632ea299e0a11f1ff38f",
+        "closure_sha256": "sha256:17c1ed5f2c7f162327cb8b59661564118101cfde331a525d3d3846e53cd660fb",
         "dependencies": [
           {
-            "content_sha256": "sha256:1c815fb4c7005d626dc1c494695cbc70d86a4009f43943888f09d0b7cc4452f5",
+            "content_sha256": "sha256:c3a67f20f311b76a6e363971c30e43d39652df539cb02cb8de315482295b0481",
             "kind": "mjcf",
             "logical_path": "environments/velociraptor/assets/raptor.xml"
           }
@@ -117,9 +117,9 @@
       },
       "species": "velociraptor",
       "visual": {
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.mujoco-visual/v1",
-        "sha256": "sha256:c901ba81e9e810d60f9815d45fd0e6f74b5bdb2f9bb71d5e6aabfed70bc7bc51"
+        "sha256": "sha256:7a9147bf05e193781eb96e95f03614c8263dd6e360f88cbc56a571a2c2a13be6"
       }
     }
   },

--- a/environments/shared/tests/test_plant_contract.py
+++ b/environments/shared/tests/test_plant_contract.py
@@ -325,8 +325,8 @@ def test_control_range_change_changes_interface_and_physics(raptor_layers):
 def test_touch_site_shape_change_changes_interface_and_visual_layers(raptor_layers):
     source, interface, version, original = raptor_layers
     changed_source = source.replace(
-        '<site name="r_foot" pos="0.05 0 -0.02" size="0.02"/>',
-        '<site name="r_foot" pos="0.05 0 -0.02" size="0.025"/>',
+        '<site name="r_foot" pos="0.05 0 0" size="0.08"/>',
+        '<site name="r_foot" pos="0.05 0 0" size="0.085"/>',
         1,
     )
     assert changed_source != source

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -68,7 +68,9 @@ def test_catalog_publishes_layered_plant_contract() -> None:
         "trex": "bipedal-target/v1",
         "brachiosaurus": "quadrupedal-target/v1",
     }
-    expected_policy_revisions = {"velociraptor": 2, "trex": 1, "brachiosaurus": 1}
+    expected_policy_revisions = {"velociraptor": 3, "trex": 1, "brachiosaurus": 1}
+    expected_physics_revisions = {"velociraptor": 2, "trex": 1, "brachiosaurus": 1}
+    expected_visual_revisions = {"velociraptor": 2, "trex": 1, "brachiosaurus": 1}
     digest_pattern = re.compile(r"sha256:[0-9a-f]{64}")
     for species in catalog["species"]:
         plant = species["model"]["plant_contract"]
@@ -76,8 +78,8 @@ def test_catalog_publishes_layered_plant_contract() -> None:
         assert digest_pattern.fullmatch(plant["source_closure_sha256"])
         assert plant["policy_interface"]["revision"] == expected_policy_revisions[species["id"]]
         assert plant["policy_interface"]["observation_schema"] == expected_observation_schemas[species["id"]]
-        assert plant["physics"]["revision"] == 1
-        assert plant["visual"]["revision"] == 1
+        assert plant["physics"]["revision"] == expected_physics_revisions[species["id"]]
+        assert plant["visual"]["revision"] == expected_visual_revisions[species["id"]]
         for layer in ("policy_interface", "physics", "visual"):
             assert digest_pattern.fullmatch(plant[layer]["sha256"])
 

--- a/environments/velociraptor/assets/raptor.xml
+++ b/environments/velociraptor/assets/raptor.xml
@@ -137,8 +137,13 @@
               <joint name="r_toe_d3_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-30 60" ref="10"/>
               <geom name="r_toe_d3_geom" type="capsule" fromto="0 0 0  0.10 0 0" size="0.02"
                     mass="0.06" material="body_mat"/>
-              <!-- Foot contact sensor (on primary weight-bearing digit) -->
-              <site name="r_foot" pos="0.05 0 -0.02" size="0.02"/>
+              <!-- Foot contact sensor (on primary weight-bearing digit).
+                   The site must envelop the whole toe capsule: a lying capsule
+                   contacts the floor near its ENDS, and a touch sensor only
+                   counts contact points inside the site volume. The original
+                   r=0.02 sphere at the capsule midpoint missed both end
+                   contacts, so the sensor read 0 during normal stance. -->
+              <site name="r_foot" pos="0.05 0 0" size="0.08"/>
             </body>
 
             <!-- Digit 4 (lateral, shorter — secondary weight-bearing) -->
@@ -185,7 +190,8 @@
               <joint name="l_toe_d3_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-30 60" ref="10"/>
               <geom name="l_toe_d3_geom" type="capsule" fromto="0 0 0  0.10 0 0" size="0.02"
                     mass="0.06" material="body_mat"/>
-              <site name="l_foot" pos="0.05 0 -0.02" size="0.02"/>
+              <!-- Same coverage rationale as r_foot above. -->
+              <site name="l_foot" pos="0.05 0 0" size="0.08"/>
             </body>
 
             <!-- Digit 4 (lateral, shorter — secondary weight-bearing) -->
@@ -234,13 +240,17 @@
          does NOT convert actuator attributes, only joint attributes. -->
 
     <!-- Right leg -->
-    <!-- Hip pitch and ankle forcerange sized at 1.5x kp (was 0.8x from 156a933):
-         the 0.8x caps clipped 34-40%/22-25% of a moderate gait cycle and broke
-         stage-2 locomotion. 1.5x keeps impact spikes bounded while leaving gait
+    <!-- Hip pitch, knee, and ankle forcerange sized at 1.5x kp (was 0.8x from
+         156a933): the 0.8x caps clipped 34-40%/22-25% of a moderate gait cycle
+         on hips/ankles and broke stage-2 locomotion. The knee measured 0% at
+         the moderate 2.5 Hz/0.8-amplitude regime but 30-46% at sprint-like
+         excitation (3-4 Hz, full amplitude), so it carries the same 1.5x
+         headroom before faster-gait training.
+         1.5x keeps impact spikes bounded while leaving gait
          torques unclipped. See docs/investigations/STAGE2_RECOMMENDATIONS.md R2. -->
     <position name="r_hip_pitch_act" joint="r_hip_pitch" kp="150" forcerange="-225 225" ctrlrange="-1.0472 1.5708"/>
     <position name="r_hip_roll_act" joint="r_hip_roll" kp="100" forcerange="-80 80" ctrlrange="-0.5236 0.5236"/>
-    <position name="r_knee_act" joint="r_knee" kp="180" forcerange="-145 145" ctrlrange="-2.0944 -0.0872"/>
+    <position name="r_knee_act" joint="r_knee" kp="180" forcerange="-270 270" ctrlrange="-2.0944 -0.0872"/>
     <position name="r_ankle_act" joint="r_ankle" kp="100" forcerange="-150 150" ctrlrange="1.0472 2.7925"/>
     <position name="r_toe_d3_act" joint="r_toe_d3_joint" kp="50" forcerange="-40 40" ctrlrange="-0.5236 1.0472"/>
     <position name="r_toe_d4_act" joint="r_toe_d4_joint" kp="50" forcerange="-40 40" ctrlrange="-0.5236 1.0472"/>
@@ -249,7 +259,7 @@
     <!-- Left leg -->
     <position name="l_hip_pitch_act" joint="l_hip_pitch" kp="150" forcerange="-225 225" ctrlrange="-1.0472 1.5708"/>
     <position name="l_hip_roll_act" joint="l_hip_roll" kp="100" forcerange="-80 80" ctrlrange="-0.5236 0.5236"/>
-    <position name="l_knee_act" joint="l_knee" kp="180" forcerange="-145 145" ctrlrange="-2.0944 -0.0872"/>
+    <position name="l_knee_act" joint="l_knee" kp="180" forcerange="-270 270" ctrlrange="-2.0944 -0.0872"/>
     <position name="l_ankle_act" joint="l_ankle" kp="100" forcerange="-150 150" ctrlrange="1.0472 2.7925"/>
     <position name="l_toe_d3_act" joint="l_toe_d3_joint" kp="50" forcerange="-40 40" ctrlrange="-0.5236 1.0472"/>
     <position name="l_toe_d4_act" joint="l_toe_d4_joint" kp="50" forcerange="-40 40" ctrlrange="-0.5236 1.0472"/>
@@ -306,6 +316,14 @@
     <!-- Prevent thigh-torso collision -->
     <exclude body1="pelvis" body2="r_thigh"/>
     <exclude body1="pelvis" body2="l_thigh"/>
+
+    <!-- Adjacent toe digits interpenetrate at rest (d3 r=0.02 at y=0, d4
+         r=0.018 at y=-/+0.015): without an exclude the solver holds a large
+         constant repulsion force between them that also pollutes the foot
+         touch sensors. The digits are anatomically side-by-side; they never
+         need to collide with each other. -->
+    <exclude body1="r_toe_d3" body2="r_toe_d4"/>
+    <exclude body1="l_toe_d3" body2="l_toe_d4"/>
   </contact>
 
   <!-- ==================== KEYFRAMES ==================== -->

--- a/environments/velociraptor/tests/test_actuator_bounds.py
+++ b/environments/velociraptor/tests/test_actuator_bounds.py
@@ -34,9 +34,21 @@ from environments.velociraptor.envs.raptor_env import RaptorEnv
 
 # Default sizing from commit 156a933; gait-critical actuators carry extra
 # headroom so the caps only bind on impact/reset spikes, not gait torques.
+# The knee joined the 1.5x set after measuring 0% clip at the moderate
+# 2.5 Hz/0.8-amplitude regime but 30-46% at sprint-like excitation
+# (3-4 Hz, full amplitude) while still capped at 0.8x kp.
 FORCERANGE_KP_RATIO = 0.8
 GAIT_HEADROOM_RATIO = 1.5
-GAIT_HEADROOM_ACTUATORS = frozenset({"r_hip_pitch_act", "l_hip_pitch_act", "r_ankle_act", "l_ankle_act"})
+GAIT_HEADROOM_ACTUATORS = frozenset(
+    {
+        "r_hip_pitch_act",
+        "l_hip_pitch_act",
+        "r_knee_act",
+        "l_knee_act",
+        "r_ankle_act",
+        "l_ankle_act",
+    }
+)
 
 
 @pytest.fixture(scope="module")
@@ -108,5 +120,25 @@ class TestDynamicSaturation:
             # timestep/integrator jitter while catching any real regression.
             assert hip < 0.10, f"hip saturation {hip:.1%} — plant lost gait headroom, stage 2 will clip"
             assert ankle < 0.05, f"ankle saturation {ankle:.1%} — plant lost gait headroom, stage 2 will clip"
+        finally:
+            env.close()
+
+    def test_sprint_excitation_keeps_knee_unclipped(self):
+        """Guards the knee's 1.5x-kp sprint headroom.
+
+        At the 0.8x-kp cap (forcerange ±145 on kp=180) the knee measured
+        0% clip at the moderate 2.5 Hz/0.8-amplitude gait but 30-46% at
+        sprint-like excitation (3-4 Hz, full amplitude) — the same
+        clipped-torque signature that collapsed stage 2 at the hips. At
+        1.5x kp (±270) the same sprint excitation measures 0.0% on the
+        knee. Hips/ankles (already 1.5x) measure ~11%/~2% at this regime,
+        which is their physical envelope, so only the knee is pinned here.
+        """
+        env = RaptorEnv()
+        try:
+            model = env.model
+            frac = measure_clip_fractions(env, mode="gait", steps=2000, hz=3.5, amplitude=1.0)
+            knee = max(clip_fraction(frac, model, f"{s}_knee_act") for s in "rl")
+            assert knee < 0.05, f"knee saturation {knee:.1%} at sprint excitation — faster-gait training will clip"
         finally:
             env.close()

--- a/environments/velociraptor/tests/test_raptor_env.py
+++ b/environments/velociraptor/tests/test_raptor_env.py
@@ -149,3 +149,61 @@ class TestNominalPoseActionScaling:
         assert second_info["reward_energy"] == pytest.approx(0.0, abs=1e-12)
         assert second_info["reward_smoothness"] == pytest.approx(0.0, abs=1e-12)
         assert second_info["action_delta"] == pytest.approx(0.0, abs=1e-12)
+
+
+class TestFootContactSensors:
+    """The foot touch sensors must report real stance contact.
+
+    The raptor is digitigrade: ground force goes through the toe capsules,
+    and a lying capsule contacts the plane near its ENDS. The original
+    r=0.02 touch sites at the toe midpoint missed both end contacts, so
+    both sensors (and the two foot-contact observation dims fed from them)
+    read 0 during normal stance. The sites now envelop the whole toe_d3
+    capsule, and the adjacent-digit contact exclude keeps the reading free
+    of the d3/d4 interpenetration force that would otherwise register even
+    airborne.
+    """
+
+    def test_sensors_read_ground_force_at_settled_stance(self):
+        env = RaptorEnv(reset_noise_scale=0.0)
+        try:
+            env.reset(seed=0)
+            info = {}
+            for _ in range(200):
+                _, _, terminated, _, info = env.step(np.zeros(env.action_space.shape))
+                assert not terminated
+            assert info["r_foot_contact"] > 1.0, "right foot touch sensor dead at stance"
+            assert info["l_foot_contact"] > 1.0, "left foot touch sensor dead at stance"
+        finally:
+            env.close()
+
+    def test_sensors_read_zero_airborne(self):
+        env = RaptorEnv(reset_noise_scale=0.0)
+        try:
+            env.reset(seed=0)
+            model, data = env.model, env.data
+            mujoco.mj_resetDataKeyframe(model, data, 0)
+            data.qpos[2] += 1.0
+            mujoco.mj_forward(model, data)
+            for _ in range(10):
+                mujoco.mj_step(model, data)
+            for name in ("r_foot_touch", "l_foot_touch"):
+                sensor_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, name)
+                adr = model.sensor_adr[sensor_id]
+                assert data.sensordata[adr] == pytest.approx(0.0, abs=1e-9), (
+                    f"{name} reads force while airborne — the site is summing a self-contact, not ground contact"
+                )
+        finally:
+            env.close()
+
+    def test_observation_foot_contact_dims_are_live(self):
+        env = RaptorEnv(reset_noise_scale=0.0)
+        try:
+            env.reset(seed=0)
+            obs = None
+            for _ in range(200):
+                obs, _, _, _, _ = env.step(np.zeros(env.action_space.shape))
+            foot_dims = obs[-6:-4]  # foot contacts sit before prey direction (3) + distance (1)
+            assert np.all(foot_dims > 0.0), f"foot-contact obs dims dead at stance: {foot_dims}"
+        finally:
+            env.close()

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -80,23 +80,23 @@
         "nu": 22,
         "dynamic_mass_kg": 13.5,
         "plant_contract": {
-          "bundle_sha256": "sha256:da93c4707c1eb7fed54295b5fdfd8f005f7e2b2c0d2d2fe37527f6d114dfdc8d",
-          "source_closure_sha256": "sha256:852bbf54cea4e451380ed6b175f001ab0e11dac8e1c3632ea299e0a11f1ff38f",
+          "bundle_sha256": "sha256:a25de61e72daa4cf453b3c3c9284577a7b0a559a0f486eeeae9f69647fa58557",
+          "source_closure_sha256": "sha256:17c1ed5f2c7f162327cb8b59661564118101cfde331a525d3d3846e53cd660fb",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 2,
+            "revision": 3,
             "observation_schema": "bipedal-target/v1",
-            "sha256": "sha256:38e9edbb4330492b9daa81523440ea5a38c643c94f5079723e24644fa6915225"
+            "sha256": "sha256:a1cddb3c11997620980eaa57d2e7ff824695d07d31359cbdd78db2002dd99a2d"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",
-            "revision": 1,
-            "sha256": "sha256:fde764755bd2f688cd6ca957d994a3d2d47087243ba9f06b5821e39a1b1bd4d6"
+            "revision": 2,
+            "sha256": "sha256:c10e6102bbe0a5ca0fc4a33e439f8e199704bbf4c27e922796787da736b65352"
           },
           "visual": {
             "schema": "mesozoic.mujoco-visual/v1",
-            "revision": 1,
-            "sha256": "sha256:c901ba81e9e810d60f9815d45fd0e6f74b5bdb2f9bb71d5e6aabfed70bc7bc51"
+            "revision": 2,
+            "sha256": "sha256:7a9147bf05e193781eb96e95f03614c8263dd6e360f88cbc56a571a2c2a13be6"
           }
         }
       },


### PR DESCRIPTION
Two velociraptor plant fixes, both breaking by contract:

1. Foot touch sensors read 0 during normal stance (policy-interface
   revision 2 -> 3, visual 1 -> 2). The raptor is digitigrade and a lying
   toe capsule contacts the floor near its ends, but the r=0.02 touch
   sites sat at the toe_d3 midpoint, so both sensors -- and the two
   foot-contact observation dims fed from them -- were dead (verified:
   six active floor contacts, zero sensor signal). The sites now envelop
   the whole toe_d3 capsule. Fixing them exposed a second defect: the
   adjacent toe digits interpenetrate at rest and the solver held a
   constant ~300 N phantom repulsion between them, which the enlarged
   sites would have summed even airborne; new d3<->d4 contact excludes
   remove it. Post-fix: ~37 N per foot at settled stance, exactly 0 N
   airborne, 48/50 standing-probe survival unchanged. The T-Rex has the
   same dead-sensor defect (recorded in KNOWN_ISSUES, not fixed here).

2. Knee actuators raised to 1.5x kp (physics revision 1 -> 2). The 0.8x
   cap (forcerange +-145 on kp=180) measured 0% clip at the moderate
   2.5 Hz/0.8-amplitude contract gait but 30-46% at sprint-like 3-4 Hz
   full-amplitude excitation -- the same clipped-torque signature that
   collapsed stage-2 locomotion at the hips. At +-270 the same sprint
   excitation measures 0% knee clip.

Regenerated both plant manifests and the species catalog at the
canonical MuJoCo 3.10.0; updated the contract/catalog tests that pin
site geometry and revision numbers; added regression tests for
stance/airborne sensor behavior and sprint-regime knee headroom.
262 tests pass.