### PR TITLE
Revise the T-Rex plant and calibrate stage-1 against a zero-action baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ Apex Predator. **Specialty:** Head-contact attack task.
 
 | Generated specification | Value |
 |---|---|
-| Observation dimension | 83 |
+| Observation dimension | 61 |
 | Action dimension / actuators | 21 |
-| Generalized coordinates / velocities | nq=40, nv=37 |
-| Compiled dynamic model mass | 85.4 kg |
-| Plant contract revisions | policy r2; physics r2; visual r2 ([details](docs/PLANT_CONTRACT.md)) |
+| Generalized coordinates / velocities | nq=28, nv=27 |
+| Compiled dynamic model mass | 85.7 kg |
+| Plant contract revisions | policy r3; physics r3; visual r3 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/trex/assets/trex.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |

--- a/configs/brachiosaurus/stage2_locomotion.toml
+++ b/configs/brachiosaurus/stage2_locomotion.toml
@@ -26,6 +26,9 @@ food_head_proximity_weight = 0.0
 food_distance_range = [8.0, 12.0]
 food_height_range = [2.0, 3.0]
 max_episode_steps = 1000
+reset_noise_scale = 0.05               # Was omitted, so SB3 silently fell back to the class default 0.01
+                                       # while [jax] used 0.05. Stage 1 raised it deliberately; stages 2-3
+                                       # inherited a 5x narrower reset distribution by accident.
 healthy_z_range = [0.85, 3.5]          # Lowered fall floor from the env default 1.0: settled stance is ~1.13 m and normal gait bob dips to ~1.10 m, so a 1.0 floor fired spurious "fallen" terminations mid-gait (short 642/1000-step episodes, high variance). 0.85 keeps real falls detectable while letting the gait breathe.
 
 [ppo]

--- a/configs/brachiosaurus/stage3_food_reach.toml
+++ b/configs/brachiosaurus/stage3_food_reach.toml
@@ -22,6 +22,9 @@ food_distance_range = [1.5, 4.0]       # Tightened from [2.0, 6.0]: closer food 
 food_lateral_range = [-1.5, 1.5]
 food_height_range = [2.0, 3.5]         # Lowered from [2.5, 4.0]: slightly lower food reduces coordination demand on neck extension
 max_episode_steps = 1000
+reset_noise_scale = 0.05               # Was omitted, so SB3 silently fell back to the class default 0.01
+                                       # while [jax] used 0.05. Stage 1 raised it deliberately; stages 2-3
+                                       # inherited a 5x narrower reset distribution by accident.
 healthy_z_range = [0.85, 3.5]          # Lowered fall floor from the env default 1.0 so the reach motion isn't cut short by spurious "fallen" terminations when the torso bobs during approach (settled stance ~1.13 m).
 
 [ppo]

--- a/configs/plant_manifest.generated.json
+++ b/configs/plant_manifest.generated.json
@@ -45,30 +45,30 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:074b27d8e93ce05cf8e233d9f4ee6a9ee2c47adb77d988120117af09aee21514",
+      "bundle_sha256": "sha256:7fd2c85f438ff5f5c86c4806440a66252d9b63a777d9d3cabaf215a0c556f176",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
-        "nq": 40,
+        "nq": 28,
         "nu": 21,
