### PR TITLE
Fix the T-Rex jitter lever, stage-2 entropy anchor, and stale height target

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Apex Predator. **Specialty:** Head-contact attack task.
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
 |---|---|---:|---:|
-| 1 — Balance | Learn to stand and balance without falling | 6M | reward ≥ 100; episode length ≥ 750; ≥ 10 episodes/evaluation; 3 consecutive passes |
+| 1 — Balance | Learn to stand and balance without falling | 6M | reward ≥ 1900; episode length ≥ 750; ≥ 10 episodes/evaluation; 3 consecutive passes |
 | 2 — Locomotion | Learn forward walking/running | 8M | reward ≥ 100; episode length ≥ 750; avg. velocity ≥ 2 m/s; ≥ 10 episodes/evaluation; 3 consecutive passes |
 | 3 — Bite | Sprint to prey and make contact with the head bite proxy | 8M | reward ≥ 100; task success ≥ 50.0%; ≥ 10 episodes/evaluation; 3 consecutive passes |
 

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -20,7 +20,16 @@ nosedive_termination_threshold = 0.47          # Terminates at forward_z < -0.51
                                                # 0.35 that preceded the natural_pitch 0.17 -> 0.05 correction. natural_pitch
                                                # now describes the measured neutral pose, so the threshold absorbs the
                                                # 0.12 shift and the absolute termination envelope is identical.
-smoothness_weight = 0.1
+smoothness_weight = 0.7                        # Raised from 0.1: the action-rate penalty was a rounding error.
+                                               # Measured on run 20260725_194916, the term paid -0.0259/step against
+                                               # an alive bonus of 1.75 -- 1.0% of return -- while RMS action change
+                                               # per joint sat at 1.018, 2-3x beyond the 0.3-0.5 "severe" band in
+                                               # docs/investigations/TREX_STAGE1_LEG_JITTER.md. That run confirmed the
+                                               # doc's escalation condition: anchoring the entropy decay annealed
+                                               # algo_std (1.012 -> 0.959, vs 1.012 -> 1.038 un-anchored) but left the
+                                               # deterministic action rate unchanged. Sized from the penalty formula
+                                               # -w*sum(da^2)/(n*4): 0.7 puts smoothness at ~10% of the alive bonus
+                                               # (~6.8% of return) instead of 1.0%. Single-variable change.
 heading_weight = 0.1                           # Small heading reward to prevent spin-to-balance exploits
 gait_symmetry_weight = 0.0                     # Disable: default formula rewards single-foot stance, bad for balance
 height_weight = 1.0                            # Increased from 1.0: stronger signal to maintain pelvis at target 0.90m
@@ -105,7 +114,16 @@ net_arch = [512, 256]                  # Match SB3 PPO architecture
 
 [curriculum]
 timesteps = 6000000
-min_avg_reward = 100.0
+min_avg_reward = 1900.0                 # Raised from 100.0, which could not bind: the zero-action policy scores
+                                        # 1800.56 +/- 1267.66 over 40 episodes on this plant and config
+                                        # (environments/shared/scripts/zero_action_baseline.py trex), so a statue
+                                        # cleared the old gate eighteen times over and advanced into stage 2. The
+                                        # July 2026 runs that scored below the do-nothing floor all passed it.
+                                        # 1900 sits just above the measured floor; run 20260725_194916 reached
+                                        # 2696.83 +/- 40.6, so a healthy run keeps ~800 of headroom.
+                                        # NOTE: this is a measured constant and will go stale if the plant or the
+                                        # reward weights change -- re-run the baseline script and update it, or
+                                        # better, wire that script in as an automatic pre-stage check.
 min_avg_episode_length = 750
 required_consecutive = 3
 collapse_min_evals = 20                 # Backstop early-stop (EvalCollapseEarlyStopCallback): wait ~1M steps before it can fire.

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -124,6 +124,23 @@ min_avg_reward = 1900.0                 # Raised from 100.0, which could not bin
                                         # NOTE: this is a measured constant and will go stale if the plant or the
                                         # reward weights change -- re-run the baseline script and update it, or
                                         # better, wire that script in as an automatic pre-stage check.
