### PR TITLE
Fix the T-Rex foot sensors, pitch reference, and SB3/MJX envelope divergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Swift Bipedal Predator. **Specialty:** Sickle-claw contact attacks.
 | Action dimension / actuators | 22 |
 | Generalized coordinates / velocities | nq=31, nv=30 |
 | Compiled dynamic model mass | 13.5 kg |
-| Plant contract revisions | policy r5; physics r2; visual r3 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r6; physics r2; visual r3 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/velociraptor/assets/raptor.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
@@ -108,7 +108,7 @@ Apex Predator. **Specialty:** Head-contact attack task.
 | Action dimension / actuators | 21 |
 | Generalized coordinates / velocities | nq=28, nv=27 |
 | Compiled dynamic model mass | 85.7 kg |
-| Plant contract revisions | policy r5; physics r3; visual r3 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r6; physics r4; visual r4 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/trex/assets/trex.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
@@ -133,7 +133,7 @@ Gentle Giant Herbivore. **Specialty:** Head-to-food reaching.
 | Action dimension / actuators | 30 |
 | Generalized coordinates / velocities | nq=38, nv=37 |
 | Compiled dynamic model mass | 175.3 kg |
-| Plant contract revisions | policy r2; physics r1; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r3; physics r1; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/brachiosaurus/assets/brachiosaurus.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
@@ -157,7 +157,7 @@ Gracile Erect-Limbed Crocodylomorph. **Specialty:** Snout-contact snap task.
 | Action dimension / actuators | 27 |
 | Generalized coordinates / velocities | nq=35, nv=34 |
 | Compiled dynamic model mass | 8.7 kg |
-| Plant contract revisions | policy r2; physics r1; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r3; physics r1; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/dibothrosuchus/assets/dibothrosuchus.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |

