### PR TITLE
Fix T-Rex home equilibrium and contact sensing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   budget.
 
 ### Fixed
+- **T-Rex neutral stance now has a viable training basin** (breaking —
+  policy-interface revision 1 → 2, physics revision 1 → 2, visual revision
+  1 → 2): the old `home` state embedded the feet as much as 9 cm into the
+  floor, loaded the rear metatarsus behind the whole-body COM, made each leg
+  spring pull toward numeric zero instead of the stance, and used raptor-scale
+  servo gains on an 85 kg plant. A shallow plantar pad now supplies a real
+  support surface; the reset is a 0.5 mm loaded contact; every leg spring
+  references the stance; lower-body joint references preserve a small ankle
+  gravity preload; and the hip/knee/ankle gains use mass scaling plus a tested
+  stance margin while retaining bounded 1.5×kp headroom. The complete policy
+  now uses the named-home residual mapping in both Gymnasium and MJX, so action
+  zero commands all 21 home controls while ±1 still reach the actuator limits.
+  The load-bearing plantar pads also own hidden box-shaped touch volumes:
+  settled readings are ~419 N per foot, airborne readings are exactly zero,
+  and four contact exclusions remove the former 28 mm adjacent-toe overlaps
+  without changing sensor order or observation dimensions.
+  The JAX factory also leaves the CPU evaluation model's XML solver and
+  parent-contact options unchanged, eliminating evaluation-only plantar/toe
+  self-contact and keeping checkpoint gates aligned with MJX training.
+  The old plant nosedived at step ~77 even under its XML home command. The
+  corrected plant survives all 1,000 Stage-1 steps in 50/50 noise-free probes,
+  50/50 JAX-style probes at 0.05 rad joint noise, and 47/50 full SB3 resets
+  (the raptor reference is 48/50), with peak actuator force at 48.1% of its
+  bound. CPU-MJX tests pin the same complete home reset, residual action
+  mapping, and live contact observations. Root-pitch, tail-spring,
+  neck-stiffness, COM-shift, and static-control A/Bs were rejected before
+  changing the stance mechanics. See
+  `docs/investigations/TREX_HOME_EQUILIBRIUM.md`.
+
 - **`metrics.json` now describes the promoted checkpoint**: the post-stage
   quality/velocity/success evaluation loaded SB3's mean-reward
   `best_model` while next-stage training loads `robust_best_model` when
@@ -73,8 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enlarged sites would have summed even airborne; new contact excludes
   remove it. Verified post-fix: ~37 N per foot at settled stance, exactly
   0 N airborne, 48/50 standing-probe survival unchanged, and regression
-  tests pin stance/airborne sensor behavior. The T-Rex has the same
-  dead-sensor defect (recorded in KNOWN_ISSUES, not yet fixed).
+  tests pin stance/airborne sensor behavior.
   Follow-up (visual revision 2 → 3): the enlarged sites rendered as large
   gray balls on the feet in run videos (first visible in run
   `20260721_141523`'s stage-1 video); they now live in site group 4,

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Apex Predator. **Specialty:** Head-contact attack task.
 | Action dimension / actuators | 21 |
 | Generalized coordinates / velocities | nq=40, nv=37 |
 | Compiled dynamic model mass | 85.4 kg |
-| Plant contract revisions | policy r1; physics r1; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r2; physics r2; visual r2 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/trex/assets/trex.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |

--- a/configs/plant_manifest.generated.json
+++ b/configs/plant_manifest.generated.json
@@ -45,30 +45,30 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:3319211ce3cbaf2fa490f035db7b5d7b2557fb2e05532cabcaa56dab9eeb361e",
+      "bundle_sha256": "sha256:074b27d8e93ce05cf8e233d9f4ee6a9ee2c47adb77d988120117af09aee21514",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
         "nq": 40,
         "nu": 21,
         "nv": 37,
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:9f89c95eacd79e82f74ecb529cbdbd81f7cc2475251e3edd601370b096e60a5c"
+        "sha256": "sha256:f2d8c348e46214face9ad525852b47e5d8d329a6bdd84bbf28fef10ccddc81f7"
       },
       "policy_interface": {
         "action_dim": 21,
         "observation_dim": 83,
         "observation_schema": "bipedal-target/v1",
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:82c0aa3bdcfd69c026c15ceb8822295df6c452e643efc8cf7f7f824aea65454c"
+        "sha256": "sha256:e8e19f929c49b47b323ed3f797beff8e88fe1e7b8ba89bd9de39f4c2be583684"
       },
       "source": {
-        "closure_sha256": "sha256:9547523534e2fb6588e6b63bf8cde439625e1dc7840402f8c3af165c636fc215",
+        "closure_sha256": "sha256:65930d8f0e67d9ec08fa8de8c1ba6b0536359944649eee49c87e8e0d306659cc",
         "dependencies": [
           {
-            "content_sha256": "sha256:9bf8b979a6819cb39573d6be5458a514c69864fc834e414660ab59c25d2fd234",
+            "content_sha256": "sha256:4a000eeca14161cd8ddd3a3eff16b177724b2abe7c8cfa391614c0acf5b7b015",
             "kind": "mjcf",
             "logical_path": "environments/trex/assets/trex.xml"
           }
@@ -78,9 +78,9 @@
       },
       "species": "trex",
       "visual": {
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.mujoco-visual/v1",
-        "sha256": "sha256:42ddadf3153254bd3824d7f787df8f49a7dde033fe4322673791888294010b91"
+        "sha256": "sha256:4b9ce49f55e2e007afe3bba363a04541f7ee044988ac815a8662a83a98c55b00"
       }
     },
     "velociraptor": {

--- a/configs/plant_versions.toml
+++ b/configs/plant_versions.toml
@@ -17,9 +17,9 @@ visual_revision = 3
 observation_schema = "bipedal-target/v1"
 
 [plants.trex]
-physics_revision = 1
-policy_interface_revision = 1
-visual_revision = 1
+physics_revision = 2
+policy_interface_revision = 2
+visual_revision = 2
 observation_schema = "bipedal-target/v1"
 
 [plants.brachiosaurus]

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -72,16 +72,18 @@ tolerance) remains the standing recommendation for the divergences above.
   food-reach gradient. (June §6.10; the rest of that finding is resolved —
   the published summary is now the 2026-07-18 run, which passes its
   stage-3 gate with success rate 1.0.)
-- **Watch item** — the Velociraptor home-residual action mapping has a
+- **Watch item** — the biped home-residual action mapping has a
   slope discontinuity at action 0 (the two piecewise segments span
   home→min and home→max, which are unequal), so zero-mean Gaussian
   exploration produces a physically biased mean command away from home
-  (hip pitch ≈ −0.29 rad toward flexion, knee ≈ −0.16, ankle ≈ +0.13 at
-  σ=1). If a fresh run's early training looks persistently crouched or
-  off-home while `algo_std` is still ≈1.0, suspect this bias before
-  suspecting rewards; possible mitigations (smaller `log_std_init`, a
-  smoothed mapping) are interface experiments and must be run in
-  isolation. (Stage-1 basin investigation follow-up)
+  wherever the home control is off-midpoint. The listed Velociraptor effect
+  is hip pitch ≈ −0.29 rad toward flexion, knee ≈ −0.16, ankle ≈ +0.13 at
+  σ=1; the T-Rex lower-body home controls are midpoint-aligned, so its
+  asymmetry is limited to neck/head controls. If a fresh run's early training
+  looks persistently off-home while `algo_std` is still ≈1.0, suspect this
+  bias before suspecting rewards; possible mitigations (smaller
+  `log_std_init`, a smoothed mapping) are interface experiments and must be
+  run in isolation. (Stage-1 basin investigation follow-up)
 
 ## Sweeps / infrastructure
 
@@ -137,7 +139,12 @@ height in its alive region (home-keyframe-controlled settle z≈0.68,
 straight-leg command z≈0.70, vs `healthy_z_range` floor 1.0 and height target
 1.2) — leg springs now reference the stance angles and the leg servos are
 stronger with bounded force, giving an actively servo-held home stand at
-z≈1.13, level, all four feet grounded. All three models now use
+z≈1.13, level, all four feet grounded. The T-Rex's former step-77 neutral
+nosedive is also fixed: a shallow plantar contact, stance-referenced springs,
+mass-scaled gait servos, named-home residual actions, and live load-bearing
+foot sensors give it a full-horizon neutral stand; see
+[the home-equilibrium investigation](investigations/TREX_HOME_EQUILIBRIUM.md).
+All three models now use
 `integrator="implicitfast"` and bounded
 `forcerange` on position actuators, sized to clip impact/reset spikes only,
 with gait-critical actuators at 1.5×kp on every species (raptor hip
@@ -148,8 +155,9 @@ sprint-like 3–4 Hz full-amplitude excitation while still capped at
 0.8×kp). The original home-control-only sizing clipped 20–50 % of
 gait-cycle torque per species and collapsed velociraptor stage-2 twice — see
 [investigations/STAGE2_RECOMMENDATIONS.md](investigations/STAGE2_RECOMMENDATIONS.md)
-§5. Post-fix gait clipping is ≤0.5 % everywhere, pinned by each species'
-`tests/test_actuator_bounds.py`; re-measure any re-sizing with
+§5. Post-fix clipping on the pinned gait-critical hip/knee/ankle actuators is
+≤0.5 %, covered by each species' `tests/test_actuator_bounds.py`; re-measure
+any re-sizing with
 `environments/shared/scripts/actuator_saturation_report.py`.
 
 Neutral-action stability and truly actuator-disabled passive behavior are now
@@ -162,27 +170,18 @@ are documented in [PLANT_CONTRACT.md](PLANT_CONTRACT.md).
 
 Still open:
 