+                                        #
+                                        # Two couplings this value carries, neither obvious from the name:
+                                        #  * A stage that misses its gate STOPS the curriculum -- stages 2 and 3
+                                        #    never run (train_base.py:1282-1292, "advancing with a weak policy
+                                        #    causes catastrophic forgetting"). With the old 100 that branch was
+                                        #    unreachable. A failed stage 1 now costs 3.7h instead of 13h, which is
+                                        #    the intent, but it means a bad stage-1 experiment ends the run.
+                                        #  * It also sets the collapse detector's arming threshold: peak_floor
+                                        #    falls back to min_avg_reward when collapse_peak_floor is unset
+                                        #    (curriculum.py:1014), and no config sets the latter. Detection now
+                                        #    arms only once the rolling-median peak clears 1900 rather than 100 --
+                                        #    safer against the long pre-convergence grind, but a run that plateaus
+                                        #    below 1900 gets no collapse protection at all.
+                                        # Note the floor itself pays no smoothness penalty (a constant action has
+                                        # no action delta), so raising smoothness_weight lowers a real policy's
+                                        # score against a gate calibrated on a statue. At the predicted ~2542 the
+                                        # margin is ~640; re-check this gate if that weight rises much further.
 min_avg_episode_length = 750
 required_consecutive = 3
 collapse_min_evals = 20                 # Backstop early-stop (EvalCollapseEarlyStopCallback): wait ~1M steps before it can fire.

--- a/configs/trex/stage2_locomotion.toml
+++ b/configs/trex/stage2_locomotion.toml
@@ -48,6 +48,15 @@ ent_coef_end = 0.001                    # Decay entropy over the stage (EntCoefD
                                         # (with fall_penalty -150 and forward_vel_max 2.5) is what carried
                                         # velociraptor stage 2 to 2706 +/- 8 @ 2.75 m/s on the 1.5x-kp plant.
                                         # See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
+ent_coef_decay_timesteps = 4000000      # Anchor the decay to half the 8M budget, matching stage 1's 3M-of-6M.
+                                        # Without it decay_timesteps defaults to the full stage budget
+                                        # (train_base._maybe_ent_coef_decay_callback:502) and ent_coef coasts high.
+                                        # Measured on run 20260725_194916, this was the only T-Rex stage without the
+                                        # anchor and the only one whose policy std ROSE: algo_std climbed
+                                        # monotonically 1.024 -> 1.211 across all five quintiles, the same signature
+                                        # as un-anchored velociraptor stage 2 (1.01 -> 1.22). It also compounds --
+                                        # stage 3 inherited the inflated std (started 1.213 against stage 1's 0.947
+                                        # finish) and climbed to 1.438 despite carrying its own anchor.
 
 target_kl = 0.05                        # Loosened from 0.03 for the locomotion stage (fast early learning); matches the JAX path's value.
 

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -127,10 +127,19 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
     catalog = build_catalog()
     species = {entry["id"]: entry for entry in catalog["species"]}
 
