### PR TITLE
Fix raptor plant defects (dead foot sensors, knee headroom) and harden the eval-collapse backstop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   0 N airborne, 48/50 standing-probe survival unchanged, and regression
   tests pin stance/airborne sensor behavior. The T-Rex has the same
   dead-sensor defect (recorded in KNOWN_ISSUES, not yet fixed).
+  Follow-up (visual revision 2 → 3): the enlarged sites rendered as large
+  gray balls on the feet in run videos (first visible in run
+  `20260721_141523`'s stage-1 video); they now live in site group 4,
+  which default rendering hides, so they no longer draw — toggle site
+  group 4 in an interactive viewer to visualize the touch volumes.
 
 ### Added
 - **Canonical result bundles for Colab/Google Drive training**: schema-v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `20260721_004731`'s healthy 2.2–2.3M transition turbulence accumulated
   2 of 8 kill-drops under the old stage-1 defaults.
 
+- **Velociraptor stage-3 budget raised 8M → 12M timesteps**: in run
+  `20260721_141523` the best strike checkpoint landed at 7.9M of 8.01M
+  with success still climbing (last evals 0.63 → 0.87 → 0.77); strike
+  discovery produced no successes until ~5.5M, leaving only ~2.5M of
+  effective hunting curriculum. 12M matches the brachiosaurus stage-3
+  budget.
+
 ### Fixed
 - **`metrics.json` now describes the promoted checkpoint**: the post-stage
   quality/velocity/success evaluation loaded SB3's mean-reward

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   home-control no-saturation guarantee are unchanged, and a new
   sprint-regime contract test pins the knee headroom.
 
+- **Eval-collapse early-stop is now variance-robust, gate-floored, and
+  loosened for stage 1**: the backstop's peak is the per-evaluation robust
+  score (mean − std) instead of the raw mean — run `20260720_203454` was
+  aborted at 1.1M/6M steps because a single 50k evaluation of
+  261.79 ± 261.72 (robust score 0.07) set a raw-mean kill threshold that
+  every later normal-dip evaluation "violated" — and detection only arms
+  once the robust peak clears the stage's `min_avg_reward` curriculum gate
+  (overridable via `collapse_peak_floor`), so the pre-convergence grind
+  can never register as a collapse. All three stage-1 TOMLs also gain the
+  explicit `collapse_min_evals = 20` / `collapse_patience = 10` /
+  `collapse_drop_fraction = 0.5` overrides stage 2 already had: run
+  `20260721_004731`'s healthy 2.2–2.3M transition turbulence accumulated
+  2 of 8 kill-drops under the old stage-1 defaults.
+
 ### Fixed
+- **`metrics.json` now describes the promoted checkpoint**: the post-stage
+  quality/velocity/success evaluation loaded SB3's mean-reward
+  `best_model` while next-stage training loads `robust_best_model` when
+  present, so the sidecar could describe a policy the curriculum never
+  promoted (in run `20260720_203454`, the degenerate lucky-peak 50k
+  checkpoint). Both paths now share one selection helper
+  (`robust_best_model` → `best_model`, each only with its matched
+  VecNormalize stats), and the sidecar records which checkpoint it
+  evaluated as `quality_eval_checkpoint`.
 - **Velociraptor foot touch sensors were dead during normal stance**
   (breaking — policy-interface revision 2 → 3, visual revision 1 → 2): the
   raptor is digitigrade and a lying toe capsule contacts the floor near its

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Swift Bipedal Predator. **Specialty:** Sickle-claw contact attacks.
 |---|---|---:|---:|
 | 1 — Balance | Learn to stand and balance without falling | 6M | reward ≥ 100; episode length ≥ 750; ≥ 10 episodes/evaluation; 3 consecutive passes |
 | 2 — Locomotion | Learn forward walking/running | 8M | reward ≥ 100; episode length ≥ 750; avg. velocity ≥ 2 m/s; ≥ 10 episodes/evaluation; 3 consecutive passes |
-| 3 — Strike | Sprint and strike prey with sickle claw | 8M | reward ≥ 100; task success ≥ 50.0%; ≥ 10 episodes/evaluation; 3 consecutive passes |
+| 3 — Strike | Sprint and strike prey with sickle claw | 12M | reward ≥ 100; task success ≥ 50.0%; ≥ 10 episodes/evaluation; 3 consecutive passes |
 
 **Backend-specific success semantics:**
 - **Stable-Baselines3 — Sickle-claw contact success:** A left or right sickle-claw geom contacts the prey geom while the strike reward is enabled.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Swift Bipedal Predator. **Specialty:** Sickle-claw contact attacks.
 | Action dimension / actuators | 22 |
 | Generalized coordinates / velocities | nq=31, nv=30 |
 | Compiled dynamic model mass | 13.5 kg |
-| Plant contract revisions | policy r3; physics r2; visual r2 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r3; physics r2; visual r3 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/velociraptor/assets/raptor.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |

--- a/configs/brachiosaurus/stage1_balance.toml
+++ b/configs/brachiosaurus/stage1_balance.toml
@@ -91,3 +91,9 @@ timesteps = 6000000
 min_avg_reward = 100.0
 min_avg_episode_length = 750
 required_consecutive = 3
+collapse_min_evals = 20                 # Backstop early-stop (EvalCollapseEarlyStopCallback): wait ~1M steps before it can fire.
+collapse_patience = 10                  # Require 10 consecutive sub-threshold evals so transition turbulence won't abort the stage.
+collapse_drop_fraction = 0.5            # Only a >50% drop from the robust peak counts. Stage-1 balance learning has a long
+                                        # low-reward grind then a noisy breakthrough (run 20260721_004731: dip to ~1.2M,
+                                        # turbulent transition at 2.2-2.3M, converged ~2.65M); the old stage-1 defaults
+                                        # killed run 20260720_203454 at 1.1M off a variance-inflated 50k peak.

--- a/configs/plant_manifest.generated.json
+++ b/configs/plant_manifest.generated.json
@@ -84,7 +84,7 @@
       }
     },
     "velociraptor": {
-      "bundle_sha256": "sha256:a25de61e72daa4cf453b3c3c9284577a7b0a559a0f486eeeae9f69647fa58557",
+      "bundle_sha256": "sha256:3a4d15176168efea7f63dc1d1051b1f3314b5c80e1e5e0826c294c440c8c66ca",
       "env_entrypoint": "environments.velociraptor.envs.raptor_env:RaptorEnv",
       "model_path": "environments/velociraptor/assets/raptor.xml",
       "physics": {
@@ -104,10 +104,10 @@
         "sha256": "sha256:a1cddb3c11997620980eaa57d2e7ff824695d07d31359cbdd78db2002dd99a2d"
       },
       "source": {
-        "closure_sha256": "sha256:17c1ed5f2c7f162327cb8b59661564118101cfde331a525d3d3846e53cd660fb",
+        "closure_sha256": "sha256:ae2ebacf577a7247484e8954fecce421b007246ead904a83ce319babb1efdec5",
         "dependencies": [
           {
-            "content_sha256": "sha256:c3a67f20f311b76a6e363971c30e43d39652df539cb02cb8de315482295b0481",
+            "content_sha256": "sha256:c8a19d7f84b92bcef5d4a3e1260ae9f8cc019a7db0da3c53cb4ee4616a8cae57",
             "kind": "mjcf",
             "logical_path": "environments/velociraptor/assets/raptor.xml"
           }
@@ -117,9 +117,9 @@
       },
       "species": "velociraptor",
       "visual": {
-        "revision": 2,
+        "revision": 3,
         "schema": "mesozoic.mujoco-visual/v1",
-        "sha256": "sha256:7a9147bf05e193781eb96e95f03614c8263dd6e360f88cbc56a571a2c2a13be6"
+        "sha256": "sha256:eb92e0ba239ec53fe4d611f9e5eae287bc765557d6f68be04f49ea94e2c9910c"
       }
     }
   },