-        "nv": 37,
-        "revision": 2,
+        "nv": 27,
+        "revision": 3,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:f2d8c348e46214face9ad525852b47e5d8d329a6bdd84bbf28fef10ccddc81f7"
+        "sha256": "sha256:da0fe5a18713fc143e8f46dcca4539edc4c90eb933fcbedb5bf79986605e43d4"
       },
       "policy_interface": {
         "action_dim": 21,
-        "observation_dim": 83,
+        "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 2,
+        "revision": 3,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:e8e19f929c49b47b323ed3f797beff8e88fe1e7b8ba89bd9de39f4c2be583684"
+        "sha256": "sha256:ee5727900cb1a9494005cc8f2972f8a293e6013700d0d2ed6f8797ab4e14a6f5"
       },
       "source": {
-        "closure_sha256": "sha256:65930d8f0e67d9ec08fa8de8c1ba6b0536359944649eee49c87e8e0d306659cc",
+        "closure_sha256": "sha256:4f0fdc428aa2ee1535dd6a3ba293aaad32ff271b612445293b792a1903a0400c",
         "dependencies": [
           {
-            "content_sha256": "sha256:4a000eeca14161cd8ddd3a3eff16b177724b2abe7c8cfa391614c0acf5b7b015",
+            "content_sha256": "sha256:1ea443f5eed93037abc8a777e88cb27e619a82e2c1a694bb74ceef15b0a7fccb",
             "kind": "mjcf",
             "logical_path": "environments/trex/assets/trex.xml"
           }
@@ -78,9 +78,9 @@
       },
       "species": "trex",
       "visual": {
-        "revision": 2,
+        "revision": 3,
         "schema": "mesozoic.mujoco-visual/v1",
-        "sha256": "sha256:4b9ce49f55e2e007afe3bba363a04541f7ee044988ac815a8662a83a98c55b00"
+        "sha256": "sha256:11418961e75956f4d3c55aaf6a5ad1aa8b9d80efec1e2499a4994679cc19186d"
       }
     },
     "velociraptor": {

--- a/configs/plant_versions.toml
+++ b/configs/plant_versions.toml
@@ -17,9 +17,9 @@ visual_revision = 3
 observation_schema = "bipedal-target/v1"
 
 [plants.trex]
-physics_revision = 2
-policy_interface_revision = 2
-visual_revision = 2
+physics_revision = 3
+policy_interface_revision = 3
+visual_revision = 3
 observation_schema = "bipedal-target/v1"
 
 [plants.brachiosaurus]

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -29,7 +29,12 @@ bite_bonus = 0.0
 bite_approach_weight = 0.0                     # Must be explicit — species default was leaking into stage 1 via key mismatch bug
 prey_distance_range = [10.0, 15.0]
 max_episode_steps = 1000                       # Match stage 2/3 for consistent episode horizon across curriculum
-reset_noise_scale = 0.05                       # Increased from 0.01 default to improve robustness (matches raptor)
+reset_noise_scale = 0.10                       # Calibrated against the zero-action baseline
+                                               # (environments/shared/scripts/zero_action_baseline.py): at 0.05 the
+                                               # do-nothing policy already reaches the full horizon in 93% of episodes,
+                                               # so the stage rewards a statue and training can only lose ground. 0.10
+                                               # drops that floor to ~67%, leaving real headroom; 0.15 drops it to 23%,
+                                               # which starts to look unlearnable.
 
 [ppo]
 learning_rate = 3e-5                    # Setting 4 sweep: 3.23e-5 — 10x lower. All successful S1→S3 runs used this. Old 3e-4 caused instability.
@@ -72,7 +77,7 @@ train_freq = 16                  # Collect 16 env steps before training — matc
 gradient_steps = 8               # 2:1 data-to-update ratio — matches raptor; reduces overfitting risk on small buffer
 
 [sac.policy_kwargs]
-net_arch = [512, 256]            # Match PPO architecture; T-Rex's 83 obs dims handled by input layer, not hidden width
+net_arch = [512, 256]            # Match PPO architecture (obs is 61 since the arms/distal tail were welded)
 
 [jax]
 num_envs = 2048                         # Parallel MJX environments on GPU
@@ -91,7 +96,7 @@ vf_clip_range = 10.0                    # Clip value function updates to prevent
 ent_coef = 0.005                        # Match SB3 PPO — 0.01 caused entropy to increase and policy std to diverge
 target_kl = 0.05                        # Early-stop PPO epochs when approx KL exceeds this — prevents policy collapse
 fall_penalty = -10.0                    # Reduced from -50: large penalties cause value loss to dominate early training (v≈1174 at init → divergence)
-reset_noise_scale = 0.05               # Joint angle perturbation range (radians) at reset
+reset_noise_scale = 0.10               # Match [env]: calibrated against the zero-action baseline
 init_qpos_noise = 0.01                 # XY position jitter at reset (meters) — JAX-only MJXEnvConfig field
 init_yaw_noise = 0.1                   # Yaw rotation perturbation at reset (radians) — JAX-only MJXEnvConfig field
 

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -16,7 +16,10 @@ energy_penalty_weight = 0.075                  # Setting 4 sweep: 0.075 forces e
 tail_stability_weight = 0.15
 posture_weight = 1.5                           # Increased from 1.5: with lower alive_bonus, stronger tilt penalty drives upright stance
 nosedive_weight = 1.5                          # Increased from 3.0: complement posture weight to prevent forward pitch exploit
-nosedive_termination_threshold = 0.35          # Tighter than default 0.5: terminate at ~25° beyond natural lean instead of ~42°
+nosedive_termination_threshold = 0.47          # Terminates at forward_z < -0.519 (~31° nose-down), unchanged from the
+                                               # 0.35 that preceded the natural_pitch 0.17 -> 0.05 correction. natural_pitch
+                                               # now describes the measured neutral pose, so the threshold absorbs the
+                                               # 0.12 shift and the absolute termination envelope is identical.
 smoothness_weight = 0.1
 heading_weight = 0.1                           # Small heading reward to prevent spin-to-balance exploits
 gait_symmetry_weight = 0.0                     # Disable: default formula rewards single-foot stance, bad for balance

--- a/configs/trex/stage2_locomotion.toml
+++ b/configs/trex/stage2_locomotion.toml
@@ -30,6 +30,9 @@ bite_bonus = 0.0
 bite_approach_weight = 0.0
 prey_distance_range = [8.0, 12.0]
 max_episode_steps = 1000
+reset_noise_scale = 0.05               # Was omitted, so SB3 silently fell back to the class default 0.01
+                                       # while [jax] used 0.05. Stage 1 raised it deliberately; stages 2-3
+                                       # inherited a 5x narrower reset distribution by accident.
 
 [ppo]
 learning_rate = 5e-5                    # Reduce from 1e-4: prevent catastrophic forgetting of Stage 1 balance
@@ -49,12 +52,12 @@ ent_coef_end = 0.001                    # Decay entropy over the stage (EntCoefD
 target_kl = 0.05                        # Loosened from 0.03 for the locomotion stage (fast early learning); matches the JAX path's value.
 
 [ppo.policy_kwargs]
-net_arch = [512, 256]                  # Larger first layer for T-Rex's higher-dimensional obs space (83 vs raptor's 67)
+net_arch = [512, 256]                  # Match raptor width; T-Rex obs is 61 since the arms/distal tail were welded
 
 [sac]
 learning_rate = 1e-4              # 3x reduction from Stage 1 — replay buffer provides natural gradient smoothing
 batch_size = 256
-gamma = 0.99                     # Keep at 0.99 — replay staleness + T-Rex's high obs dimensionality (83) makes
+gamma = 0.99                     # Keep at 0.99 — replay staleness at high gamma makes
                                  # high gamma risky; the buffer naturally handles temporal credit assignment
 tau = 0.005
 ent_coef = "auto"                # Auto-entropy handles Stage 1→2 transition exploration naturally
@@ -65,7 +68,7 @@ train_freq = 16                  # Collect 16 env steps before training — matc
 gradient_steps = 8               # 2:1 data-to-update ratio — matches raptor; reduces overfitting risk on replay buffer
 
 [sac.policy_kwargs]
-net_arch = [512, 256]            # Larger first layer for T-Rex's higher-dimensional obs space (83 vs raptor's 67)
+net_arch = [512, 256]            # Match raptor width; T-Rex obs is 61 since the arms/distal tail were welded
 
 [jax]
 num_envs = 2048

--- a/configs/trex/stage3_bite.toml
+++ b/configs/trex/stage3_bite.toml
@@ -20,6 +20,9 @@ bite_head_proximity_weight = 1.0       # Head-to-prey proximity shaping: provide
 prey_distance_range = [2.0, 6.0]       # Tightened from [3.0, 8.0]: closer prey makes bite discovery much more likely during exploration
 prey_lateral_range = [-1.5, 1.5]
 max_episode_steps = 1000
+reset_noise_scale = 0.05               # Was omitted, so SB3 silently fell back to the class default 0.01
+                                       # while [jax] used 0.05. Stage 1 raised it deliberately; stages 2-3
+                                       # inherited a 5x narrower reset distribution by accident.
 
 [ppo]
 learning_rate = 5e-5

--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -27,6 +27,9 @@ heading_weight = 0.3
 lateral_penalty_weight = 0.1
 prey_distance_range = [8.0, 12.0]
 max_episode_steps = 1000
+reset_noise_scale = 0.05               # Was omitted, so SB3 silently fell back to the class default 0.01
+                                       # while [jax] used 0.05. Stage 1 raised it deliberately; stages 2-3
+                                       # inherited a 5x narrower reset distribution by accident.
 
 [ppo]
 learning_rate = 5e-5

--- a/configs/velociraptor/stage3_strike.toml
+++ b/configs/velociraptor/stage3_strike.toml
@@ -23,6 +23,9 @@ strike_claw_proximity_weight = 1.0     # Reduced from 2.0: still provides final 
 prey_distance_range = [2.0, 6.0]       # Tightened from [3.0, 8.0]: closer prey makes strike discovery much more likely during exploration
 prey_lateral_range = [-1.5, 1.5]
 max_episode_steps = 1000
+reset_noise_scale = 0.05               # Was omitted, so SB3 silently fell back to the class default 0.01
+                                       # while [jax] used 0.05. Stage 1 raised it deliberately; stages 2-3
+                                       # inherited a 5x narrower reset distribution by accident.
 
 [ppo]
 learning_rate = 5e-5

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -184,6 +184,19 @@ Still open:
   torque-to-inertia; slams its limits); contype-0 neck geoms can visually
   clip the floor; no `<light>`/`<visual>` block for nicer renders; brachio
   food has no collision partner.
+- **HIGH** — the brachiosaurus cannot hold its home stance. Under the neutral
+  action (`action = 0`, i.e. the exact home controls) with `reset_noise_scale`
+  set to **zero**, the torso sags 1.21 m → ~1.04 m and the episode terminates
+  `fallen` at step 202 of 1000, against a `healthy_z_range` floor of 1.0 m.
+  With stage-1 noise it falls at ~100 steps, and the zero-action baseline is
+  0% full-horizon at every reset-noise level (110.37 ± 57.86 reward). CI misses
+  it because `NeutralActionStabilityBase.test_survives_100_neutral_action_steps`
+  stops at 100 steps and the full-horizon variant
+  (`test_survives_full_noise_free_episode`) is defined only on the T-Rex
+  subclass. Either the servo-held stand from the July 2026 repair regressed or
+  it never held for a full episode. Fix the sag, add the full-horizon neutral
+  test to the shared base, then re-measure with
+  `environments/shared/scripts/zero_action_baseline.py brachiosaurus`.
 - **LOW** — the T-Rex `tail_1_geom` overlaps both thigh capsules by 18.8 mm at
   the home keyframe, injecting a constant self-contact force into the stance
   (pre-existing; unchanged by the July 2026 plant revision, which measured it

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -176,21 +176,19 @@ Still open:
   knee measures 0 % after its 1.5× bump. Re-measure with
   `environments/shared/scripts/actuator_saturation_report.py` before any
   faster-gait (stage-3 sprint) work and consider 1.5× toes if they bind.
-- **LOW** — the T-Rex exact-home 2.5 Hz diagnostic produces one transient
-  clipping window on `r_toe_d4` (5.4 % over 2,500 steps) after the scripted
-  plant destabilizes; every stance-critical hip/knee/ankle remains at 0 %
-  and bounded-vs-unbounded root-z RMS divergence is 0.5 mm. This is not a
-  Stage-1 balance blocker, but re-measure it against a learned locomotion
-  rollout before promoting Stage 2.
 - **LOW** — scene boilerplate (skybox/grid/floor/option) is copy-pasted
   across the three XMLs → extract a shared `scene.xml` include; limbs are
   hand-mirrored sign-flips → generate via script/PyMJCF or add a left/right
   symmetry test.
 - **LOW** — raptor claw `motor gear="50"` on a 0.05 kg claw (huge
-  torque-to-inertia; slams its limits); trex passive ball-joint arms are
-  8 of 37 DOF doing nothing (weld to cut MJX cost ~20%); contype-0 neck
-  geoms can visually clip the floor; no `<light>`/`<visual>` block for
-  nicer renders; brachio food has no collision partner.
+  torque-to-inertia; slams its limits); contype-0 neck geoms can visually
+  clip the floor; no `<light>`/`<visual>` block for nicer renders; brachio
+  food has no collision partner.
+- **LOW** — the T-Rex `tail_1_geom` overlaps both thigh capsules by 18.8 mm at
+  the home keyframe, injecting a constant self-contact force into the stance
+  (pre-existing; unchanged by the July 2026 plant revision, which measured it
+  rather than fixing it). Either exclude the pair like the sibling toes, or
+  reshape `tail_1` so the overlap is gone; re-measure the home stance after.
 - **Experiment** — with `implicitfast`, a `timestep` 0.002→0.004 A/B is
   worth running (halves sim cost if stable).
 