-    for entry in species.values():
+    # Stage-1 reward gates are per-species because only the T-Rex has been
+    # calibrated against its zero-action baseline. 100.0 is the original
+    # placeholder, which cannot bind: every species' do-nothing policy clears
+    # it by a wide margin, so a statue advances into stage 2. The T-Rex's 1900
+    # sits just above its measured floor of 1800.56 +/- 1267.66
+    # (environments/shared/scripts/zero_action_baseline.py trex). The other
+    # three still need the same treatment.
+    stage_one_min_avg_reward = {"trex": 1900.0, "velociraptor": 100.0, "brachiosaurus": 100.0, "dibothrosuchus": 100.0}
+
+    for species_id, entry in species.items():
         stage_one, stage_two, stage_three = [stage["advancement_gate"] for stage in entry["stages"]]
         assert stage_one == {
-            "min_avg_reward": 100.0,
+            "min_avg_reward": stage_one_min_avg_reward[species_id],
             "min_avg_episode_length": 750,
             "min_avg_forward_velocity": None,
             "min_success_rate": None,

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -427,7 +427,14 @@ class TRexEnv(BaseDinoEnv):
 
         # 8c. Height maintenance reward (smooth gradient toward staying upright)
         min_z = self.healthy_z_range[0]
-        target_z = 0.90
+        # Settled pelvis height under the home controller, measured (zero action,
+        # zero reset noise, 600 steps: 0.9757 m, sd 0.0001).  This must track the
+        # plant: the previous 0.90 was the root height of the PRE-repair plant,
+        # and after the July home-equilibrium fix raised the stance to 0.9757 the
+        # term saturated at 1.0 everywhere in the healthy band -- a flat constant
+        # worth 39% of stage-1 and 10% of stage-2 return that shaped nothing.
+        # ``TestHeightTargetTracksStance`` pins it to the measured stance.
+        target_z = 0.9757
         height_frac = float(np.clip((pelvis_height - min_z) / (target_z - min_z), 0.0, 1.0))
         reward_height = self.height_weight * height_frac
         info["reward_height"] = reward_height

--- a/environments/trex/mjx_config.py
+++ b/environments/trex/mjx_config.py
@@ -58,7 +58,7 @@ register_species_mjx(
     sensor_tail_gyro_start=_SENSOR_TAIL_GYRO_START,
     forward_vel_max=8.0,
     fall_penalty=-100.0,
-    target_standing_z=0.90,  # SB3 height-maintenance target (trex_env.py)
+    target_standing_z=0.9757,  # SB3 height-maintenance target (trex_env.py); settled stance
     target_distance_range=(3.0, 8.0),
     target_lateral_range=(-2.0, 2.0),
     target_z=0.5,

--- a/environments/trex/tests/test_trex_env.py
+++ b/environments/trex/tests/test_trex_env.py
@@ -293,3 +293,75 @@ class TestFootContactSensors:
             frozenset((env.data.contact[index].geom1, env.data.contact[index].geom2)) for index in range(env.data.ncon)
         }
         assert adjacent_pairs.isdisjoint(actual_pairs)
+
+
+class TestHeightTargetTracksStance:
+    """The height-maintenance reward must have gradient at the operating point.
+
+    ``target_z`` is a measured constant: it has to track the plant's settled
+    stance.  It did not, and that is how it went stale.  The pre-repair T-Rex
+    stood at 0.90 m; the July 2026 home-equilibrium fix raised the stance to
+    0.9757 m and nothing updated the target, so ``height_frac`` clipped to 1.0
+    everywhere in the healthy band.  The term became a flat constant worth 39%
+    of stage-1 and 10% of stage-2 return while shaping nothing -- measured on
+    run 20260725_194916 as ``reward_height`` = 0.9995/step against
+    ``height_weight`` = 1.0.
+
+    These assert the property rather than the literal, so they stay valid if
+    the plant moves again.  (A cross-species version is blocked on the
+    brachiosaurus stance bug: its target is 1.2 m against a settled 1.078 m.)
+    """
+
+    @staticmethod
+    def _height_reward_at(env, pelvis_z: float) -> float:
+        mujoco.mj_resetDataKeyframe(env.model, env.data, env.home_keyframe_id)
+        # xpos is only populated by mj_forward, so resolve the current pelvis
+        # height before differencing against the target.
+        mujoco.mj_forward(env.model, env.data)
+        env.data.qpos[2] += pelvis_z - float(env.data.xpos[env.pelvis_id, 2])
+        mujoco.mj_forward(env.model, env.data)
+        assert float(env.data.xpos[env.pelvis_id, 2]) == pytest.approx(pelvis_z, abs=1e-6)
+        _, info = env._get_reward_info(np.zeros(env.action_space.shape, dtype=np.float32))
+        return info["reward_height"]
+
+    @staticmethod
+    def _settled_height(env) -> float:
+        env.reset(seed=0)
+        action = np.zeros(env.action_space.shape, dtype=np.float32)
+        for _ in range(300):
+            env.step(action)
+        return float(env.data.xpos[env.pelvis_id, 2])
+
+    def test_reward_is_saturated_at_the_settled_stance(self):
+        env = TRexEnv(reset_noise_scale=0.0, height_weight=1.0, healthy_z_range=(0.75, 1.6))
+        try:
+            settled = self._settled_height(env)
+            reward = self._height_reward_at(env, settled)
+            # Near-full rather than exactly 1.0: the target sits a hair above
+            # the settled stance, which leaves a sliver of headroom instead of
+            # clipping. Anything well below 1.0 means the target is too high.
+            assert 0.99 <= reward <= 1.0, (
+                f"a correctly standing T-Rex should earn essentially the full height reward, got {reward:.4f} "
+                f"at the settled stance {settled:.4f}"
+            )
+        finally:
+            env.close()
+
+    def test_reward_still_has_gradient_below_the_settled_stance(self):
+        """The regression: a target below the stance flattens the whole band."""
+        env = TRexEnv(reset_noise_scale=0.0, height_weight=1.0, healthy_z_range=(0.75, 1.6))
+        try:
+            settled = self._settled_height(env)
+            floor = env.healthy_z_range[0]
+            # Sample the healthy band between the fallen floor and the stance.
+            sagged = [settled - f * (settled - floor) for f in (0.25, 0.5, 0.75)]
+            rewards = [self._height_reward_at(env, z) for z in sagged]
+            assert all(r < 1.0 for r in rewards), (
+                f"height reward is saturated while sagging ({rewards} at {sagged}) -- target_z is "
+                f"below the settled stance {settled:.4f}, so the term is a constant, not a gradient"
+            )
+            assert rewards[0] > rewards[1] > rewards[2], (
+                f"height reward must fall monotonically as the pelvis sags, got {rewards}"
+            )
+        finally:
+            env.close()

--- a/environments/trex/tests/test_trex_env.py
+++ b/environments/trex/tests/test_trex_env.py
@@ -365,3 +365,31 @@ class TestHeightTargetTracksStance:
             )
         finally:
             env.close()