--- a/configs/plant_versions.toml
+++ b/configs/plant_versions.toml
@@ -13,7 +13,7 @@ canonical_mujoco_version = "3.10.0"
 [plants.velociraptor]
 physics_revision = 2
 policy_interface_revision = 3
-visual_revision = 2
+visual_revision = 3
 observation_schema = "bipedal-target/v1"
 
 [plants.trex]

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -92,3 +92,9 @@ timesteps = 6000000
 min_avg_reward = 100.0
 min_avg_episode_length = 750
 required_consecutive = 3
+collapse_min_evals = 20                 # Backstop early-stop (EvalCollapseEarlyStopCallback): wait ~1M steps before it can fire.
+collapse_patience = 10                  # Require 10 consecutive sub-threshold evals so transition turbulence won't abort the stage.
+collapse_drop_fraction = 0.5            # Only a >50% drop from the robust peak counts. Stage-1 balance learning has a long
+                                        # low-reward grind then a noisy breakthrough (run 20260721_004731: dip to ~1.2M,
+                                        # turbulent transition at 2.2-2.3M, converged ~2.65M); the old stage-1 defaults
+                                        # killed run 20260720_203454 at 1.1M off a variance-inflated 50k peak.

--- a/configs/velociraptor/stage1_balance.toml
+++ b/configs/velociraptor/stage1_balance.toml
@@ -85,3 +85,9 @@ timesteps = 6000000
 min_avg_reward = 100.0
 min_avg_episode_length = 750
 required_consecutive = 3
+collapse_min_evals = 20                 # Backstop early-stop (EvalCollapseEarlyStopCallback): wait ~1M steps before it can fire.
+collapse_patience = 10                  # Require 10 consecutive sub-threshold evals so transition turbulence won't abort the stage.
+collapse_drop_fraction = 0.5            # Only a >50% drop from the robust peak counts. Stage-1 balance learning has a long
+                                        # low-reward grind then a noisy breakthrough (run 20260721_004731: dip to ~1.2M,
+                                        # turbulent transition at 2.2-2.3M, converged ~2.65M); the old stage-1 defaults
+                                        # killed run 20260720_203454 at 1.1M off a variance-inflated 50k peak.

--- a/configs/velociraptor/stage3_strike.toml
+++ b/configs/velociraptor/stage3_strike.toml
@@ -36,7 +36,7 @@ gae_lambda = 0.95
 clip_range = 0.15                      # Widened from 0.1: allow larger policy updates to escape local optimum (survival-only behavior)
 ent_coef = 0.005                       # 5x increase from 0.001: more exploration needed to discover sparse strike reward
 ent_coef_end = 0.001                   # Enabled: decay entropy to a low floor once the strike behaviour is discovered, so the
-ent_coef_decay_timesteps = 3000000     # policy consolidates instead of drifting late. Anchored below the 8M budget.
+ent_coef_decay_timesteps = 3000000     # policy consolidates instead of drifting late. Anchored below the stage budget.
 target_kl = 0.03                       # Cap destabilising late PPO updates (early-stop epochs on high approx-KL).
 
 [ppo.policy_kwargs]
@@ -87,7 +87,10 @@ ramp_start_fraction = 0.1
 net_arch = [512, 256]
 
 [curriculum]
-timesteps = 8000000
+timesteps = 12000000                    # Raised from 8M (run 20260721_141523): best checkpoint landed at 7.9M with
+                                        # success still climbing (last evals 0.63->0.87->0.77) -- strike discovery
+                                        # produced no successes until ~5.5M, leaving only ~2.5M of effective hunting
+                                        # curriculum. 12M matches the brachiosaurus stage-3 budget.
 min_avg_reward = 100.0
 min_success_rate = 0.5                  # At least 50% strike success — confirms hunting behavior emerged
 required_consecutive = 3

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -67,11 +67,21 @@ tolerance) remains the standing recommendation for the divergences above.
 - **MEDIUM (perf)** — `EvalCallback` runs 30 serial episodes every 50k steps
   plus supplementary + post-stage evals — up to ~3.6M serial eval steps per
   6M-step stage. Vectorize the eval env or trim episodes. (June §6.1)