--- a/environments/shared/data/plant_manifest.generated.json
+++ b/environments/shared/data/plant_manifest.generated.json
@@ -45,30 +45,30 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:074b27d8e93ce05cf8e233d9f4ee6a9ee2c47adb77d988120117af09aee21514",
+      "bundle_sha256": "sha256:7fd2c85f438ff5f5c86c4806440a66252d9b63a777d9d3cabaf215a0c556f176",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
-        "nq": 40,
+        "nq": 28,
         "nu": 21,
-        "nv": 37,
-        "revision": 2,
+        "nv": 27,
+        "revision": 3,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:f2d8c348e46214face9ad525852b47e5d8d329a6bdd84bbf28fef10ccddc81f7"
+        "sha256": "sha256:da0fe5a18713fc143e8f46dcca4539edc4c90eb933fcbedb5bf79986605e43d4"
       },
       "policy_interface": {
         "action_dim": 21,
-        "observation_dim": 83,
+        "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 2,
+        "revision": 3,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:e8e19f929c49b47b323ed3f797beff8e88fe1e7b8ba89bd9de39f4c2be583684"
+        "sha256": "sha256:ee5727900cb1a9494005cc8f2972f8a293e6013700d0d2ed6f8797ab4e14a6f5"
       },
       "source": {
-        "closure_sha256": "sha256:65930d8f0e67d9ec08fa8de8c1ba6b0536359944649eee49c87e8e0d306659cc",
+        "closure_sha256": "sha256:4f0fdc428aa2ee1535dd6a3ba293aaad32ff271b612445293b792a1903a0400c",
         "dependencies": [
           {
-            "content_sha256": "sha256:4a000eeca14161cd8ddd3a3eff16b177724b2abe7c8cfa391614c0acf5b7b015",
+            "content_sha256": "sha256:1ea443f5eed93037abc8a777e88cb27e619a82e2c1a694bb74ceef15b0a7fccb",
             "kind": "mjcf",
             "logical_path": "environments/trex/assets/trex.xml"
           }
@@ -78,9 +78,9 @@
       },
       "species": "trex",
       "visual": {
-        "revision": 2,
+        "revision": 3,
         "schema": "mesozoic.mujoco-visual/v1",
-        "sha256": "sha256:4b9ce49f55e2e007afe3bba363a04541f7ee044988ac815a8662a83a98c55b00"
+        "sha256": "sha256:11418961e75956f4d3c55aaf6a5ad1aa8b9d80efec1e2499a4994679cc19186d"
       }
     },
     "velociraptor": {

--- a/environments/shared/scripts/compare_run_diagnostics.py
+++ b/environments/shared/scripts/compare_run_diagnostics.py
@@ -1,0 +1,246 @@
+"""Compare policy/optimizer diagnostics and eval curves across training runs.
+
+``diagnostics.npz`` already carries SB3's per-update ``train/*`` metrics under
+``algo_*`` keys (policy std, entropy loss, approx KL, clip fraction, explained
+variance), but nothing plots or prints them — every investigation so far has
+hand-parsed the npz. This script turns that into one command, and reports two
+runs side by side so a single-variable config change can be attributed.
+
+The first/last-20% window methodology matches
+``docs/investigations/TREX_STAGE1_LEG_JITTER.md`` so numbers stay comparable
+with that investigation's table.
+
+``action_delta`` is reported as RMS action change per joint per step
+(``sqrt(action_delta / n_actuators)``) because the raw sum scales with the
+actuator count and is not comparable across species. For reference on that
+scale: <0.1 is smooth, 0.3-0.5 is severe jitter, ~1.0 is full-scale thrash.
+
+Usage::
+
+    python environments/shared/scripts/compare_run_diagnostics.py \\
+        pre=/path/to/run_a/stage1 post=/path/to/run_b/stage1
+
+    # labels are optional; the directory name is used when omitted
+    python environments/shared/scripts/compare_run_diagnostics.py run_a/stage1
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Signals worth comparing between two runs, in report order.  Each entry is
+# (npz key, display label, n_actuators-normalized?).
+_ALGO_SIGNALS = (
+    ("algo_std", "policy std (algo_std)", False),
+    ("algo_entropy_loss", "entropy loss", False),
+    ("algo_approx_kl", "approx KL", False),
+    ("algo_clip_fraction", "clip fraction", False),
+    ("algo_explained_variance", "explained variance", False),
+    ("algo_value_loss", "value loss", False),
+)
+
+_ENV_SIGNALS = (
+    ("action_delta", "RMS action change / joint / step", True),
+    ("abs_speed", "body speed (m/s)", False),
+    ("drift_distance", "drift from spawn (m)", False),
+    ("tilt_angle", "tilt (rad)", False),
+    ("pelvis_height", "pelvis height (m)", False),
+)
+
+_WINDOW = 0.20
+
+
+def _finite(arr):
+    arr = np.asarray(arr, dtype=float).reshape(-1)
+    return arr[np.isfinite(arr)]
+
+
+def _window_means(values):
+    """Return (first 20% mean, last 20% mean) of a 1-D series."""
+    vals = _finite(values)
+    if vals.size == 0:
+        return None, None
+    n = max(1, int(round(vals.size * _WINDOW)))
+    return float(vals[:n].mean()), float(vals[-n:].mean())
+
+
+def _n_actuators(stage_dir: Path) -> int | None:
+    """Read the action dimension from the stage's saved plant identity."""
+    for name in ("stage_config.json", "plant_identity.json"):
+        path = stage_dir / name
+        if not path.exists():
+            continue
+        try:
+            blob = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        plant = blob.get("plant_identity", blob)
+        dim = plant.get("action_dim") or plant.get("nu")
+        if dim:
+            return int(dim)
+    return None
+
+
+class Run:
+    """One stage directory's diagnostics + evaluation history."""
+
+    def __init__(self, label: str, stage_dir: Path):
+        self.label = label
+        self.stage_dir = stage_dir
+        diag_path = stage_dir / "diagnostics.npz"
+        if not diag_path.exists():
+            raise SystemExit(f"{diag_path} not found")
+        self.diag = np.load(str(diag_path))
+        self.n_act = _n_actuators(stage_dir)
+        eval_path = stage_dir / "evaluations.npz"
+        self.evals = np.load(str(eval_path)) if eval_path.exists() else None
+
+    def signal(self, key: str, normalize: bool):
+        """Window means for *key*, RMS-per-joint normalized when asked."""
+        if key not in self.diag.files:
+            return None, None
+        first, last = _window_means(self.diag[key])
+        if normalize and first is not None and self.n_act:
+            first = float(np.sqrt(first / self.n_act))
+            last = float(np.sqrt(last / self.n_act))
+        return first, last
+
+    def termination_shares(self) -> dict:
+        """Mean fraction per termination reason over the last 20% of training."""
+        out = {}
+        for key in self.diag.files:
+            if not key.startswith("term_") or key == "term_timesteps":
+                continue
+            _, last = _window_means(self.diag[key])
+            if last:
+                out[key[len("term_") :]] = last
+        return out
+
+    def eval_curve(self):
+        """Return (timesteps, per-eval mean reward, per-eval mean length)."""
+        if self.evals is None:
+            return None
+        return (
+            np.asarray(self.evals["timesteps"], dtype=float),
+            np.asarray(self.evals["results"], dtype=float).mean(axis=1),
+            np.asarray(self.evals["ep_lengths"], dtype=float).mean(axis=1),
+        )
+
+    def full_horizon_share(self, horizon: int = 1000) -> float | None:
+        """Fraction of episodes in the final evaluation that hit the horizon.
+
+        Mean episode length hides a bimodal fall distribution; this is the
+        signal that actually separates a reliable balance policy from a
+        lucky-average one.
+        """
+        if self.evals is None:
+            return None
+        lengths = np.asarray(self.evals["ep_lengths"], dtype=float)[-1]
+        return float((lengths >= horizon).mean())
+
+
+def _fmt(value, digits=3):
+    return "n/a" if value is None else f"{value:.{digits}f}"
+
+
+def _delta(a, b):
+    if a is None or b is None:
+        return ""
+    diff = b - a
+    return f"{diff:+.3f}"
+
+
+def _report_signals(runs, signals, heading):
+    print(f"\n{heading}")
+    print("-" * 96)
+    header = f"{'signal':34s}"
+    for run in runs:
+        header += f"{run.label + ' first→last':>28s}"
+    if len(runs) == 2:
+        header += f"{'Δ(last)':>12s}"
+    print(header)
+    for key, label, normalize in signals:
+        cells, lasts = [], []
+        for run in runs:
+            first, last = run.signal(key, normalize)
+            lasts.append(last)
+            cells.append("n/a" if first is None else f"{first:.3f} → {last:.3f}")
+        if all(c == "n/a" for c in cells):
+            continue
+        row = f"{label:34s}" + "".join(f"{c:>28s}" for c in cells)
+        if len(runs) == 2:
+            row += f"{_delta(lasts[0], lasts[1]):>12s}"
+        print(row)
+
+
+def _report_eval(runs):
+    print("\nEvaluation history")
+    print("-" * 96)
+    for run in runs:
+        curve = run.eval_curve()
+        if curve is None:
+            print(f"{run.label}: no evaluations.npz")
+            continue
+        ts, rewards, lengths = curve
+        best = int(rewards.argmax())
+        share = run.full_horizon_share()
+        print(f"{run.label}:")
+        print(f"    evaluations           {len(ts)} over {ts[-1]:,.0f} steps")
+        print(f"    best mean reward      {rewards[best]:.1f} at {ts[best]:,.0f} steps")
+        print(f"    final mean reward     {rewards[-1]:.1f}  ({rewards[-1] / rewards[best]:.0%} of peak)")
+        print(f"    final mean ep length  {lengths[-1]:.1f}")
+        if share is not None:
+            print(f"    final eval: {share:.0%} of episodes reached the 1000-step horizon")
+        # Decile trace makes a peak-then-decline shape obvious without a plot.
+        step = max(1, len(rewards) // 10)
+        trace = " ".join(f"{r:.0f}" for r in rewards[::step])
+        print(f"    reward decile trace   {trace}")
+
+
+def _report_terminations(runs):
+    print("\nTermination mix over the last 20% of training")
+    print("-" * 96)
+    reasons = sorted({r for run in runs for r in run.termination_shares()})
+    if not reasons:
+        print("(no termination data recorded)")
+        return
+    shares = [run.termination_shares() for run in runs]
+    header = f"{'reason':34s}" + "".join(f"{run.label:>28s}" for run in runs)
+    print(header)
+    for reason in reasons:
+        row = f"{reason:34s}" + "".join(f"{s.get(reason, 0.0):>27.1%} " for s in shares)
+        print(row)
+
+
+def compare(runs):
+    print("=" * 96)
+    print("Run diagnostics comparison")
+    print("=" * 96)
+    for run in runs:
+        print(f"{run.label:10s} {run.stage_dir}  (action_dim={run.n_act or 'unknown'})")
+    _report_signals(runs, _ALGO_SIGNALS, "Policy / optimizer diagnostics (first 20% → last 20%)")
+    _report_signals(runs, _ENV_SIGNALS, "Rollout behaviour (first 20% → last 20%)")
+    _report_terminations(runs)
+    _report_eval(runs)
+    print()
+
+
+def main(argv):
+    if not argv:
+        raise SystemExit(__doc__)
+    runs = []
+    for arg in argv:
+        label, sep, path = arg.partition("=")
+        if not sep:
+            label, path = Path(arg).name, arg
+        stage_dir = Path(path).expanduser()
+        if not stage_dir.is_dir():
+            raise SystemExit(f"not a directory: {stage_dir}")
+        runs.append(Run(label, stage_dir))
+    compare(runs)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/environments/shared/scripts/zero_action_baseline.py
+++ b/environments/shared/scripts/zero_action_baseline.py
@@ -1,0 +1,166 @@
+"""Score the do-nothing policy on a stage, as the floor every run must clear.
+
+Residual actions are centred on each species' home keyframe, so ``action = 0``
+commands exactly the nominal stance.  On a passively stable plant that is a
+real policy, and on a balance stage it can be a *strong* one: the T-Rex
+stage-1 zero-action score beat both trained policies from the 2026-07-23/24
+runs on reward, on mean-minus-std, and on full-horizon survival.  Six million
+PPO steps produced something worse than ``np.zeros(21)`` and nothing in the
+pipeline noticed, because no run was ever compared against this floor.
+
+Run it before and after any plant or task change: the baseline re-anchors
+automatically, so it stays a valid comparison across model revisions.  A
+trained stage-1 policy that does not beat it on all three of reward,
+mean-minus-std, and full-horizon share has not learned to balance.
+
+It is also how the stage-1 reset noise gets calibrated.  Too little and the
+plant survives on its own, leaving nothing for a policy to earn (T-Rex at
+``reset_noise_scale = 0.05`` scores 93% full-horizon); too much and the task
+stops being learnable.
+
+Usage::
+
+    python environments/shared/scripts/zero_action_baseline.py trex
+    python environments/shared/scripts/zero_action_baseline.py trex:2 velociraptor
+    python environments/shared/scripts/zero_action_baseline.py trex --sweep-noise
+"""
+
+import argparse
+import importlib
+import sys
+import tomllib
+from pathlib import Path
+
+import numpy as np
+
+_repo_root = str(Path(__file__).resolve().parents[3])
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+SPECIES_ENVS = {
+    "trex": ("environments.trex.envs.trex_env", "TRexEnv"),
+    "velociraptor": ("environments.velociraptor.envs.raptor_env", "RaptorEnv"),
+    "brachiosaurus": ("environments.brachiosaurus.envs.brachio_env", "BrachioEnv"),
+}
+
+STAGE_CONFIGS = {
+    1: "stage1_balance",
+    2: "stage2_locomotion",
+    3: {"trex": "stage3_bite", "velociraptor": "stage3_strike", "brachiosaurus": "stage3_food_reach"},
+}
+
+# Keys the TOML [env] block carries for the MJX path only; the Gymnasium envs
+# do not accept them.  Mirrors the JAX-only note in the stage-1 configs.
+JAX_ONLY_ENV_KEYS = frozenset({"foot_contact_weight", "foot_contact_gate"})
+
+NOISE_SWEEP = (0.01, 0.05, 0.10, 0.15, 0.20)
+
+
+def build_env(species: str, stage: int):
+    """Instantiate a species env from its committed stage TOML."""
+    module_name, class_name = SPECIES_ENVS[species]
+    env_class = getattr(importlib.import_module(module_name), class_name)
+    stem = STAGE_CONFIGS[stage]
+    if isinstance(stem, dict):
+        stem = stem[species]
+    config_path = Path(_repo_root) / "configs" / species / f"{stem}.toml"
+    env_section = tomllib.loads(config_path.read_text()).get("env", {})
+    kwargs = {
+        key: (tuple(value) if isinstance(value, list) else value)
+        for key, value in env_section.items()
+        if key not in JAX_ONLY_ENV_KEYS
+    }
+    return env_class(**kwargs)
+
+
+def score(env, episodes: int, seed: int, noise: float | None = None) -> dict:
+    """Roll out the zero action for *episodes* and summarise the outcome."""
+    if noise is not None:
+        env.reset_noise_scale = noise
+    action = np.zeros(env.action_space.shape, dtype=np.float32)
+    rewards: list[float] = []
+    lengths: list[int] = []
+    terminations: dict[str, int] = {}
+
+    for index in range(episodes):
+        env.reset(seed=seed + index)
+        total, steps = 0.0, 0
+        while True:
+            _, reward, terminated, truncated, info = env.step(action)
+            total += float(reward)
+            steps += 1
+            if terminated or truncated:
+                reason = info.get("termination_reason", "truncated")
+                terminations[reason] = terminations.get(reason, 0) + 1
+                break
+        rewards.append(total)
+        lengths.append(steps)
+
+    rewards_arr = np.asarray(rewards)
+    lengths_arr = np.asarray(lengths)
+    horizon = env.max_episode_steps
+    return {
+        "reward_mean": float(rewards_arr.mean()),
+        "reward_std": float(rewards_arr.std()),
+        # The gate a trained policy must clear: a fat failure tail shows up here
+        # while it hides in the mean.
+        "reward_mean_minus_std": float(rewards_arr.mean() - rewards_arr.std()),
+        "length_mean": float(lengths_arr.mean()),
+        "full_horizon_share": float((lengths_arr >= horizon).mean()),
+        "terminations": terminations,
+        "horizon": horizon,
+    }
+
+
+def report(species: str, stage: int, episodes: int, seed: int, sweep: bool) -> None:
+    env = build_env(species, stage)
+    try:
+        label = f"{species} stage {stage}"
+        if sweep:
+            print(f"\n{label}: zero-action baseline vs reset_noise_scale ({episodes} episodes)")
+            print(f"  {'noise':>7}{'reward':>12}{'mean-std':>11}{'ep length':>11}{'full-horizon':>14}")
+            for noise in NOISE_SWEEP:
+                result = score(env, episodes, seed, noise=noise)
+                print(
+                    f"  {noise:>7}{result['reward_mean']:>12.1f}{result['reward_mean_minus_std']:>11.1f}"
+                    f"{result['length_mean']:>11.1f}{result['full_horizon_share']:>13.0%}"
+                )
+            return
+
+        result = score(env, episodes, seed)
+        print(f"\n{label}: zero-action baseline ({episodes} episodes, reset_noise={env.reset_noise_scale})")
+        print(f"  reward             {result['reward_mean']:.2f} +/- {result['reward_std']:.2f}")
+        print(f"  reward mean-std    {result['reward_mean_minus_std']:.2f}")
+        print(f"  episode length     {result['length_mean']:.1f} of {result['horizon']}")
+        print(f"  full-horizon share {result['full_horizon_share']:.0%}")
+        print(f"  terminations       {result['terminations']}")
+        print("  a trained policy must beat all three of reward, mean-std, and full-horizon share")
+    finally:
+        env.close()
+
+
+def main(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "targets",
+        nargs="*",
+        default=["trex", "velociraptor", "brachiosaurus"],
+        help="species, optionally with a stage suffix (e.g. trex:2). Default: all species, stage 1.",
+    )
+    parser.add_argument("--episodes", type=int, default=30, help="episodes per measurement (default 30)")
+    parser.add_argument("--seed", type=int, default=3042, help="first evaluation seed (default 3042)")
+    parser.add_argument("--sweep-noise", action="store_true", help="sweep reset_noise_scale instead of one point")
+    args = parser.parse_args(argv)
+
+    for target in args.targets:
+        species, _, stage_text = target.partition(":")
+        if species not in SPECIES_ENVS:
+            raise SystemExit(f"unknown species {species!r}; choose from {sorted(SPECIES_ENVS)}")
+        stage = int(stage_text) if stage_text else 1
+        if stage not in STAGE_CONFIGS:
+            raise SystemExit(f"unknown stage {stage}; choose from {sorted(STAGE_CONFIGS)}")
+        report(species, stage, args.episodes, args.seed, args.sweep_noise)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/environments/shared/tests/test_mjcf_assets.py
+++ b/environments/shared/tests/test_mjcf_assets.py
@@ -22,7 +22,7 @@ ENVIRONMENTS_DIR = Path(__file__).resolve().parents[2]
 
 EXPECTED_MODELS = {
     "brachiosaurus/assets/brachiosaurus.xml": ModelExpectations(38, 37, 30, 175.3),
-    "trex/assets/trex.xml": ModelExpectations(40, 37, 21, 85.44),
+    "trex/assets/trex.xml": ModelExpectations(28, 27, 21, 85.72),
     "velociraptor/assets/raptor.xml": ModelExpectations(31, 30, 22, 13.5),
 }
 

--- a/environments/shared/tests/test_plant_contract.py
+++ b/environments/shared/tests/test_plant_contract.py
@@ -149,7 +149,7 @@ def test_runtime_identity_falls_back_to_bundled_manifest(monkeypatch, tmp_path):
 
 @pytest.mark.parametrize(
     ("species", "observation_dim", "action_dim"),
-    [("velociraptor", 67, 22), ("trex", 83, 21), ("brachiosaurus", 83, 30)],
+    [("velociraptor", 67, 22), ("trex", 61, 21), ("brachiosaurus", 83, 30)],
 )
 def test_current_identity_matches_each_executable_environment(species, observation_dim, action_dim):
     # Identity generation requires exact SB3/MJX observation parity.

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -41,7 +41,7 @@ def test_catalog_derives_current_model_and_stage_facts() -> None:
         for species_id, entry in species.items()
     } == {
         "velociraptor": (67, 22, 31, 30, 22, 13.5),
-        "trex": (83, 21, 40, 37, 21, 85.44),
+        "trex": (61, 21, 28, 27, 21, 85.72),
         "brachiosaurus": (83, 30, 38, 37, 30, 175.3),
     }
 
@@ -68,9 +68,9 @@ def test_catalog_publishes_layered_plant_contract() -> None:
         "trex": "bipedal-target/v1",
         "brachiosaurus": "quadrupedal-target/v1",
     }