+
+    def test_sb3_and_mjx_height_targets_agree(self):
+        """The SB3 target and the MJX registry's copy must not drift apart.
+
+        ``target_z`` lives as a literal inside ``_get_reward_info`` while the
+        MJX path reads ``target_standing_z`` from the species registry, and
+        neither is fingerprinted. That is exactly how ``natural_forward_z``,
+        ``healthy_z_range`` and ``max_tilt_angle`` drifted between the two
+        paths. Compared behaviourally so the constant does not have to be
+        exposed: both paths must produce the same height reward.
+        """
+        import environments.trex.mjx_config  # noqa: F401
+        from environments.shared.mjx_env import _SPECIES_CONFIGS
+        from environments.shared.reward_functions import reward_height_maintenance
+
+        registered = _SPECIES_CONFIGS["trex"]["target_standing_z"]
+        env = TRexEnv(reset_noise_scale=0.0, height_weight=1.0, healthy_z_range=(0.75, 1.6))
+        try:
+            floor = env.healthy_z_range[0]
+            for pelvis_z in (0.9757, 0.95, 0.90, 0.85, 0.80):
+                sb3 = self._height_reward_at(env, pelvis_z)
+                mjx = float(reward_height_maintenance(pelvis_z, floor, registered, 1.0))
+                assert sb3 == pytest.approx(mjx, rel=1e-9), (
+                    f"height reward diverges at pelvis_z={pelvis_z}: SB3 {sb3:.6f} vs MJX {mjx:.6f} "
+                    f"(registry target_standing_z={registered})"
+                )
+        finally:
+            env.close()

--- a/environments/trex/tests/test_trex_env.py
+++ b/environments/trex/tests/test_trex_env.py
@@ -313,7 +313,7 @@ class TestHeightTargetTracksStance:
     """
 
     @staticmethod
-    def _height_reward_at(env, pelvis_z: float) -> float:
+    def _height_reward_at(env: TRexEnv, pelvis_z: float) -> float:
         mujoco.mj_resetDataKeyframe(env.model, env.data, env.home_keyframe_id)
         # xpos is only populated by mj_forward, so resolve the current pelvis
         # height before differencing against the target.
@@ -322,10 +322,10 @@ class TestHeightTargetTracksStance:
         mujoco.mj_forward(env.model, env.data)
         assert float(env.data.xpos[env.pelvis_id, 2]) == pytest.approx(pelvis_z, abs=1e-6)
         _, info = env._get_reward_info(np.zeros(env.action_space.shape, dtype=np.float32))
-        return info["reward_height"]
+        return float(info["reward_height"])
 
     @staticmethod
-    def _settled_height(env) -> float:
+    def _settled_height(env: TRexEnv) -> float:
         env.reset(seed=0)
         action = np.zeros(env.action_space.shape, dtype=np.float32)
         for _ in range(300):

--- a/environments/trex/tests/test_trex_env.py
+++ b/environments/trex/tests/test_trex_env.py
@@ -313,7 +313,11 @@ class TestHeightTargetTracksStance:
     """
 
     @staticmethod