-- **MEDIUM** — the T-Rex foot touch sensors read 0 during settled stance
-  (verified empirically: both `r/l_foot_contact` are 0.0 after a settle),
-  the same defect fixed on the velociraptor: a lying toe capsule contacts
-  the floor near its ends, and the r=0.06 site at the toe midpoint misses
-  those contact points. The two foot-contact observation dims and any
-  foot-contact reward gating are dead. Fix as on the raptor: enlarge the
-  site to envelop the toe capsule, check for adjacent-digit
-  interpenetration (add contact excludes if the digits overlap at rest),
-  and bump the trex plant revisions.
 - **LOW** — the raptor's toe-clipping margin now sits at the toes: at
   sprint-like excitation (3–4 Hz, full amplitude) the 0.8×kp toe caps clip
   10–16 % and the 1.5×kp hip pitch ~11–16 % (its physical envelope); the
   knee measures 0 % after its 1.5× bump. Re-measure with
   `environments/shared/scripts/actuator_saturation_report.py` before any
   faster-gait (stage-3 sprint) work and consider 1.5× toes if they bind.
-- **MEDIUM** — the T-Rex home keyframe (pitch 0) is ~35° from its passive
-  equilibrium (settles to forward_z −0.583), which is *past* the stage-1
-  nosedive termination line (−0.519 with the TOML's 0.35 threshold): every
-  episode opens with a dive the policy must catch, and pure passivity is
-  death. Move the passive equilibrium near the intended ~10° natural pitch
-  (tail `springref`, neck stiffness, or hip `ref`/keyframe lean).
+- **LOW** — the T-Rex exact-home 2.5 Hz diagnostic produces one transient
+  clipping window on `r_toe_d4` (5.4 % over 2,500 steps) after the scripted
+  plant destabilizes; every stance-critical hip/knee/ankle remains at 0 %
+  and bounded-vs-unbounded root-z RMS divergence is 0.5 mm. This is not a
+  Stage-1 balance blocker, but re-measure it against a learned locomotion
+  rollout before promoting Stage 2.
 - **LOW** — scene boilerplate (skybox/grid/floor/option) is copy-pasted
   across the three XMLs → extract a shared `scene.xml` include; limbs are
   hand-mirrored sign-flips → generate via script/PyMJCF or add a left/right

--- a/docs/PLANT_CONTRACT.md
+++ b/docs/PLANT_CONTRACT.md
@@ -29,10 +29,11 @@ Each semantic layer has an independent positive revision: `policy_interface_revi
 - A visual-only change does not make a policy incompatible.
 - A policy-interface or physics change makes an existing policy incompatible, even when dimensions happen to match.
 
-The Velociraptor home-residual change is an example where tensor dimensions and
-XML physics stayed fixed but action meaning changed, requiring a policy-interface
-revision and fresh checkpoints. See the
-[Stage-1 basin investigation](investigations/VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md).
+The biped home-residual changes are examples where tensor dimensions can stay
+fixed while action meaning changes, requiring a policy-interface revision and
+fresh checkpoints. See the
+[Velociraptor Stage-1 basin investigation](investigations/VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md)
+and [T-Rex home-equilibrium investigation](investigations/TREX_HOME_EQUILIBRIUM.md).
 
 The generator compares the existing committed manifest with the new one and refuses to write a changed semantic layer
 unless its revision increased. Pull-request CI also compares against the base branch, so deleting or replacing the local

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ than rewrite.
 | [STAGE2_INVESTIGATION.md](investigations/STAGE2_INVESTIGATION.md) | 2026-07-09 | Root cause of the velociraptor stage-2 locomotion collapse (bounded-plant actuator clipping) |
 | [STAGE2_RECOMMENDATIONS.md](investigations/STAGE2_RECOMMENDATIONS.md) | 2026-07-11 | Replication review of run 20260711_165924, corrected fall-penalty math, ranked plan — validated 2026-07-12 by run 20260711_235303 (stages 1–3 cleared, stage-2 record); §5 has the outcome and cross-species lessons |
 | [VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md](investigations/VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md) | 2026-07-20 | Commit A physics probe and A-only PPO run 20260720_203454; natural-lean reward-conflict diagnosis, pending Commit B validation, and fresh-run decision rules |
+| [TREX_HOME_EQUILIBRIUM.md](investigations/TREX_HOME_EQUILIBRIUM.md) | 2026-07-23 | T-Rex neutral-stance basin repair, home-residual action mapping, and live plantar contact sensors |
 
 ## Code & repo reviews
 

--- a/docs/hardware/SIM_TO_REAL_PLAN.md
+++ b/docs/hardware/SIM_TO_REAL_PLAN.md
@@ -46,9 +46,10 @@ charismatic species. The honest summary:
   linear velocity and an absolute prey/food beacon) that **no onboard sensor can
   measure**. Closing this needs a legged base-state estimator *and* an onboard
   perception stack — neither exists in the repo.
-- **The heavy species are not servo-buildable.** T-Rex (85 kg) demands
-  ~150–375 N·m and Brachiosaurus (175 kg) up to ~900 N·m at the hips — beyond
-  all COTS smart servos and most quasi-direct-drive (QDD) units.
+- **The heavy species are not servo-buildable.** The T-Rex model (85 kg) now
+  permits 1,800–2,250 N·m at its gait-critical hip/knee servos, and
+  Brachiosaurus (175 kg) permits up to ~900 N·m at the hips — beyond all COTS
+  smart servos and most quasi-direct-drive (QDD) units.
 - **The good news:** compute is a non-issue (a ~200K-parameter MLP at 100 Hz
   runs on a microcontroller), and the observation-building, action-scaling, and
   normalization code already exist as pure, backend-agnostic modules — so the
@@ -128,10 +129,10 @@ proprioception-only task formulation).
 
 ### 3.2 Morphology & actuation
 
-| Species | Mass | Actuated DOF | Peak hip/knee torque (model) | Buildable as servo project? |
+| Species | Mass | Actuated DOF | Hip/knee torque caps (model) | Buildable as servo project? |
 |---|---:|---:|---|---|
 | Velociraptor | 13.5 kg | 22 | ~145–225 N·m | **With work** (prune DOF, QDD BLDC) |
-| T-Rex | 85.4 kg | 21 | ~300–375 N·m | No — Cheetah-3-class / hydraulic |
+| T-Rex | 85.4 kg | 21 | 1,800–2,250 N·m | No — industrial / hydraulic |
 | Brachiosaurus | 175.3 kg | 30 | ~500–900 N·m | No — industrial / hydraulic |
 
 Key idealizations that don't map to hardware:
@@ -146,9 +147,10 @@ Key idealizations that don't map to hardware:
   (`environments/shared/scripts/actuator_saturation_report.py`,
   `tests/test_actuator_bounds.py`): lower 0.8× kp caps clipped 20–50% of real
   gait torque and broke Stage-2 locomotion, so gait-critical joints were raised
-  to 1.5× kp. **Real per-joint peak torque therefore lies between ~0.8× and
-  1.5× kp** — the heavy-species torque problem is real, not an artifact of
-  oversizing.
+  to 1.5× kp. These caps are safety ceilings, not measured hardware
+  requirements: the latest T-Rex standing probe stayed below 48.1% of its
+  bounds, and learned-rollout peak and RMS/duty-cycle torque still need to be
+  re-measured before hardware sizing.
 - **Uniform-density geometry.** Mass sits at limb geometric centers, not at the
   joints (motors + gearboxes) and trunk (battery) where a real robot carries it —
   so CoM and inertia tensors are miscalibrated for balance transfer.
@@ -228,9 +230,10 @@ items. This plan agrees with that posture and sequences the work accordingly.
   At 13.5 kg, realistic gait torques are tens of N·m, coverable by
   mini-cheetah/Unitree-class QDD BLDC (~17 N·m cont., ~33–40 N·m peak) with mild
   gearing. The obstacle is DOF density, not torque — prune to ~8–10 leg DOF.
-- **T-Rex — impractical.** ~150–375 N·m at hip/knee exceeds all COTS smart
-  servos and most QDD units; needs Cheetah-3-class geared actuators or
-  hydraulics.
+- **T-Rex — impractical.** The current hip/knee model caps are
+  1,800–2,250 N·m. Those are not learned-rollout torque measurements, but they
+  put the current 85 kg plant outside COTS smart-servo and ordinary QDD
+  territory; hardware sizing remains blocked on learned peak and RMS torque.
 - **Brachiosaurus — impractical.** ~500–900 N·m plus non-physical lossless
   load-bearing springs. Industrial/hydraulic territory only.
 

--- a/docs/investigations/TREX_HOME_EQUILIBRIUM.md
+++ b/docs/investigations/TREX_HOME_EQUILIBRIUM.md
@@ -1,0 +1,106 @@
+# T-Rex home-equilibrium investigation
+
+> **Date:** 2026-07-23
+
+## Decision
+
+Repair the lower-body support mechanics before starting another PPO run. The
+failure was not primarily a tail, neck, or root keyframe problem: the old
+stance was an impact followed by an underpowered inverted-pendulum fall.
+
+Once the physical stance had a robust basin, complete the policy interface in
+the same unreleased plant revision: use the named-home residual mapping in
+both Gymnasium and MJX, and make the foot sensors observe the plantar pads
+that actually carry the load.
+
+## Reproduction on the old plant
+
+Under the Stage-1 configuration and the XML `home` command:
+
+- the noise-free episode terminated as a nosedive at step 77;
+- none of 50 resets at noise 0.05 survived the 1,000-step horizon;
+- whole-body COM was at x=0.0866 m, while the loaded rear contact was near
+  x=0.030 m;
+- the root z=0.90 reset put the metatarsus surface about 90 mm below the
+  floor and the toe surfaces about 75–78 mm below it;
+- the leg default declared stiffness 40 but no stance `springref`, so the
+  compiled springs pulled hip, knee, ankle, and toe coordinates toward zero
+  while the controls pulled toward the keyframe; and
+- the ankle moved from 90° toward its 50° lower limit while the torso pitched
+  forward. The forces remained well below their bounds, identifying
+  insufficient local servo stiffness rather than clipping.
+
+The 85 kg T-Rex plant is roughly six times the raptor's mass, but its
+hip/knee/ankle gains were only 1.3–1.5 times the raptor values.
+
+## Rejected isolated fixes
+
+Each candidate was compiled from a temporary XML and exercised through the
+real Stage-1 environment:
+
+- root pitch in either direction;
+- hip-reference or keyframe-angle shifts;
+- tail `springref`, tail stiffness, and tail-mass sweeps;
+- neck and head stiffness;
+- stronger gait gains without repairing the support contact;
+- explicit leg `springref` without repairing support;
+- fore-aft hip attachment and tail-mass shifts;
+- random standing poses and symmetric constant-control searches.
+
+The best one-dimensional balance shifts merely moved the plant across a
+razor-thin boundary between nosedive and tail contact. They did not create a
+robust basin. A thin support surface alone also failed because the original
+servos let the stance joints sag before the front edge could carry load.
+
+## Corrected stance contract
+
+The final change keeps the authored physical leg pose while correcting how it
+is represented and loaded:
+
+1. Root/default and keyframe height are 0.9795 m, producing a shallow 0.5 mm
+   loaded contact instead of a reset impact.
+2. Each metatarsus radius is reduced from 0.04 to 0.025 m.
+3. Each foot has a thin plantar box spanning the three toe bases and tips,
+   creating a fore-aft support surface.
+4. Every leg spring explicitly references its stance coordinate.
+5. Knee, ankle, and toe joint references place the lower-body home controls at
+   their range midpoints. The ankle retains a 5.5° target offset as gravity
+   preload.
+6. Hip-pitch, knee, and ankle gains use mass scaling plus the tested stance
+   margin (1200/1500/900), with their existing 1.5×kp force headroom. Leg
+   damping rises from 15 to 45; passive stiffness remains 40 so the policy can
+   still articulate the legs.
+7. The piecewise named-home residual mapping makes action zero command all 21
+   home controls in Gymnasium and MJX while preserving the ±1 endpoints.
+8. Box-shaped touch sites now share each plantar pad's metatarsus body and
+   enclose its floor contacts. Four adjacent-toe exclusions remove the former
+   28 mm d2/d3 and d3/d4 overlaps and their phantom self-contact forces.
+
+## Acceptance results
+
+All probes used the Stage-1 nosedive threshold of 0.35.
+
+| Probe | Result |
+|---|---:|
+| Noise-free neutral action, 1,000 steps | 50/50 survive |
+| JAX-style reset, 0.05 rad joint noise, nominal root height/velocity | 50/50 survive |
+| Full SB3 reset, 0.05 joint/velocity/height noise | 47/50 survive |
+| Raptor reference under the same full SB3 probe | 48/50 survive |
+| Peak actuator force fraction in the full SB3 probe | 48.1% |
+| Settled mean `forward_z`, noise-free | -0.048 |
+| Exact-home plantar penetration | 0.5 mm |
+| Settled foot touch sensors | ~419 N per foot |
+| Airborne foot touch sensors | 0 N |
+| Gymnasium ↔ MJX residual mapping/reset/contact parity | Pass |
+
+The full SB3 misses are the three seeds whose independent Gaussian root-height
+noise starts the long T-Rex legs about 8–11 cm inside the floor. JAX training
+does not add root-height or velocity noise, and the JAX-style probe survives
+all seeds.
+
+## Remaining watch item
+
+Re-measure gait excitation after any further gain, force-range, or reset
+change. The piecewise residual map has unequal slopes only for T-Rex
+neck/head controls because its lower-body home controls are midpoint-aligned;
+watch early exploration for a persistent head/neck command bias.

--- a/environments/shared/data/plant_manifest.generated.json
+++ b/environments/shared/data/plant_manifest.generated.json
@@ -45,30 +45,30 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:3319211ce3cbaf2fa490f035db7b5d7b2557fb2e05532cabcaa56dab9eeb361e",
+      "bundle_sha256": "sha256:074b27d8e93ce05cf8e233d9f4ee6a9ee2c47adb77d988120117af09aee21514",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
         "nq": 40,
         "nu": 21,
         "nv": 37,
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:9f89c95eacd79e82f74ecb529cbdbd81f7cc2475251e3edd601370b096e60a5c"
+        "sha256": "sha256:f2d8c348e46214face9ad525852b47e5d8d329a6bdd84bbf28fef10ccddc81f7"
       },
       "policy_interface": {
         "action_dim": 21,
         "observation_dim": 83,
         "observation_schema": "bipedal-target/v1",
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:82c0aa3bdcfd69c026c15ceb8822295df6c452e643efc8cf7f7f824aea65454c"
+        "sha256": "sha256:e8e19f929c49b47b323ed3f797beff8e88fe1e7b8ba89bd9de39f4c2be583684"
       },
       "source": {
-        "closure_sha256": "sha256:9547523534e2fb6588e6b63bf8cde439625e1dc7840402f8c3af165c636fc215",
+        "closure_sha256": "sha256:65930d8f0e67d9ec08fa8de8c1ba6b0536359944649eee49c87e8e0d306659cc",
         "dependencies": [
           {
-            "content_sha256": "sha256:9bf8b979a6819cb39573d6be5458a514c69864fc834e414660ab59c25d2fd234",
+            "content_sha256": "sha256:4a000eeca14161cd8ddd3a3eff16b177724b2abe7c8cfa391614c0acf5b7b015",
             "kind": "mjcf",
             "logical_path": "environments/trex/assets/trex.xml"
           }
@@ -78,9 +78,9 @@
       },
       "species": "trex",
       "visual": {
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.mujoco-visual/v1",
-        "sha256": "sha256:42ddadf3153254bd3824d7f787df8f49a7dde033fe4322673791888294010b91"
+        "sha256": "sha256:4b9ce49f55e2e007afe3bba363a04541f7ee044988ac815a8662a83a98c55b00"
       }
     },
     "velociraptor": {

--- a/environments/shared/jax_setup.py
+++ b/environments/shared/jax_setup.py
@@ -399,27 +399,17 @@ def build_env_kwargs(
     return env_kwargs
 
 
-def apply_mjx_solver_tuning(mj_model: Any) -> None:
-    """Apply standard MJX solver tuning to a MuJoCo model.
-
-    Should be called *before* creating ``MJXDinoEnv`` (which internalises
-    the model).
-    """
-    import mujoco
-
-    mj_model.opt.solver = mujoco.mjtSolver.mjSOL_CG
-    mj_model.opt.iterations = 4
-    mj_model.opt.ls_iterations = 4
-    mj_model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_FILTERPARENT
-
-
 def create_env(
     ctx: SpeciesContext,
     num_envs: int = 2048,
 ) -> Any:
     """Create and return a ``MJXDinoEnv`` from a species context.
 
-    Applies solver tuning and merges env kwargs automatically.
+    Merges environment kwargs automatically. The context's CPU model is kept
+    at its XML-authored options because checkpoint evaluation and video use
+    that instance, while ``MJXDinoEnv`` loads a separate training model.
+    Mutating only the CPU copy would make evaluation physics diverge from
+    training.
 
     Args:
         ctx: Species context from :func:`setup_species`.
@@ -430,7 +420,6 @@ def create_env(
     """
     from .mjx_env import MJXDinoEnv
 
-    apply_mjx_solver_tuning(ctx.mj_model)
     env_kwargs = build_env_kwargs(ctx.reward_cfg, ctx.jax_kwargs)
 
     env = MJXDinoEnv(

--- a/environments/shared/tests/test_jax_eval.py
+++ b/environments/shared/tests/test_jax_eval.py
@@ -187,7 +187,8 @@ class TestSuccessAndVelGates:
         assert passed
 
 
-def test_cpu_evaluation_noise_free_reset_restores_complete_home_state():
+@pytest.mark.parametrize("species", ("velociraptor", "trex"))
+def test_cpu_evaluation_noise_free_reset_restores_complete_home_state(species):
     jax = pytest.importorskip("jax")
     pytest.importorskip("mujoco.mjx")
     import jax.numpy as jnp
@@ -197,7 +198,7 @@ def test_cpu_evaluation_noise_free_reset_restores_complete_home_state():
     from environments.shared.mjx_env import _get_model_path
     from environments.shared.mjx_utils import reset_mujoco_data_to_home
 
-    model = mujoco.MjModel.from_xml_path(_get_model_path("velociraptor"))
+    model = mujoco.MjModel.from_xml_path(_get_model_path(species))
     home_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "home")
     captured: dict[str, np.ndarray] = {}
 

--- a/environments/shared/tests/test_mjcf_assets.py
+++ b/environments/shared/tests/test_mjcf_assets.py
@@ -22,7 +22,7 @@ ENVIRONMENTS_DIR = Path(__file__).resolve().parents[2]
 
 EXPECTED_MODELS = {
     "brachiosaurus/assets/brachiosaurus.xml": ModelExpectations(38, 37, 30, 175.3),
-    "trex/assets/trex.xml": ModelExpectations(40, 37, 21, 85.4),
+    "trex/assets/trex.xml": ModelExpectations(40, 37, 21, 85.44),
     "velociraptor/assets/raptor.xml": ModelExpectations(31, 30, 22, 13.5),
 }
 

--- a/environments/shared/tests/test_mjx_env.py
+++ b/environments/shared/tests/test_mjx_env.py
@@ -38,6 +38,8 @@ class TestMJXDinoEnv:
         assert env.action_dim == 21
         assert env.num_envs == 4
         assert env.config.posture_target_forward_z is None
+        assert env.config.action_mapping == "home-keyframe-residual/v1"
+        assert env.nominal_ctrl is not None
 
     def test_raptor_creation(self):
         """MJXDinoEnv can be created for Velociraptor."""
@@ -88,6 +90,20 @@ class TestMJXDinoEnv:
         assert env.num_envs == 4
         assert env.config.posture_target_forward_z is None
 
+    @pytest.mark.parametrize("species", ("velociraptor", "trex", "brachiosaurus"))
+    def test_stage_factory_preserves_canonical_compiled_plant(self, species):
+        from environments.shared.jax_setup import create_env, setup_species
+        from environments.shared.plant_contract import current_plant_identity, validate_compiled_plant
+
+        ctx = setup_species(species, stage=1)
+        env = create_env(ctx, num_envs=1)
+        identity = current_plant_identity(species, verify_generated=False)
+
+        validate_compiled_plant(ctx.mj_model, identity, artifact=f"{species} CPU evaluation model")
+        validate_compiled_plant(env.mj_model, identity, artifact=f"{species} MJX training model")
+        for option in ("solver", "iterations", "ls_iterations", "disableflags"):
+            assert getattr(ctx.mj_model.opt, option) == getattr(env.mj_model.opt, option)
+
     def test_stage_cannot_override_versioned_plant_interface(self):
         import environments.trex.mjx_config  # noqa: F401
         from environments.shared.mjx_env import MJXDinoEnv
@@ -99,7 +115,7 @@ class TestMJXDinoEnv:
                 "trex",
                 stage=1,
                 num_envs=1,
-                env_kwargs={"action_mapping": "home-keyframe-residual/v1"},
+                env_kwargs={"action_mapping": "midpoint/v1"},
             )
 
     def test_reset_returns_state(self):
@@ -239,21 +255,44 @@ class TestHomeKeyframeActionMapping:
         finally:
             env.close()
 
-    def test_setup_species_trex_retains_midpoint_mapping(self):
+    def test_setup_species_trex_zero_action_maps_to_xml_home(self):
         import jax.numpy as jnp
+        import mujoco
 
         from environments.shared.jax_setup import make_scale_action_fn, setup_species
 
         ctx = setup_species("trex", stage=1)
         scale_action = make_scale_action_fn(ctx)
+        home_id = mujoco.mj_name2id(ctx.mj_model, mujoco.mjtObj.mjOBJ_KEY, "home")
 
-        assert ctx.action_mapping == "midpoint/v1"
+        assert ctx.action_mapping == "home-keyframe-residual/v1"
+        assert home_id >= 0
         np.testing.assert_allclose(
             np.asarray(scale_action(jnp.zeros(ctx.act_dim))),
-            np.mean(ctx.mj_model.actuator_ctrlrange, axis=1),
+            ctx.mj_model.key_ctrl[home_id],
             rtol=0,
             atol=1e-7,
         )
+
+    def test_trex_jax_mapping_matches_gymnasium_mapping(self):
+        import jax.numpy as jnp
+
+        from environments.shared.jax_setup import make_scale_action_fn, setup_species
+        from environments.trex.envs.trex_env import TRexEnv
+
+        ctx = setup_species("trex", stage=1)
+        scale_action = make_scale_action_fn(ctx)
+        env = TRexEnv()
+        try:
+            action = np.linspace(-1.5, 1.5, ctx.act_dim, dtype=np.float32)
+            np.testing.assert_allclose(
+                np.asarray(scale_action(jnp.asarray(action))),
+                env._scale_action(action),
+                rtol=0,
+                atol=1e-7,
+            )
+        finally:
+            env.close()
 
     def test_noise_free_raptor_mjx_reset_restores_complete_home_state(self):
         import jax
@@ -278,6 +317,76 @@ class TestHomeKeyframeActionMapping:
                 atol=1e-7,
                 err_msg=f"MJX reset field {field} diverged from the XML home keyframe",
             )
+
+    def test_noise_free_trex_mjx_reset_restores_complete_home_state(self):
+        import jax
+        import mujoco
+
+        import environments.trex.mjx_config  # noqa: F401
+        from environments.shared.mjx_env import MJXDinoEnv
+        from environments.shared.mjx_utils import reset_mujoco_data_to_home
+
+        env = MJXDinoEnv("trex", stage=1, num_envs=1)
+        states = env.reset(jax.random.PRNGKey(17))
+
+        expected = mujoco.MjData(env.mj_model)
+        reset_mujoco_data_to_home(env.mj_model, expected)
+        mujoco.mj_forward(env.mj_model, expected)
+
+        for field in ("qpos", "qvel", "act", "ctrl", "mocap_pos", "mocap_quat"):
+            np.testing.assert_allclose(
+                np.asarray(getattr(states.data, field)[0]),
+                np.asarray(getattr(expected, field)),
+                rtol=0,
+                atol=1e-7,
+                err_msg=f"T-Rex MJX reset field {field} diverged from the XML home keyframe",
+            )
+
+    def test_trex_mjx_reset_exposes_live_foot_contacts(self):
+        import jax
+
+        import environments.trex.mjx_config  # noqa: F401
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        env = MJXDinoEnv("trex", stage=1, num_envs=1)
+        states = env.reset(jax.random.PRNGKey(23))
+        foot_sensors = np.asarray(states.data.sensordata[0, 10:12])
+        foot_observation = np.asarray(states.obs[0, -6:-4])
+
+        assert np.all(foot_sensors > 0.1), f"T-Rex MJX foot sensors are dead at home: {foot_sensors}"
+        np.testing.assert_allclose(foot_observation, foot_sensors, rtol=0, atol=1e-7)
+
+    def test_trex_stage1_factory_preserves_contact_physics_and_rewards(self):
+        import jax
+        import mujoco
+
+        from environments.shared.jax_setup import create_env, setup_species
+        from environments.shared.mjx_utils import reset_mujoco_data_to_home
+
+        ctx = setup_species("trex", stage=1)
+        ctx.jax_kwargs = {
+            **ctx.jax_kwargs,
+            "reset_noise_scale": 0.0,
+            "init_qpos_noise": 0.0,
+            "init_yaw_noise": 0.0,
+        }
+        env = create_env(ctx, num_envs=1)
+        states = env.reset(jax.random.PRNGKey(23))
+        foot_sensors = np.asarray(states.data.sensordata[0, 10:12])
+
+        for option in ("solver", "iterations", "ls_iterations", "disableflags"):
+            assert getattr(ctx.mj_model.opt, option) == getattr(env.mj_model.opt, option)
+
+        cpu_data = mujoco.MjData(ctx.mj_model)
+        reset_mujoco_data_to_home(ctx.mj_model, cpu_data)
+        mujoco.mj_forward(ctx.mj_model, cpu_data)
+        np.testing.assert_allclose(foot_sensors, cpu_data.sensordata[10:12], rtol=1e-5, atol=1e-3)
+
+        assert env.config.action_mapping == "home-keyframe-residual/v1"
+        assert env.config.reward_weights["foot_contact_gate"] == pytest.approx(1.0)
+        assert env.config.reward_weights["foot_contact_weight"] == pytest.approx(0.8)
+        assert np.all(foot_sensors > 0.1), f"Stage-1 reset has no load-bearing foot contact: {foot_sensors}"
+        np.testing.assert_allclose(np.asarray(states.obs[0, -6:-4]), foot_sensors, rtol=0, atol=1e-7)
 
     def test_home_reset_requires_named_home_keyframe(self):
         import mujoco

--- a/environments/shared/tests/test_plant_contract.py
+++ b/environments/shared/tests/test_plant_contract.py
@@ -36,6 +36,7 @@ from environments.shared.plant_contract import (
     validate_recorded_identity,
     write_plant_identity,
 )
+from environments.trex.envs.trex_env import TRexEnv
 from environments.velociraptor.envs.raptor_env import RaptorEnv
 
 CANONICAL_MUJOCO_VERSION = load_plant_versions()[0]
@@ -386,21 +387,25 @@ def test_cached_observation_body_mapping_changes_interface_fingerprint(raptor_la
     assert changed["visual_sha256"] == original["visual_sha256"]
 
 
-def test_raptor_policy_contract_records_home_residual_action_mapping(raptor_layers):
-    _source, env, version, _original = raptor_layers
+@pytest.mark.parametrize(("env_class", "species"), ((RaptorEnv, "velociraptor"), (TRexEnv, "trex")))
+def test_biped_policy_contract_records_home_residual_action_mapping(env_class, species):
+    env = env_class(reset_noise_scale=0.0)
+    try:
+        version = load_plant_versions()[1][species]
+        payload = plant_contract._policy_interface_payload(env.model, env, version, require_backend_parity=True)
+        mapping = payload["action_mapping"]
 
-    payload = plant_contract._policy_interface_payload(env.model, env, version, require_backend_parity=True)
-    mapping = payload["action_mapping"]
+        assert mapping["mode"] == "home-keyframe-residual/v1"
+        assert mapping["origin"]["keyframe"] == "home"
+        np.testing.assert_allclose(mapping["origin"]["ctrl"], env.model.key_ctrl[env.home_keyframe_id])
+        assert set(payload["interface_implementations"]["jax_action_mapping"]) == {"scale_action_around_nominal_jax"}
+        assert set(payload["interface_implementations"]["home_reset"]["jax"]) == {"reset_mujoco_data_to_home"}
+        assert payload["jax_interface"]["action_mapping"] == "home-keyframe-residual/v1"
+    finally:
+        env.close()
 
-    assert mapping["mode"] == "home-keyframe-residual/v1"
-    assert mapping["origin"]["keyframe"] == "home"
-    np.testing.assert_allclose(mapping["origin"]["ctrl"], env.model.key_ctrl[env.home_keyframe_id])
-    assert set(payload["interface_implementations"]["jax_action_mapping"]) == {"scale_action_around_nominal_jax"}
-    assert set(payload["interface_implementations"]["home_reset"]["jax"]) == {"reset_mujoco_data_to_home"}
-    assert payload["jax_interface"]["action_mapping"] == "home-keyframe-residual/v1"
 
-
-def test_other_species_retain_midpoint_action_mapping_contract():
+def test_brachio_retains_midpoint_action_mapping_contract():
     env = BrachioEnv(reset_noise_scale=0.0)
     try:
         version = load_plant_versions()[1]["brachiosaurus"]

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -41,7 +41,7 @@ def test_catalog_derives_current_model_and_stage_facts() -> None:
         for species_id, entry in species.items()
     } == {
         "velociraptor": (67, 22, 31, 30, 22, 13.5),
-        "trex": (83, 21, 40, 37, 21, 85.4),
+        "trex": (83, 21, 40, 37, 21, 85.44),
         "brachiosaurus": (83, 30, 38, 37, 30, 175.3),
     }
 
@@ -68,9 +68,9 @@ def test_catalog_publishes_layered_plant_contract() -> None:
         "trex": "bipedal-target/v1",
         "brachiosaurus": "quadrupedal-target/v1",
     }
-    expected_policy_revisions = {"velociraptor": 3, "trex": 1, "brachiosaurus": 1}
-    expected_physics_revisions = {"velociraptor": 2, "trex": 1, "brachiosaurus": 1}
-    expected_visual_revisions = {"velociraptor": 3, "trex": 1, "brachiosaurus": 1}
+    expected_policy_revisions = {"velociraptor": 3, "trex": 2, "brachiosaurus": 1}
+    expected_physics_revisions = {"velociraptor": 2, "trex": 2, "brachiosaurus": 1}
+    expected_visual_revisions = {"velociraptor": 3, "trex": 2, "brachiosaurus": 1}
     digest_pattern = re.compile(r"sha256:[0-9a-f]{64}")
     for species in catalog["species"]:
         plant = species["model"]["plant_contract"]

--- a/environments/trex/README.md
+++ b/environments/trex/README.md
@@ -46,7 +46,9 @@ python environments/trex/scripts/view_model.py
 ## Environment Details
 
 Observation and action totals are generated in the catalog entry linked above. The source of the observation layout and
-action-to-actuator mapping is `envs/trex_env.py`; actions are normalized to [-1, 1] and scaled to actuator ranges.
+action-to-actuator mapping is `envs/trex_env.py`; actions are normalized to
+[-1, 1] residuals, where zero commands the complete XML `home` control and
+the endpoints retain access to the full actuator ranges.
 
 ### Termination Conditions
 - Pelvis height outside healthy range (0.5m–1.6m)

--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -10,9 +10,11 @@
     <geom contype="1" conaffinity="1" friction="1.2 0.005 0.0001"/>
     <motor ctrllimited="true" ctrlrange="-1 1"/>
 
-    <!-- Leg joints: high stiffness for massive biped -->
+    <!-- Leg joints: the T-Rex plant is roughly six times the raptor's mass.
+         The higher damping absorbs stance/reset transients without increasing
+         the passive stiffness that the locomotion policy must overcome. -->
     <default class="leg_joint">
-      <joint damping="15.0" armature="0.1" stiffness="40.0"/>
+      <joint damping="45.0" armature="0.1" stiffness="40.0"/>
     </default>
 
     <!-- Tail joints: very stiff, acts as heavy counterbalance to skull -->
@@ -71,7 +73,7 @@
       - Body pivots at hips, skull and tail balance each other
     -->
 
-    <body name="pelvis" pos="0 0 0.90">
+    <body name="pelvis" pos="0 0 0.9795">
       <freejoint name="root"/>
 
       <!-- Main torso: forward-leaning, angled ~30 deg from horizontal -->
@@ -166,42 +168,59 @@
 
       <body name="r_thigh" pos="-0.05 -0.14 -0.05">
         <!-- Hip: 2 DOF -->
-        <joint name="r_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0" range="-50 80" ref="15"/>
-        <joint name="r_hip_roll" class="leg_joint" type="hinge" axis="1 0 0" range="-25 25"/>
+        <joint name="r_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0"
+               range="-50 80" ref="15" springref="15"/>
+        <joint name="r_hip_roll" class="leg_joint" type="hinge" axis="1 0 0"
+               range="-25 25" springref="0"/>
         <geom name="r_thigh_geom" type="capsule" fromto="0 0 0  0.03 0 -0.35" size="0.09"
               mass="5.0" material="body_mat"/>
 
         <body name="r_tibia" pos="0.03 0 -0.35">
           <!-- Knee: 1 DOF -->
-          <joint name="r_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-110 -10" ref="-70"/>
+          <joint name="r_knee" class="leg_joint" type="hinge" axis="0 1 0"
+                 range="-110 -10" ref="-60" springref="-60"/>
           <geom name="r_tibia_geom" type="capsule" fromto="0 0 0  -0.03 0 -0.35" size="0.07"
                 mass="3.5" material="body_mat"/>
 
           <body name="r_metatarsus" pos="-0.03 0 -0.35">
             <!-- Ankle: 1 DOF (digitigrade stance) -->
-            <joint name="r_ankle" class="leg_joint" type="hinge" axis="0 1 0" range="50 150" ref="90"/>
-            <geom name="r_metatarsus_geom" type="capsule" fromto="0 0 0  0.08 0 -0.2" size="0.04"
+            <joint name="r_ankle" class="leg_joint" type="hinge" axis="0 1 0"
+                   range="50 150" ref="94.5" springref="94.5"/>
+            <geom name="r_metatarsus_geom" type="capsule" fromto="0 0 0  0.08 0 -0.2" size="0.025"
                   mass="1.2" material="body_mat"/>
+            <!-- Thin plantar pad: gives the three digits one load-bearing
+                 fore-aft surface instead of balancing on the rear
+                 metatarsus endpoint. -->
+            <geom name="r_plantar_geom" type="box" pos="0.14 0 -0.22"
+                  size="0.07 0.045 0.01" mass="0.02" material="claw_mat"/>
+            <!-- Touch volume belongs to the same metatarsus body as the
+                 load-bearing plantar pad. It encloses the entire pad and its
+                 floor contacts; group 4 keeps the diagnostic volume hidden
+                 in default renders. -->
+            <site name="r_foot" type="box" pos="0.14 0 -0.22"
+                  size="0.075 0.05 0.015" group="4"/>
 
             <!-- Toes: 3 separate forward-facing digits (anatomically correct) -->
             <!-- Digit 2 (medial, shortest) -->
             <body name="r_toe_d2" pos="0.08 0.025 -0.2">
-              <joint name="r_toe_d2_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-25 50" ref="15"/>
+              <joint name="r_toe_d2_joint" class="leg_joint" type="hinge" axis="0 1 0"
+                     range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
               <geom name="r_toe_d2_geom" type="capsule" fromto="0 0 0  0.08 0.015 0" size="0.025"
                     mass="0.12" material="claw_mat"/>
             </body>
 
             <!-- Digit 3 (central, longest — primary weight-bearing) -->
             <body name="r_toe_d3" pos="0.08 0 -0.2">
-              <joint name="r_toe_d3_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-25 50" ref="15"/>
+              <joint name="r_toe_d3_joint" class="leg_joint" type="hinge" axis="0 1 0"
+                     range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
               <geom name="r_toe_d3_geom" type="capsule" fromto="0 0 0  0.12 0 0" size="0.028"
                     mass="0.16" material="claw_mat"/>
-              <site name="r_foot" pos="0.06 0 -0.02" size="0.06"/>
             </body>
 
             <!-- Digit 4 (lateral, medium) -->
             <body name="r_toe_d4" pos="0.08 -0.025 -0.2">
-              <joint name="r_toe_d4_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-25 50" ref="15"/>
+              <joint name="r_toe_d4_joint" class="leg_joint" type="hinge" axis="0 1 0"
+                     range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
               <geom name="r_toe_d4_geom" type="capsule" fromto="0 0 0  0.09 -0.015 0" size="0.025"
                     mass="0.12" material="claw_mat"/>
             </body>
@@ -212,40 +231,50 @@
       <!-- ==================== LEFT LEG ==================== -->
 
       <body name="l_thigh" pos="-0.05 0.14 -0.05">
-        <joint name="l_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0" range="-50 80" ref="15"/>
-        <joint name="l_hip_roll" class="leg_joint" type="hinge" axis="1 0 0" range="-25 25"/>
+        <joint name="l_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0"
+               range="-50 80" ref="15" springref="15"/>
+        <joint name="l_hip_roll" class="leg_joint" type="hinge" axis="1 0 0"
+               range="-25 25" springref="0"/>
         <geom name="l_thigh_geom" type="capsule" fromto="0 0 0  0.03 0 -0.35" size="0.09"
               mass="5.0" material="body_mat"/>
 
         <body name="l_tibia" pos="0.03 0 -0.35">
-          <joint name="l_knee" class="leg_joint" type="hinge" axis="0 1 0" range="-110 -10" ref="-70"/>
+          <joint name="l_knee" class="leg_joint" type="hinge" axis="0 1 0"
+                 range="-110 -10" ref="-60" springref="-60"/>
           <geom name="l_tibia_geom" type="capsule" fromto="0 0 0  -0.03 0 -0.35" size="0.07"
                 mass="3.5" material="body_mat"/>
 
           <body name="l_metatarsus" pos="-0.03 0 -0.35">
-            <joint name="l_ankle" class="leg_joint" type="hinge" axis="0 1 0" range="50 150" ref="90"/>
-            <geom name="l_metatarsus_geom" type="capsule" fromto="0 0 0  0.08 0 -0.2" size="0.04"
+            <joint name="l_ankle" class="leg_joint" type="hinge" axis="0 1 0"
+                   range="50 150" ref="94.5" springref="94.5"/>
+            <geom name="l_metatarsus_geom" type="capsule" fromto="0 0 0  0.08 0 -0.2" size="0.025"
                   mass="1.2" material="body_mat"/>
+            <geom name="l_plantar_geom" type="box" pos="0.14 0 -0.22"
+                  size="0.07 0.045 0.01" mass="0.02" material="claw_mat"/>
+            <site name="l_foot" type="box" pos="0.14 0 -0.22"
+                  size="0.075 0.05 0.015" group="4"/>
 
             <!-- Toes: 3 separate forward-facing digits (anatomically correct) -->
             <!-- Digit 2 (medial, shortest) -->
             <body name="l_toe_d2" pos="0.08 -0.025 -0.2">
-              <joint name="l_toe_d2_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-25 50" ref="15"/>
+              <joint name="l_toe_d2_joint" class="leg_joint" type="hinge" axis="0 1 0"
+                     range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
               <geom name="l_toe_d2_geom" type="capsule" fromto="0 0 0  0.08 -0.015 0" size="0.025"
                     mass="0.12" material="claw_mat"/>
             </body>
 
             <!-- Digit 3 (central, longest — primary weight-bearing) -->
             <body name="l_toe_d3" pos="0.08 0 -0.2">
-              <joint name="l_toe_d3_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-25 50" ref="15"/>
+              <joint name="l_toe_d3_joint" class="leg_joint" type="hinge" axis="0 1 0"
+                     range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
               <geom name="l_toe_d3_geom" type="capsule" fromto="0 0 0  0.12 0 0" size="0.028"
                     mass="0.16" material="claw_mat"/>
-              <site name="l_foot" pos="0.06 0 -0.02" size="0.06"/>
             </body>
 
             <!-- Digit 4 (lateral, medium) -->
             <body name="l_toe_d4" pos="0.08 0.025 -0.2">
-              <joint name="l_toe_d4_joint" class="leg_joint" type="hinge" axis="0 1 0" range="-25 50" ref="15"/>
+              <joint name="l_toe_d4_joint" class="leg_joint" type="hinge" axis="0 1 0"
+                     range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
               <geom name="l_toe_d4_geom" type="capsule" fromto="0 0 0  0.09 0.015 0" size="0.025"
                     mass="0.12" material="claw_mat"/>
             </body>
@@ -300,23 +329,24 @@
     <position name="head_pitch_act" joint="head_pitch" kp="80" forcerange="-65 65" ctrlrange="-0.4363 0.6109"/>
 
     <!-- Right leg -->
-    <!-- Hip pitch, knee, and ankle forcerange sized at 1.5x kp (was 0.8x): the 0.8x
-         caps clipped 44-50% (hips), 10-14% (knees), and ~31% (ankles) of a moderate
-         gait cycle — the same plant defect that broke velociraptor stage-2 before
-         commit fd3ffbc fixed it. See docs/investigations/STAGE2_RECOMMENDATIONS.md. -->
-    <position name="r_hip_pitch_act" joint="r_hip_pitch" kp="200" forcerange="-300 300" ctrlrange="-0.8727 1.3963"/>
+    <!-- The 85 kg plant is about six times the raptor's mass, while the
+         original 200/250/150 gains let all three stance joints sag by
+         16-23 degrees before producing support torque. These gains combine
+         mass scaling with the tested stance margin; the existing 1.5x-kp
+         gait headroom remains unchanged. -->
+    <position name="r_hip_pitch_act" joint="r_hip_pitch" kp="1200" forcerange="-1800 1800" ctrlrange="-0.8727 1.3963"/>
     <position name="r_hip_roll_act" joint="r_hip_roll" kp="150" forcerange="-120 120" ctrlrange="-0.4363 0.4363"/>
-    <position name="r_knee_act" joint="r_knee" kp="250" forcerange="-375 375" ctrlrange="-1.9199 -0.1745"/>
-    <position name="r_ankle_act" joint="r_ankle" kp="150" forcerange="-225 225" ctrlrange="0.8727 2.6180"/>
+    <position name="r_knee_act" joint="r_knee" kp="1500" forcerange="-2250 2250" ctrlrange="-1.9199 -0.1745"/>
+    <position name="r_ankle_act" joint="r_ankle" kp="900" forcerange="-1350 1350" ctrlrange="0.8727 2.6180"/>
     <position name="r_toe_d2_act" joint="r_toe_d2_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
     <position name="r_toe_d3_act" joint="r_toe_d3_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
     <position name="r_toe_d4_act" joint="r_toe_d4_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
 
     <!-- Left leg -->
-    <position name="l_hip_pitch_act" joint="l_hip_pitch" kp="200" forcerange="-300 300" ctrlrange="-0.8727 1.3963"/>
+    <position name="l_hip_pitch_act" joint="l_hip_pitch" kp="1200" forcerange="-1800 1800" ctrlrange="-0.8727 1.3963"/>
     <position name="l_hip_roll_act" joint="l_hip_roll" kp="150" forcerange="-120 120" ctrlrange="-0.4363 0.4363"/>
-    <position name="l_knee_act" joint="l_knee" kp="250" forcerange="-375 375" ctrlrange="-1.9199 -0.1745"/>
-    <position name="l_ankle_act" joint="l_ankle" kp="150" forcerange="-225 225" ctrlrange="0.8727 2.6180"/>
+    <position name="l_knee_act" joint="l_knee" kp="1500" forcerange="-2250 2250" ctrlrange="-1.9199 -0.1745"/>
+    <position name="l_ankle_act" joint="l_ankle" kp="900" forcerange="-1350 1350" ctrlrange="0.8727 2.6180"/>
     <position name="l_toe_d2_act" joint="l_toe_d2_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
     <position name="l_toe_d3_act" joint="l_toe_d3_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
     <position name="l_toe_d4_act" joint="l_toe_d4_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
@@ -373,24 +403,33 @@
     <!-- Arm-torso -->
     <exclude body1="pelvis" body2="r_arm"/>
     <exclude body1="pelvis" body2="l_arm"/>
+
+    <!-- Adjacent toe capsules intentionally share a close, splayed
+         anatomical origin. Exclude sibling collisions so their 28 mm
+         home-pose overlap cannot inject constant self-contact forces into
+         the stance or foot sensors. -->
+    <exclude body1="r_toe_d2" body2="r_toe_d3"/>
+    <exclude body1="r_toe_d3" body2="r_toe_d4"/>
+    <exclude body1="l_toe_d2" body2="l_toe_d3"/>
+    <exclude body1="l_toe_d3" body2="l_toe_d4"/>
   </contact>
 
   <!-- ==================== KEYFRAMES ==================== -->
-  <!-- Standing pose with COM balanced over feet.
-       Without this, knee (range -110..-10) and ankle (range 50..150)
-       start at 0 deg which is outside their limits, causing violent
-       constraint-force corrections on the first simulation step. -->
+  <!-- Standing pose with a shallow (0.5 mm) plantar contact. Joint
+       references define the same authored physical stance while placing
+       the lower-body neutral controls at the actuator-range midpoints.
+       The ankle midpoint retains a 5.5 deg preload against gravity. -->
 
   <keyframe>
     <key name="home"
-         qpos="0 0 0.90 1 0 0 0
+         qpos="0 0 0.9795 1 0 0 0
                0 0 0 0 0 0 0 0 0
-               0.261799 0 -1.221730 1.570796 0.261799 0.261799 0.261799
-               0.261799 0 -1.221730 1.570796 0.261799 0.261799 0.261799
+               0.261799 0 -1.047198 1.649336 0.218166 0.218166 0.218166
+               0.261799 0 -1.047198 1.649336 0.218166 0.218166 0.218166
                1 0 0 0 0 1 0 0 0 0"
          ctrl="0 0 0
-               0.261799 0 -1.221730 1.570796 0.261799 0.261799 0.261799
-               0.261799 0 -1.221730 1.570796 0.261799 0.261799 0.261799
+               0.2618 0 -1.0472 1.74535 0.2182 0.2182 0.2182
+               0.2618 0 -1.0472 1.74535 0.2182 0.2182 0.2182
                0 0 0 0"/>
   </keyframe>
 

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -12,7 +12,7 @@ Observation space (total dimension is generated in the public species catalog):
     - Pelvis angular velocity (gyroscope) — 3
     - Pelvis linear velocity — 3
     - Pelvis acceleration — 3
-    - Foot contact states (2 feet, sensed on central digit 3) — 2
+    - Foot contact forces (2 plantar-pad touch sensors) — 2
     - Prey direction (unit vector) — 3
     - Prey distance (scalar) — 1
 
@@ -59,6 +59,7 @@ from environments.shared.base_env import BaseDinoEnv
 class TRexEnv(BaseDinoEnv):
     """Tyrannosaurus Rex bipedal locomotion and bite-attack environment."""
 
+    action_mapping = "home-keyframe-residual/v1"
     _camera_distance = 3.0
     _camera_azimuth = 135
     _camera_elevation = -20
@@ -170,6 +171,15 @@ class TRexEnv(BaseDinoEnv):
 
     def _cache_ids(self):
         """Cache MuJoCo IDs for bodies, geoms, and sites."""
+        # T-Rex policies command residuals around the complete XML home
+        # control vector. Cache the named keyframe so Gymnasium reset and
+        # action zero share one nominal state.
+        self.home_keyframe_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_KEY, "home")
+        if self.home_keyframe_id < 0:
+            raise ValueError("T-Rex model must define a named 'home' keyframe")
+        self._reset_keyframe_id = self.home_keyframe_id
+        self._home_ctrl = self.model.key_ctrl[self.home_keyframe_id].copy()
+
         # Body IDs
         self.pelvis_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, "pelvis")
         self.skull_body_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, "skull")
@@ -219,6 +229,23 @@ class TRexEnv(BaseDinoEnv):
         # are inherited from BaseDinoEnv (0, 3, 6 respectively).
         self._sensor_r_foot = 10
         self._sensor_l_foot = 11
+
+    def _scale_action(self, action: np.ndarray) -> np.ndarray:
+        """Map normalized residual actions around the XML home controls.
+
+        The two halves are scaled independently so the mapping preserves the
+        actuator endpoints while making action zero exactly the named home
+        control, even when that control is not the range midpoint.
+        """
+        residual = np.clip(action, -1.0, 1.0)
+        ctrl_range = self.model.actuator_ctrlrange
+        ctrl_min = ctrl_range[:, 0]
+        ctrl_max = ctrl_range[:, 1]
+
+        below_home = residual * (self._home_ctrl - ctrl_min)
+        above_home = residual * (ctrl_max - self._home_ctrl)
+        scaled = self._home_ctrl + np.where(residual < 0.0, below_home, above_home)
+        return np.asarray(scaled)
 
     def _get_obs(self) -> np.ndarray:
         """Construct observation vector."""

--- a/environments/trex/mjx_config.py
+++ b/environments/trex/mjx_config.py
@@ -18,6 +18,7 @@ _SENSOR_TAIL_GYRO_START = 21
 
 register_species_mjx(
     species="trex",
+    action_mapping="home-keyframe-residual/v1",
     frame_skip=5,
     max_episode_steps=1000,
     healthy_z_range=(0.75, 1.6),

--- a/environments/trex/tests/test_actuator_bounds.py
+++ b/environments/trex/tests/test_actuator_bounds.py
@@ -6,8 +6,10 @@ gait-like excitation that clipped 44-50% of hip-pitch, 10-14% of knee, and ~31% 
 the same plant defect that collapsed velociraptor stage-2 twice (see
 docs/investigations/STAGE2_RECOMMENDATIONS.md). Hip pitch, knee, and
 ankle were re-sized to 1.5x kp, which measures <1% gait-cycle clipping
-and ~0 pelvis-z divergence from an unbounded plant. These tests pin that
-contract before the next trex stage-2 run trains against the plant.
+and ~0 pelvis-z divergence from an unbounded plant. The home-equilibrium
+repair later raised their gains to 1200/1500/900 while preserving that
+1.5x headroom. These tests pin that contract before the next T-Rex run
+trains against the plant.
 
 Run ``environments/shared/scripts/actuator_saturation_report.py trex``
 for the full per-actuator numbers on the current model.
@@ -76,7 +78,7 @@ class TestForceBoundsConfiguration(PositionActuatorConfigurationBase):
 class TestHomeControlSaturation:
     def test_no_saturation_during_home_control_settle(self):
         """Settling under XML home-keyframe controls never clips forces."""
-        env = TRexEnv()
+        env = TRexEnv(reset_noise_scale=0.0)
         try:
             frac = measure_clip_fractions(env, mode="home_control", steps=1000)
             worst = max(frac[i] for i in position_actuator_ids(env.model))
@@ -95,7 +97,7 @@ class TestDynamicSaturation:
         the plant lost gait headroom — see
         docs/investigations/STAGE2_RECOMMENDATIONS.md before re-sizing.
         """
-        env = TRexEnv()
+        env = TRexEnv(reset_noise_scale=0.0)
         try:
             model = env.model
             frac = measure_clip_fractions(env, mode="gait", steps=2000)

--- a/environments/trex/tests/test_static_balance.py
+++ b/environments/trex/tests/test_static_balance.py
@@ -9,6 +9,8 @@ Mirrors the velociraptor static balance tests, adapted for T-Rex proportions
 (heavier mass, higher pelvis, same digitigrade foot structure).
 """
 
+import mujoco
+import numpy as np
 import pytest
 
 from environments.shared.tests.static_balance_helpers import (
@@ -21,6 +23,8 @@ from environments.shared.tests.static_balance_helpers import (
 from environments.trex.envs.trex_env import TRexEnv
 
 FOOT_GEOM_NAMES = [
+    "r_plantar_geom",
+    "l_plantar_geom",
     "r_toe_d3_geom",
     "l_toe_d3_geom",
     "r_toe_d4_geom",
@@ -33,7 +37,7 @@ ROOT_BODY = "pelvis"
 
 @pytest.fixture
 def env():
-    e = TRexEnv(reset_noise_scale=0.0)
+    e = TRexEnv(reset_noise_scale=0.0, nosedive_termination_threshold=0.35)
     e.reset(seed=0)
     yield e
     e.close()
@@ -47,12 +51,75 @@ class TestHomePoseCOM(HomePoseCOMBase):
     max_support_distance = 0.20
     species_label = "T-Rex"
 
+    def test_plantar_contacts_are_shallow(self, env):
+        """The home stance loads the pads without a reset impact."""
+        floor_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_GEOM, "floor")
+        plantar_ids = {
+            mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_GEOM, name)
+            for name in ("r_plantar_geom", "l_plantar_geom")
+        }
+        contacts = {
+            plantar_id: [
+                env.data.contact[index]
+                for index in range(env.data.ncon)
+                if plantar_id in (env.data.contact[index].geom1, env.data.contact[index].geom2)
+                and floor_id in (env.data.contact[index].geom1, env.data.contact[index].geom2)
+            ]
+            for plantar_id in plantar_ids
+        }
+
+        assert all(contacts.values()), "both plantar pads must load the floor"
+        assert min(contact.dist for pad_contacts in contacts.values() for contact in pad_contacts) >= -0.001
+
 
 class TestNeutralActionStability(NeutralActionStabilityBase):
     species_name = "T-Rex"
     root_body_id_attr = "pelvis_id"
     max_height_drop = 0.15
     max_tilt_increase = 0.27  # 15 degrees
+
+    def test_neutral_controls_match_complete_home(self, env):
+        """Residual action zero must command every home-keyframe control."""
+        neutral_ctrl = env._scale_action(np.zeros(env.action_space.shape, dtype=np.float32))
+        np.testing.assert_allclose(
+            neutral_ctrl,
+            env.model.key_ctrl[env.home_keyframe_id],
+            atol=1e-12,
+        )
+
+    def test_survives_full_noise_free_episode(self, env):
+        """The neutral stance must remain viable for the full Stage-1 horizon."""
+        env.reset(seed=0)
+        neutral_action = np.zeros(env.action_space.shape, dtype=np.float32)
+
+        for step in range(1, env.max_episode_steps + 1):
+            _, _, terminated, truncated, info = env.step(neutral_action)
+            assert not terminated, (
+                f"T-Rex terminated at step {step}/{env.max_episode_steps} "
+                f"under its neutral stance command: {info.get('termination_reason', 'unknown')}"
+            )
+            assert truncated is (step == env.max_episode_steps)
+
+    @pytest.mark.parametrize("seed", (0, 27, 38, 44))
+    def test_survives_representative_jax_joint_noise(self, env, seed):
+        """The stance tolerates Stage-1 joint noise without SB3-only root noise."""
+        env.reset_noise_scale = 0.05
+        env.reset(seed=seed)
+
+        home_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_KEY, "home")
+        env.data.qpos[2] = env.model.key_qpos[home_id, 2]
+        env.data.qvel[:] = 0.0
+        mujoco.mj_forward(env.model, env.data)
+
+        neutral_action = np.zeros(env.action_space.shape, dtype=np.float32)
+        for step in range(1, env.max_episode_steps + 1):
+            _, _, terminated, truncated, info = env.step(neutral_action)
+            assert not terminated, (
+                f"T-Rex terminated at step {step}/{env.max_episode_steps} "
+                f"from seed {seed} with JAX-style joint noise: "
+                f"{info.get('termination_reason', 'unknown')}"
+            )
+            assert truncated is (step == env.max_episode_steps)
 
 
 class TestActuatorDisabledPassive(ActuatorDisabledPassiveBase):
@@ -65,6 +132,30 @@ class TestActuatorDisabledPassive(ActuatorDisabledPassiveBase):
 class TestJointLimitsAtHome(JointLimitsAtHomeBase):
     knee_names = ["r_knee", "l_knee"]
     knee_margin_deg = 20.0
+
+    def test_leg_springs_reference_home(self, env):
+        """Passive leg springs must not fight the intended stance."""
+        home_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_KEY, "home")
+        joint_names = [
+            f"{side}_{suffix}"
+            for side in ("r", "l")
+            for suffix in (
+                "hip_pitch",
+                "hip_roll",
+                "knee",
+                "ankle",
+                "toe_d2_joint",
+                "toe_d3_joint",
+                "toe_d4_joint",
+            )
+        ]
+        for name in joint_names:
+            joint_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_JOINT, name)
+            qpos_address = env.model.jnt_qposadr[joint_id]
+            assert env.model.qpos_spring[qpos_address] == pytest.approx(
+                env.model.key_qpos[home_id, qpos_address],
+                abs=1e-6,
+            )
 
 
 class TestMassDistribution(MassDistributionBase):

--- a/environments/trex/tests/test_trex_env.py
+++ b/environments/trex/tests/test_trex_env.py
@@ -95,3 +95,130 @@ class TestTRexSpecific:
         action = np.zeros(env.action_space.shape, dtype=np.float32)
         _, _, _, _, info = env.step(action)
         assert info["reward_nosedive"] <= 0.0
+
+
+class TestNominalPoseActionScaling:
+    """T-Rex actions are residuals around the complete XML home controls."""
+
+    def test_reset_and_action_origin_use_same_named_home_keyframe(self, env):
+        assert env._reset_keyframe_id == env.home_keyframe_id
+
+    def test_zero_action_maps_exactly_to_home_controls(self, env):
+        action = np.zeros(env.action_space.shape, dtype=np.float32)
+        np.testing.assert_array_equal(
+            env._scale_action(action),
+            env.model.key_ctrl[env.home_keyframe_id],
+        )
+
+    def test_action_endpoints_retain_full_control_range(self, env):
+        ctrl_range = env.model.actuator_ctrlrange
+        np.testing.assert_allclose(
+            env._scale_action(-np.ones(env.action_space.shape, dtype=np.float32)),
+            ctrl_range[:, 0],
+            atol=1e-12,
+        )
+        np.testing.assert_allclose(
+            env._scale_action(np.ones(env.action_space.shape, dtype=np.float32)),
+            ctrl_range[:, 1],
+            atol=1e-12,
+        )
+
+    def test_piecewise_mapping_interpolates_on_each_side_of_home(self, env):
+        ctrl_range = env.model.actuator_ctrlrange
+        home_ctrl = env.model.key_ctrl[env.home_keyframe_id]
+
+        below = env._scale_action(np.full(env.action_space.shape, -0.5, dtype=np.float32))
+        above = env._scale_action(np.full(env.action_space.shape, 0.5, dtype=np.float32))
+
+        np.testing.assert_allclose(below, (ctrl_range[:, 0] + home_ctrl) / 2.0, atol=1e-12)
+        np.testing.assert_allclose(above, (home_ctrl + ctrl_range[:, 1]) / 2.0, atol=1e-12)
+
+    def test_zero_residual_keeps_energy_and_smoothness_penalties_zero(self, env):
+        env.reset(seed=42)
+        action = np.zeros(env.action_space.shape, dtype=np.float32)
+
+        _, _, terminated, truncated, first_info = env.step(action)
+        assert not terminated
+        assert not truncated
+        _, _, _, _, second_info = env.step(action)
+
+        assert first_info["reward_energy"] == pytest.approx(0.0, abs=1e-12)
+        assert second_info["reward_energy"] == pytest.approx(0.0, abs=1e-12)
+        assert second_info["reward_smoothness"] == pytest.approx(0.0, abs=1e-12)
+        assert second_info["action_delta"] == pytest.approx(0.0, abs=1e-12)
+
+
+class TestFootContactSensors:
+    """Touch observations must measure plantar-floor load, not self-contact."""
+
+    def test_sites_share_the_load_bearing_plantar_bodies(self, env):
+        for side in ("r", "l"):
+            site_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_SITE, f"{side}_foot")
+            geom_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_GEOM, f"{side}_plantar_geom")
+            assert env.model.site_bodyid[site_id] == env.model.geom_bodyid[geom_id]
+
+    def test_sensors_read_ground_force_at_settled_stance(self):
+        env = TRexEnv(reset_noise_scale=0.0, nosedive_termination_threshold=0.35)
+        try:
+            env.reset(seed=0)
+            info = {}
+            for _ in range(200):
+                _, _, terminated, _, info = env.step(np.zeros(env.action_space.shape, dtype=np.float32))
+                assert not terminated
+            assert info["r_foot_contact"] > 1.0, "right foot touch sensor dead at stance"
+            assert info["l_foot_contact"] > 1.0, "left foot touch sensor dead at stance"
+        finally:
+            env.close()
+
+    def test_sensors_read_zero_airborne(self):
+        env = TRexEnv(reset_noise_scale=0.0)
+        try:
+            env.reset(seed=0)
+            mujoco.mj_resetDataKeyframe(env.model, env.data, env.home_keyframe_id)
+            env.data.qpos[2] += 1.0
+            mujoco.mj_forward(env.model, env.data)
+            for _ in range(10):
+                mujoco.mj_step(env.model, env.data)
+            for name in ("r_foot_touch", "l_foot_touch"):
+                sensor_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_SENSOR, name)
+                sensor_address = env.model.sensor_adr[sensor_id]
+                assert env.data.sensordata[sensor_address] == pytest.approx(0.0, abs=1e-9)
+        finally:
+            env.close()
+
+    def test_observation_foot_contact_dims_are_live(self):
+        env = TRexEnv(reset_noise_scale=0.0, nosedive_termination_threshold=0.35)
+        try:
+            env.reset(seed=0)
+            obs = None
+            for _ in range(200):
+                obs, _, terminated, _, _ = env.step(np.zeros(env.action_space.shape, dtype=np.float32))
+                assert not terminated
+            foot_dims = obs[-6:-4]
+            assert np.all(foot_dims > 0.0), f"foot-contact obs dims dead at stance: {foot_dims}"
+        finally:
+            env.close()
+
+    def test_adjacent_digits_do_not_self_contact_at_home(self, env):
+        env.reset(seed=0)
+        adjacent_pairs = {
+            frozenset(
+                (
+                    mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_GEOM, f"{side}_toe_d2_geom"),
+                    mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_GEOM, f"{side}_toe_d3_geom"),
+                )
+            )
+            for side in ("r", "l")
+        } | {
+            frozenset(
+                (
+                    mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_GEOM, f"{side}_toe_d3_geom"),
+                    mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_GEOM, f"{side}_toe_d4_geom"),
+                )
+            )
+            for side in ("r", "l")
+        }
+        actual_pairs = {
+            frozenset((env.data.contact[index].geom1, env.data.contact[index].geom2)) for index in range(env.data.ncon)
+        }
+        assert adjacent_pairs.isdisjoint(actual_pairs)

--- a/notebooks/jax_training.ipynb
+++ b/notebooks/jax_training.ipynb
@@ -437,7 +437,7 @@
    },
    "outputs": [],
    "source": [
-    "# Create MJXDinoEnv via library helper (applies solver tuning + env_kwargs merge)\n",
+    "# Create the canonical MJXDinoEnv via the library helper (merges env_kwargs)\n",
     "env = create_env(ctx, num_envs=NUM_ENVS)\n",
     "mjx_model = env.mjx_model\n",
     "\n",

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -355,25 +355,25 @@
         "nq": 40,
         "nv": 37,
         "nu": 21,
-        "dynamic_mass_kg": 85.4,
+        "dynamic_mass_kg": 85.44,
         "plant_contract": {
-          "bundle_sha256": "sha256:3319211ce3cbaf2fa490f035db7b5d7b2557fb2e05532cabcaa56dab9eeb361e",
-          "source_closure_sha256": "sha256:9547523534e2fb6588e6b63bf8cde439625e1dc7840402f8c3af165c636fc215",
+          "bundle_sha256": "sha256:074b27d8e93ce05cf8e233d9f4ee6a9ee2c47adb77d988120117af09aee21514",
+          "source_closure_sha256": "sha256:65930d8f0e67d9ec08fa8de8c1ba6b0536359944649eee49c87e8e0d306659cc",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 1,
+            "revision": 2,
             "observation_schema": "bipedal-target/v1",
-            "sha256": "sha256:82c0aa3bdcfd69c026c15ceb8822295df6c452e643efc8cf7f7f824aea65454c"
+            "sha256": "sha256:e8e19f929c49b47b323ed3f797beff8e88fe1e7b8ba89bd9de39f4c2be583684"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",
-            "revision": 1,
-            "sha256": "sha256:9f89c95eacd79e82f74ecb529cbdbd81f7cc2475251e3edd601370b096e60a5c"
+            "revision": 2,
+            "sha256": "sha256:f2d8c348e46214face9ad525852b47e5d8d329a6bdd84bbf28fef10ccddc81f7"
           },
           "visual": {
             "schema": "mesozoic.mujoco-visual/v1",
-            "revision": 1,
-            "sha256": "sha256:42ddadf3153254bd3824d7f787df8f49a7dde033fe4322673791888294010b91"
+            "revision": 2,
+            "sha256": "sha256:4b9ce49f55e2e007afe3bba363a04541f7ee044988ac815a8662a83a98c55b00"
           }
         }
       },


### PR DESCRIPTION
## Summary

- repair the T-Rex neutral stance with shallow plantar support, stance-referenced leg springs, corrected joint references, and mass-appropriate gait servo gains
- switch Gymnasium and MJX to the named-home residual action mapping so action zero commands the full 21-actuator home control vector
- move foot touch volumes onto the load-bearing plantar bodies and exclude the four overlapping adjacent-toe pairs without changing sensor order or observation dimensions
- preserve canonical XML solver/contact options in the JAX factory so CPU checkpoint evaluation matches MJX training
- bump the T-Rex policy, physics, and visual plant revisions from 1 to 2 and regenerate manifests/catalogs

## Root cause

The old home pose began with the feet deeply embedded in the floor, used leg springs referenced to numeric zero, loaded support behind the whole-body center of mass, and lacked enough local servo stiffness for the 85 kg plant. Separately, action zero still meant actuator-range midpoint rather than the authored home command, and the toe-mounted touch sites missed the actual load-bearing contacts.

During review, the production JAX factory also exposed a CPU-evaluation-only mismatch: it disabled parent filtering and changed solver settings on the CPU model while `MJXDinoEnv` reloaded the canonical XML. With the new plantar pads, that created phantom multi-kN plantar/toe self-contact during checkpoint evaluation. The factory now leaves both models at the canonical plant options, with regression coverage for all species.

## Impact

This is a breaking T-Rex plant update. Existing revision-1 T-Rex policies, normalization statistics, and checkpoints are incompatible; the next PPO run must start fresh. Observation and action dimensions remain 83 and 21.

The corrected neutral command survives the full 1,000-step Stage-1 horizon in all 50 noise-free and all 50 JAX-style reset probes. Settled foot readings are approximately 419 N per foot, reset readings are approximately 498 N, and airborne readings are zero.

## Validation

- `JAX_PLATFORMS=cpu pytest environments/shared/tests/ environments/trex/tests/ -q`
- `pytest environments/shared/tests/test_mjx_env.py -q`
- `mypy environments/ --ignore-missing-imports`
- `ruff check environments/`
- `ruff format --check environments/`
- `python -m environments.shared.plant_contract --check`
- `python -m environments.shared.plant_contract --check --baseline <origin-main-manifest>`
- `python -m environments.shared.species_catalog --check`
- `git diff --check`

The review also re-ran the actuator saturation diagnostic and verified exact CPU/MJX reset/contact parity.