-- **Experiment** — the [historical, unverified Brachiosaurus summary](../results/brachiosaurus/ppo/summary.json)
-  records a stage-3 result below its gate and was trained under since-fixed
-  gate bugs; re-run it, and consider tightening
-  `head_proximity_max_dist` (~2.0 m) to concentrate the last-mile gradient.
-  (June §6.10)
+- **Experiment** — consider tightening Brachiosaurus
+  `head_proximity_max_dist` (~2.0 m) to concentrate the last-mile
+  food-reach gradient. (June §6.10; the rest of that finding is resolved —
+  the published summary is now the 2026-07-18 run, which passes its
+  stage-3 gate with success rate 1.0.)
+- **Watch item** — the Velociraptor home-residual action mapping has a
+  slope discontinuity at action 0 (the two piecewise segments span
+  home→min and home→max, which are unequal), so zero-mean Gaussian
+  exploration produces a physically biased mean command away from home
+  (hip pitch ≈ −0.29 rad toward flexion, knee ≈ −0.16, ankle ≈ +0.13 at
+  σ=1). If a fresh run's early training looks persistently crouched or
+  off-home while `algo_std` is still ≈1.0, suspect this bias before
+  suspecting rewards; possible mitigations (smaller `log_std_init`, a
+  smoothed mapping) are interface experiments and must be run in
+  isolation. (Stage-1 basin investigation follow-up)
 
 ## Sweeps / infrastructure
 

--- a/environments/shared/curriculum.py
+++ b/environments/shared/curriculum.py
@@ -878,22 +878,43 @@ class RewardRampCallback(BaseCallback):  # type: ignore[misc]
 
 
 class EvalCollapseEarlyStopCallback(BaseCallback):  # type: ignore[misc]
-    """Stop training if eval reward drops significantly from the peak.
+    """Stop training if the risk-adjusted eval score collapses from its peak.
 
-    Monitors evaluation results and stops training when the mean reward
-    drops below ``(1 - drop_fraction) * peak_reward`` for
-    ``patience`` consecutive evaluations.  This prevents wasting compute
-    on a policy that has already collapsed past recovery.
+    Monitors evaluation results and stops training when the robust score
+    (per-evaluation ``mean - std`` of episode rewards) stays below
+    ``(1 - drop_fraction) * peak_robust_score`` for ``patience``
+    consecutive evaluations. This is a backstop against a genuinely
+    diverged stage, not an optimizer, and two properties keep it from
+    condemning healthy runs:
+
+    * **The peak is the robust score, not the raw mean.** In run
+      20260720_203454 a single 50k-step evaluation of 261.79 ± 261.72
+      (robust score 0.07 — one lucky long episode among 29 failures) set
+      a raw-mean peak whose 0.6× threshold every later normal-dip
+      evaluation "violated", aborting stage 1 at 1.1M/6M steps. A
+      variance-inflated eval cannot set a robust peak.
+    * **Detection stays disarmed until the robust peak clears
+      ``peak_floor``** (wired to the stage's ``min_avg_reward``
+      curriculum gate by ``_build_core_callbacks``): a run can only
+      "collapse" from a level that was actually good, so the
+      pre-convergence grind can never trip the backstop. Run
+      20260721_004731's 2.2–2.3M transition turbulence (robust scores
+      briefly negative against a healthy climb) accumulated kill-drops
+      under the old raw-mean rule; under the robust rule with the gate
+      floor it accumulates none until the run has genuinely converged
+      and then genuinely collapses.
 
     Args:
         eval_callback: The ``EvalCallback`` whose ``evaluations.npz``
             to monitor.
-        drop_fraction: Fractional drop from peak that triggers early
-            stopping (default 0.3 = 30% drop).
+        drop_fraction: Fractional drop from the robust peak that counts
+            as a collapse evaluation (default 0.3 = 30% drop).
         patience: Number of consecutive below-threshold evaluations
             before stopping (default 3).
         min_evals: Minimum number of evaluations before early stopping
             can activate (default 5).