--- a/configs/plant_manifest.generated.json
+++ b/configs/plant_manifest.generated.json
@@ -6,7 +6,7 @@
   },
   "plants": {
     "brachiosaurus": {
-      "bundle_sha256": "sha256:612755a3515428460fa9eb7b0762b385403ab3c6a8c682fde741e4d9f0e5757a",
+      "bundle_sha256": "sha256:243c8a158b88d5199cd0ea05dca518acfd99cf738d7651775eab457ffd5eed13",
       "env_entrypoint": "environments.brachiosaurus.envs.brachio_env:BrachioEnv",
       "model_path": "environments/brachiosaurus/assets/brachiosaurus.xml",
       "physics": {
@@ -21,9 +21,9 @@
         "action_dim": 30,
         "observation_dim": 83,
         "observation_schema": "quadrupedal-target/v1",
-        "revision": 2,
+        "revision": 3,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:4065e79ba595e617201ddc695e4e8fd9d4554c322642ec9523dc2a121726b5ed"
+        "sha256": "sha256:f192ccd9f533fb757aa530b8bda89f9c129f4dc3d4ae34103464d97fdbbf55ec"
       },
       "source": {
         "closure_sha256": "sha256:586e8c38684b4132c63872662333b37a2471b7740a6bc265def721f86fad1a5b",
@@ -45,7 +45,7 @@
       }
     },
     "dibothrosuchus": {
-      "bundle_sha256": "sha256:b0ac834677699f4fd2451340b1d9584f1844d04a5e5e39141aadcad708a50821",
+      "bundle_sha256": "sha256:a1cd823c627c5b243eb58757c487c68410ffae491442927cd012fb55fa008495",
       "env_entrypoint": "environments.dibothrosuchus.envs.dibothrosuchus_env:DibothrosuchusEnv",
       "model_path": "environments/dibothrosuchus/assets/dibothrosuchus.xml",
       "physics": {
@@ -60,9 +60,9 @@
         "action_dim": 27,
         "observation_dim": 77,
         "observation_schema": "quadrupedal-target/v1",
-        "revision": 2,
+        "revision": 3,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:193e3e4537f259af014cde06c27c46e6e4dca456015b872a1b6df1665e819ee1"
+        "sha256": "sha256:ebaa8846cfe572e69fb0dde92c3724d83717fd078e2f8935809f7599b77ff2d3"
       },
       "source": {
         "closure_sha256": "sha256:5532fad56a1613020f09bfa197f14f0916306e664d5cf18609b757d3c5948bc3",
@@ -84,30 +84,30 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:11a79cd6a1dd41037b10735297d0a642dd762b11f72bc6837f9ad370a5237f3d",
+      "bundle_sha256": "sha256:a626ed80300c0575e283661ab4df0ef94c7daf7b20449acefaf7f5957380cf52",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
         "nq": 28,
         "nu": 21,
         "nv": 27,
-        "revision": 3,
+        "revision": 4,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:da0fe5a18713fc143e8f46dcca4539edc4c90eb933fcbedb5bf79986605e43d4"
+        "sha256": "sha256:0c194766307bee3a7c9c555a841687f85e851fa443b57f151d26b4ee472a38cf"
       },
       "policy_interface": {
         "action_dim": 21,
         "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 5,
+        "revision": 6,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:e6dd172814433dc00a7390c0e47c5f1532cfc47073439ed26f09483c15969e1f"
+        "sha256": "sha256:db76ea6cb0b9a08d576fe324ec7ad169d15ba24c61daa3f1822259168821f9f2"
       },
       "source": {
-        "closure_sha256": "sha256:4f0fdc428aa2ee1535dd6a3ba293aaad32ff271b612445293b792a1903a0400c",
+        "closure_sha256": "sha256:f499af17638e3c91a24b470c711e9c47ebc94f3576bf321c2cd56a50e12cfa01",
         "dependencies": [
           {
-            "content_sha256": "sha256:1ea443f5eed93037abc8a777e88cb27e619a82e2c1a694bb74ceef15b0a7fccb",
+            "content_sha256": "sha256:aef603402e5a26ccfbb21540954443672cc285ee0def1ffd0103d98ad99d8242",
             "kind": "mjcf",
             "logical_path": "environments/trex/assets/trex.xml"
           }
@@ -117,13 +117,13 @@
       },
       "species": "trex",
       "visual": {
-        "revision": 3,
+        "revision": 4,
         "schema": "mesozoic.mujoco-visual/v1",
-        "sha256": "sha256:11418961e75956f4d3c55aaf6a5ad1aa8b9d80efec1e2499a4994679cc19186d"
+        "sha256": "sha256:7042dcd597fbd0ce25489164a7f132d51e1c2adbc050729c9866d7bde42e35a4"
       }
     },
     "velociraptor": {
-      "bundle_sha256": "sha256:2ed2e9c4ea84956beed41667274723335ef40815bed1e4b21ee57415a81b225a",
+      "bundle_sha256": "sha256:9841757f572a06864478219cae05b25107aa393511c64bb265c2053564394d83",
       "env_entrypoint": "environments.velociraptor.envs.raptor_env:RaptorEnv",
       "model_path": "environments/velociraptor/assets/raptor.xml",
       "physics": {
@@ -138,9 +138,9 @@
         "action_dim": 22,
         "observation_dim": 67,
         "observation_schema": "bipedal-target/v1",
-        "revision": 5,
+        "revision": 6,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:fe3fc35cc6f5f37e976982ad2e302121266e9aaf322cd5d7ae884ae384de5fdb"
+        "sha256": "sha256:cd69b759369f88ad43324a61069dfeb37f4fde5e1c15ba8d042c2b031f76e2eb"
       },
       "source": {
         "closure_sha256": "sha256:ae2ebacf577a7247484e8954fecce421b007246ead904a83ce319babb1efdec5",

--- a/configs/plant_versions.toml
+++ b/configs/plant_versions.toml
@@ -24,27 +24,44 @@ canonical_mujoco_version = "3.10.0"
 #    arithmetic exactly, so velociraptor and trex reset distributions are
 #    unchanged and their existing checkpoints remain valid.  Dibothrosuchus is
 #    the one species whose reset distribution really does change.
+#
+# 3. The T-Rex foot-contact repair.  A MuJoCo touch sensor sums only contacts on
+#    geoms belonging to its site's OWN body, so the metatarsus-mounted r_foot /
+#    l_foot sensors could never see the three digits -- which the preceding
+#    plant revision had just made load-bearing.  At the home keyframe each foot
+#    transmitted 500.4 N while its sensor reported 388.4 N, and under load
+#    transfer the reading could drop to zero on a foot carrying full weight.
+#    Each digit now has its own touch site and sensor, appended after the tail
+#    block so every existing sensor index keeps its position, and both paths sum
+#    pad + digits into one value per foot.  Observation width is unchanged (61
+#    for trex) and the summed reading matches measured floor force exactly.
+#    The T-Rex physics and visual fingerprints move because the MJCF gained
+#    sites and sensors; the DYNAMICS do not -- old and new models are
+#    bit-identical in qpos over 2000 perturbed steps and total mass is
+#    unchanged.  build_mjx_observation is fingerprinted directly and had to
+#    learn to sum, so every species' policy interface revision increments;
+#    only the T-Rex's observation values actually change.
 
 [plants.velociraptor]
 physics_revision = 2
-policy_interface_revision = 5
+policy_interface_revision = 6
 visual_revision = 3
 observation_schema = "bipedal-target/v1"
 
 [plants.trex]
-physics_revision = 3
-policy_interface_revision = 5
-visual_revision = 3
+physics_revision = 4
+policy_interface_revision = 6
+visual_revision = 4
 observation_schema = "bipedal-target/v1"
 
 [plants.brachiosaurus]
 physics_revision = 1
-policy_interface_revision = 2
+policy_interface_revision = 3
 visual_revision = 1
 observation_schema = "quadrupedal-target/v1"
 
 [plants.dibothrosuchus]
 physics_revision = 1
-policy_interface_revision = 2
+policy_interface_revision = 3
 visual_revision = 1
 observation_schema = "quadrupedal-target/v1"

--- a/environments/shared/data/plant_manifest.generated.json
+++ b/environments/shared/data/plant_manifest.generated.json
@@ -6,7 +6,7 @@
   },
   "plants": {
     "brachiosaurus": {
-      "bundle_sha256": "sha256:612755a3515428460fa9eb7b0762b385403ab3c6a8c682fde741e4d9f0e5757a",
+      "bundle_sha256": "sha256:243c8a158b88d5199cd0ea05dca518acfd99cf738d7651775eab457ffd5eed13",
       "env_entrypoint": "environments.brachiosaurus.envs.brachio_env:BrachioEnv",
       "model_path": "environments/brachiosaurus/assets/brachiosaurus.xml",
       "physics": {
@@ -21,9 +21,9 @@
         "action_dim": 30,
         "observation_dim": 83,
         "observation_schema": "quadrupedal-target/v1",
-        "revision": 2,
+        "revision": 3,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:4065e79ba595e617201ddc695e4e8fd9d4554c322642ec9523dc2a121726b5ed"
+        "sha256": "sha256:f192ccd9f533fb757aa530b8bda89f9c129f4dc3d4ae34103464d97fdbbf55ec"
       },
       "source": {
         "closure_sha256": "sha256:586e8c38684b4132c63872662333b37a2471b7740a6bc265def721f86fad1a5b",
@@ -45,7 +45,7 @@
       }
     },
     "dibothrosuchus": {
-      "bundle_sha256": "sha256:b0ac834677699f4fd2451340b1d9584f1844d04a5e5e39141aadcad708a50821",
+      "bundle_sha256": "sha256:a1cd823c627c5b243eb58757c487c68410ffae491442927cd012fb55fa008495",
       "env_entrypoint": "environments.dibothrosuchus.envs.dibothrosuchus_env:DibothrosuchusEnv",
       "model_path": "environments/dibothrosuchus/assets/dibothrosuchus.xml",
       "physics": {
@@ -60,9 +60,9 @@
         "action_dim": 27,
         "observation_dim": 77,
         "observation_schema": "quadrupedal-target/v1",
-        "revision": 2,
+        "revision": 3,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:193e3e4537f259af014cde06c27c46e6e4dca456015b872a1b6df1665e819ee1"
+        "sha256": "sha256:ebaa8846cfe572e69fb0dde92c3724d83717fd078e2f8935809f7599b77ff2d3"
       },
       "source": {
         "closure_sha256": "sha256:5532fad56a1613020f09bfa197f14f0916306e664d5cf18609b757d3c5948bc3",
@@ -84,30 +84,30 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:11a79cd6a1dd41037b10735297d0a642dd762b11f72bc6837f9ad370a5237f3d",
+      "bundle_sha256": "sha256:a626ed80300c0575e283661ab4df0ef94c7daf7b20449acefaf7f5957380cf52",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
         "nq": 28,
         "nu": 21,
         "nv": 27,
-        "revision": 3,
+        "revision": 4,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:da0fe5a18713fc143e8f46dcca4539edc4c90eb933fcbedb5bf79986605e43d4"
+        "sha256": "sha256:0c194766307bee3a7c9c555a841687f85e851fa443b57f151d26b4ee472a38cf"
       },
       "policy_interface": {
         "action_dim": 21,
         "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 5,
+        "revision": 6,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:e6dd172814433dc00a7390c0e47c5f1532cfc47073439ed26f09483c15969e1f"
+        "sha256": "sha256:db76ea6cb0b9a08d576fe324ec7ad169d15ba24c61daa3f1822259168821f9f2"
       },
       "source": {
-        "closure_sha256": "sha256:4f0fdc428aa2ee1535dd6a3ba293aaad32ff271b612445293b792a1903a0400c",
+        "closure_sha256": "sha256:f499af17638e3c91a24b470c711e9c47ebc94f3576bf321c2cd56a50e12cfa01",
         "dependencies": [
           {
-            "content_sha256": "sha256:1ea443f5eed93037abc8a777e88cb27e619a82e2c1a694bb74ceef15b0a7fccb",
+            "content_sha256": "sha256:aef603402e5a26ccfbb21540954443672cc285ee0def1ffd0103d98ad99d8242",
             "kind": "mjcf",
             "logical_path": "environments/trex/assets/trex.xml"
           }
@@ -117,13 +117,13 @@
       },
       "species": "trex",
       "visual": {
-        "revision": 3,
+        "revision": 4,
         "schema": "mesozoic.mujoco-visual/v1",
-        "sha256": "sha256:11418961e75956f4d3c55aaf6a5ad1aa8b9d80efec1e2499a4994679cc19186d"
+        "sha256": "sha256:7042dcd597fbd0ce25489164a7f132d51e1c2adbc050729c9866d7bde42e35a4"
       }
     },
     "velociraptor": {
-      "bundle_sha256": "sha256:2ed2e9c4ea84956beed41667274723335ef40815bed1e4b21ee57415a81b225a",
+      "bundle_sha256": "sha256:9841757f572a06864478219cae05b25107aa393511c64bb265c2053564394d83",
       "env_entrypoint": "environments.velociraptor.envs.raptor_env:RaptorEnv",
       "model_path": "environments/velociraptor/assets/raptor.xml",
       "physics": {
@@ -138,9 +138,9 @@
         "action_dim": 22,
         "observation_dim": 67,
         "observation_schema": "bipedal-target/v1",
-        "revision": 5,
+        "revision": 6,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:fe3fc35cc6f5f37e976982ad2e302121266e9aaf322cd5d7ae884ae384de5fdb"
+        "sha256": "sha256:cd69b759369f88ad43324a61069dfeb37f4fde5e1c15ba8d042c2b031f76e2eb"
       },
       "source": {
         "closure_sha256": "sha256:ae2ebacf577a7247484e8954fecce421b007246ead904a83ce319babb1efdec5",

--- a/environments/shared/jax_eval.py
+++ b/environments/shared/jax_eval.py
@@ -166,6 +166,7 @@ def evaluate_policy_cpu(
     reward_cfg: dict[str, float],
     config: EvalConfig,
     foot_sensor_indices: tuple[int, ...] = (),
+    foot_aux_indices: tuple[tuple[int, ...], ...] = (),
 ) -> EvalResults:
     """Run deterministic evaluation episodes on CPU MuJoCo.
 
@@ -180,7 +181,12 @@ def evaluate_policy_cpu(
         reward_fn: Function(mjx_data, action, reward_cfg) -> scalar reward.
         reward_cfg: Reward weight dict.
         config: Evaluation configuration.
-        foot_sensor_indices: Sensor indices for foot contacts (for diagnostics).
+        foot_sensor_indices: Sensor indices for foot contacts (for diagnostics),
+            one per foot.
+        foot_aux_indices: Extra sensors summed into each foot's reading,
+            aligned with ``foot_sensor_indices``.  Species whose toes are
+            separate bodies need these, since one touch sensor cannot see
+            geoms on child bodies.
 
     Returns:
         ``EvalResults`` with per-episode and per-step metrics.
@@ -284,8 +290,15 @@ def evaluate_policy_cpu(
             # than lumping every non-first foot into the left series.
             for i, idx in enumerate(foot_sensor_indices):
                 if len(mj_data.sensordata) > idx:
+                    force = float(mj_data.sensordata[idx])
+                    if i < len(foot_aux_indices):
+                        force += sum(
+                            float(mj_data.sensordata[aux])
+                            for aux in foot_aux_indices[i]
+                            if len(mj_data.sensordata) > aux
+                        )
                     target_list = results.diag_r_foot if i % 2 == 0 else results.diag_l_foot
-                    target_list.append(float(mj_data.sensordata[idx]))
+                    target_list.append(force)
 
             # Reward decomposition — all active components
             fwd_norm = float(np.clip(fwd_vel / config.forward_vel_max, -1.0, 1.0))

--- a/environments/shared/jax_setup.py
+++ b/environments/shared/jax_setup.py
@@ -276,6 +276,7 @@ def setup_species(species: str, stage: int = 1) -> SpeciesContext:
         accel_start=species_kw.get("sensor_accel_start", 3),
         quat_start=species_kw.get("sensor_quat_start", 6),
         foot_indices=species_kw.get("sensor_foot_indices", (10, 11)),
+        foot_aux_indices=species_kw.get("sensor_foot_aux_indices", ()),
     )
     sensor_tail_gyro_start = species_kw.get("sensor_tail_gyro_start")
 
@@ -543,7 +544,13 @@ def make_reward_fns(ctx: SpeciesContext):
         n_actuators=ctx.mj_model.nu,
         sensor_quat_start=ctx.sensor_layout.quat_start,
         sensor_gyro_start=ctx.sensor_layout.gyro_start,
-        foot_indices=ctx.sensor_layout.foot_indices,
+        # Flattened: this feeds "is any foot in contact", so pad and digit
+        # sensors are interchangeable here.  Per-foot totals (which must stay
+        # grouped) are built separately for the eval diagnostics below.
+        foot_indices=(
+            tuple(ctx.sensor_layout.foot_indices)
+            + tuple(index for group in ctx.sensor_layout.foot_aux_indices for index in group)
+        ),
         sensor_tail_gyro_start=ctx.sensor_tail_gyro_start,
         forward_vel_max=ctx.forward_vel_max,
         dt=float(ctx.mj_model.opt.timestep) * ctx.frame_skip,
@@ -667,6 +674,7 @@ def run_stage_evaluation(
     )
 
     foot_indices = tuple(ctx.sensor_layout.foot_indices)
+    foot_aux_indices = tuple(ctx.sensor_layout.foot_aux_indices)
 
     selected_eval_results = evaluate_policy_cpu(
         ctx.mj_model,
@@ -680,6 +688,7 @@ def run_stage_evaluation(
         reward_cfg=ctx.reward_cfg,
         config=eval_config,
         foot_sensor_indices=foot_indices,
+        foot_aux_indices=foot_aux_indices,
     )
     final_eval_results = (
         selected_eval_results
@@ -696,6 +705,7 @@ def run_stage_evaluation(
             reward_cfg=ctx.reward_cfg,
             config=eval_config,
             foot_sensor_indices=foot_indices,
+            foot_aux_indices=foot_aux_indices,
         )
     )
 

--- a/environments/shared/mjx_env.py
+++ b/environments/shared/mjx_env.py
@@ -149,6 +149,11 @@ class MJXEnvConfig:
     reward_weights: dict[str, float] = field(default_factory=dict)
     body_ids: dict[str, int] = field(default_factory=dict)
     sensor_foot_indices: tuple[int, ...] = ()
+    # Extra touch sensors summed into each foot's reading, aligned with
+    # ``sensor_foot_indices``.  Needed where the load-bearing geoms sit on
+    # child bodies that a single touch sensor cannot see.  Empty leaves both
+    # the observation width and the per-foot value unchanged.
+    sensor_foot_aux_indices: tuple[tuple[int, ...], ...] = ()
     sensor_gyro_start: int = 0
     sensor_accel_start: int = 3
     sensor_quat_start: int = 6
@@ -252,6 +257,7 @@ _PLANT_INTERFACE_CONFIG_FIELDS = frozenset(
         "frame_skip",
         "body_ids",
         "sensor_foot_indices",
+        "sensor_foot_aux_indices",
         "sensor_gyro_start",
         "sensor_accel_start",
         "sensor_quat_start",
@@ -278,8 +284,10 @@ def build_mjx_observation(data: Any, target_pos: Any, config: MJXEnvConfig | Map
     """
     from .obs_functions import SensorLayout, build_bipedal_obs, build_quadruped_obs
 
-    def value(name: str) -> Any:
-        return config[name] if isinstance(config, Mapping) else getattr(config, name)
+    def value(name: str, default: Any = None) -> Any:
+        if isinstance(config, Mapping):
+            return config[name] if name in config else default
+        return getattr(config, name, default)
 
     body_ids = value("body_ids")
     # Dispatch on the registered root body, not on a species allow-list: every
@@ -295,6 +303,9 @@ def build_mjx_observation(data: Any, target_pos: Any, config: MJXEnvConfig | Map
         accel_start=int(value("sensor_accel_start")),
         quat_start=int(value("sensor_quat_start")),
         foot_indices=tuple(int(index) for index in value("sensor_foot_indices")),
+        foot_aux_indices=tuple(
+            tuple(int(index) for index in group) for group in (value("sensor_foot_aux_indices", ()) or ())
+        ),
     )
     observation_builder = build_quadruped_obs if quadrupedal else build_bipedal_obs
     return observation_builder(
@@ -571,11 +582,19 @@ class MJXDinoEnv:
             r_forward, fwd_vel = reward_forward_velocity(
                 vel_2d, forward_ref, config.forward_vel_max, forward_vel_weight
             )
-            # Foot contact: read touch sensors
+            # Foot contact: read touch sensors.  Each foot's reading is the
+            # pad sensor plus any per-toe sensors declared for it, because a
+            # touch sensor cannot see geoms on child bodies -- without the
+            # aux terms a T-Rex standing on its digits reads as airborne.
             foot_contact_threshold = 0.1  # Newtons
+            aux_groups = config.sensor_foot_aux_indices
             has_foot_contact = jnp.bool_(False)
-            for foot_idx in config.sensor_foot_indices:
-                has_foot_contact = has_foot_contact | (data.sensordata[foot_idx] > foot_contact_threshold)
+            for position, foot_idx in enumerate(config.sensor_foot_indices):
+                foot_force = data.sensordata[foot_idx]
+                if position < len(aux_groups):
+                    for aux_idx in aux_groups[position]:
+                        foot_force = foot_force + data.sensordata[aux_idx]
+                has_foot_contact = has_foot_contact | (foot_force > foot_contact_threshold)
 
             # Condition alive bonus on height AND foot contact:
             # no reward for lying flat or balancing on head/nose

--- a/environments/shared/obs_functions.py
+++ b/environments/shared/obs_functions.py
@@ -46,8 +46,27 @@ class SensorLayout:
     gyro_start: int = 0
     accel_start: int = 3
     quat_start: int = 6
-    # Species-specific foot sensor indices (filled per species)
+    # Species-specific foot sensor indices (filled per species).  One entry
+    # per foot; each contributes exactly one observation channel.
     foot_indices: tuple[int, ...] = ()
+    # Optional extra touch sensors to add into each foot's channel, aligned
+    # with ``foot_indices``.  A MuJoCo touch sensor only sums contacts on
+    # geoms of its site's own body, so a species whose toes are separate
+    # bodies needs one sensor per toe and sums them here.  Empty (the
+    # default, and the case for every species with single-body feet) leaves
+    # the reading and the observation width exactly as they were.
+    foot_aux_indices: tuple[tuple[int, ...], ...] = ()
+
+    def foot_contact_values(self, sensordata: Array) -> list[Array]:
+        """Return one total contact force per foot, pad plus any aux sensors."""
+        totals = []
+        for position, index in enumerate(self.foot_indices):
+            total = sensordata[index]
+            if position < len(self.foot_aux_indices):
+                for aux_index in self.foot_aux_indices[position]:
+                    total = total + sensordata[aux_index]
+            totals.append(total)
+        return totals
 
 
 # ---------------------------------------------------------------------------
@@ -93,7 +112,7 @@ def build_bipedal_obs(
     pelvis_accel = sensordata[sl.accel_start : sl.accel_start + 3]
     pelvis_linvel = qvel[:3]
 
-    foot_contacts = xp.array([sensordata[i] for i in sl.foot_indices])
+    foot_contacts = xp.array(sl.foot_contact_values(sensordata))
 
     target_rel = target_pos - pelvis_xpos
     target_dist = xp.linalg.norm(target_rel)

--- a/environments/shared/plant_contract.py
+++ b/environments/shared/plant_contract.py
@@ -750,12 +750,21 @@ def _jax_policy_interface_payload(
         accel_start=int(raw_config.get("sensor_accel_start", 3)),
         quat_start=int(raw_config.get("sensor_quat_start", 6)),
         foot_indices=tuple(int(index) for index in raw_config.get("sensor_foot_indices", ())),
+        foot_aux_indices=tuple(
+            tuple(int(index) for index in group) for group in raw_config.get("sensor_foot_aux_indices", ())
+        ),
     )
+    if len(sensor_layout.foot_aux_indices) > len(sensor_layout.foot_indices):
+        raise PlantContractError(
+            f"MJX sensor layout for {version.species} declares more aux foot sensor groups "
+            f"({len(sensor_layout.foot_aux_indices)}) than feet ({len(sensor_layout.foot_indices)})"
+        )
     used_sensor_indices = (
         *range(sensor_layout.gyro_start, sensor_layout.gyro_start + 3),
         *range(sensor_layout.accel_start, sensor_layout.accel_start + 3),
         *range(sensor_layout.quat_start, sensor_layout.quat_start + 4),
         *sensor_layout.foot_indices,
+        *(index for group in sensor_layout.foot_aux_indices for index in group),
     )
     if any(index < 0 or index >= model.nsensordata for index in used_sensor_indices):
         raise PlantContractError(
@@ -786,6 +795,7 @@ def _jax_policy_interface_payload(
                 "sensor_accel_start": sensor_layout.accel_start,
                 "sensor_quat_start": sensor_layout.quat_start,
                 "sensor_foot_indices": sensor_layout.foot_indices,
+                "sensor_foot_aux_indices": sensor_layout.foot_aux_indices,
             },
         )
     )
@@ -805,6 +815,7 @@ def _jax_policy_interface_payload(
             "accel_start": sensor_layout.accel_start,
             "quat_start": sensor_layout.quat_start,
             "foot_indices": sensor_layout.foot_indices,
+            "foot_aux_indices": sensor_layout.foot_aux_indices,
         },
         "observation_builder": (
             "build_quadruped_obs" if version.observation_schema == "quadrupedal-target/v1" else "build_bipedal_obs"
@@ -1691,6 +1702,7 @@ def validate_mjx_environment_plant(
         "frame_skip",
         "body_ids",
         "sensor_foot_indices",
+        "sensor_foot_aux_indices",
         "sensor_gyro_start",
         "sensor_accel_start",
         "sensor_quat_start",

--- a/environments/shared/tests/test_mjx_env.py
+++ b/environments/shared/tests/test_mjx_env.py
@@ -444,11 +444,24 @@ class TestHomeKeyframeActionMapping:
 
         env = MJXDinoEnv("trex", stage=1, num_envs=1)
         states = env.reset(jax.random.PRNGKey(23))
-        foot_sensors = np.asarray(states.data.sensordata[0, 10:12])
+        sensordata = np.asarray(states.data.sensordata[0])
+        pad_sensors = sensordata[10:12]
+        # A touch sensor sums only geoms on its site's own body, so the pad
+        # sensors cannot see the digits -- which are the load-bearing geoms.
+        # The observation carries pad + digits, so assert against that, not
+        # against the pad alone: a pad-only expectation is what let the digits
+        # go unmeasured after they were made load-bearing.
+        expected = np.array(
+            [pad + sensordata[list(group)].sum() for pad, group in zip(pad_sensors, env.config.sensor_foot_aux_indices)]
+        )
         foot_observation = np.asarray(states.obs[0, -6:-4])
 
-        assert np.all(foot_sensors > 0.1), f"T-Rex MJX foot sensors are dead at home: {foot_sensors}"
-        np.testing.assert_allclose(foot_observation, foot_sensors, rtol=0, atol=1e-7)
+        assert np.all(pad_sensors > 0.1), f"T-Rex MJX foot sensors are dead at home: {pad_sensors}"
+        assert np.all(expected > pad_sensors), (
+            "digits carry no load at the home keyframe, so this test can no longer "
+            f"detect a pad-only foot-contact signal: pad={pad_sensors}, total={expected}"
+        )
+        np.testing.assert_allclose(foot_observation, expected, rtol=0, atol=1e-7)
 
     def test_trex_stage1_factory_preserves_contact_physics_and_rewards(self):
         import jax
@@ -480,7 +493,16 @@ class TestHomeKeyframeActionMapping:
         assert env.config.reward_weights["foot_contact_gate"] == pytest.approx(1.0)
         assert env.config.reward_weights["foot_contact_weight"] == pytest.approx(0.8)
         assert np.all(foot_sensors > 0.1), f"Stage-1 reset has no load-bearing foot contact: {foot_sensors}"
-        np.testing.assert_allclose(np.asarray(states.obs[0, -6:-4]), foot_sensors, rtol=0, atol=1e-7)
+        # The observation sums the pad sensor with the three per-digit sensors
+        # for each foot; see test_trex_mjx_reset_exposes_live_foot_contacts.
+        sensordata = np.asarray(states.data.sensordata[0])
+        expected_contacts = np.array(
+            [
+                pad + sensordata[list(group)].sum()
+                for pad, group in zip(foot_sensors, env.config.sensor_foot_aux_indices)
+            ]
+        )
+        np.testing.assert_allclose(np.asarray(states.obs[0, -6:-4]), expected_contacts, rtol=0, atol=1e-7)
 
     def test_home_reset_requires_named_home_keyframe(self):
         import mujoco

--- a/environments/shared/tests/test_mjx_env.py
+++ b/environments/shared/tests/test_mjx_env.py
@@ -461,7 +461,13 @@ class TestHomeKeyframeActionMapping:
             "digits carry no load at the home keyframe, so this test can no longer "
             f"detect a pad-only foot-contact signal: pad={pad_sensors}, total={expected}"
         )
-        np.testing.assert_allclose(foot_observation, expected, rtol=0, atol=1e-7)
+        # Relative tolerance, not exact: the four-term sum is evaluated twice,
+        # once inside the jitted observation builder and once here in numpy,
+        # so the results differ by about one float32 ULP (3e-5 at this
+        # magnitude).  1e-5 relative is ~300x that and still four orders of
+        # magnitude tighter than a dropped digit, which would show up as the
+        # ~112 N the three digits carry per foot.
+        np.testing.assert_allclose(foot_observation, expected, rtol=1e-5, atol=1e-3)
 
     def test_trex_stage1_factory_preserves_contact_physics_and_rewards(self):
         import jax
@@ -502,7 +508,10 @@ class TestHomeKeyframeActionMapping:
                 for pad, group in zip(foot_sensors, env.config.sensor_foot_aux_indices)
             ]
         )
-        np.testing.assert_allclose(np.asarray(states.obs[0, -6:-4]), expected_contacts, rtol=0, atol=1e-7)
+        # Same float32 summation tolerance as
+        # test_trex_mjx_reset_exposes_live_foot_contacts, and matching the
+        # rtol already used for the MJX-vs-CPU sensor comparison above.
+        np.testing.assert_allclose(np.asarray(states.obs[0, -6:-4]), expected_contacts, rtol=1e-5, atol=1e-3)
 
     def test_home_reset_requires_named_home_keyframe(self):
         import mujoco

--- a/environments/shared/tests/test_mjx_env.py
+++ b/environments/shared/tests/test_mjx_env.py
@@ -40,6 +40,27 @@ class TestMJXDinoEnv:
         assert env.config.posture_target_forward_z is None
         assert env.config.action_mapping == "home-keyframe-residual/v1"
         assert env.nominal_ctrl is not None
+        # Pin the pitch reference against the Gymnasium default rather than a
+        # literal: the two drifted apart once already, when the SB3 side moved
+        # to the measured neutral pose and this registration kept -sin(0.17).
+        # Only the override path was covered, so it passed either way.
+        from environments.trex.envs.trex_env import TRexEnv
+
+        sb3_natural_pitch = inspect.signature(TRexEnv.__init__).parameters["natural_pitch"].default
+        assert env.config.natural_forward_z == pytest.approx(-np.sin(sb3_natural_pitch))
+
+    def test_trex_foot_sensors_cover_the_digits(self):
+        """Each foot must sum its pad sensor plus one sensor per digit.
+
+        A touch sensor sums only geoms on its site's own body, so without the
+        aux groups a T-Rex standing on its toes reads as airborne.
+        """
+        import environments.trex.mjx_config  # noqa: F401
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        env = MJXDinoEnv("trex", stage=1, num_envs=1)
+        assert len(env.config.sensor_foot_aux_indices) == len(env.config.sensor_foot_indices)
+        assert all(len(group) == 3 for group in env.config.sensor_foot_aux_indices)
 
     def test_raptor_creation(self):
         """MJXDinoEnv can be created for Velociraptor."""

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -75,9 +75,9 @@ def test_catalog_publishes_layered_plant_contract() -> None:
         "brachiosaurus": "quadrupedal-target/v1",
         "dibothrosuchus": "quadrupedal-target/v1",
     }
-    expected_policy_revisions = {"velociraptor": 5, "trex": 5, "brachiosaurus": 2, "dibothrosuchus": 2}
-    expected_physics_revisions = {"velociraptor": 2, "trex": 3, "brachiosaurus": 1, "dibothrosuchus": 1}
-    expected_visual_revisions = {"velociraptor": 3, "trex": 3, "brachiosaurus": 1, "dibothrosuchus": 1}
+    expected_policy_revisions = {"velociraptor": 6, "trex": 6, "brachiosaurus": 3, "dibothrosuchus": 3}
+    expected_physics_revisions = {"velociraptor": 2, "trex": 4, "brachiosaurus": 1, "dibothrosuchus": 1}
+    expected_visual_revisions = {"velociraptor": 3, "trex": 4, "brachiosaurus": 1, "dibothrosuchus": 1}
     digest_pattern = re.compile(r"sha256:[0-9a-f]{64}")
     for species in catalog["species"]:
         plant = species["model"]["plant_contract"]

--- a/environments/shared/tests/test_species_integration.py
+++ b/environments/shared/tests/test_species_integration.py
@@ -11,6 +11,8 @@ brachiosaurus, snout snap for dibothrosuchus).  All shared behavior is tested
 here via parametrization.
 """
 
+import importlib
+
 import numpy as np
 import pytest
 
@@ -438,3 +440,56 @@ class TestEdgeCases:
         with pytest.raises(AttributeError):
             env.set_reward_weight("nonexistent_weight_xyz", 1.0)
         env.close()
+
+
+MJX_CONFIG_MODULES = {
+    "velociraptor": "environments.velociraptor.mjx_config",
+    "trex": "environments.trex.mjx_config",
+    "brachiosaurus": "environments.brachiosaurus.mjx_config",
+    "dibothrosuchus": "environments.dibothrosuchus.mjx_config",
+}
+
+
+class TestSB3MJXEnvelopeParity:
+    """The Gymnasium env and the MJX registry must agree on the alive envelope.
+
+    ``healthy_z_range`` and ``max_tilt_angle`` are absent from the fingerprinted
+    plant interface, so nothing else catches a divergence.  That is how the
+    T-Rex came to run with ``healthy_z_range`` (0.5, 1.6) on one path and
+    (0.75, 1.6) on the other, and ``max_tilt_angle`` 1.047 against 0.7, while
+    the other three species matched.
+
+    A mismatch changes the task rather than just the cutoff: on the MJX path
+    ``healthy_z_range`` also scales the alive bonus (``height_frac``), and
+    ``max_tilt_angle`` normalises the posture penalty as
+    ``(tilt / max_tilt_angle) ** 2``.
+    """
+
+    @pytest.mark.parametrize("env_class, species", SPECIES_ENVS)
+    def test_healthy_z_range_matches(self, env_class, species):
+        importlib.import_module(MJX_CONFIG_MODULES[species])
+        from environments.shared.mjx_env import _SPECIES_CONFIGS
+
+        registered = _SPECIES_CONFIGS[species]["healthy_z_range"]
+        env = env_class()
+        try:
+            assert tuple(registered) == tuple(env.healthy_z_range), (
+                f"{species}: MJX registers healthy_z_range={tuple(registered)} but the "
+                f"Gymnasium env uses {tuple(env.healthy_z_range)}"
+            )
+        finally:
+            env.close()
+
+    @pytest.mark.parametrize("env_class, species", SPECIES_ENVS)
+    def test_max_tilt_angle_matches(self, env_class, species):
+        importlib.import_module(MJX_CONFIG_MODULES[species])
+        from environments.shared.mjx_env import _SPECIES_CONFIGS
+
+        registered = _SPECIES_CONFIGS[species]["max_tilt_angle"]
+        env = env_class()
+        try:
+            assert registered == pytest.approx(env.max_tilt_angle), (
+                f"{species}: MJX registers max_tilt_angle={registered} but the Gymnasium env uses {env.max_tilt_angle}"
+            )
+        finally:
+            env.close()

--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -212,6 +212,11 @@
                      range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
               <geom name="r_toe_d2_geom" type="capsule" fromto="0 0 0  0.13 0.02 0" size="0.025"
                     mass="0.16" material="claw_mat"/>
+              <!-- Per-digit touch volume.  A touch sensor only sums contacts
+                   on geoms of its site's OWN body, so the metatarsus site
+                   cannot see any digit however large it is made. -->
+              <site name="r_toe_d2_site" type="box" pos="0.065 0.01 0"
+                    size="0.10 0.05 0.04" group="4"/>
             </body>
 
             <!-- Digit 3 (central, longest — primary weight-bearing) -->
@@ -220,6 +225,8 @@
                      range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
               <geom name="r_toe_d3_geom" type="capsule" fromto="0 0 0  0.19 0 0" size="0.028"
                     mass="0.22" material="claw_mat"/>
+              <site name="r_toe_d3_site" type="box" pos="0.095 0 0"
+                    size="0.13 0.05 0.04" group="4"/>
             </body>
 
             <!-- Digit 4 (lateral, medium) -->
@@ -228,6 +235,8 @@
                      range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
               <geom name="r_toe_d4_geom" type="capsule" fromto="0 0 0  0.15 -0.02 0" size="0.025"
                     mass="0.16" material="claw_mat"/>
+              <site name="r_toe_d4_site" type="box" pos="0.075 -0.01 0"
+                    size="0.11 0.05 0.04" group="4"/>
             </body>
           </body>
         </body>
@@ -266,6 +275,8 @@
                      range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
               <geom name="l_toe_d2_geom" type="capsule" fromto="0 0 0  0.13 -0.02 0" size="0.025"
                     mass="0.16" material="claw_mat"/>
+              <site name="l_toe_d2_site" type="box" pos="0.065 -0.01 0"
+                    size="0.10 0.05 0.04" group="4"/>
             </body>
 
             <!-- Digit 3 (central, longest — primary weight-bearing) -->
@@ -274,6 +285,8 @@
                      range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
               <geom name="l_toe_d3_geom" type="capsule" fromto="0 0 0  0.19 0 0" size="0.028"
                     mass="0.22" material="claw_mat"/>
+              <site name="l_toe_d3_site" type="box" pos="0.095 0 0"
+                    size="0.13 0.05 0.04" group="4"/>
             </body>
 
             <!-- Digit 4 (lateral, medium) -->
@@ -282,6 +295,8 @@
                      range="-25 50" ref="12.5" springref="12.5" damping="15.0"/>
               <geom name="l_toe_d4_geom" type="capsule" fromto="0 0 0  0.15 0.02 0" size="0.025"
                     mass="0.16" material="claw_mat"/>
+              <site name="l_toe_d4_site" type="box" pos="0.075 0.01 0"
+                    size="0.11 0.05 0.04" group="4"/>
             </body>
           </body>
         </body>
@@ -372,7 +387,12 @@
     <accelerometer name="pelvis_accel" site="imu"/>
     <framequat name="pelvis_orientation" objtype="site" objname="imu"/>
 
-    <!-- Foot contact forces -->
+    <!-- Foot contact forces.  These two see the plantar pad ONLY: a touch
+         sensor sums contacts on geoms belonging to its site's own body, and
+         the digits are child bodies (they carry actuated hinges, so they
+         cannot be merged into the metatarsus).  The per-digit sensors at the
+         end of this block carry the rest; the envs sum pad + 3 digits into
+         one contact value per foot.  See sensor_foot_aux_indices. -->
     <touch name="r_foot_touch" site="r_foot"/>
     <touch name="l_foot_touch" site="l_foot"/>
 
@@ -383,6 +403,16 @@
     <framepos name="tail_tip_pos" objtype="site" objname="tail_tip"/>
     <velocimeter name="tail_tip_linvel" site="tail_tip"/>
     <gyro name="tail_tip_angvel" site="tail_tip"/>
+
+    <!-- Per-digit contact forces (indices 24-29).  Appended last so every
+         index above stays put.  Summed with the plantar pad by the envs, so
+         the observation still carries one contact value per foot. -->
+    <touch name="r_toe_d2_touch" site="r_toe_d2_site"/>
+    <touch name="r_toe_d3_touch" site="r_toe_d3_site"/>
+    <touch name="r_toe_d4_touch" site="r_toe_d4_site"/>
+    <touch name="l_toe_d2_touch" site="l_toe_d2_site"/>
+    <touch name="l_toe_d3_touch" site="l_toe_d3_site"/>
+    <touch name="l_toe_d4_touch" site="l_toe_d4_site"/>
   </sensor>
 
   <!-- ==================== CONTACT EXCLUSIONS ==================== -->

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -101,7 +101,19 @@ class TRexEnv(BaseDinoEnv):
         # Environment settings
         prey_distance_range: tuple[float, float] = (3.0, 8.0),
         prey_lateral_range: tuple[float, float] = (-2.0, 2.0),
-        healthy_z_range: tuple[float, float] = (0.5, 1.6),
+        # Matches the MJX registration, which is the value the evidence
+        # supports.  The old SB3 floor of 0.50 could essentially never be the
+        # binding termination: tail_3/4/5 are unconditional termination geoms
+        # and the tail reaches the floor at a pelvis height of ~0.55-0.57 in a
+        # level squat, so the plant is already lying down before 0.50 is
+        # reached.  0.75 costs nothing measurable -- healthy full-horizon
+        # episodes bottom out at 0.884 m, 0.134 m of margin, 0/34 false
+        # terminations, and 1/300 stage-1 resets spawn below it (that episode
+        # was not recoverable anyway) -- while ending doomed episodes a median
+        # 74 steps sooner.  It also gives the MJX alive bonus, which scales by
+        # (z - floor) / (ceiling - floor), a 0.266 fraction at settled stance
+        # against the velociraptor's 0.275.
+        healthy_z_range: tuple[float, float] = (0.75, 1.6),
         reset_noise_scale: float = 0.01,
     ):
         model_path = str(Path(__file__).parent.parent / "assets" / "trex.xml")

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -235,6 +235,21 @@ class TRexEnv(BaseDinoEnv):
         # are inherited from BaseDinoEnv (0, 3, 6 respectively).
         self._sensor_r_foot = 10
         self._sensor_l_foot = 11
+        # The pad sensors above see the plantar box only: a touch sensor sums
+        # contacts on geoms of its site's own body, and the three digits are
+        # child bodies (they carry actuated hinges).  Their own sensors are
+        # appended after the tail block, so pad + digits is the force the foot
+        # actually transmits -- at the home keyframe 388.4 N + 112.0 N against
+        # a measured 500.4 N of floor contact.
+        self._sensor_r_foot_digits = (24, 25, 26)
+        self._sensor_l_foot_digits = (27, 28, 29)
+
+    def _foot_contact_forces(self) -> tuple[float, float]:
+        """Total floor contact force under each foot: plantar pad and digits."""
+        sensordata = self.data.sensordata
+        right = sensordata[self._sensor_r_foot] + sum(sensordata[index] for index in self._sensor_r_foot_digits)
+        left = sensordata[self._sensor_l_foot] + sum(sensordata[index] for index in self._sensor_l_foot_digits)
+        return float(right), float(left)
 
     def _scale_action(self, action: np.ndarray) -> np.ndarray:
         """Map normalized residual actions around the XML home controls.
@@ -270,12 +285,7 @@ class TRexEnv(BaseDinoEnv):
         pelvis_linvel = self.data.qvel[0:3].copy()
 
         # Foot contact (from touch sensors)
-        foot_contact = np.array(
-            [
-                self.data.sensordata[self._sensor_r_foot],
-                self.data.sensordata[self._sensor_l_foot],
-            ]
-        )
+        foot_contact = np.array(self._foot_contact_forces())
 
         # Prey info (relative to pelvis)
         pelvis_pos = self.data.xpos[self.pelvis_id]
@@ -411,10 +421,9 @@ class TRexEnv(BaseDinoEnv):
         info["reward_height"] = reward_height
 
         # 9. Gait symmetry (reward alternating foot contacts, shared helper)
-        r_contact = self.data.sensordata[self._sensor_r_foot]
-        l_contact = self.data.sensordata[self._sensor_l_foot]
-        info["r_foot_contact"] = float(r_contact)
-        info["l_foot_contact"] = float(l_contact)
+        r_contact, l_contact = self._foot_contact_forces()
+        info["r_foot_contact"] = r_contact
+        info["l_foot_contact"] = l_contact
 
         reward_gait, alternation_ratio = self._compute_gait_symmetry(
             float(r_contact), float(l_contact), self.gait_symmetry_weight

--- a/environments/trex/mjx_config.py
+++ b/environments/trex/mjx_config.py
@@ -39,7 +39,16 @@ register_species_mjx(
     frame_skip=5,
     max_episode_steps=1000,
     healthy_z_range=(0.75, 1.6),
-    max_tilt_angle=0.7,
+    # Matches the Gymnasium env (the BaseDinoEnv default), which is the value
+    # the evidence supports.  max_tilt_angle is the absolute backstop; nosedive
+    # is the per-stage tunable pitch gate.  Stages 2 and 3 leave
+    # nosedive_termination_threshold at the 0.62 default, which allows 0.734 rad
+    # of forward pitch -- so a 0.700 cap would terminate first and silently
+    # override that calibration in exactly the stages whose configs ask for a
+    # head-forward running posture.  It also normalises the posture penalty as
+    # (tilt / max_tilt_angle)**2, and posture_weight = 1.5 is a swept constant
+    # shared by all four species at 1.047.
+    max_tilt_angle=1.047,
     sensor_foot_indices=(_SENSOR_R_FOOT, _SENSOR_L_FOOT),
     sensor_foot_aux_indices=(_SENSOR_R_FOOT_DIGITS, _SENSOR_L_FOOT_DIGITS),
     sensor_gyro_start=0,

--- a/environments/trex/mjx_config.py
+++ b/environments/trex/mjx_config.py
@@ -6,13 +6,30 @@ Registers the T-Rex species with the MJX environment so that
 
 from __future__ import annotations
 
+import math
+
 from environments.shared.mjx_env import register_species_mjx
+
+# Must track ``TRexEnv.__init__``'s ``natural_pitch`` default (trex_env.py).
+# The pelvis frame is level at the home keyframe and settles ~2.9 deg
+# nose-down under the home controller; the nosedive penalty and termination
+# are both measured relative to that pose.  Kept as the angle rather than a
+# rounded forward_z so the two paths derive the same number from the same
+# quantity -- test_mjx_env.test_trex_creation pins them equal.
+_NATURAL_PITCH = 0.05
 
 # Sensor indices match the MJCF sensor definition order:
 # pelvis_gyro(3), pelvis_accel(3), pelvis_orientation(4),
 # r_foot_touch(1), l_foot_touch(1)
 _SENSOR_R_FOOT = 10
 _SENSOR_L_FOOT = 11
+# The two sensors above cover the plantar pad only.  Each digit is its own
+# body (it carries an actuated hinge), and a touch sensor cannot see geoms on
+# child bodies, so the digits carry their own sensors -- appended after the
+# tail block so every index above keeps its position.  Summed per foot, they
+# restore the reading to the force the foot actually transmits.
+_SENSOR_R_FOOT_DIGITS = (24, 25, 26)
+_SENSOR_L_FOOT_DIGITS = (27, 28, 29)
 # Tail tip gyro starts after: gyro(3) + accel(3) + quat(4) + touch(2) + head_pos(3) + tail_pos(3) + tail_linvel(3) = 21
 _SENSOR_TAIL_GYRO_START = 21
 
@@ -24,10 +41,11 @@ register_species_mjx(
     healthy_z_range=(0.75, 1.6),
     max_tilt_angle=0.7,
     sensor_foot_indices=(_SENSOR_R_FOOT, _SENSOR_L_FOOT),
+    sensor_foot_aux_indices=(_SENSOR_R_FOOT_DIGITS, _SENSOR_L_FOOT_DIGITS),
     sensor_gyro_start=0,
     sensor_accel_start=3,
     sensor_quat_start=6,
-    natural_forward_z=-0.169,  # -sin(0.17)  ~10° natural pitch
+    natural_forward_z=-math.sin(_NATURAL_PITCH),
     sensor_tail_gyro_start=_SENSOR_TAIL_GYRO_START,
     forward_vel_max=8.0,
     fall_penalty=-100.0,

--- a/environments/trex/tests/test_trex_env.py
+++ b/environments/trex/tests/test_trex_env.py
@@ -148,16 +148,66 @@ class TestNominalPoseActionScaling:
         assert second_info["action_delta"] == pytest.approx(0.0, abs=1e-12)
 
 
+def _true_floor_force_per_foot(env) -> dict[str, float]:
+    """Sum the real floor normal force under each foot, straight from contacts."""
+    floor_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_GEOM, "floor")
+    totals = {"r": 0.0, "l": 0.0}
+    for index in range(env.data.ncon):
+        contact = env.data.contact[index]
+        if floor_id not in (contact.geom1, contact.geom2):
+            continue
+        other = contact.geom2 if contact.geom1 == floor_id else contact.geom1
+        name = mujoco.mj_id2name(env.model, mujoco.mjtObj.mjOBJ_GEOM, other) or ""
+        side = name[:1]
+        if side in totals:
+            force = np.zeros(6)
+            mujoco.mj_contactForce(env.model, env.data, index, force)
+            totals[side] += float(force[0])
+    return totals
+
+
 class TestFootContactSensors:
     """Touch observations must measure plantar-floor load, not self-contact."""
 
-    def test_sites_share_the_load_bearing_plantar_bodies(self, env):
-        for side in ("r", "l"):
-            site_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_SITE, f"{side}_foot")
-            geom_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_GEOM, f"{side}_plantar_geom")
-            assert env.model.site_bodyid[site_id] == env.model.geom_bodyid[geom_id]
+    def test_every_load_bearing_foot_body_carries_a_touch_sensor(self, env):
+        """A touch sensor only sums geoms on its site's own body.
 
-    def test_sensors_read_ground_force_at_settled_stance(self):
+        The digits are child bodies of the metatarsus, so the plantar site
+        cannot see them however large it is made.  Each load-bearing body
+        therefore needs its own sensor.
+        """
+        for side in ("r", "l"):
+            sensor_bodies = set()
+            for name in (
+                f"{side}_foot_touch",
+                f"{side}_toe_d2_touch",
+                f"{side}_toe_d3_touch",
+                f"{side}_toe_d4_touch",
+            ):
+                sensor_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_SENSOR, name)
+                assert sensor_id >= 0, f"missing touch sensor {name}"
+                sensor_bodies.add(int(env.model.site_bodyid[env.model.sensor_objid[sensor_id]]))
+
+            for geom_name in (
+                f"{side}_plantar_geom",
+                f"{side}_toe_d2_geom",
+                f"{side}_toe_d3_geom",
+                f"{side}_toe_d4_geom",
+            ):
+                geom_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_GEOM, geom_name)
+                body_id = int(env.model.geom_bodyid[geom_id])
+                assert body_id in sensor_bodies, (
+                    f"{geom_name} bears load on a body with no touch sensor; "
+                    "its contacts would be invisible to the foot-contact signal"
+                )
+
+    def test_sensors_account_for_all_floor_force_at_settled_stance(self):
+        """The summed reading must equal the force the foot really transmits.
+
+        A pad-only reading also passes a ``> 0`` check, which is how the
+        digits went unmeasured after they were made load-bearing, so assert
+        against the measured contact forces instead of a threshold.
+        """
         env = TRexEnv(reset_noise_scale=0.0, nosedive_termination_threshold=0.35)
         try:
             env.reset(seed=0)
@@ -165,8 +215,19 @@ class TestFootContactSensors:
             for _ in range(200):
                 _, _, terminated, _, info = env.step(np.zeros(env.action_space.shape, dtype=np.float32))
                 assert not terminated
-            assert info["r_foot_contact"] > 1.0, "right foot touch sensor dead at stance"
-            assert info["l_foot_contact"] > 1.0, "left foot touch sensor dead at stance"
+
+            truth = _true_floor_force_per_foot(env)
+            assert truth["r"] > 1.0, "right foot carries no measurable load at stance"
+            assert truth["l"] > 1.0, "left foot carries no measurable load at stance"
+            assert info["r_foot_contact"] == pytest.approx(truth["r"], rel=1e-6)
+            assert info["l_foot_contact"] == pytest.approx(truth["l"], rel=1e-6)
+
+            # Guard the specific regression: the pad alone must not be
+            # mistaken for the whole foot while the digits bear load.
+            pad_only = float(env.data.sensordata[env._sensor_r_foot])
+            assert pad_only < truth["r"], (
+                "digits carry no load at stance, so this test can no longer detect a pad-only foot-contact signal"
+            )
         finally:
             env.close()
 
@@ -179,10 +240,17 @@ class TestFootContactSensors:
             mujoco.mj_forward(env.model, env.data)
             for _ in range(10):
                 mujoco.mj_step(env.model, env.data)
-            for name in ("r_foot_touch", "l_foot_touch"):
-                sensor_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_SENSOR, name)
-                sensor_address = env.model.sensor_adr[sensor_id]
-                assert env.data.sensordata[sensor_address] == pytest.approx(0.0, abs=1e-9)
+            for side in ("r", "l"):
+                for name in (
+                    f"{side}_foot_touch",
+                    f"{side}_toe_d2_touch",
+                    f"{side}_toe_d3_touch",
+                    f"{side}_toe_d4_touch",
+                ):
+                    sensor_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_SENSOR, name)
+                    sensor_address = env.model.sensor_adr[sensor_id]
+                    assert env.data.sensordata[sensor_address] == pytest.approx(0.0, abs=1e-9)
+            assert env._foot_contact_forces() == pytest.approx((0.0, 0.0), abs=1e-9)
         finally:
             env.close()
 
@@ -196,6 +264,9 @@ class TestFootContactSensors:
                 assert not terminated
             foot_dims = obs[-6:-4]
             assert np.all(foot_dims > 0.0), f"foot-contact obs dims dead at stance: {foot_dims}"
+            truth = _true_floor_force_per_foot(env)
+            assert foot_dims[0] == pytest.approx(truth["r"], rel=1e-5)
+            assert foot_dims[1] == pytest.approx(truth["l"], rel=1e-5)
         finally:
             env.close()
 

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -80,13 +80,13 @@
         "nu": 22,
         "dynamic_mass_kg": 13.5,
         "plant_contract": {
-          "bundle_sha256": "sha256:2ed2e9c4ea84956beed41667274723335ef40815bed1e4b21ee57415a81b225a",
+          "bundle_sha256": "sha256:9841757f572a06864478219cae05b25107aa393511c64bb265c2053564394d83",
           "source_closure_sha256": "sha256:ae2ebacf577a7247484e8954fecce421b007246ead904a83ce319babb1efdec5",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 5,
+            "revision": 6,
             "observation_schema": "bipedal-target/v1",
-            "sha256": "sha256:fe3fc35cc6f5f37e976982ad2e302121266e9aaf322cd5d7ae884ae384de5fdb"
+            "sha256": "sha256:cd69b759369f88ad43324a61069dfeb37f4fde5e1c15ba8d042c2b031f76e2eb"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",
@@ -357,23 +357,23 @@
         "nu": 21,
         "dynamic_mass_kg": 85.72,
         "plant_contract": {
-          "bundle_sha256": "sha256:11a79cd6a1dd41037b10735297d0a642dd762b11f72bc6837f9ad370a5237f3d",
-          "source_closure_sha256": "sha256:4f0fdc428aa2ee1535dd6a3ba293aaad32ff271b612445293b792a1903a0400c",
+          "bundle_sha256": "sha256:a626ed80300c0575e283661ab4df0ef94c7daf7b20449acefaf7f5957380cf52",
+          "source_closure_sha256": "sha256:f499af17638e3c91a24b470c711e9c47ebc94f3576bf321c2cd56a50e12cfa01",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 5,
+            "revision": 6,
             "observation_schema": "bipedal-target/v1",
-            "sha256": "sha256:e6dd172814433dc00a7390c0e47c5f1532cfc47073439ed26f09483c15969e1f"
+            "sha256": "sha256:db76ea6cb0b9a08d576fe324ec7ad169d15ba24c61daa3f1822259168821f9f2"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",
-            "revision": 3,
-            "sha256": "sha256:da0fe5a18713fc143e8f46dcca4539edc4c90eb933fcbedb5bf79986605e43d4"
+            "revision": 4,
+            "sha256": "sha256:0c194766307bee3a7c9c555a841687f85e851fa443b57f151d26b4ee472a38cf"
           },
           "visual": {
             "schema": "mesozoic.mujoco-visual/v1",
-            "revision": 3,
-            "sha256": "sha256:11418961e75956f4d3c55aaf6a5ad1aa8b9d80efec1e2499a4994679cc19186d"
+            "revision": 4,
+            "sha256": "sha256:7042dcd597fbd0ce25489164a7f132d51e1c2adbc050729c9866d7bde42e35a4"
           }
         }
       },