-    expected_policy_revisions = {"velociraptor": 3, "trex": 2, "brachiosaurus": 1}
-    expected_physics_revisions = {"velociraptor": 2, "trex": 2, "brachiosaurus": 1}
-    expected_visual_revisions = {"velociraptor": 3, "trex": 2, "brachiosaurus": 1}
+    expected_policy_revisions = {"velociraptor": 3, "trex": 3, "brachiosaurus": 1}
+    expected_physics_revisions = {"velociraptor": 2, "trex": 3, "brachiosaurus": 1}
+    expected_visual_revisions = {"velociraptor": 3, "trex": 3, "brachiosaurus": 1}
     digest_pattern = re.compile(r"sha256:[0-9a-f]{64}")
     for species in catalog["species"]:
         plant = species["model"]["plant_contract"]

--- a/environments/shared/tests/test_species_integration.py
+++ b/environments/shared/tests/test_species_integration.py
@@ -28,7 +28,7 @@ SPECIES_ENVS = [
 # Expected observation and action dimensions per species
 SPECIES_DIMS = {
     "velociraptor": {"obs": 67, "act": 22},
-    "trex": {"obs": 83, "act": 21},
+    "trex": {"obs": 61, "act": 21},
     "brachiosaurus": {"obs": 83, "act": 30},
 }
 

--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -56,21 +56,25 @@
       +Y = left
       +Z = up
 
-    Approximate dimensions (scaled for simulation):
+    Approximate dimensions (scaled for simulation, measured from the home keyframe):
       Body length: 1.2m (torso)
-      Hip height: 1.1m (in neutral stance)
+      Hip height: 0.93m (pelvis body at 0.9775m)
       Skull length: 0.5m
       Tail length: 1.5m
-      Total height at hip: ~1.1m
-      Total mass: ~80kg (scaled)
+      Total mass: 85.7kg (scaled)
 
     T-Rex anatomy:
-      - Massive skull (~60% of body force)
-      - Tiny vestigial forelimbs (2 fingers)
-      - Powerful digitigrade hind legs
-      - Heavy muscular tail as counterbalance to skull
-      - Forward-leaning posture (~45 deg torso angle)
-      - Body pivots at hips, skull and tail balance each other
+      - Large skull; head + neck are ~16% of body mass
+      - Tiny vestigial forelimbs (2 fingers), welded — see the forelimb block
+      - Powerful digitigrade hind legs; all three digits bear load
+      - Heavy muscular tail as counterbalance to skull (~18% of mass)
+      - Vertebral column held roughly horizontal: the PELVIS FRAME IS LEVEL at
+        the home keyframe, and settles ~2.9 deg nose-down under the home
+        controller.  Only the torso capsule slopes (~10 deg).  Reward code
+        reads the pelvis frame, so natural_pitch tracks that 2.9 deg, not the
+        capsule slope.
+      - Body pivots at hips, skull and tail balance each other: the CoM sits
+        3mm behind the foot-contact centroid at home
     -->
 
     <body name="pelvis" pos="0 0 0.9795">
@@ -146,13 +150,14 @@
             <geom name="tail_3_geom" type="capsule" fromto="0 0 0  -0.3 0 0" size="0.08"
                   mass="3.0" material="body_mat"/>
 
+            <!-- Distal tail (segments 4-5): fused.  Ossified tendons stiffen the
+                 distal caudal series, so these carry their counterbalance mass
+                 as one rigid segment instead of articulating. -->
             <body name="tail_4" pos="-0.3 0 0">
-              <joint name="tail_4_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
               <geom name="tail_4_geom" type="capsule" fromto="0 0 0  -0.25 0 0.01" size="0.06"
                     mass="1.5" material="body_mat"/>
 
               <body name="tail_5" pos="-0.25 0 0.01">
-                <joint name="tail_5_pitch" class="tail_joint" type="hinge" axis="0 1 0"/>
                 <geom name="tail_5_geom" type="capsule" fromto="0 0 0  -0.2 0 0.02" size="0.035"
                       mass="0.6" material="body_mat"/>
                 <site name="tail_tip" pos="-0.2 0 0.02" size="0.015"/>
@@ -191,38 +196,38 @@
             <!-- Thin plantar pad: gives the three digits one load-bearing
                  fore-aft surface instead of balancing on the rear
                  metatarsus endpoint. -->
-            <geom name="r_plantar_geom" type="box" pos="0.14 0 -0.22"
+            <geom name="r_plantar_geom" type="box" pos="0.14 0 -0.218"
                   size="0.07 0.045 0.01" mass="0.02" material="claw_mat"/>
             <!-- Touch volume belongs to the same metatarsus body as the
                  load-bearing plantar pad. It encloses the entire pad and its
                  floor contacts; group 4 keeps the diagnostic volume hidden
                  in default renders. -->
-            <site name="r_foot" type="box" pos="0.14 0 -0.22"
-                  size="0.075 0.05 0.015" group="4"/>
+            <site name="r_foot" type="box" pos="0.16 0 -0.218"
+                  size="0.15 0.07 0.02" group="4"/>
 
             <!-- Toes: 3 separate forward-facing digits (anatomically correct) -->
             <!-- Digit 2 (medial, shortest) -->
-            <body name="r_toe_d2" pos="0.08 0.025 -0.2">
+            <body name="r_toe_d2" pos="0.08 0.025 -0.203">
               <joint name="r_toe_d2_joint" class="leg_joint" type="hinge" axis="0 1 0"
                      range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
-              <geom name="r_toe_d2_geom" type="capsule" fromto="0 0 0  0.08 0.015 0" size="0.025"
-                    mass="0.12" material="claw_mat"/>
+              <geom name="r_toe_d2_geom" type="capsule" fromto="0 0 0  0.13 0.02 0" size="0.025"
+                    mass="0.16" material="claw_mat"/>
             </body>
 
             <!-- Digit 3 (central, longest — primary weight-bearing) -->
             <body name="r_toe_d3" pos="0.08 0 -0.2">
               <joint name="r_toe_d3_joint" class="leg_joint" type="hinge" axis="0 1 0"
                      range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
-              <geom name="r_toe_d3_geom" type="capsule" fromto="0 0 0  0.12 0 0" size="0.028"
-                    mass="0.16" material="claw_mat"/>
+              <geom name="r_toe_d3_geom" type="capsule" fromto="0 0 0  0.19 0 0" size="0.028"
+                    mass="0.22" material="claw_mat"/>
             </body>
 
             <!-- Digit 4 (lateral, medium) -->
-            <body name="r_toe_d4" pos="0.08 -0.025 -0.2">
+            <body name="r_toe_d4" pos="0.08 -0.025 -0.203">
               <joint name="r_toe_d4_joint" class="leg_joint" type="hinge" axis="0 1 0"
                      range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
-              <geom name="r_toe_d4_geom" type="capsule" fromto="0 0 0  0.09 -0.015 0" size="0.025"
-                    mass="0.12" material="claw_mat"/>
+              <geom name="r_toe_d4_geom" type="capsule" fromto="0 0 0  0.15 -0.02 0" size="0.025"
+                    mass="0.16" material="claw_mat"/>
             </body>
           </body>
         </body>
@@ -249,49 +254,49 @@
                    range="50 150" ref="94.5" springref="94.5"/>
             <geom name="l_metatarsus_geom" type="capsule" fromto="0 0 0  0.08 0 -0.2" size="0.025"
                   mass="1.2" material="body_mat"/>
-            <geom name="l_plantar_geom" type="box" pos="0.14 0 -0.22"
+            <geom name="l_plantar_geom" type="box" pos="0.14 0 -0.218"
                   size="0.07 0.045 0.01" mass="0.02" material="claw_mat"/>
-            <site name="l_foot" type="box" pos="0.14 0 -0.22"
-                  size="0.075 0.05 0.015" group="4"/>
+            <site name="l_foot" type="box" pos="0.16 0 -0.218"
+                  size="0.15 0.07 0.02" group="4"/>
 
             <!-- Toes: 3 separate forward-facing digits (anatomically correct) -->
             <!-- Digit 2 (medial, shortest) -->
-            <body name="l_toe_d2" pos="0.08 -0.025 -0.2">
+            <body name="l_toe_d2" pos="0.08 -0.025 -0.203">
               <joint name="l_toe_d2_joint" class="leg_joint" type="hinge" axis="0 1 0"
                      range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
-              <geom name="l_toe_d2_geom" type="capsule" fromto="0 0 0  0.08 -0.015 0" size="0.025"
-                    mass="0.12" material="claw_mat"/>
+              <geom name="l_toe_d2_geom" type="capsule" fromto="0 0 0  0.13 -0.02 0" size="0.025"
+                    mass="0.16" material="claw_mat"/>
             </body>
 
             <!-- Digit 3 (central, longest — primary weight-bearing) -->
             <body name="l_toe_d3" pos="0.08 0 -0.2">
               <joint name="l_toe_d3_joint" class="leg_joint" type="hinge" axis="0 1 0"
                      range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
-              <geom name="l_toe_d3_geom" type="capsule" fromto="0 0 0  0.12 0 0" size="0.028"
-                    mass="0.16" material="claw_mat"/>
+              <geom name="l_toe_d3_geom" type="capsule" fromto="0 0 0  0.19 0 0" size="0.028"
+                    mass="0.22" material="claw_mat"/>
             </body>
 
             <!-- Digit 4 (lateral, medium) -->
-            <body name="l_toe_d4" pos="0.08 0.025 -0.2">
+            <body name="l_toe_d4" pos="0.08 0.025 -0.203">
               <joint name="l_toe_d4_joint" class="leg_joint" type="hinge" axis="0 1 0"
                      range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
-              <geom name="l_toe_d4_geom" type="capsule" fromto="0 0 0  0.09 0.015 0" size="0.025"
-                    mass="0.12" material="claw_mat"/>
+              <geom name="l_toe_d4_geom" type="capsule" fromto="0 0 0  0.15 0.02 0" size="0.025"
+                    mass="0.16" material="claw_mat"/>
             </body>
           </body>
         </body>
       </body>
 
       <!-- ==================== FORELIMBS (vestigial) ==================== -->
-      <!-- T-Rex arms: tiny, 2 fingers, very limited range -->
-      <!-- Not actuated - purely cosmetic/passive -->
+      <!-- T-Rex arms: tiny, 2 fingers, very limited range.  Welded to the
+           torso: forelimb excursion is negligible in life, and the chain drove
+           no actuator, no reward term and no ground contact while costing 18 of
+           the 83 observation dimensions. -->
 
       <body name="r_arm" pos="0.45 -0.1 -0.02">
-        <joint name="r_shoulder" type="ball" damping="3.0" range="0 30"/>
         <geom name="r_upper_arm_geom" type="capsule" fromto="0 0 0  0.04 -0.02 -0.08" size="0.025"
               mass="0.3" material="body_mat"/>
         <body name="r_forearm" pos="0.04 -0.02 -0.08">
-          <joint name="r_elbow" type="hinge" axis="0 1 0" range="-40 10" damping="2.0"/>
           <geom name="r_forearm_geom" type="capsule" fromto="0 0 0  0.02 0 -0.05" size="0.018"
                 mass="0.1" material="body_mat"/>
           <!-- Two-fingered hand -->
@@ -301,11 +306,9 @@
       </body>
 
       <body name="l_arm" pos="0.45 0.1 -0.02">
-        <joint name="l_shoulder" type="ball" damping="3.0" range="0 30"/>
         <geom name="l_upper_arm_geom" type="capsule" fromto="0 0 0  0.04 0.02 -0.08" size="0.025"
               mass="0.3" material="body_mat"/>
         <body name="l_forearm" pos="0.04 0.02 -0.08">
-          <joint name="l_elbow" type="hinge" axis="0 1 0" range="-40 10" damping="2.0"/>
           <geom name="l_forearm_geom" type="capsule" fromto="0 0 0  0.02 0 -0.05" size="0.018"
                 mass="0.1" material="body_mat"/>
           <geom name="l_hand" type="sphere" pos="0.02 0 -0.06" size="0.02"
@@ -422,11 +425,10 @@
 
   <keyframe>
     <key name="home"
-         qpos="0 0 0.9795 1 0 0 0
-               0 0 0 0 0 0 0 0 0
+         qpos="0 0 0.9775 1 0 0 0
+               0 0 0 0 0 0 0
                0.261799 0 -1.047198 1.649336 0.218166 0.218166 0.218166
-               0.261799 0 -1.047198 1.649336 0.218166 0.218166 0.218166
-               1 0 0 0 0 1 0 0 0 0"
+               0.261799 0 -1.047198 1.649336 0.218166 0.218166 0.218166"
          ctrl="0 0 0
                0.2618 0 -1.0472 1.74535 0.2182 0.2182 0.2182
                0.2618 0 -1.0472 1.74535 0.2182 0.2182 0.2182

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -6,8 +6,8 @@ The Stage 3 task uses contact between a fixed head geom and prey as a
 "bite" proxy; the model has no articulated jaw.
 
 Observation space (total dimension is generated in the public species catalog):
-    - Joint positions (qpos[7:]) — 33 (25 hinge + 2x4 ball shoulders)
-    - Joint velocities (qvel[6:]) — 31 (25 hinge + 2x3 ball shoulders)
+    - Joint positions (qpos[7:]) — 21 (21 hinge)
+    - Joint velocities (qvel[6:]) — 21 (21 hinge)
     - Pelvis orientation (quaternion) — 4
     - Pelvis angular velocity (gyroscope) — 3
     - Pelvis linear velocity — 3
@@ -81,7 +81,7 @@ class TRexEnv(BaseDinoEnv):
         bite_head_proximity_weight: float = 0.0,
         posture_weight: float = 0.2,
         nosedive_weight: float = 0.0,
-        natural_pitch: float = 0.17,
+        natural_pitch: float = 0.05,
         height_weight: float = 0.0,
         gait_symmetry_weight: float = 0.0,
         smoothness_weight: float = 0.05,
@@ -97,7 +97,7 @@ class TRexEnv(BaseDinoEnv):
         forward_vel_max: float = 8.0,
         foot_contact_weight: float = 0.0,
         foot_contact_gate: float = 0.0,
-        nosedive_termination_threshold: float = 0.5,
+        nosedive_termination_threshold: float = 0.62,
         # Environment settings
         prey_distance_range: tuple[float, float] = (3.0, 8.0),
         prey_lateral_range: tuple[float, float] = (-2.0, 2.0),
@@ -130,9 +130,15 @@ class TRexEnv(BaseDinoEnv):
         self.foot_contact_gate = foot_contact_gate
         self.nosedive_termination_threshold = nosedive_termination_threshold
 
-        # Natural forward pitch (~10°). The nosedive penalty and termination
-        # are measured relative to this angle so the T-Rex isn't punished for
-        # its biomechanically correct forward lean.
+        # Natural forward pitch (~2.9°), measured: the pelvis frame at the home
+        # keyframe is level, and under the home controller the plant settles at
+        # forward_z ≈ -0.050.  The nosedive penalty and termination are measured
+        # relative to that neutral pose.  The former 0.17 rad (9.7°) described
+        # the torso capsule's built-in slope, not the pelvis frame the reward
+        # actually reads, so it granted ~7 deg of unpenalized nose-down pitch.
+        # Unlike the raptor, the T-Rex posture reward stays centred on world
+        # vertical (see _get_reward_info); the MJX path matches by leaving
+        # posture_target_forward_z unset for this species.
         self._natural_forward_z = -np.sin(natural_pitch)
 
         # T-Rex-specific env settings

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -347,33 +347,33 @@
       ],
       "environment": {
         "entrypoint": "environments.trex.envs.trex_env:TRexEnv",
-        "observation_dim": 83,
+        "observation_dim": 61,
         "action_dim": 21
       },
       "model": {
         "path": "environments/trex/assets/trex.xml",
-        "nq": 40,
-        "nv": 37,
+        "nq": 28,
+        "nv": 27,
         "nu": 21,
-        "dynamic_mass_kg": 85.44,
+        "dynamic_mass_kg": 85.72,
         "plant_contract": {
-          "bundle_sha256": "sha256:074b27d8e93ce05cf8e233d9f4ee6a9ee2c47adb77d988120117af09aee21514",
-          "source_closure_sha256": "sha256:65930d8f0e67d9ec08fa8de8c1ba6b0536359944649eee49c87e8e0d306659cc",
+          "bundle_sha256": "sha256:7fd2c85f438ff5f5c86c4806440a66252d9b63a777d9d3cabaf215a0c556f176",
+          "source_closure_sha256": "sha256:4f0fdc428aa2ee1535dd6a3ba293aaad32ff271b612445293b792a1903a0400c",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 2,
+            "revision": 3,
             "observation_schema": "bipedal-target/v1",
-            "sha256": "sha256:e8e19f929c49b47b323ed3f797beff8e88fe1e7b8ba89bd9de39f4c2be583684"
+            "sha256": "sha256:ee5727900cb1a9494005cc8f2972f8a293e6013700d0d2ed6f8797ab4e14a6f5"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",
-            "revision": 2,
-            "sha256": "sha256:f2d8c348e46214face9ad525852b47e5d8d329a6bdd84bbf28fef10ccddc81f7"
+            "revision": 3,
+            "sha256": "sha256:da0fe5a18713fc143e8f46dcca4539edc4c90eb933fcbedb5bf79986605e43d4"
           },
           "visual": {
             "schema": "mesozoic.mujoco-visual/v1",
-            "revision": 2,
-            "sha256": "sha256:4b9ce49f55e2e007afe3bba363a04541f7ee044988ac815a8662a83a98c55b00"
+            "revision": 3,
+            "sha256": "sha256:11418961e75956f4d3c55aaf6a5ad1aa8b9d80efec1e2499a4994679cc19186d"
           }
         }
       },