+        peak_floor: Minimum robust peak before collapse detection arms
+            (default 0.0 — arm on any positive robust peak).
         verbose: Verbosity level.
     """
 
@@ -903,6 +924,7 @@ class EvalCollapseEarlyStopCallback(BaseCallback):  # type: ignore[misc]
         drop_fraction: float = 0.3,
         patience: int = 3,
         min_evals: int = 5,
+        peak_floor: float = 0.0,
         verbose: int = 0,
     ):
         if not _SB3_AVAILABLE:
@@ -912,7 +934,8 @@ class EvalCollapseEarlyStopCallback(BaseCallback):  # type: ignore[misc]
         self.drop_fraction = drop_fraction
         self.patience = patience
         self.min_evals = min_evals
-        self._peak_reward = -np.inf
+        self.peak_floor = peak_floor
+        self._peak_score = -np.inf
         self._consecutive_drops = 0
         self._last_seen_n_evals = 0
 
@@ -934,30 +957,32 @@ class EvalCollapseEarlyStopCallback(BaseCallback):  # type: ignore[misc]
         if n_evals < self.min_evals:
             return True
 
-        mean_rewards = np.array([float(np.mean(r)) for r in results])
-        current_peak = float(mean_rewards.max())
-        self._peak_reward = max(self._peak_reward, current_peak)
+        robust_scores = np.array([float(np.mean(r)) - float(np.std(r)) for r in results])
+        self._peak_score = max(self._peak_score, float(robust_scores.max()))
 
-        latest_mean = float(mean_rewards[-1])
-        threshold = (1.0 - self.drop_fraction) * self._peak_reward
+        latest_score = float(robust_scores[-1])
+        threshold = (1.0 - self.drop_fraction) * self._peak_score
+        armed = self._peak_score > 0 and self._peak_score >= self.peak_floor
 
-        if self._peak_reward > 0 and latest_mean < threshold:
+        if armed and latest_score < threshold:
             self._consecutive_drops += 1
             logger.warning(
-                "EvalCollapseEarlyStop: reward %.1f < %.1f (%.0f%% of peak %.1f), consecutive drops: %d/%d",
-                latest_mean,
+                "EvalCollapseEarlyStop: robust score %.1f < %.1f (%.0f%% of robust peak %.1f), "
+                "consecutive drops: %d/%d",
+                latest_score,
                 threshold,
                 100 * (1 - self.drop_fraction),
-                self._peak_reward,
+                self._peak_score,
                 self._consecutive_drops,
                 self.patience,
             )
             if self._consecutive_drops >= self.patience:
                 logger.warning(
-                    "EvalCollapseEarlyStop: stopping training at step %d — reward collapsed from peak %.1f to %.1f",
+                    "EvalCollapseEarlyStop: stopping training at step %d — robust score collapsed "
+                    "from peak %.1f to %.1f",
                     self.num_timesteps,
-                    self._peak_reward,
-                    latest_mean,
+                    self._peak_score,
+                    latest_score,
                 )
                 return False
         else:

--- a/environments/shared/data/plant_manifest.generated.json
+++ b/environments/shared/data/plant_manifest.generated.json
@@ -84,7 +84,7 @@
       }
     },
     "velociraptor": {
-      "bundle_sha256": "sha256:a25de61e72daa4cf453b3c3c9284577a7b0a559a0f486eeeae9f69647fa58557",
+      "bundle_sha256": "sha256:3a4d15176168efea7f63dc1d1051b1f3314b5c80e1e5e0826c294c440c8c66ca",
       "env_entrypoint": "environments.velociraptor.envs.raptor_env:RaptorEnv",
       "model_path": "environments/velociraptor/assets/raptor.xml",
       "physics": {
@@ -104,10 +104,10 @@
         "sha256": "sha256:a1cddb3c11997620980eaa57d2e7ff824695d07d31359cbdd78db2002dd99a2d"
       },
       "source": {
-        "closure_sha256": "sha256:17c1ed5f2c7f162327cb8b59661564118101cfde331a525d3d3846e53cd660fb",
+        "closure_sha256": "sha256:ae2ebacf577a7247484e8954fecce421b007246ead904a83ce319babb1efdec5",
         "dependencies": [
           {
-            "content_sha256": "sha256:c3a67f20f311b76a6e363971c30e43d39652df539cb02cb8de315482295b0481",
+            "content_sha256": "sha256:c8a19d7f84b92bcef5d4a3e1260ae9f8cc019a7db0da3c53cb4ee4616a8cae57",
             "kind": "mjcf",
             "logical_path": "environments/velociraptor/assets/raptor.xml"
           }
@@ -117,9 +117,9 @@
       },
       "species": "velociraptor",
       "visual": {
-        "revision": 2,
+        "revision": 3,
         "schema": "mesozoic.mujoco-visual/v1",
-        "sha256": "sha256:7a9147bf05e193781eb96e95f03614c8263dd6e360f88cbc56a571a2c2a13be6"
+        "sha256": "sha256:eb92e0ba239ec53fe4d611f9e5eae287bc765557d6f68be04f49ea94e2c9910c"
       }
     }
   },

--- a/environments/shared/tests/test_curriculum.py
+++ b/environments/shared/tests/test_curriculum.py
@@ -1093,7 +1093,8 @@ class TestEvalCollapseEarlyStopCallback:
         cb = object.__new__(EvalCollapseEarlyStopCallback)
         cb.eval_callback = MagicMock(spec=[])  # no evaluations_results
         cb._last_seen_n_evals = 0
-        cb._peak_reward = float("-inf")
+        cb._peak_score = float("-inf")
+        cb.peak_floor = 0.0
         cb._consecutive_drops = 0
         assert cb._on_step() is True
 
@@ -1102,7 +1103,8 @@ class TestEvalCollapseEarlyStopCallback:
         cb.eval_callback = MagicMock()
         cb.eval_callback.evaluations_results = []
         cb._last_seen_n_evals = 0
-        cb._peak_reward = float("-inf")
+        cb._peak_score = float("-inf")
+        cb.peak_floor = 0.0
         cb._consecutive_drops = 0
         assert cb._on_step() is True
 
@@ -1112,7 +1114,8 @@ class TestEvalCollapseEarlyStopCallback:
         cb.eval_callback = MagicMock()
         cb.eval_callback.evaluations_results = [[10.0, 20.0], [15.0, 25.0]]
         cb._last_seen_n_evals = 0
-        cb._peak_reward = float("-inf")
+        cb._peak_score = float("-inf")
+        cb.peak_floor = 0.0
         cb._consecutive_drops = 0
         cb.min_evals = 5  # Need 5 evals, only have 2
         cb.drop_fraction = 0.3
@@ -1125,7 +1128,8 @@ class TestEvalCollapseEarlyStopCallback:
         cb.eval_callback = MagicMock()
         cb.eval_callback.evaluations_results = [[10.0]]
         cb._last_seen_n_evals = 1  # Already seen this eval
-        cb._peak_reward = float("-inf")
+        cb._peak_score = float("-inf")
+        cb.peak_floor = 0.0
         cb._consecutive_drops = 0
         assert cb._on_step() is True
 
@@ -1143,7 +1147,8 @@ class TestEvalCollapseEarlyStopCallback:
             [10.0, 10.0],  # drop 3 -> stop
         ]
         cb._last_seen_n_evals = 0
-        cb._peak_reward = float("-inf")
+        cb._peak_score = float("-inf")
+        cb.peak_floor = 0.0
         cb._consecutive_drops = 0
         cb.min_evals = 3
         cb.drop_fraction = 0.3
@@ -1169,7 +1174,8 @@ class TestEvalCollapseEarlyStopCallback:
             [45.0, 45.0],  # recovery
         ]
         cb._last_seen_n_evals = 0
-        cb._peak_reward = float("-inf")
+        cb._peak_score = float("-inf")
+        cb.peak_floor = 0.0
         cb._consecutive_drops = 0
         cb.min_evals = 5
         cb.drop_fraction = 0.3
@@ -1181,6 +1187,78 @@ class TestEvalCollapseEarlyStopCallback:
         # 45.0 >= 35.0 -> consecutive_drops reset to 0
         assert result is True
         assert cb._consecutive_drops == 0
+
+    def test_variance_inflated_eval_cannot_set_the_peak(self):
+        # Run 20260720_203454's 50k eval was 261.79 +/- 261.72 (robust
+        # score 0.07): under the old raw-mean rule it set a 157 kill
+        # threshold that every later normal eval "violated". The robust
+        # peak must come from the consistent evals instead.
+        cb = object.__new__(EvalCollapseEarlyStopCallback)
+        cb.eval_callback = MagicMock()
+        cb.eval_callback.evaluations_results = [
+            [523.5, 0.0],  # mean 261.75, std 261.75 -> robust ~0
+            [150.0, 148.0],
+            [150.0, 148.0],
+            [150.0, 148.0],
+        ]
+        cb._last_seen_n_evals = 0
+        cb._peak_score = float("-inf")
+        cb.peak_floor = 100.0
+        cb._consecutive_drops = 0
+        cb.min_evals = 3
+        cb.drop_fraction = 0.4
+        cb.patience = 1
+        cb.num_timesteps = 1000
+
+        result = cb._on_step()
+        assert result is True
+        assert cb._consecutive_drops == 0
+        assert cb._peak_score == pytest.approx(148.0)  # not 261.75
+
+    def test_peak_floor_disarms_below_gate_peaks(self):
+        # A pre-convergence grind (robust peak below the curriculum
+        # reward gate) can never register collapse drops.
+        cb = object.__new__(EvalCollapseEarlyStopCallback)
+        cb.eval_callback = MagicMock()
+        cb.eval_callback.evaluations_results = [
+            [80.0, 80.0],
+            [10.0, 10.0],
+            [10.0, 10.0],
+            [10.0, 10.0],
+        ]
+        cb._last_seen_n_evals = 0
+        cb._peak_score = float("-inf")
+        cb.peak_floor = 100.0
+        cb._consecutive_drops = 0
+        cb.min_evals = 3
+        cb.drop_fraction = 0.4
+        cb.patience = 1
+        cb.num_timesteps = 1000
+
+        result = cb._on_step()
+        assert result is True
+        assert cb._consecutive_drops == 0
+
+    def test_robust_collapse_above_floor_still_stops(self):
+        # A genuinely converged run (robust peak above the gate) that
+        # genuinely collapses must still trip the backstop.
+        cb = object.__new__(EvalCollapseEarlyStopCallback)
+        cb.eval_callback = MagicMock()
+        cb.eval_callback.evaluations_results = [
+            [1500.0, 1300.0],  # mean 1400, std 100 -> robust 1300
+            [800.0, 0.0],  # mean 400, std 400 -> robust 0
+        ]
+        cb._last_seen_n_evals = 0
+        cb._peak_score = float("-inf")
+        cb.peak_floor = 100.0
+        cb._consecutive_drops = 0
+        cb.min_evals = 2
+        cb.drop_fraction = 0.5
+        cb.patience = 1
+        cb.num_timesteps = 1000
+
+        result = cb._on_step()
+        assert result is False
 
 
 class TestReadLatestEvalSuccesses:

--- a/environments/shared/tests/test_plant_contract.py
+++ b/environments/shared/tests/test_plant_contract.py
@@ -325,8 +325,8 @@ def test_control_range_change_changes_interface_and_physics(raptor_layers):
 def test_touch_site_shape_change_changes_interface_and_visual_layers(raptor_layers):
     source, interface, version, original = raptor_layers
     changed_source = source.replace(
-        '<site name="r_foot" pos="0.05 0 0" size="0.08"/>',
-        '<site name="r_foot" pos="0.05 0 0" size="0.085"/>',
+        '<site name="r_foot" pos="0.05 0 0" size="0.08" group="4"/>',
+        '<site name="r_foot" pos="0.05 0 0" size="0.085" group="4"/>',
         1,
     )
     assert changed_source != source

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -45,7 +45,7 @@ def test_catalog_derives_current_model_and_stage_facts() -> None:
         "brachiosaurus": (83, 30, 38, 37, 30, 175.3),
     }
 
-    assert [stage["timesteps"] for stage in species["velociraptor"]["stages"]] == [6_000_000, 8_000_000, 8_000_000]
+    assert [stage["timesteps"] for stage in species["velociraptor"]["stages"]] == [6_000_000, 8_000_000, 12_000_000]
     assert [stage["timesteps"] for stage in species["trex"]["stages"]] == [6_000_000, 8_000_000, 8_000_000]
     assert [stage["timesteps"] for stage in species["brachiosaurus"]["stages"]] == [
         6_000_000,

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -70,7 +70,7 @@ def test_catalog_publishes_layered_plant_contract() -> None:
     }
     expected_policy_revisions = {"velociraptor": 3, "trex": 1, "brachiosaurus": 1}
     expected_physics_revisions = {"velociraptor": 2, "trex": 1, "brachiosaurus": 1}
-    expected_visual_revisions = {"velociraptor": 2, "trex": 1, "brachiosaurus": 1}
+    expected_visual_revisions = {"velociraptor": 3, "trex": 1, "brachiosaurus": 1}
     digest_pattern = re.compile(r"sha256:[0-9a-f]{64}")
     for species in catalog["species"]:
         plant = species["model"]["plant_contract"]

--- a/environments/shared/tests/test_train_base.py
+++ b/environments/shared/tests/test_train_base.py
@@ -28,6 +28,7 @@ from environments.shared.train_base import (
     _make_local_tb_dir,
     _prepare_alg_kwargs,
     _save_final_and_sync_tb,
+    _select_handoff_checkpoint,
     _sync_tb_to_gcs,
     cosine_schedule,
     linear_schedule,
@@ -254,20 +255,57 @@ class TestBuildCoreCallbacks:
 
         # Explicit [curriculum] overrides are honoured.
         cb = _build_collapse_cb(
-            {"min_avg_reward": 100.0, "collapse_min_evals": 20, "collapse_patience": 10, "collapse_drop_fraction": 0.5}
+            {
+                "min_avg_reward": 100.0,
+                "collapse_min_evals": 20,
+                "collapse_patience": 10,
+                "collapse_drop_fraction": 0.5,
+                "collapse_peak_floor": 42.0,
+            }
         )
         assert cb.min_evals == 20
         assert cb.patience == 10
         assert cb.drop_fraction == 0.5
+        assert cb.peak_floor == 42.0
 
-        # Defaults are lenient (looser than the old hardcoded 8 / 5 / 0.3).
+        # Defaults are lenient (looser than the old hardcoded 8 / 5 / 0.3),
+        # and the arming floor falls back to the stage's own reward gate.
         cb_default = _build_collapse_cb({"min_avg_reward": 100.0})
         assert cb_default.min_evals == 12
         assert cb_default.patience == 8
         assert cb_default.drop_fraction == 0.4
+        assert cb_default.peak_floor == 100.0
 
 
 # ── cosine_schedule ─────────────────────────────────────────────────────
+
+
+class TestSelectHandoffCheckpoint:
+    """The quality eval and next-stage loading must agree on the checkpoint."""
+
+    def test_returns_none_when_nothing_saved(self, tmp_path):
+        assert _select_handoff_checkpoint(tmp_path) is None
+
+    def test_ignores_candidates_without_matched_vecnorm(self, tmp_path):
+        (tmp_path / "best_model.zip").touch()
+        assert _select_handoff_checkpoint(tmp_path) is None
+
+    def test_selects_best_model_when_complete(self, tmp_path):
+        (tmp_path / "best_model.zip").touch()
+        (tmp_path / "best_model_vecnorm.pkl").touch()
+        name, model_path, vecnorm_path = _select_handoff_checkpoint(tmp_path)
+        assert name == "best_model"
+        assert model_path == str(tmp_path / "best_model")
+        assert vecnorm_path == str(tmp_path / "best_model_vecnorm.pkl")
+
+    def test_prefers_robust_best_model(self, tmp_path):
+        for stem in ("best_model", "robust_best_model"):
+            (tmp_path / f"{stem}.zip").touch()
+            (tmp_path / f"{stem}_vecnorm.pkl").touch()
+        name, model_path, vecnorm_path = _select_handoff_checkpoint(tmp_path)
+        assert name == "robust_best_model"
+        assert model_path == str(tmp_path / "robust_best_model")
+        assert vecnorm_path == str(tmp_path / "robust_best_model_vecnorm.pkl")
 
 
 class TestCosineSchedule:

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -439,7 +439,11 @@ def _build_core_callbacks(
     # Its thresholds are configurable via the stage's [curriculum] section;
     # defaults are lenient (looser than the former hardcoded 8 / 5 / 0.3) so a
     # normal early-training dip does not abort a stage before entropy decay /
-    # LR annealing have had a chance to engage.
+    # LR annealing have had a chance to engage. The peak is risk-adjusted
+    # (mean - std) and detection only arms once that robust peak clears the
+    # stage's own reward gate (overridable via collapse_peak_floor), so a
+    # variance-inflated early eval cannot set a kill threshold and the
+    # pre-convergence grind cannot register as a collapse.
     collapse_cfg = stage_config.get("curriculum_kwargs", {})
     callbacks.append(
         EvalCollapseEarlyStopCallback(
@@ -447,6 +451,7 @@ def _build_core_callbacks(
             min_evals=int(collapse_cfg.get("collapse_min_evals", 12)),
             patience=int(collapse_cfg.get("collapse_patience", 8)),
             drop_fraction=float(collapse_cfg.get("collapse_drop_fraction", 0.4)),
+            peak_floor=float(collapse_cfg.get("collapse_peak_floor", collapse_cfg.get("min_avg_reward", 0.0))),
             verbose=verbose,
         )
     )
@@ -460,6 +465,23 @@ def _build_core_callbacks(
         callbacks.append(PeriodicTbSyncCallback(local_tb_dir, gcs_tb_path, sync_freq=save_freq, verbose=verbose))
 
     return callbacks, eval_callback, save_vecnorm_cb
+
+
+def _select_handoff_checkpoint(model_dir: Path) -> "tuple[str, str, str] | None":
+    """The checkpoint the curriculum actually promotes to the next stage.
+
+    Preference order matches next-stage loading: the risk-adjusted
+    ``robust_best_model``, then SB3's mean-reward ``best_model`` — each
+    only when its matched VecNormalize stats exist, so obs normalization
+    matches the policy weights. Returns ``(name, model_path_without_ext,
+    vecnorm_path)`` or ``None`` when neither candidate is complete.
+    """
+    for candidate in ("robust_best_model", "best_model"):
+        cand_zip = model_dir / f"{candidate}.zip"
+        cand_vecnorm = model_dir / f"{candidate}_vecnorm.pkl"
+        if cand_zip.exists() and cand_vecnorm.exists():
+            return candidate, str(model_dir / candidate), str(cand_vecnorm)
+    return None
 
 
 def _maybe_ent_coef_decay_callback(config: dict, algorithm: str, total_timesteps: int):
@@ -864,28 +886,50 @@ def _report_hpt_metrics(
     from .curriculum import load_vecnorm_stats
 
     best_model_zip = model_dir / "best_model.zip"
-    best_vecnorm_path = model_dir / "best_model_vecnorm.pkl"
     alg_cls = sb3["SAC"] if algorithm == "sac" else sb3["PPO"]
 
-    if best_model_zip.exists():
+    # Evaluate the same checkpoint the curriculum hands to the next stage
+    # (robust_best_model before mean-reward best_model, via
+    # _select_handoff_checkpoint), so metrics.json describes the promoted
+    # policy rather than a possibly-degenerate lucky-peak mean-best one
+    # (run 20260720_203454's best_model was the 50k checkpoint whose eval
+    # was 261.79 ± 261.72). The chosen name is recorded in the sidecar as
+    # quality_eval_checkpoint.
+    handoff = _select_handoff_checkpoint(model_dir)
+    if handoff is not None:
+        ckpt_name, ckpt_path, ckpt_vecnorm = handoff
+        eval_model = alg_cls.load(ckpt_path, env=eval_env)
+        if plant_identity is not None:
+            validate_model_plant(eval_model, plant_identity, artifact=ckpt_path + ".zip")
+        load_kwargs: dict[str, Any]
+        if plant_identity is not None:
+            load_kwargs = {"current_plant": plant_identity}
+        else:
+            load_kwargs = {"unsafe_skip_plant_validation": True}
+        load_vecnorm_stats(ckpt_vecnorm, eval_env, **load_kwargs)
+        eval_env.training = False
+        eval_env.norm_reward = False
+        aux_metrics["quality_eval_checkpoint"] = ckpt_name
+        logger.info("HPT eval: using %s + matched VecNormalize", ckpt_name)
+    elif best_model_zip.exists():
+        # Legacy fallback: a best_model saved without matched VecNormalize
+        # stats. Evaluate it rather than nothing, but flag the mismatch.
         eval_model = alg_cls.load(str(model_dir / "best_model"), env=eval_env)
         if plant_identity is not None:
             validate_model_plant(eval_model, plant_identity, artifact=str(best_model_zip))
-        if best_vecnorm_path.exists():
-            load_kwargs: dict[str, Any]
-            if plant_identity is not None:
-                load_kwargs = {"current_plant": plant_identity}
-            else:
-                load_kwargs = {"unsafe_skip_plant_validation": True}
-            load_vecnorm_stats(str(best_vecnorm_path), eval_env, **load_kwargs)
         eval_env.training = False
         eval_env.norm_reward = False
-        logger.info("HPT eval: using best model + matched VecNormalize")
+        aux_metrics["quality_eval_checkpoint"] = "best_model"
+        logger.warning(
+            "HPT eval: best_model has no matched VecNormalize stats — quality eval "
+            "normalization may not match the policy weights"
+        )
     else:
         eval_model = model
         eval_env.training = False
         eval_env.norm_reward = False
-        logger.warning("HPT eval: best_model.zip not found, falling back to final model")
+        aux_metrics["quality_eval_checkpoint"] = "final_model"
+        logger.warning("HPT eval: no saved checkpoint found, falling back to final model")
 
     # Quality evaluation with full LocomotionMetrics (spinning detection,
     # heading alignment, reward breakdown, etc.)
@@ -1202,19 +1246,15 @@ def train_curriculum(
         # policy weights.
         load_path = str(final_path)
         prev_vecnorm_path = str(final_path) + "_vecnorm.pkl"
-        for candidate in ("robust_best_model", "best_model"):
-            cand_zip = model_dir / f"{candidate}.zip"
-            cand_vecnorm = str(model_dir / f"{candidate}_vecnorm.pkl")
-            if cand_zip.exists() and Path(cand_vecnorm).exists():
-                load_path = str(model_dir / candidate)
-                prev_vecnorm_path = cand_vecnorm
-                logger.info(
-                    "Next stage will load %s (%s) with VecNormalize: %s",
-                    candidate,
-                    load_path,
-                    prev_vecnorm_path,
-                )
-                break
+        handoff = _select_handoff_checkpoint(model_dir)
+        if handoff is not None:
+            candidate, load_path, prev_vecnorm_path = handoff
+            logger.info(
+                "Next stage will load %s (%s) with VecNormalize: %s",
+                candidate,
+                load_path,
+                prev_vecnorm_path,
+            )
 
         train_env.close()
         eval_env.close()

--- a/environments/velociraptor/assets/raptor.xml
+++ b/environments/velociraptor/assets/raptor.xml
@@ -143,7 +143,11 @@
                    counts contact points inside the site volume. The original
                    r=0.02 sphere at the capsule midpoint missed both end
                    contacts, so the sensor read 0 during normal stance. -->
-              <site name="r_foot" pos="0.05 0 0" size="0.08"/>
+              <site name="r_foot" pos="0.05 0 0" size="0.08" group="4"/>
+              <!-- group="4": sensor volume only — groups 3+ are hidden in
+                   default rendering, so the enlarged site doesn't draw as a
+                   large gray ball on the foot in videos. Toggle site group 4
+                   in an interactive viewer to visualize the touch volume. -->
             </body>
 
             <!-- Digit 4 (lateral, shorter — secondary weight-bearing) -->
@@ -190,8 +194,8 @@
               <joint name="l_toe_d3_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-30 60" ref="10"/>
               <geom name="l_toe_d3_geom" type="capsule" fromto="0 0 0  0.10 0 0" size="0.02"
                     mass="0.06" material="body_mat"/>
-              <!-- Same coverage rationale as r_foot above. -->
-              <site name="l_foot" pos="0.05 0 0" size="0.08"/>
+              <!-- Same coverage and group="4" rationale as r_foot above. -->
+              <site name="l_foot" pos="0.05 0 0" size="0.08" group="4"/>
             </body>
 
             <!-- Digit 4 (lateral, shorter — secondary weight-bearing) -->

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -183,7 +183,7 @@
           "title": "Strike",
           "description": "Sprint and strike prey with sickle claw",
           "config_path": "configs/velociraptor/stage3_strike.toml",
-          "timesteps": 8000000,
+          "timesteps": 12000000,
           "advancement_gate": {
             "min_avg_reward": 100.0,
             "min_avg_episode_length": null,

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -80,8 +80,8 @@
         "nu": 22,
         "dynamic_mass_kg": 13.5,
         "plant_contract": {
-          "bundle_sha256": "sha256:a25de61e72daa4cf453b3c3c9284577a7b0a559a0f486eeeae9f69647fa58557",
-          "source_closure_sha256": "sha256:17c1ed5f2c7f162327cb8b59661564118101cfde331a525d3d3846e53cd660fb",
+          "bundle_sha256": "sha256:3a4d15176168efea7f63dc1d1051b1f3314b5c80e1e5e0826c294c440c8c66ca",
+          "source_closure_sha256": "sha256:ae2ebacf577a7247484e8954fecce421b007246ead904a83ce319babb1efdec5",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
             "revision": 3,
@@ -95,8 +95,8 @@
           },
           "visual": {
             "schema": "mesozoic.mujoco-visual/v1",
-            "revision": 2,
-            "sha256": "sha256:7a9147bf05e193781eb96e95f03614c8263dd6e360f88cbc56a571a2c2a13be6"
+            "revision": 3,
+            "sha256": "sha256:eb92e0ba239ec53fe4d611f9e5eae287bc765557d6f68be04f49ea94e2c9910c"
           }
         }
       },


### PR DESCRIPTION
Two rounds of fixes from the PPO/velociraptor regression review, verified against the real run evidence (`20260720_203454` A-only failure, `20260721_004731` A+B run).

## 1. Velociraptor plant fixes (`aa3395c`) — breaking by contract

**Dead foot touch sensors** (policy-interface revision 2 → 3, visual 1 → 2). The raptor is digitigrade and a lying toe capsule contacts the floor near its *ends*, but the r=0.02 touch sites sat at the toe_d3 midpoint — so both sensors, and the two foot-contact observation dims fed from them, read 0 during normal stance (verified: six active floor contacts, zero sensor signal). The sites now envelop the whole toe_d3 capsule. Fixing them exposed a second defect: the adjacent toe digits interpenetrate at rest and the solver held a constant ~300 N phantom repulsion between them, which the enlarged sites would have summed even airborne; new d3↔d4 contact excludes remove it.

Post-fix: ~37 N per foot at settled stance, exactly 0 N airborne, 48/50 standing-probe survival unchanged. The T-Rex has the same dead-sensor defect (recorded in KNOWN_ISSUES, not fixed here).

**Knee forcerange ±145 → ±270, i.e. 0.8×kp → 1.5×kp** (physics revision 1 → 2). The knee measured 0% clip at the moderate 2.5 Hz/0.8-amplitude contract gait but 30–46% at sprint-like 3–4 Hz full-amplitude excitation — the same clipped-torque signature that collapsed stage-2 locomotion at the hips. Post-bump the same sprint excitation measures 0% knee clip, pinned by a new sprint-regime contract test.

Both plant manifests and the species catalog were regenerated at the canonical MuJoCo 3.10.0; the writer itself demanded each revision bump.

> **Note:** merging this makes pre-merge checkpoints (including the in-flight `20260721_004731` run's) historical by contract — the next fresh Stage-1 run should start from scratch on the new plant.

## 2. Training-infrastructure fixes (`db0421e`) — non-breaking

**Eval-collapse backstop hardened.** `EvalCollapseEarlyStopCallback`'s peak is now the per-evaluation robust score (mean − std) instead of the raw mean: run `20260720_203454` was aborted at 1.1M/6M steps because a single 50k evaluation of 261.79 ± 261.72 (robust score 0.07 — one lucky episode among 29 failures) set a raw-mean kill threshold that every later normal-dip evaluation "violated". Detection also stays disarmed until the robust peak clears the stage's `min_avg_reward` curriculum gate (overridable via `collapse_peak_floor`), so the pre-convergence grind can never register as a collapse. All three stage-1 TOMLs gain the explicit 20/10/0.5 overrides stage 2 already had — `20260721_004731`'s healthy 2.2–2.3M transition turbulence accumulated 2 of 8 kill-drops under the old stage-1 defaults.

**`metrics.json` now describes the promoted checkpoint.** The post-stage quality eval loaded SB3's mean-reward `best_model` while next-stage training loads `robust_best_model` when present, so the sidecar could describe a policy the curriculum never promoted. Both paths now share `_select_handoff_checkpoint`, and the sidecar records the evaluated checkpoint as `quality_eval_checkpoint`.

Neither change affects what is learned — only when a run is aborted and which checkpoint gets reported — so post-merge runs remain comparable to `20260721_004731`.

**Doc riders:** retired the stale KNOWN_ISSUES claim that the published Brachiosaurus summary fails its stage-3 gate (the 2026-07-18 run passes with success 1.0), and added a watch item for the home-residual mapping's slope kink at action 0 (biases zero-mean Gaussian exploration off-home; diagnostic: crouched early training with `algo_std` ≈ 1.0).

## Testing

- 1410 tests pass locally (86 JAX-optional skips), including new regression tests: stance/airborne sensor behavior, sprint-regime knee headroom, variance-inflated-peak/gate-floor/genuine-collapse behavior of the backstop, and handoff-checkpoint selection.
- Empirical probes on the new plant: 50-seed standing probe 48/50 (unchanged), saturation report 0% at the contract regime, 0% knee at 3.5 Hz/1.0.