-    def _height_reward_at(env: TRexEnv, pelvis_z: float) -> float:
+    def _height_reward_at(env, pelvis_z: float) -> float:
+        # ``env`` is left untyped to match the rest of this module: annotating
+        # it resolves ``action_space.shape`` to ``tuple[int, ...] | None``,
+        # which then fails the np.zeros and step() calls below. The explicit
+        # float() on the return is what keeps mypy happy about the Any.
         mujoco.mj_resetDataKeyframe(env.model, env.data, env.home_keyframe_id)
         # xpos is only populated by mj_forward, so resolve the current pelvis
         # height before differencing against the target.
@@ -325,7 +329,7 @@ class TestHeightTargetTracksStance:
         return float(info["reward_height"])
 
     @staticmethod
-    def _settled_height(env: TRexEnv) -> float:
+    def _settled_height(env) -> float:
         env.reset(seed=0)
         action = np.zeros(env.action_space.shape, dtype=np.float32)
         for _ in range(300):

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -408,7 +408,7 @@
           "config_path": "configs/trex/stage1_balance.toml",
           "timesteps": 6000000,
           "advancement_gate": {
-            "min_avg_reward": 100.0,
+            "min_avg_reward": 1900.0,
             "min_avg_episode_length": 750,
             "min_avg_forward_velocity": null,
             "min_success_rate": null,


### PR DESCRIPTION
## Summary

Four changes driven by run `20260725_194916` — the first full curriculum on the repaired plant, and the best T-Rex result on record: stage 1 **2696.83 ± 40.6** at 1000/1000 steps, stage 2 **3001.13 ± 8.27** at 3.34 m/s, stage 3 **1353.47 ± 207** at 97% success. All three stages passed.

The plant is now correct. These address the *task*, which the run showed is still mis-shaped.

## 1. `smoothness_weight` 0.1 → 0.7 (stage 1)

The run confirmed the escalation condition in `TREX_STAGE1_LEG_JITTER.md`. Anchoring the entropy decay did anneal the policy noise — `algo_std` 1.012 → 0.959, against 1.012 → 1.038 un-anchored — but the action rate did not move:

| signal | first 20% | last 20% |
|---|---|---|
| `algo_std` | 1.0119 | 0.9590 |
| **RMS action change / joint** | 1.0119 | **1.0175** |

That is still two to three times beyond the 0.3–0.5 "severe" band the doc defines. The reason is in the reward decomposition: the action-rate penalty paid **−0.0259/step against an alive bonus of 1.75 — 1.0% of return** — and it decays further across the curriculum (0.46% in stage 2, 0.09% in stage 3).

Sized from the penalty formula `−w·Σ(Δa)²/(n·4)`, 0.7 moves it to 0.181/step, about 10% of the alive bonus.

**This change is self-diagnosing.** The zero-action floor is unaffected by the weight (a constant action has zero action delta), so the comparison to the 2696.83 baseline stays clean:

| next stage-1 result | means |
|---|---|
| ~2542 | jitter unchanged (RMS ~1.02) — escalate further |
| ~2677 | RMS roughly halved |
| ~2707 | genuinely smooth (RMS ~0.3) |

Even paying the penalty in full the policy sits ~740 above the floor, so it cannot profit by collapsing into a statue.

## 2. `ent_coef_decay_timesteps = 4000000` (stage 2)

Half the 8M budget, matching stage 1's 3M of 6M. Stage 2 was the only T-Rex stage without the anchor and the only one whose policy noise rose:

| stage | anchor | first 20% | last 20% | trajectory |
|---|---|---|---|---|
| 1 | yes | 1.012 | 0.959 | 1.012 1.016 1.005 0.983 0.959 |
| 2 | **no** | 1.024 | **1.211** | 1.024 1.121 1.166 1.196 1.211 |
| 3 | yes | 1.330 | 1.438 | 1.330 1.456 1.451 1.441 1.438 |

Monotonic across all five quintiles — the same signature as un-anchored velociraptor stage 2 (1.01 → 1.22). **It compounds:** stage 3 started at 1.213, inheriting stage 2's finish rather than stage 1's 0.947, and climbed to 1.438 despite carrying its own anchor.

## 3. `target_z` 0.90 → 0.9757

Third instance of the same staleness class as `natural_pitch` and the foot sensors: a constant that did not move when the plant did. 0.90 was the root height of the **pre-repair** plant; the July home-equilibrium fix raised the settled stance to **0.9757 m** (measured, zero action and zero reset noise over 600 steps, sd 0.0001).

With the target below the stance, `height_frac` clipped to 1.0 everywhere in the healthy band, so the term was a flat constant worth **39% of stage-1 and 10% of stage-2 return that shaped nothing** — `reward_height` measured 0.9995/step against `height_weight` 1.0.

This barely moves the converged score (a well-standing policy still earns ~0.9995) or the zero-action floor (1802.71 → 1800.56), so the 2696.83 baseline stays comparable. What it restores is gradient in the sag region, where the term is supposed to work.

## 4. Stage-1 `min_avg_reward` 100.0 → 1900.0

The old gate could not bind — the zero-action policy scores **1800.56 ± 1267.66**, so a statue cleared it eighteen times over, and every July 2026 run that scored *below* the do-nothing floor still advanced into stage 2. 1900 sits just above the measured floor and leaves a healthy run ~800 of headroom.

## Adversarial pass (second commit)

Reviewing the above found one real defect and two undocumented couplings.

**The defect:** `target_z` was corrected in two places — the literal in `trex_env._get_reward_info` and `target_standing_z` in the MJX registry — with nothing pinning them together, and neither is fingerprinted. That is exactly how `natural_forward_z`, `healthy_z_range` and `max_tilt_angle` drifted between the two paths earlier in this branch. Having just fixed three instances of that class, the first commit created a fourth. `test_sb3_and_mjx_height_targets_agree` closes it behaviourally at five pelvis heights; diverging the registry back to 0.90 fails it with both values named.

**Coupling 1 — the gate stops the run.** A stage missing its gate breaks the curriculum (`train_base.py:1282-1292`); stages 2 and 3 never run. With the old 100 that branch was unreachable, so raising it activates a control-flow path this config has never exercised. It is the intent (a failed stage 1 costs 3.7h instead of 13h), but a bad stage-1 experiment now ends the whole run.

**Coupling 2 — the gate arms the collapse detector.** `peak_floor` falls back to `min_avg_reward` when `collapse_peak_floor` is unset (`curriculum.py:1014`), and no config sets the latter. Detection now arms only once the rolling-median peak clears 1900 rather than 100 — safer against the long pre-convergence grind, but a run plateauing below 1900 gets no collapse protection at all.

Both are documented in the config rather than changed, since the behaviour is what's wanted.

## New guards

- `TestHeightTargetTracksStance` — asserts the *property*, not the literal: full reward at the measured settled stance, strictly monotonic falloff across the healthy band. Survives the plant moving again. Reverting to 0.90 fails it with the saturated values named.
- `test_sb3_and_mjx_height_targets_agree` — pins the two paths' height rewards together.
- The catalog gate test becomes per-species; only the T-Rex has been calibrated, and the other three still carry the unbindable placeholder.

## Deliberately not changed

**Stage 2/3 `nosedive_weight`.** I had flagged the `natural_pitch` correction as leaving it ~5× stiffer at running lean. Measured on this run, `reward_nosedive` is **−0.0048/step in stage 2, 0.16% of return**. It does not bite; the recommendation was wrong.

**Stage-3 checkpoint selection.** The selector promotes the slower hunter: the final policy bites in 175 steps at 1.84 m/s with 96.7% success, while the promoted one takes 295 steps at 1.10 m/s for 97% — less reward per step but more per episode, because the approach and proximity terms keep accruing while it dawdles. Changing the criterion affects how every species' results are selected and published, so it needs a decision rather than a unilateral edit.

## Verification

1622 passed, 0 failures, 100 skipped (JAX/SB3 unavailable in the sandbox). Ruff clean. Plant manifest and species catalog both current — no revision bump needed, as none of these fields are fingerprinted. Verified independently that the MJX height path uses the same shared `reward_height_maintenance` as the SB3 inline formula (0.0 difference at every sampled height), that no stage config overrides `healthy_z_range`, and that `ent_coef_decay_timesteps` sits in the `[ppo]` block where `train_base.py:502` reads it.

## Follow-up

The gate is itself a measured constant and will go stale the same way the last three did. Wiring `zero_action_baseline.py` in as an automatic pre-stage check is the durable fix and is not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169ZTbUkuHzBpn1D6e1japH

---
_Generated by [Claude Code](https://claude.ai/code/session_0169ZTbUkuHzBpn1D6e1japH)_