### PR DESCRIPTION
## Why

While reviewing the T-Rex stage-1 runs I ran the control nobody had run: what does `action = np.zeros(21)` score? Residual actions are centred on the home keyframe, so on a passively stable plant the zero vector is a real policy.

| T-Rex stage-1 policy (30 eps, `reset_noise_scale = 0.05`) | reward | ep length | full-horizon | mean − std |
|---|---|---|---|---|
| **`action = zeros(21)`** | **2754.72 ± 481.10** | **970.2** | **97%** | **2273.6** |
| pre-fix trained (`robust_best`, `20260723_204941`) | 2376.41 ± 455.83 | 960.9 | 87% | 1920.6 |
| post-fix trained (`robust_best`, `20260724_140441`) | 1952.24 ± 727.23 | 793.2 | 47% | 1225.0 |

Doing nothing beat both trained policies on every axis. 6M PPO steps and 3h34m of L4 time produced something worse than the zero vector, and nothing in the pipeline noticed — because no run was ever compared against that floor.

That is a task problem, not only a tuning problem. Chasing it surfaced four measured defects in the plant as well.

## What changed

### 1. Plant revision (`98caef4`) — revisions bumped 2/2/2 → 3/3/3

| | before | after |
|---|---|---|
| **digit–floor contact** (12k steps, perturbed standing) | **4.0%** | **71.1%** *(raptor: 76.4%)* |
| fore-aft support | 0.140 m | **0.200 m** |
| support ÷ CoM height | 0.150 | **0.215** *(raptor: 0.203)* |
| `nq` / `nv` / `nu` | 40 / 37 / 21 | **28 / 27 / 21** |
| observation dim | 83 | **61** |
| mass | 85.44 kg | 85.72 kg |
| actuator clipping at gait | `r_toe_d4` **5.4%** | **0.0% everywhere** |
| bounded-vs-unbounded root-z RMS | 0.5 mm | **0.0 mm** |
| nosedive termination cut | `forward_z < −0.5192` | `−0.5200` *(preserved)* |