@@ -570,13 +570,13 @@
         "nu": 30,
         "dynamic_mass_kg": 175.3,
         "plant_contract": {
-          "bundle_sha256": "sha256:612755a3515428460fa9eb7b0762b385403ab3c6a8c682fde741e4d9f0e5757a",
+          "bundle_sha256": "sha256:243c8a158b88d5199cd0ea05dca518acfd99cf738d7651775eab457ffd5eed13",
           "source_closure_sha256": "sha256:586e8c38684b4132c63872662333b37a2471b7740a6bc265def721f86fad1a5b",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 2,
+            "revision": 3,
             "observation_schema": "quadrupedal-target/v1",
-            "sha256": "sha256:4065e79ba595e617201ddc695e4e8fd9d4554c322642ec9523dc2a121726b5ed"
+            "sha256": "sha256:f192ccd9f533fb757aa530b8bda89f9c129f4dc3d4ae34103464d97fdbbf55ec"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",
@@ -766,13 +766,13 @@
         "nu": 27,
         "dynamic_mass_kg": 8.65,
         "plant_contract": {
-          "bundle_sha256": "sha256:b0ac834677699f4fd2451340b1d9584f1844d04a5e5e39141aadcad708a50821",
+          "bundle_sha256": "sha256:a1cd823c627c5b243eb58757c487c68410ffae491442927cd012fb55fa008495",
           "source_closure_sha256": "sha256:5532fad56a1613020f09bfa197f14f0916306e664d5cf18609b757d3c5948bc3",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 2,
+            "revision": 3,
             "observation_schema": "quadrupedal-target/v1",
-            "sha256": "sha256:193e3e4537f259af014cde06c27c46e6e4dca456015b872a1b6df1665e819ee1"
+            "sha256": "sha256:ebaa8846cfe572e69fb0dde92c3724d83717fd078e2f8935809f7599b77ff2d3"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",


### PR DESCRIPTION
## Summary

Three defects that made the MJX/JAX path measure something other than what the stage TOMLs describe. The T-Rex was the only species affected by any of them.

## 1. The foot touch sensors could not see the digits

A MuJoCo touch sensor sums only contacts on geoms belonging to its site's **own** body. `r_foot`/`l_foot` sit on `r_metatarsus`/`l_metatarsus`, whose contact geoms are the metatarsus capsule and the plantar box; the three digits are child bodies, because they carry actuated hinges and cannot be merged. So the preceding plant revision — which made the digits load-bearing — moved load onto exactly the geoms the sensor is blind to. Enlarging the site could not help, since the filter is by body, not by volume.

| | before | after |
|---|---|---|
| Home-keyframe reading vs true 500.368 N | 388.367 N | **500.368 N** (residual 0) |
| Sensed/true ratio over 13,813 loaded-foot samples | mean 0.781 | **1.0000** (min = max) |
| Samples reading ≤0.1 N while the foot carries load | 1.41% | **0** |
| Steps with both sensors blind while both feet loaded | 65 | **0** |

On the JAX path this gates `alive_bonus` (1.75/step) and pays `foot_contact_weight` (0.8/step), so a T-Rex standing on its toes was scored as airborne — the reward opposed the plant change. On the SB3 path the sensors feed the observation and `_compute_gait_symmetry`, and `gait_symmetry_weight = 0.0` in all three stages, so reward was unaffected there but two observation channels and the gait diagnostics were wrong.

Each digit now carries its own touch site and sensor, appended after the tail block so every existing sensor index keeps its position (new indices 24–29). Both paths sum pad + 3 digits into one value per foot, so the observation width is unchanged at 61.

## 2. `mjx_config.py` kept the old natural pitch

The preceding revision moved `natural_pitch` 0.17 → 0.05 in the Gymnasium env and paid for it by raising the nosedive thresholds, but never touched `environments/trex/mjx_config.py`, which still declared `natural_forward_z = -0.169`. Because stage 1's threshold had been raised to compensate for a shift that never happened on that path, the compensation became a pure loosening:

| | pitch reference | threshold | absolute cut | nose-down |
|---|---|---|---|---|
| Before (both paths) | −0.1692 | 0.35 | −0.5192 | 31.3° |
| SB3 after | −0.0500 | 0.47 | −0.5200 | 31.3° |
| **JAX after (bug)** | **−0.169** | **0.47** | **−0.6390** | **39.7°** |

That is 8.4° looser than any prior T-Rex stage-1 run, in the stage whose config comment exists to prevent a forward-pitch exploit. `natural_forward_z` is now derived from the same pitch angle as the Gymnasium default, so both paths read `-0.04997916927067833`.

## 3. The alive envelope diverged between the two paths

`healthy_z_range` was `(0.5, 1.6)` in `TRexEnv` against `(0.75, 1.6)` in the registry, and `max_tilt_angle` 1.047 against 0.7. The other three species matched exactly on both. Neither field is fingerprinted, so nothing caught it — and the divergence is not merely where episodes get cut: on the MJX path `healthy_z_range` also scales the alive bonus and `max_tilt_angle` normalises the posture penalty, so the two paths were optimising different objectives from the same TOML.

Resolved by simulation, and the two fields resolve in **opposite** directions.

**`healthy_z_range` 0.5 → 0.75 on the SB3 side.** The old floor could essentially never bind: `tail_3/4/5` are unconditional termination geoms and the tail reaches the floor at a pelvis height of ~0.55–0.57 m, so the plant is already lying down before 0.50 is reached. Measured over 60 zero-action stage-1 episodes, every episode dipping below 0.75 also dips below 0.50, a median **74 steps** later. Raising it costs nothing measurable — healthy full-horizon episodes bottom out at **0.884 m** (0.134 m margin, 0/34 false terminations) and 1/300 stage-1 resets spawn below 0.75, that one not standing either way. It also puts the MJX alive fraction at settled stance at **0.266** against the velociraptor's **0.275**.

The ceiling of 1.6 is left alone. It looks anomalous normalised by stance height, but ceilings here are not meant to be reachable: maximum reachable versus committed ceiling is 1.203 vs 1.6 for the T-Rex (1.33×) and 0.653 vs 1.0 for the velociraptor (1.53×, more generous).

**`max_tilt_angle` 0.7 → 1.047 on the MJX side.** `max_tilt_angle` is the absolute backstop; nosedive is the per-stage tunable pitch gate. Stage 1 sets `nosedive_termination_threshold = 0.47`, capping forward pitch at 0.547 rad — below either candidate, so nosedive binds. Stages 2 and 3 leave it at the 0.62 default, allowing **0.734 rad**, so a 0.700 cap would terminate first and silently override that calibration in exactly the stages whose configs ask for a head-forward running posture. The contrary evidence is real but stage-1 only (1.047 fires in 0/26 falls; 0.7 binds first in 6/26, a median 8 steps sooner, at zero false terminations), and `max_tilt_angle` is constructor-level and shared across all three stages.

## Changes

- **`trex.xml`** — one touch site per digit body, six touch sensors appended after the tail block (indices 24–29).
- **`trex_env.py`** — `_foot_contact_forces()` summing pad + digits; `healthy_z_range` default → `(0.75, 1.6)`.
- **`trex/mjx_config.py`** — `natural_forward_z` derived from `_NATURAL_PITCH = 0.05`; digit sensors registered as `sensor_foot_aux_indices`; `max_tilt_angle` → 1.047.
- **`obs_functions.py`** — `SensorLayout.foot_aux_indices` and `foot_contact_values()`. Empty for every other species, leaving their readings and observation widths untouched.
- **`mjx_env.py`** — `MJXEnvConfig.sensor_foot_aux_indices`; `build_mjx_observation` and the foot-contact gate sum the aux sensors.
- **`plant_contract.py`** — aux indices validated and fingerprinted.
- **`jax_setup.py` / `jax_eval.py`** — flattened indices for the contact gate, grouped for per-foot eval diagnostics, which split by parity and would otherwise misassign digits to the wrong foot.

## Why this survived CI, and what now catches it

`test_trex_creation` pinned `posture_target_forward_z` but not `natural_forward_z`, and the only T-Rex test naming `natural_forward_z` asserted it *after* overriding `natural_pitch` through `env_kwargs`, so it passed whatever the committed default was. On the sensor side the assertions were `info["r_foot_contact"] > 1.0` and `foot_dims > 0.0`, both satisfied by the pad alone at 388 N, and `test_sites_share_the_load_bearing_plantar_bodies` asserted the very placement that caused the bug. Nothing compared the two configs at all.

Now: the summed reading must equal the floor normal force measured from the contacts; every load-bearing foot geom must sit on a body carrying a touch sensor; the MJX pitch reference is pinned against the Gymnasium signature default; and `TestSB3MJXEnvelopeParity` asserts both envelope fields match across all four species. Reverting any of these fails a test with the offending values named.

## Compatibility

**Existing T-Rex checkpoints are not valid against this revision.** Sensor *indices* are preserved, but the observation *values* change — the foot channels now carry pad + digits — which is why `policy_interface_revision` increments. `PlantIdentity` enforces this on checkpoint load.

Revisions: trex physics 3 → 4 and visual 3 → 4 (the MJCF gained sites and sensors), policy interface 5 → 6. `build_mjx_observation` is fingerprinted directly and had to learn to sum, so velociraptor 5 → 6 and brachiosaurus/dibothrosuchus 2 → 3 increment too — none of their observation values change. The envelope change needs no bump, as neither field is fingerprinted.

**Dynamics are unchanged**: sites and touch sensors do not enter the solve, and old versus new models are bit-identical in `qpos` over 2000 perturbed steps (`max|Δq| = 0.000e+00`) at unchanged total mass.

## Known remaining divergence

With both paths now on `(0.75, 1.6)`, the MJX alive bonus at settled stance is `1.75 × 0.266 = 0.465`/step while SB3 pays a flat 1.75. That is a formula divergence rather than a constant one, and it is not yet in the documented SB3↔JAX divergence list in `docs/KNOWN_ISSUES.md`.