- **The digits never touched the ground.** The plantar box protruded 2–5 mm below all three digit capsules, so on a flat floor it captured every contact. Tyrannosaurid trackways show three toe impressions, so the model was wrong in the *opposite* direction from "too many digits". Digits now lengthen past the pad and sit coplanar with it.
- **Vestigial forelimbs welded** — 8 DOF and 0.9 kg (1% of mass) driving no actuator, no reward term and no ground contact, while costing 18 of the 83 observation dimensions.
- **Distal tail fused** — ossified tendons stiffen the distal caudal series; `tail_4`/`tail_5` keep their counterbalance mass as one rigid segment.
- **`natural_pitch` 0.17 → 0.05.** The pelvis frame is level at the home keyframe and settles 2.9° nose-down; 0.17 rad (9.7°) described the *torso capsule's* slope, not the frame the reward reads, so it granted ~7° of unpenalized nose-down pitch. Termination thresholds absorb the shift so the absolute cut is unchanged — only the penalty reference moves, deliberately.

> **Worth knowing:** the first foot design tipped the model over. Shrinking the pad into a true metatarsal pad put the rigid load path 3.5 cm *behind* the CoM; the nose-down moment fed forward through the compliant digit hinges and the plant fell on its face by step 1000 under its own home controller (pelvis 0.98 → 0.55 m). The pad is the rigid support and belongs under the CoM; the digits are compliant and can only *add* forward margin.

### 2. Stage-1 noise calibration (`d6f44c1`)

New `zero_action_baseline.py` scores the do-nothing floor for any species/stage and sweeps reset noise. It recomputes per plant and per task, so it re-anchors automatically — which is what makes a batched plant change safe to evaluate.

```
reset_noise      0.05   0.10   0.15   0.20     (% full-horizon, zero action)
trex              93%    67%    23%    10%
velociraptor      97%    80%    60%    37%
brachiosaurus      0%     0%     0%     0%
```

T-Rex stage 1 → **0.10**. The other two are left alone on purpose (see open questions).

**Separately:** stages 2 and 3 omitted `reset_noise_scale` from `[env]` for **all three species**, so SB3 silently used the class default `0.01` while `[jax]` used `0.05` — an unintended divergence and a 5× narrower reset distribution than stage 1. All six now set `0.05` explicitly.

### 3. `compare_run_diagnostics.py` (`2c28bc3`)

`diagnostics.npz` already stores SB3's `train/*` metrics (policy std, entropy loss, approx KL, clip fraction, explained variance) but nothing plotted or printed them — every investigation so far hand-parsed the npz. This reports two runs side by side with the same first/last-20% windowing the leg-jitter investigation used, plus termination mix and the eval curve.

## Testing

`1543 passed, 94 skipped, 0 failed` across all four CI targets, plus `plant_contract --check` and `species_catalog --check` clean. Manifests, species catalog, README and pinned dimension expectations regenerated.

## Deliberately not included

- **The digit merge / shared-flexor tendon.** A control-space choice, not an anatomy fix, and it can't be evaluated until the digits bear load. My original justification for it (the arctometatarsus couples the phalanges) was wrong — that describes the metatarsals.
- **All RL tuning** (`ent_coef`, `n_epochs`, γ). Those are hypotheses about learning and need one variable per run; that's the lesson from the entropy-anchor run this PR grew out of.

## Open questions for review

1. **Raptor stage-1 noise.** It would need ~0.15 to sit in the T-Rex's difficulty band. Its `1000.0 ± 0.0` today is partly an artifact of a too-easy task — but raising it changes a config whose full curriculum works end to end. Your call.
2. **Expect raptor stage-2 error bars to widen** from the current `± 7.55` once the reset-noise fix lands. That's the honest number appearing, not a regression — worth agreeing in advance so nobody reverts it.
3. **New HIGH in `KNOWN_ISSUES.md`:** the brachiosaurus cannot hold its home stance — under the neutral action at **zero** reset noise the torso sags 1.21 m → ~1.04 m and terminates `fallen` at step 202, against a 1.0 m floor. CI misses it because the shared neutral-action test stops at 100 steps and the full-horizon variant exists only on the T-Rex subclass. Not fixed here.
4. Also newly logged: `tail_1_geom` overlaps both T-Rex thigh capsules by 18.8 mm at home (pre-existing, unchanged here — measured, not fixed).

## Note for whoever merges

This invalidates every T-Rex checkpoint and the published `results/trex/ppo` numbers by plant contract. That's expected and is the reason the model changes are batched. Next step is one stage-1 run whose success criterion is beating the recomputed zero-action baseline (**1981.21 reward / 773.16 mean−std / 67% full-horizon**) on all three measures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B21RRtVwJtZfdT3eMhBUXy)_