### PR TITLE
Stand the T-Rex on a flexed theropod limb, not a columnar one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] — Reproducible Runs & Velociraptor Stage-1 Diagnosis (v0.3.4)
 
 ### Changed
+- **T-Rex home stance corrected to a flexed theropod limb** (breaking — plant
+  change, physics revision 4 → 5 **and** policy interface revision 6 → 7; all
+  existing T-Rex checkpoints are invalidated): the home keyframe stood the
+  animal on a 172.1° interior knee, 7.9° from full extension and inside the
+  singular region for leg-length control. Hip-to-ankle distance changed at
+  only 0.024 m/rad there, so servicing stage 1's live height term
+  (`height_weight = 1.0`) cost 23.7° of knee travel per centimetre of pelvis
+  height — geometry alone accounting for the 31°-per-step knee excursions that
+  three `smoothness_weight` escalations (0.1 → 0.7 → 2.0) reduced but could
+  not remove. The keyframe now flexes to a **135.0°** interior knee: 45° of
+  flexion from a fully columnar limb, the figure Hutchinson, Anderson, Blemker
+  & Delp (2005), "Analysis of hindlimb muscle moment arms in *Tyrannosaurus
+  rex* using a three-dimensional musculoskeletal computer model",
+  *Paleobiology* 31(4):676–701, use for *T. rex* in Fig. 8, converted by their
+  Table 1 rule ("for the knee subtract the angle here from 180°"). Leg-length
+  authority rises to 0.134 m/rad, i.e. **4.3° of knee per centimetre**. Femur
+  and tibia sit symmetrically 22.5° either side of vertical, the one
+  inclination that holds the hip over the ankle at this plant's tibia:femur of
+  1.000, so the CoM still sits 33.8% of the way heel-to-toe through the
+  support polygon against 34.3% before. The three rotations sum to zero, so
+  the metatarsus keeps its 21.8° digitigrade slope and the plantar pads and
+  digits keep their 0.5 mm contact; segment vectors, masses and inertias are
+  untouched. Leg `ctrlrange`s were re-centred on the new pose at unchanged
+  width, preserving the `home-keyframe-residual/v1` invariant that the range
+  midpoint *is* the home control — which incidentally cuts reachable knee
+  hyperextension from 40.2° to 5.0°. Every dependent constant was re-measured
+  on the new plant rather than adjusted by eye: `target_z` and
+  `target_standing_z` 0.9757 → 0.9260, `natural_pitch` 0.05 → 0.027,
+  `nosedive_termination_threshold` 0.47 → 0.493 (holding the absolute −0.520
+  forward_z envelope), `healthy_z_range` (0.75, 1.6) → (0.70, 1.55), and
+  `min_avg_reward` 1900 → 1840 from a re-run zero-action baseline of
+  1743.73 ± 1275.54 (was 1800.56 ± 1267.66). `visual_revision` is deliberately
+  unchanged: that layer fingerprints body-local geom/site/material/camera
+  definitions, which a pose edit does not touch. See
+  `docs/TREX_LEG_FLEXING_PLAN.md`.
+
 - **Velociraptor knee actuators raised to 1.5×kp** (breaking — plant change,
   physics revision 1 → 2): the knee measured 0 % clip at the moderate
   2.5 Hz/0.8-amplitude contract gait but 30–46 % at sprint-like 3–4 Hz

--- a/README.md
+++ b/README.md
@@ -108,12 +108,12 @@ Apex Predator. **Specialty:** Head-contact attack task.
 | Action dimension / actuators | 21 |
 | Generalized coordinates / velocities | nq=28, nv=27 |
 | Compiled dynamic model mass | 85.7 kg |
-| Plant contract revisions | policy r6; physics r4; visual r4 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r7; physics r5; visual r4 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/trex/assets/trex.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
 |---|---|---:|---:|
-| 1 — Balance | Learn to stand and balance without falling | 6M | reward ≥ 1900; episode length ≥ 750; ≥ 10 episodes/evaluation; 3 consecutive passes |
+| 1 — Balance | Learn to stand and balance without falling | 6M | reward ≥ 1840; episode length ≥ 750; ≥ 10 episodes/evaluation; 3 consecutive passes |
 | 2 — Locomotion | Learn forward walking/running | 8M | reward ≥ 100; episode length ≥ 750; avg. velocity ≥ 2 m/s; ≥ 10 episodes/evaluation; 3 consecutive passes |
 | 3 — Bite | Sprint to prey and make contact with the head bite proxy | 8M | reward ≥ 100; task success ≥ 50.0%; ≥ 10 episodes/evaluation; 3 consecutive passes |
 

--- a/configs/plant_manifest.generated.json
+++ b/configs/plant_manifest.generated.json
@@ -84,30 +84,30 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:a626ed80300c0575e283661ab4df0ef94c7daf7b20449acefaf7f5957380cf52",
+      "bundle_sha256": "sha256:a07cb824c731349e61506a4165dc8e66f3aa690fe9f7d336f9c2f9705858a94a",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
         "nq": 28,
         "nu": 21,
         "nv": 27,
-        "revision": 4,
+        "revision": 5,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:0c194766307bee3a7c9c555a841687f85e851fa443b57f151d26b4ee472a38cf"
+        "sha256": "sha256:0dc4e7798bad17cfda88ef6d79007cfc7cce31a4cffb972d6e798424b874f541"
       },
       "policy_interface": {
         "action_dim": 21,
         "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 6,
+        "revision": 7,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:db76ea6cb0b9a08d576fe324ec7ad169d15ba24c61daa3f1822259168821f9f2"
+        "sha256": "sha256:5f2ef9adf326ced7600b2bf7849e1971e92db87fb07472eccb8619da07149694"
       },
       "source": {
-        "closure_sha256": "sha256:f499af17638e3c91a24b470c711e9c47ebc94f3576bf321c2cd56a50e12cfa01",
+        "closure_sha256": "sha256:bd63a662293202088b354cb27de8fc52f6f0dfbf379932a60c06984d14c9cbf5",
         "dependencies": [
           {
-            "content_sha256": "sha256:aef603402e5a26ccfbb21540954443672cc285ee0def1ffd0103d98ad99d8242",
+            "content_sha256": "sha256:c64fb09dbe07d8dfc12525a491a4383f0a7e2ba27ef29c3f9946f90f4dbb628c",
             "kind": "mjcf",
             "logical_path": "environments/trex/assets/trex.xml"
           }

--- a/configs/plant_versions.toml
+++ b/configs/plant_versions.toml
@@ -48,9 +48,31 @@ policy_interface_revision = 6
 visual_revision = 3
 observation_schema = "bipedal-target/v1"
 
+# 4. The T-Rex theropod stance correction.  The home keyframe stood the animal
+#    on a near-straight knee (172.1 deg interior, 7.9 deg from full extension),
+#    which is the singular region for leg-length control: hip-to-ankle distance
+#    changes at only 0.024 m/rad there, so servicing the stage-1 height term
+#    cost 23.7 deg of knee travel per centimetre of pelvis height.  The keyframe
+#    now flexes the limb to a 135.0 deg interior knee -- 45 deg of flexion from
+#    the columnar reference pose, the figure Hutchinson et al. (2005,
+#    Paleobiology 31:676-701, Fig. 8) use for T. rex, converted by their own
+#    Table 1 rule ("for the knee subtract the angle here from 180 deg").  Femur
+#    and tibia sit symmetrically at 22.5 deg either side of vertical, which is
+#    the unique inclination holding the hip over the ankle for this plant's
+#    1.000 tibia:femur, so the CoM / support-polygon relationship is unchanged
+#    (33.8% heel-to-toe against 34.3% before).  Leg-length authority rises
+#    0.024 -> 0.134 m/rad, i.e. 23.7 -> 4.3 deg of knee per centimetre.
+#    Segment vectors, masses, inertias and the whole foot are untouched: the
+#    metatarsus keeps its authored 21.8 deg digitigrade slope because the three
+#    rotations sum to zero, so the plantar pad and digits keep their 0.5 mm
+#    contact.  PHYSICS moves (keyframe qpos, joint ranges, spring references);
+#    the POLICY INTERFACE moves because the leg ctrlranges were re-centred on
+#    the new pose and the home control vector -- which is what action zero
+#    commands under home-keyframe-residual/v1 -- moved with them.  Every
+#    existing T-Rex checkpoint is invalidated.
 [plants.trex]
-physics_revision = 4
-policy_interface_revision = 6
+physics_revision = 5
+policy_interface_revision = 7
 visual_revision = 4
 observation_schema = "bipedal-target/v1"
 

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -16,10 +16,14 @@ energy_penalty_weight = 0.075                  # Setting 4 sweep: 0.075 forces e
 tail_stability_weight = 0.15
 posture_weight = 1.5                           # Increased from 1.5: with lower alive_bonus, stronger tilt penalty drives upright stance
 nosedive_weight = 1.5                          # Increased from 3.0: complement posture weight to prevent forward pitch exploit
-nosedive_termination_threshold = 0.47          # Terminates at forward_z < -0.519 (~31° nose-down), unchanged from the
+nosedive_termination_threshold = 0.493         # Terminates at forward_z < -0.520 (~31.3° nose-down), unchanged from the
                                                # 0.35 that preceded the natural_pitch 0.17 -> 0.05 correction. natural_pitch
-                                               # now describes the measured neutral pose, so the threshold absorbs the
-                                               # 0.12 shift and the absolute termination envelope is identical.
+                                               # describes the measured neutral pose, so the threshold absorbs every shift in
+                                               # it and the absolute termination envelope stays put. The theropod stance
+                                               # correction moved natural_pitch 0.05 -> 0.027 (the flexed limb settles 1.55°
+                                               # nose-down where the columnar one settled 2.9°), so this re-derives as
+                                               #   0.493 = sin(0.05) + 0.47 - sin(0.027)
+                                               # and the plant still terminates at the same absolute -0.520.
 smoothness_weight = 2.0                        # Second escalation: 0.1 -> 0.7 -> 2.0. The lever works but was
                                                # under-dosed. 0.1 was a rounding error (-0.0259/step, 1.0% of
                                                # return) and left RMS action change per joint flat at 1.018 for a
@@ -134,13 +138,24 @@ net_arch = [512, 256]                  # Match SB3 PPO architecture
 
 [curriculum]
 timesteps = 6000000
-min_avg_reward = 1900.0                 # Raised from 100.0, which could not bind: the zero-action policy scores
-                                        # 1800.56 +/- 1267.66 over 40 episodes on this plant and config
+min_avg_reward = 1840.0                 # Raised from 100.0, which could not bind: the zero-action policy scores
+                                        # 1743.73 +/- 1275.54 over 40 episodes on this plant and config
                                         # (environments/shared/scripts/zero_action_baseline.py trex), so a statue
-                                        # cleared the old gate eighteen times over and advanced into stage 2. The
+                                        # cleared the old gate seventeen times over and advanced into stage 2. The
                                         # July 2026 runs that scored below the do-nothing floor all passed it.
-                                        # 1900 sits just above the measured floor; run 20260725_194916 reached
-                                        # 2696.83 +/- 40.6, so a healthy run keeps ~800 of headroom.
+                                        # 1840 sits just above the measured floor; run 20260725_194916 reached
+                                        # 2696.83 +/- 40.6 on the columnar plant, ~800 of headroom over its gate.
+                                        # Re-derived for the theropod stance correction, which moved the floor:
+                                        #    columnar   1800.56 +/- 1267.66, 60% full-horizon, gate 1900 (+5.5%)
+                                        #    theropod   1743.73 +/- 1275.54, 57% full-horizon, gate 1840 (+5.5%)
+                                        # The same +5.5% margin over the measured floor, which is the rule the
+                                        # 1900 was set by. The flexed stance costs the statue less than the plan
+                                        # expected -- -3.2% of reward and -3 points of full-horizon share, with a
+                                        # near-identical termination mix (23/13/4 truncated/nosedive/fallen
+                                        # against 24/12/4) -- because the position servos and their spring
+                                        # references moved with the pose, so the home controller still holds it.
+                                        # NOT yet confirmed against a trained policy on this plant: whether one
+                                        # still reaches ~2650 is what the stage-1 validation run measures.
                                         # NOTE: this is a measured constant and will go stale if the plant or the
                                         # reward weights change -- re-run the baseline script and update it, or
                                         # better, wire that script in as an automatic pre-stage check.
@@ -154,27 +169,35 @@ min_avg_reward = 1900.0                 # Raised from 100.0, which could not bin
                                         #  * It also sets the collapse detector's arming threshold: peak_floor
                                         #    falls back to min_avg_reward when collapse_peak_floor is unset
                                         #    (curriculum.py:1014), and no config sets the latter. Detection now
-                                        #    arms only once the rolling-median peak clears 1900 rather than 100 --
+                                        #    arms only once the rolling-median peak clears 1840 rather than 100 --
                                         #    safer against the long pre-convergence grind, but a run that plateaus
-                                        #    below 1900 gets no collapse protection at all.
+                                        #    below 1840 gets no collapse protection at all.
                                         # Note the floor itself pays no smoothness penalty (a constant action has
                                         # no action delta), so raising smoothness_weight lowers a real policy's
                                         # score against a gate calibrated on a statue. That asymmetry is now the
                                         # binding constraint on how far that weight can go, so re-check here on
                                         # every increase:
-                                        #  * The floor is unchanged at 1900. Re-measured on the merged plant after
-                                        #    smoothness_weight 0.1 -> 0.7 and target_z 0.90 -> 0.9757: still
-                                        #    1800.56 +/- 1267.66 over 40 episodes, identical to the original.
+                                        #  * The reward-weight history did not move the floor: re-measured on the
+                                        #    merged plant after smoothness_weight 0.1 -> 0.7 and target_z 0.90 ->
+                                        #    0.9757 it was still 1800.56 +/- 1267.66, identical to the original.
                                         #    Neither change moves a statue -- a constant action has no action
-                                        #    delta, and zero-action settles at exactly 0.9757 so height_frac
-                                        #    saturates under both targets.
+                                        #    delta, and zero-action settled at exactly the height target either
+                                        #    way, so height_frac saturated under both.
+                                        #  * The PLANT does move it. The stance correction is the first change
+                                        #    that has: 1800.56 -> 1743.73, which is what this gate re-derives
+                                        #    from. Re-run the baseline on any further plant edit.
                                         #  * At w=0.7 a real policy scored 2516.9 (run 20260726_191730), margin
-                                        #    ~617 over the gate.
-                                        #  * At w=2.0 the added tax is ~181/episode at the observed action rate,
-                                        #    so expect ~2340 before the policy adapts downward -- margin ~440.
-                                        # Still comfortable. But the tax scales with w while the floor does not,
-                                        # and a stage-1 miss halts the whole curriculum (see above), so treat
-                                        # ~3.0 as the point where this gate needs lowering rather than re-checking.
+                                        #    ~617 over the gate it faced.
+                                        #  * At w=2.0 the added tax was ~181/episode at the action rate the
+                                        #    columnar plant provoked, so ~2340 before the policy adapts downward.
+                                        #    The stance correction should shrink that tax rather than grow it:
+                                        #    the tax is w*r^2/4 per step, and the whole point of restoring
+                                        #    leg-length authority (23.7 -> 4.3 deg of knee per centimetre of
+                                        #    pelvis height) is that the height term no longer demands the large
+                                        #    excursions that set r = 0.628. Judge it on the validation run.
+                                        # But the tax scales with w while the floor does not, and a stage-1 miss
+                                        # halts the whole curriculum (see above), so treat ~3.0 as the point where
+                                        # this gate needs lowering rather than re-checking.
 min_avg_episode_length = 750
 required_consecutive = 3
 collapse_min_evals = 20                 # Backstop early-stop (EvalCollapseEarlyStopCallback): wait ~1M steps before it can fire.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -13,6 +13,7 @@ lands, fold its open items in here and archive the review document.
 | [reviews/CODE_REVIEW.md](reviews/CODE_REVIEW.md) (2026-03) | Duplication + code quality | Consolidation done in v0.3.0; bugs fixed except thread-unsafe CSV writes (below) |
 | [reviews/REPO_REVIEW_2026_06.md](reviews/REPO_REVIEW_2026_06.md) | Full repo: SB3 + JAX RL correctness, sweeps, configs, docs | ~25 verified bugs fixed in PRs #423–#425 |
 | [reviews/REPO_REVIEW_2026_07_RL_GCP.md](reviews/REPO_REVIEW_2026_07_RL_GCP.md) | GCP/Vertex integration, SB3/JAX/sweep delta pass, notebooks | ~30 verified bugs fixed in PR #426 (incl. the JAX eval/CLI follow-up pass) |
+| [reviews/VELOCIRAPTOR_PLANT_REVIEW.md](reviews/VELOCIRAPTOR_PLANT_REVIEW.md) (2026-07-27) | Raptor plant: anatomy vs published *Velociraptor* material, and mechanics | 11 findings, all open — **execution deferred until the T-Rex clears stages 1–3**; see below |
 
 Severity: **HIGH** = wrong results in common cases, **MEDIUM** = edge cases /
 robustness, **LOW** = cosmetic / QoL.
@@ -195,6 +196,79 @@ any re-sizing with
 Neutral-action stability and truly actuator-disabled passive behavior are now
 separate test contracts. Layered policy, physics, visual, and source identities
 are documented in [PLANT_CONTRACT.md](PLANT_CONTRACT.md).
+
+### Velociraptor plant — open (July 2026 raptor review)
+
+**The stance-referenced-spring migration above never reached the raptor.** It
+is the only species still carrying the pre-fix arrangement, and the
+consequences compound. Full evidence and method in
+[reviews/VELOCIRAPTOR_PLANT_REVIEW.md](reviews/VELOCIRAPTOR_PLANT_REVIEW.md).
+**Execution is deferred until the T-Rex clears stages 1–3** on the corrected
+stance (PR #464).
+
+| species | \|leg spring torque\| at home | `springref` outside the joint limit |
+|---|---|---|
+| **velociraptor** | **145.21 N·m** | **4 joints** |
+| trex | 0.00 N·m | 0 |
+| brachiosaurus | 0.47 N·m | 0 |
+| dibothrosuchus | 0.00 N·m | 0 |
+
+- **HIGH — stage 1 is already solved by doing nothing.** A zero-action policy
+  scores 1704.93 ± 259.12 at 98% full-horizon survival against
+  `min_avg_reward = 100.0`; it clears the gate **17×** and is promoted into
+  stage 2. Same failure the T-Rex config fixed by re-deriving its gate from the
+  measured statue floor. The reset-noise calibration was not carried over
+  either — the raptor is still at 0.05, measured at 97% statue survival, where
+  0.10 gives 80%. *Config-only fix, no checkpoint cost.*
+- **HIGH — the plant does not stand on its actuators.** No raptor leg joint
+  sets `springref`, so the springs are neutral at `qpos = 0` — which is
+  *outside the legal range* for the knee and ankle, making them a permanent
+  one-directional bias rather than a restoring element. Zero-action survival is
+  95% as committed, **0% with the springs deleted, and 0% with the same
+  stiffness anchored at the stance** (falls in ~1.4 s either way). The support
+  comes from the offset, not the stiffness. Deleting the T-Rex's leg springs,
+  by contrast, changes nothing (55% → 55%). Fixing this requires re-sizing the
+  leg actuators at the same time — exactly the pairing the brachiosaurus fix
+  needed.
+- **HIGH — foot touch sensors report 55.6% of transmitted force.** The
+  `r_foot`/`l_foot` sites sit on the `toe_d3` bodies, so digit IV (12.07 N) and
+  the metatarsus (17.36 N) are invisible against 36.79 N sensed of 66.22 N
+  real. This is the *same defect* as the T-Rex foot-contact repair (which was
+  at 77.6%); the raptor is worse and was never brought along. Foot contact is
+  a trained observation and feeds the JAX `foot_contact_gate`.
+- **HIGH (fidelity) — the metatarsus is 78% too long** relative to the femur:
+  model MT III/femur 0.741 against 0.416 (Persons & Currie 2016, *Sci Rep*
+  6:19828, Table 1, IGM 100/986) and ~0.51 from a second specimen (Norell &
+  Makovicky 1999, *AMNH Novitates* 3282). It also bears 26.2% of each foot's
+  load and forms the *rear* edge of the support polygon, so the "digitigrade"
+  foot is functionally part-plantigrade. tibia:femur is within 3.6% and correct
+  — leave it alone.
+- **MEDIUM — `natural_pitch` is stale by 4.0°.** Configured 0.35, the plant
+  settles at 0.4200. Because the raptor centres its posture reward on that
+  angle, standing naturally costs **~104 reward/episode** (1.745 → 1.850 per
+  step). *Verified free — the plant manifest stays current, so no checkpoint is
+  invalidated.*
+- **MEDIUM — the two claw motors are the only unbounded actuators** in any
+  plant (`forcelimited=False`, `gear=50`): 693 N at the claw tip, 5.2× body
+  weight, on the geom that scores stage 3. The July 2026 `forcerange` sweep
+  missed them.
+- **MEDIUM — SB3/MJX termination asymmetry.** SB3 terminates on floor contact
+  of torso, neck, head and tail_3/4/5; the MJX registration lists only the
+  three tail bodies and no `termination_site_heights`. On MJX the raptor can
+  put its face on the ground without terminating.
+- **LOW — `nosedive_termination_threshold` is hardcoded** at
+  `raptor_env.py:530` while the MJX path reads it from stage config. They agree
+  today only because no raptor TOML sets the key.
+- **Not recommended:** porting the T-Rex stance correction here. That argument
+  rests on a live stage-1 height term forcing knee travel through a
+  near-singular joint, and the raptor env has **no height reward at all** —
+  five height mentions, none of them a reward term, against 21 in
+  `trex_env.py`.
+- **Note for the hardware track:** because the springs are load-bearing, the
+  raptor's true actuator requirement is *higher* than its sim actuator forces
+  suggest, which pushes against the torque crux already flagged in
+  [hardware/HARDWARE_BOM.md](hardware/HARDWARE_BOM.md) §2.1. Magnitude needs
+  the retune; only the direction is known.
 
 > **Note:** these changes alter the physics plant. Policies trained before the
 > change are incompatible by contract, including when a change seems marginal;

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ past a couple of files get their own subdirectory with a short README index
 | [ROADMAP.md](ROADMAP.md) | 2026-04-18 | Active — phased project timeline |
 | [RECOMMENDATIONS.md](RECOMMENDATIONS.md) | 2026-03-25 | Active — codebase-wide improvement backlog |
 | [RL_TRAINING_PLAN.md](RL_TRAINING_PLAN.md) | 2026-03-26 | Active — remaining SAC/PPO runs across species |
-| [TREX_LEG_FLEXING_PLAN.md](TREX_LEG_FLEXING_PLAN.md) | 2026-07-27 | Proposed — stance correction (ranked over action scaling) for T-Rex leg flexing |
+| [TREX_LEG_FLEXING_PLAN.md](TREX_LEG_FLEXING_PLAN.md) | 2026-07-27 | Option 1 (stance correction) implemented; options 2–4 open, step 5 (port to the raptor) withdrawn — see the raptor review |
 | [MJX_CONVERSION_PLAN.md](MJX_CONVERSION_PLAN.md) | 2026-07-13 | Implemented design record — current divergences live in KNOWN_ISSUES and the JAX guide |
 | [WEBSITE_PLAN.md](WEBSITE_PLAN.md) | — | Active — Docusaurus site improvements |
 | [BALANCE_REWARD_METRICS.md](BALANCE_REWARD_METRICS.md) | 2026-03-16 | Proposed — composite ASHA metric for stage-1 sweeps |
@@ -80,7 +80,8 @@ than rewrite.
 Archived point-in-time reviews in [`reviews/`](reviews/) —
 [VELOCIRAPTOR_PLANT_REVIEW.md](reviews/VELOCIRAPTOR_PLANT_REVIEW.md)
 (2026-07-27, anatomy and mechanics audit of the raptor plant against published
-*Velociraptor* measurements),
+*Velociraptor* measurements; findings open, execution deferred until the T-Rex
+clears stages 1–3),
 [REPO_REVIEW_2026_06.md](reviews/REPO_REVIEW_2026_06.md),
 [REPO_REVIEW_2026_07_RL_GCP.md](reviews/REPO_REVIEW_2026_07_RL_GCP.md),
 [CODE_REVIEW.md](reviews/CODE_REVIEW.md) (superseded). Open findings live in

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,9 @@ than rewrite.
 ## Code & repo reviews
 
 Archived point-in-time reviews in [`reviews/`](reviews/) —
+[VELOCIRAPTOR_PLANT_REVIEW.md](reviews/VELOCIRAPTOR_PLANT_REVIEW.md)
+(2026-07-27, anatomy and mechanics audit of the raptor plant against published
+*Velociraptor* measurements),
 [REPO_REVIEW_2026_06.md](reviews/REPO_REVIEW_2026_06.md),
 [REPO_REVIEW_2026_07_RL_GCP.md](reviews/REPO_REVIEW_2026_07_RL_GCP.md),
 [CODE_REVIEW.md](reviews/CODE_REVIEW.md) (superseded). Open findings live in

--- a/docs/TREX_LEG_FLEXING_PLAN.md
+++ b/docs/TREX_LEG_FLEXING_PLAN.md
@@ -269,8 +269,21 @@ Also global across stages, and stage 2 reaches 6.36 m/s on that swing.
    pre-work for sizing `action_scale`, which is now demoted, and the model is
    saved on Drive so the measurement can be taken at any time.
 4. **Re-evaluate whether `action_scale` is still needed.** It may not be.
-5. **Apply the same stance treatment to the raptor**, and extend the geometry
-   probe to the quadrupeds.
+5. ~~**Apply the same stance treatment to the raptor**~~ — **withdrawn.** The
+   raptor was reviewed on 2026-07-27
+   ([reviews/VELOCIRAPTOR_PLANT_REVIEW.md](reviews/VELOCIRAPTOR_PLANT_REVIEW.md))
+   and the argument does not transfer: this plan's mechanism is a live stage-1
+   height term forcing knee travel through a near-singular joint, and the
+   raptor env carries **no height reward at all**. Its columnar stance is real
+   (163.1°, 20.5°/cm) but nothing pulls on it. The review found two larger
+   problems instead — the raptor's stage 1 is passed by a do-nothing policy at
+   17× its gate, and the plant is held upright by unreferenced leg springs
+   (145 N·m at home; 0% survival without them) — and those must be fixed first.
+   **Also note:** this document's raptor comparison table (`r = 0.925`, ~53° of
+   knee per step, the "22× vs 11× authority ratio" row) was measured on that
+   plant, so it is not a usable benchmark for judging the T-Rex result.
+   Raptor work is scheduled after the T-Rex clears stages 1–3.
+   Extending the geometry probe to the quadrupeds is still open.
 
 ## Blast radius of the stance fix
 

--- a/docs/TREX_LEG_FLEXING_PLAN.md
+++ b/docs/TREX_LEG_FLEXING_PLAN.md
@@ -1,6 +1,6 @@
 # T-Rex Stage-1 Leg Flexing — Remediation Plan
 
-**Status:** Proposed — not implemented.
+**Status:** Option 1 implemented (2026-07-27); options 2–5 still open.
 **Date:** 2026-07-27
 **Motivating runs:** `20260725_194916` (w=0.1), `20260726_191730` (w=0.7),
 `20260727_130726` (w=2.0), all T-Rex stage 1, PPO, seed 42.
@@ -160,10 +160,58 @@ anything about them either way.
 
 ## Options, ranked
 
-### 1. Correct the home-keyframe stance (recommended)
+### 1. Correct the home-keyframe stance (recommended) — **DONE**
 
 Flex the home keyframe to a defensible theropod posture and re-centre the leg
 `ctrlrange` on the new pose.
+
+> **Implemented 2026-07-27.** Knee 172.1° → **135.0°** interior, which is 45°
+> of flexion from a fully columnar limb — the figure Hutchinson et al. (2005),
+> *Paleobiology* 31(4):676–701 use for *T. rex* in Fig. 8, converted by their
+> own Table 1 rule ("for the knee subtract the angle here from 180°"). The
+> same paper argues for "a more upright (but not completely columnar) pose,
+> rather than a more crouched pose" (p. 692), so 135° sits at the upright end
+> of the 110–140° spread rather than at its midpoint. Femur and tibia are
+> symmetric at 22.5° either side of vertical — the one inclination that keeps
+> the hip over the ankle at this plant's tibia:femur of 1.000, so the CoM
+> still sits 33.8% of the way heel-to-toe through the support polygon against
+> 34.3% before. Measured outcome:
+>
+> | | before | after |
+> |---|---|---|
+> | knee interior | 172.1° | 135.0° |
+> | ankle interior | 153.3° | 135.7° |
+> | femur from vertical | 4.9° | 22.5° |
+> | leg-length authority | 0.024 m/rad | **0.134 m/rad** |
+> | knee travel per 1 cm | 23.7° | **4.3°** |
+> | settled pelvis height | 0.9757 m | 0.9260 m |
+> | settled pitch | 2.90° nose-down | 1.55° nose-down |
+> | hip / knee / ankle hold | 52.1 / 49.5 / 58.0 N·m | 48.9 / 7.2 / 54.4 N·m |
+> | zero-action baseline | 1800.56 ± 1267.66 | 1743.73 ± 1275.54 |
+>
+> Segment vectors, masses, inertias and the whole foot are untouched: the
+> three rotations sum to zero, so the metatarsus keeps its 21.8° digitigrade
+> slope and the 0.5 mm plantar contact. `physics_revision` 4→5 and
+> `policy_interface_revision` 6→7; `visual_revision` stays at 4 because that
+> layer fingerprints body-local geom/site/material/camera definitions, none of
+> which a pose edit touches.
+>
+> Two things the fix did **not** do, both worth reading before sizing
+> anything else against it:
+>
+> - **It did not make the actuators work harder.** The knee's static hold
+>   *fell*, 49.5 → 7.2 N·m, because a properly flexed limb puts that joint
+>   almost on the line of the vertical ground reaction force. The "22×
+>   authority ratio" observation in this document is unchanged by the stance
+>   fix and is a separate question.
+> - **The zero-action floor barely moved** (−3.2% reward, 60% → 57%
+>   full-horizon). The risk section below predicted the statue would fall
+>   faster; it does, but only slightly, because the position servos and their
+>   spring references moved with the pose. The stage gate was still
+>   re-derived (1900 → 1840) rather than reused.
+>
+> Still outstanding from the Validation section: the stage-1 curriculum run
+> itself, and `test-jax-cpu` / `test-sb3`, which need CI.
 
 - Attacks the root cause. Restores height authority (~7× per the table above),
   loads the actuators sensibly, and plausibly shrinks the excursions without
@@ -208,8 +256,12 @@ Also global across stages, and stage 2 reaches 6.36 m/s on that swing.
 
 1. ~~**Measure the raptor's stance.**~~ **Done** — it is columnar too (table
    above). Scope this as a plant-wide issue with the T-Rex as the pilot.
-2. **Fix the T-Rex stance** (option 1), re-derive the dependent constants,
-   re-run. Nothing below blocks this.
+2. ~~**Fix the T-Rex stance** (option 1), re-derive the dependent constants,
+   re-run.~~ **Done** — see option 1 above. The dependent constants moved to
+   `target_z` 0.9260, `target_standing_z` 0.9260, `natural_pitch` 0.027,
+   `nosedive_termination_threshold` 0.493 (same absolute −0.520 envelope),
+   `healthy_z_range` (0.70, 1.55), `min_avg_reward` 1840. The re-run itself
+   is still outstanding.
 3. **Capture the current joint envelope** —
    `joint_excursion_report.py trex 1 <best_model.zip>` against
    `20260727_130726/stage1`, ~10 min in Colab. This is the "before" picture for

--- a/docs/hardware/HARDWARE_BOM.md
+++ b/docs/hardware/HARDWARE_BOM.md
@@ -116,6 +116,18 @@ The sim hip actuator caps at **±225 N·m** (`forcerange`, gear=1). Two readings
 - **First-principles walk:** static per-leg load ~66–132 N at a 0.2–0.3 m moment
   arm → ~13–40 N·m static, ×2–4 dynamic → **~40–80 N·m peak** at hip/knee.
   **COTS QDD actuators meet this.**
+
+> ⚠️ **The sim's static numbers currently understate the requirement** (found
+> 2026-07-27, see [../reviews/VELOCIRAPTOR_PLANT_REVIEW.md](../reviews/VELOCIRAPTOR_PLANT_REVIEW.md)
+> §3.2). No raptor leg joint sets `springref`, so passive joint springs supply
+> **145 N·m at the home stance** — load carried by an element with no BOM entry.
+> Deleting those springs drops zero-action survival from 95% to 0%, so they are
+> load-bearing, and a real robot's actuators would have to supply what they
+> supply. The direction is therefore known — **the true static requirement is
+> above what the sim's actuator forces show** — while the magnitude needs the
+> spring/gain retune tracked in [../KNOWN_ISSUES.md](../KNOWN_ISSUES.md).
+> Re-derive this section after that lands. The T-Rex, brachiosaurus and
+> dibothrosuchus reference their springs to the stance and are unaffected.
 - **Sim-cap / sprint:** the actuator-saturation study showed a 0.8×kp (120 N·m)
   cap clipped 34–40% of gait torque, so real gait torque sits **above 120 N·m**
   in the sprint/impact regime, bounded by the 225 N·m cap. **No single COTS

--- a/docs/reviews/VELOCIRAPTOR_PLANT_REVIEW.md
+++ b/docs/reviews/VELOCIRAPTOR_PLANT_REVIEW.md
@@ -5,6 +5,10 @@
 its MJX registration. Nothing was changed; this is a findings document.
 **Plant reviewed:** `physics_revision = 2`, `policy_interface_revision = 6`,
 `visual_revision = 3` (`configs/plant_versions.toml`).
+**Status:** findings accepted, **execution deferred** — the raptor changes are
+scheduled after the T-Rex clears stages 1–3 on the corrected stance (PR #464).
+Open items are mirrored into [KNOWN_ISSUES.md](../KNOWN_ISSUES.md) per the
+`docs/reviews/` convention.
 
 Every claim below is either a number measured on the committed plant or a
 published figure with a citation. Where a recommendation rests on a judgement
@@ -362,6 +366,66 @@ That is the distinction between "the model has passive tendon stiffness, which
 is biologically reasonable" and "the model has an invisible prop." Passive
 stiffness anchored near the neutral posture is the former. This is the latter.
 
+#### This is an unfinished migration, not a new discovery
+
+`KNOWN_ISSUES.md` already records **"stance-referenced springs"** as part of the
+July 2026 model review, applied to fix the brachiosaurus (which "could not
+physically hold any torso height in its alive region") and the T-Rex (its
+"former step-77 neutral nosedive"). Three of four species received it. The
+raptor did not:
+
+| species | sprung non-tail joints | \|spring torque\| at home | `springref` outside the joint limit |
+|---|---|---|---|
+| **velociraptor** | 12 | **145.21 N·m** | **4 joints** |
+| trex | 14 | 0.00 N·m | 0 |
+| brachiosaurus | 26 | 0.47 N·m | 0 |
+| dibothrosuchus | 23 | 0.00 N·m | 0 |
+
+So the project already decided this question — actuators carry the load, springs
+are referenced to the stance — and already paid the cost twice. The raptor was
+simply left out of the sweep. That makes R2 a *migration to an established
+convention with two working reference implementations in-tree*, not a design
+debate.
+
+(The same July sweep gave every species bounded `forcerange` on its position
+actuators. The raptor's two claw **motors** were missed by that pass as well —
+§3.3.)
+
+#### Why springs rather than actuators, and which is right here
+
+The XML shows the intent was deliberate: *"Hip ref angles are set to 38 deg …
+so joint springs hold this pose at rest."* Passive elastic support is a
+reasonable idea — tendon energy storage and series-elastic actuation are
+central to real legged locomotion. What makes this instance wrong is not that
+it is a spring but that it is an **undeclared** spring doing **unaccounted**
+work at an anchor nobody chose:
+
+- **The anchor is illegal.** `springref = 0` sits *outside* the joint range for
+  the knee (`[−120, −5]`) and the ankle (`[60, 160]`). The spring can never
+  reach equilibrium anywhere the joint is allowed to be, so across the whole
+  legal range it is a one-directional bias, never a restoring element. Nobody
+  picks a spring equilibrium the joint cannot reach.
+- **The reward cannot see it.** `BaseDinoEnv._reward_energy` is
+  `sum(action²) / n_actuators` — a pure function of the *action*, not of torque
+  or work. Passive support is therefore free, and the plant reads as more
+  efficient than it is.
+- **It has no part number.** `docs/hardware/HARDWARE_BOM.md` budgets sim torque
+  against purchasable actuators and already concludes the raptor is
+  "Walking: yes. Sprinting: no," because "Sim hip torque (225 N·m) exceeds any
+  single COTS actuator (~120 N·m max)." A 145 N·m passive bias holding the
+  animal up does not appear anywhere in that budget. Since removing it drops
+  survival to 0%, the true actuator requirement is **higher** than the sim's
+  actuator forces currently suggest — so this masks a sim-to-real gap in the
+  direction that makes the existing torque crux worse. The magnitude needs the
+  R2 retune to establish; only the sign is known today.
+
+The defensible pattern already exists in-tree. `HARDWARE_BOM.md` lists a
+*"passive compliant foot (v1)"* as an explicit BOM line, and the T-Rex's ankle
+carries a deliberate **5.5° preload** implemented as a *control* offset — named,
+documented, and visible as real actuator force (86.4 N·m at the keyframe), so it
+lands in the torque budget. Passive elements are welcome when they are declared
+parts anchored at the operating point; not when they are defaults.
+
 **Control: the T-Rex does not behave this way.** Same experiment, same
 protocol, on `trex.xml` (which sets `springref` to the stance on every leg
 joint, total spring torque at home 0.00 N·m):
@@ -551,16 +615,29 @@ constructor argument as the T-Rex has.
 | **R7** | Promote `nosedive_termination_threshold` to a constructor argument | §4.2 | config only |
 | **R8** | Shorten the metatarsus toward MT III / femur ≈ 0.42–0.51 | §2.2, two independent specimens | physics + policy revision; changes mass/inertia |
 
-**R1 first, and it is urgent rather than merely cheap.** It costs nothing, it
-requires no plant edit, and until it lands every raptor stage-1 run promotes a
-do-nothing policy into stage 2. It also has to be redone after R2, because R2
-moves the statue floor — but doing it now stops the bleeding.
+**Sequencing decision (2026-07-27):** none of this is being executed yet. The
+raptor work is scheduled **after the T-Rex clears stages 1–3** on the corrected
+stance (PR #464). Rationale: the T-Rex is currently the only species whose
+stage 1 is a real task — its statue *fails* its gate at 57% survival, where the
+raptor's clears by 17× at 98% — so it is the only platform that will produce a
+trustworthy curriculum result, and its outcome should inform how hard to push
+the raptor retune.
+
+**R1 first when work starts, and it is urgent rather than merely cheap.** It
+costs nothing, it requires no plant edit, and until it lands every raptor
+stage-1 run promotes a do-nothing policy into stage 2. It also has to be redone
+after R2, because R2 moves the statue floor — but it stops the bleeding on its
+own.
 
 **R2 is the real work** and everything else is small beside it. It is not a
 one-line change: the naive fix collapses the plant (§3.2), so the actuators
 have to be re-sized to take over the load the spring bias is currently
 carrying. Budget it as a design pass with its own before/after baselines, not
-as a bug fix.
+as a bug fix. Two things make it more tractable than it looks: the repo has
+**two working reference implementations** of stance-referenced springs (T-Rex,
+brachiosaurus), and `KNOWN_ISSUES.md` records that the brachiosaurus needed
+exactly the same pairing — stance-referenced springs *plus* stronger bounded
+leg servos — to reach an "actively servo-held home stand."
 
 **R3 is free and independent** — do it whenever.
 

--- a/docs/reviews/VELOCIRAPTOR_PLANT_REVIEW.md
+++ b/docs/reviews/VELOCIRAPTOR_PLANT_REVIEW.md
@@ -1,0 +1,655 @@
+# Velociraptor Plant Review — Anatomy and Mechanics
+
+**Date:** 2026-07-27
+**Scope:** `environments/velociraptor/assets/raptor.xml`, its Gymnasium env, and
+its MJX registration. Nothing was changed; this is a findings document.
+**Plant reviewed:** `physics_revision = 2`, `policy_interface_revision = 6`,
+`visual_revision = 3` (`configs/plant_versions.toml`).
+
+Every claim below is either a number measured on the committed plant or a
+published figure with a citation. Where a recommendation rests on a judgement
+call rather than a measurement, it says so.
+
+---
+
+## How to reproduce the measurements
+
+All plant numbers come from loading `raptor.xml`, resetting to the `home`
+keyframe, holding `key_ctrl`, and stepping 600 env steps (3000 MuJoCo steps at
+`timestep 0.002`, `frame_skip 5` — i.e. 6 s of settling at 100 Hz control).
+Contact forces use `mj_contactForce`; spring torques are computed directly as
+`-jnt_stiffness * (qpos - qpos_spring)`; the reward figures come from stepping
+the real `RaptorEnv` with `reset_noise_scale = 0` and the committed
+`configs/velociraptor/stage1_balance.toml` weights.
+
+Counterfactuals (§3.2) rebuild the model from modified MJCF text held in a
+temporary file, with `mujoco.MjModel.from_xml_path` redirected for the duration
+— nothing in the repository is edited, and the same stage config and seeds are
+used across variants so only the one attribute differs.
+
+This is the same instrument used for the T-Rex stance work, which reproduced
+that plant's committed constants exactly (`target_z` 0.9757, `natural_pitch`
+0.05, zero-action baseline 1800.56 ± 1267.66) before being trusted — so the
+protocol is validated against known-good numbers. The T-Rex also serves as the
+control for the §3.2 spring experiment.
+
+---
+
+## Summary of findings
+
+Ranked by (evidence strength × consequence). "Free" means the change moves no
+plant fingerprint and so invalidates no checkpoints — verified by regenerating
+the manifest, not assumed.
+
+| # | Finding | Evidence | Severity | Cost to fix |
+|---|---|---|---|---|
+| 1 | **Stage 1 is already solved by doing nothing** — a statue scores 17× the advancement gate at 98% survival | measured (§3.0) | **Critical** | config only |
+| 2 | **The plant does not stand on its actuators.** Remove the (unintended) leg spring bias and it falls in 1.4 s, 0% survival | measured, 3-way counterfactual + T-Rex control (§3.2) | **Critical** | plant + gain retune |
+| 3 | Foot touch sensor sees **55.6%** of transmitted floor force | measured | High — same bug class the T-Rex already fixed | plant revision bump |
+| 4 | Metatarsus **78% too long** relative to femur; also bears 26% of load, extending the support base rearward | Persons & Currie 2016 + measured | High | plant revision bump |
+| 5 | `natural_pitch` stale by **4.0°**, costing **~104 reward/episode** | measured | Medium | **free** |
+| 6 | Claw motors are the **only unbounded actuators** (693 N at tip, 5.2× body weight) | measured | Medium | plant revision bump |
+| 7 | MJX has **no torso/neck/head termination**; SB3 does | code, both paths | Medium | config only |
+| 8 | Ankle parks at **20.2%** of its range, not mid-range | measured | Medium — consequence of #2 | plant |
+| 9 | Stance is columnar (**163.1°** knee, 20.5°/cm) | measured | Low *for now* — see §3.5 | plant |
+| 10 | No neck or head articulation at all | code | Low–Medium | plant + obs change |
+| 11 | Forelimbs are 2-DOF stubs, 25% of femur+tibia+metatarsus length | measured | Low | design question |
+
+> **Findings 1 and 2 are the review's main result and they compound.** The
+> plant is held upright by a passive bias torque that no biological or robotic
+> system would get, and the stage that is supposed to teach it to balance is
+> already passed by a policy that does nothing. Every raptor training result to
+> date — including the `r = 0.925` jitter figure that
+> `docs/TREX_LEG_FLEXING_PLAN.md` compares the T-Rex against — was obtained on
+> this plant.
+
+**Correct as-is, do not change:** digit II is non-weight-bearing (§2.3),
+tibia:femur is within 3.6% of the published value (§2.2), the mass budget is
+close to published estimates (§2.1).
+
+---
+
+## 1. What the plant is
+
+| | value |
+|---|---|
+| `nq` / `nv` / `nu` | 31 / 30 / 22 |
+| bodies / geoms / sensors | 22 / 24 / 10 |
+| timestep, frame skip | 0.002 s, 5 → **100 Hz** control |
+| integrator | `implicitfast`, warmstart enabled |
+| total mass (prey excluded) | **13.50 kg** |
+| settled pelvis height | 0.4932 m |
+| settled pitch | 24.06° nose-down |
+
+Mass budget:
+
+| group | mass | share |
+|---|---|---|
+| axial (torso + neck + head, one rigid body) | 5.30 kg | 39.3% |
+| tail (5 segments) | 3.00 kg | 22.2% |
+| legs (both) | 4.90 kg | 36.3% |
+| forelimbs (both) | 0.30 kg | 2.2% |
+
+---
+
+## 2. Anatomical fidelity
+
+### 2.1 Size and mass — good
+
+Volumetric reconstructions of *Velociraptor mongoliensis* (holotype AMNH 6515)
+give **14.1–19.7 kg**. The model is **13.5 kg** — 4% below the bottom of that
+range, and clearly the right order. Hip height 0.493 m is consistent with the
+commonly cited ~0.5 m. The XML's "~2 m nose-to-tail" claim is roughly borne out
+(geom-centre extent 1.22 m, plus capsule half-lengths and the tail tip).
+
+**No action.** The animal is the right size.
+
+### 2.2 Hindlimb proportions — one segment is badly wrong
+
+Persons & Currie (2016), *Scientific Reports* 6:19828, Table 1, specimen
+**IGM 100/986** (*V. mongoliensis*): femur **238 mm**, tibia **255 mm**,
+metatarsal III **99 mm**.
+
+Measured on the plant (capsule lengths from `r_thigh_geom`, `r_tibia_geom`,
+`r_metatarsus_geom`):
+
+| segment | model | IGM 100/986 | model / real |
+|---|---|---|---|
+| femur | 181.1 mm | 238 mm | 0.761 |
+| tibia | 201.0 mm | 255 mm | 0.788 |
+| metatarsal III | **134.2 mm** | **99 mm** | **1.356** |
+| total limb | 516 mm | 592 mm | 0.872 |
+
+| ratio | model | real | error |
+|---|---|---|---|
+| tibia / femur | 1.110 | 1.071 | **+3.6%** ✔ |
+| MT III / femur | **0.741** | **0.416** | **+78.1%** ✘ |
+
+Share of total limb length: model femur 35.1% / tibia 38.9% / metatarsus
+**26.0%**; real 40.2% / 43.1% / **16.7%**.
+
+Norell & Makovicky (1999), *AMNH Novitates* 3282, give a second, independent
+data point on a different specimen (MPC-D 100/985): femur ~220 mm, metatarsal
+IV ~113 mm → MT/femur ≈ 0.51. The model's 0.741 is well above *both* published
+figures, so this is not an artefact of one specimen or one measurement
+convention.
+
+**tibia:femur is genuinely good** and should be left alone — it is the
+cursorial condition and the model has it within 4%. The problem is isolated to
+the metatarsus, which is roughly 45–78% too long depending on which specimen
+you compare against.
+
+This matters mechanically, not just cosmetically. A long metatarsus lengthens
+the moment arm from the ankle to the ground, which is exactly the joint already
+carrying the plant's highest actuator load (§3.4), and it makes the model look
+*more* cursorial than the animal was — Persons & Currie specifically find that
+"many dromaeosaur taxa, including *Velociraptor* and *Deinonychus*, have **low**
+cursorial-limb-proportion scores."
+
+### 2.3 The foot and digit II — correct, and worth protecting
+
+The sickle claw geoms carry `contype="2" conaffinity="2"` while the floor is
+`contype="1" conaffinity="1"`, so **the claw can never contact the ground** but
+*can* contact the prey (also class 2). Weight passes through digits III and IV
+only.
+
+That is the right call and it matches the literature. Fowler, Freedman,
+Scannella & Kambic (2011), *PLoS ONE* 6(12):e28964, "The Predatory Ecology of
+*Deinonychus* and the Origin of Flapping in Birds," argue the hypertrophied
+digit II claw was functionally analogous to the enlarged digit II talon of
+accipitrid hawks and eagles — a **prey-restraint** structure used to grip and
+pin, not a slashing or running structure. Held clear of the ground is exactly
+where it belongs.
+
+**No action** — but see §3.3, because the claw's *actuator* is not as carefully
+specified as its collision class.
+
+### 2.4 The tail — defensible, but not graded
+
+Dromaeosaurids are diagnosed partly by greatly elongated prezygapophyses and
+chevrons spanning several caudal vertebrae. Ostrom's original interpretation
+(from *Deinonychus*) was that these stiffened the tail so it could flex only at
+the base and swing as one rigid lever. That has since been softened: an
+articulated *V. mongoliensis* tail preserved in a long horizontal S-curve shows
+real lateral flexibility in life. The modern reading is that the rods raise
+stiffness so the tail works as a **dynamic stabilizer**.
+
+The model gives all five tail joints the *same* ±15° range and the *same*
+stiffness 40 / damping 15, and actuates only the proximal four DOF:
+
+| joint | range | stiffness | actuator |
+|---|---|---|---|
+| tail_1_pitch | ±15° | 40 | yes |
+| tail_1_yaw | ±10° | 40 | yes |
+| tail_2_pitch | ±15° | 40 | yes |
+| tail_3_pitch | ±15° | 40 | yes |
+| tail_4_pitch | ±15° | 40 | **none (passive)** |
+| tail_5_pitch | ±15° | 40 | **none (passive)** |
+
+So mobility is uniform rather than concentrated at the base, and cumulative
+deflection is ±75°. This is a reasonable engineering compromise and it is
+*directly* relevant to the project's robotics aims — Libby, Moore, Chang-Siu,
+Li, Cohen, Jusufi & Full (2012), *Nature* 481:181–184, "Tail-assisted pitch
+control in lizards, robots and dinosaurs," show an active tail stabilising body
+attitude by transferring angular momentum, using a lizard-sized robot.
+
+For contrast, the T-Rex plant took the other route and **fused** its distal two
+tail segments into rigid geometry, citing ossified tendons. The raptor keeping
+them jointed-but-passive is not wrong, but the two species now model the same
+anatomical structure two different ways, and neither file mentions the other.
+
+**Low priority.** If touched, grade the stiffness distally rather than adding
+range.
+
+### 2.5 Head and neck — absent
+
+There is **no neck or head body**. `neck` and `head` are geoms attached
+directly to the `pelvis` body, so the animal's head is rigidly welded to its
+torso with zero degrees of freedom.
+
+For a balance stage this is survivable. For **stage 3 (strike)** it is a real
+simplification: the task rewards bringing a claw to the prey, and the animal
+cannot orient its head at all. The T-Rex, whose stage 3 is a *bite* task, has
+`neck_pitch`, `neck_yaw` and `head_pitch`.
+
+**Judgement call, not a defect.** Flagged because it is invisible from the
+config layer and surprising given the T-Rex precedent.
+
+### 2.6 Forelimbs — heavily under-scaled
+
+Each arm is a single 0.130 m capsule, 0.15 kg, with two shoulder DOF and no
+elbow or wrist — **25% of the femur+tibia+metatarsus length** (21% if digit III
+is counted into the leg). Real
+*Velociraptor* forelimbs are long relative to the hindlimb and, under Fowler et
+al. (2011), functionally important: that paper's "stability flapping"
+hypothesis has dromaeosaurs beating their forelimbs to stay balanced atop
+pinned prey — precisely the stage-3 scenario this species trains for.
+
+Measured settled load on the shoulder actuators is **0.02 N·m (0.2% of
+forcerange)**, i.e. they currently do nothing, while costing 4 actuators and 8
+observation dimensions.
+
+**Judgement call.** Either commit to them (longer, with an elbow, per Fowler)
+or weld them as the T-Rex did — the current state is the expensive middle.
+
+---
+
+## 3. Plant mechanics defects
+
+### 3.0 Stage 1 is already solved by doing nothing
+
+`environments/shared/scripts/zero_action_baseline.py velociraptor --episodes 40`,
+committed stage-1 config:
+
+| | velociraptor | T-Rex (post stance fix) |
+|---|---|---|
+| statue reward | **1704.93 ± 259.12** | 1743.73 ± 1275.54 |
+| statue mean − std | **1445.81** | 468.19 |
+| statue episode length | **977.5 / 1000** | 638.1 |
+| statue full-horizon share | **98%** | 57% |
+| `min_avg_reward` gate | **100.0** | 1840 |
+| statue clears its gate by | **17×** | fails it |
+
+A policy that outputs `np.zeros(22)` survives 98% of episodes, scores 17× the
+stage's advancement gate, and is promoted into stage 2. There is almost nothing
+for a stage-1 policy to learn, and a run that learns nothing is indistinguishable
+from one that learns to balance.
+
+This is the exact failure the T-Rex config already documents and fixed —
+"a statue cleared the old gate eighteen times over and advanced into stage 2"
+(`configs/trex/stage1_balance.toml`). The raptor has the same problem, unfixed,
+at 17×.
+
+The reset-noise calibration was not carried over either. The T-Rex config
+records that `reset_noise_scale = 0.05` leaves a 93% statue floor so "the stage
+rewards a statue and training can only lose ground," which is why it moved to
+0.10. The raptor is still at 0.05:
+
+| `reset_noise_scale` | statue full-horizon | statue mean − std |
+|---|---|---|
+| 0.01 | 100% | 1745.4 |
+| **0.05 (committed)** | **97%** | **1393.4** |
+| 0.10 | 80% | 774.7 |
+| 0.15 | 60% | 301.7 |
+| 0.20 | 37% | −102.9 |
+
+In fairness, part of the gap to the T-Rex is the noise setting, not the plant:
+at matched noise (0.10) the raptor statue is 80% against the T-Rex's 57%. But
+80% is still a stage where doing nothing mostly works. The rest of the gap is
+§3.2.
+
+### 3.1 The foot touch sensor sees 55.6% of the force — the T-Rex bug, unfixed
+
+A MuJoCo touch sensor sums only contacts on geoms belonging to **its own
+site's body**. The `r_foot` / `l_foot` sites sit on the `*_toe_d3` bodies. The
+other two load paths are separate bodies and are therefore invisible:
+
+| body | floor force | sensed? |
+|---|---|---|
+| `r_toe_d3` | 36.79 N | **yes** |
+| `r_metatarsus` | 17.36 N | no |
+| `r_toe_d4` | 12.07 N | no |
+| **total transmitted** | **66.22 N** | sensor reports **36.79 N** |
+
+**The sensor captures 55.6% of the force the foot actually transmits**,
+identically on both feet.
+
+This is the *same defect, in the same repo*, that the T-Rex plant already
+fixed. `configs/plant_versions.toml` item 3 records it: "At the home keyframe
+each foot transmitted 500.4 N while its sensor reported 388.4 N" — 77.6%. The
+raptor is **worse** (55.6%), and the fix is already designed and shipped for
+the other species: give each load-bearing body its own touch site and sensor,
+append them after the existing sensor block so no index moves, and sum them in
+both the SB3 and MJX paths (`sensor_foot_aux_indices`).
+
+Two observations make this concrete rather than theoretical:
+
+- Foot contact is an **observation** the policy trains on, and it is used by
+  the JAX `foot_contact_gate` / `foot_contact_weight` reward terms.
+- Under load transfer the error is not a constant scale factor. If weight
+  shifts onto digit IV and the metatarsus, the reading can fall while the true
+  force rises — the same failure mode the T-Rex note describes ("under load
+  transfer the reading could drop to zero on a foot carrying full weight").
+
+### 3.2 `springref` is unset, and the springs are holding the animal up
+
+The `leg_joint` default class sets `stiffness="20.0"`. **No raptor leg joint
+sets `springref`**, so it defaults to 0 and every spring pulls its joint toward
+zero rather than toward the stance:
+
+| joint | home qpos | `ref` | `springref` | spring torque at home |
+|---|---|---|---|---|
+| `r_hip_pitch` | +38.0° | +38.0° | **0.0°** | −13.26 N·m |
+| `r_knee` | −50.0° | −50.0° | **0.0°** | +17.45 N·m |
+| `r_ankle` | +100.0° | +100.0° | **0.0°** | −34.91 N·m |
+| | | | **total** | **65.62 N·m per leg** |
+
+The T-Rex sets `springref` explicitly on every leg joint; its equivalent total
+is **0.00 N·m**.
+
+**The XML says this was not the intent.** The keyframe comment reads:
+
+> Hip ref angles are set to 38 deg (= 18 deg crouch + 20 deg lean compensation)
+> so **joint springs hold this pose at rest**.
+
+In MuJoCo `ref` sets the qpos↔pose mapping and `springref` sets the spring
+equilibrium; they are independent. Setting `ref` alone does not do what the
+comment describes. This is an author-intent mismatch documented in the file
+itself.
+
+**This is not a tidiness problem. The plant does not stand on its actuators.**
+
+Three-way counterfactual, zero action, committed stage-1 config, 20 episodes
+each (the model is rebuilt from modified MJCF; nothing in the repo is changed):
+
+| leg spring configuration | reward | episode length | full-horizon |
+|---|---|---|---|
+| **as committed** (stiffness 20, `springref` → 0) | 1671.8 ± 311.7 | 962.3 | **95%** |
+| springs deleted (stiffness 0) | 173.0 ± 56.7 | 138.9 | **0%** |
+| same stiffness, `springref` = stance | 161.9 ± 45.0 | 132.2 | **0%** |
+
+Remove the spring bias and the animal falls in ~139 steps — **1.4 seconds,
+every episode**. The position actuators cannot hold the pose on their own.
+
+The detail that matters most: **both** counterfactuals collapse. Anchoring the
+*same* stiffness at the pose the animal actually holds kills it as thoroughly
+as deleting the springs. So the support is not coming from the stiffness — it
+is coming from the **offset**. What holds the raptor up is a constant
+antigravity bias torque, 65.6 N·m per leg, that falls out of an unset attribute
+and is anchored at a joint coordinate with no anatomical meaning.
+
+That is the distinction between "the model has passive tendon stiffness, which
+is biologically reasonable" and "the model has an invisible prop." Passive
+stiffness anchored near the neutral posture is the former. This is the latter.
+
+**Control: the T-Rex does not behave this way.** Same experiment, same
+protocol, on `trex.xml` (which sets `springref` to the stance on every leg
+joint, total spring torque at home 0.00 N·m):
+
+| | as committed | springs deleted |
+|---|---|---|
+| reward | 1671.7 ± 1290.4 | 1681.5 ± 1283.9 |
+| full-horizon | 55% | **55%** |
+
+Deleting the T-Rex's leg springs changes nothing measurable. It stands on its
+actuators. So this is a raptor-specific defect, not a shared modelling
+convention — and the fix has a working reference implementation in the same
+repo.
+
+Secondary consequence: because the servos are dragged off their commanded pose,
+**the plant does not stand in the pose anyone authored.** The ankle is
+commanded to 100° and settles at 80.2°. The `home` keyframe is not the stance.
+
+`springref` and the actuator sizing have to move together, and the honest
+expectation is that fixing this makes stage 1 markedly harder — which is the
+point of fixing it.
+
+This also **re-explains a number the T-Rex leg-flexing plan flagged as
+notable.** That plan's comparison table gives raptor hip/knee/ankle hold at
+4.7% / 5.6% / **23.0%** of force limit against the T-Rex's 2.9% / 2.2% / 4.3%,
+and reads the raptor as the better-loaded plant. The measurement says
+otherwise: the ankle actuator is applying 34.54 N·m against a **−28.00 N·m
+spring**, so ~81% of that "load" is the plant fighting itself, not carrying the
+animal.
+
+### 3.3 The claw motors are the only unbounded actuators in the plant
+
+Every position actuator declares an explicit `forcerange`. The two claw
+actuators do not:
+
+```
+r_claw_act   forcelimited=False   forcerange=[0. 0.]   gear=50
+l_claw_act   forcelimited=False   forcerange=[0. 0.]   gear=50
+```
+
+`gear="50"` with `ctrlrange="-1 1"` means ±50 N·m applied to a 0.05 kg claw on
+a 0.0721 m geom — **693 N at the claw tip, 5.2× the animal's 132 N body
+weight**. Because the claw is the geom that contacts the prey
+(§2.3) and stage 3 rewards exactly that contact, this is the actuator most
+directly coupled to the task reward and the only one with no bound.
+
+The repo has a documented convention for this — `0.8× kp` spike caps, raised to
+`1.5× kp` for the stance joints, recorded in the actuator comment block and in
+`docs/investigations/STAGE2_RECOMMENDATIONS.md` R2. The claws were never
+brought into it.
+
+### 3.4 The ankle parks near the bottom of its range
+
+| joint | range | home | settled | position in range |
+|---|---|---|---|---|
+| `r_hip_pitch` | [−60, 90] | 38.0 | 34.0 | 62.7% |
+| `r_knee` | [−120, −5] | −50.0 | −45.2 | 65.1% |
+| `r_ankle` | [60, 160] | 100.0 | **80.2** | **20.2%** |
+| `r_toe_d3` | [−30, 60] | 10.0 | 5.1 | 39.0% |
+
+The ankle settles **20.2° from its lower stop** while carrying the plant's
+highest actuator load, and it sags 19.8° below its commanded 100° because it is
+fighting the −28 N·m spring (§3.2). The T-Rex's equivalent joints all park at
+46–50% of range by design.
+
+This is a consequence of §3.2, not an independent defect, and it should be
+re-measured after any `springref` work rather than fixed on its own.
+
+### 3.5 The stance is columnar, but the T-Rex argument does not transfer
+
+Measured: knee interior **163.1°**, ankle 127.9°, femur 13.7° from vertical,
+leg-length authority 0.0280 m/rad → **20.5° of knee travel per centimetre** of
+hip height.
+
+That is the same class of geometry the T-Rex stance correction just fixed
+(172.1° → 135.0°, 23.7°/cm → 4.3°/cm), and `TREX_LEG_FLEXING_PLAN.md` step 5
+proposes porting the treatment here.
+
+**The premise does not hold for this species.** The T-Rex argument was
+specifically that stage 1 carries a live height term (`height_weight = 1.0`,
+target 0.9757) which, from a locked knee, can only be serviced by large knee
+excursions. The raptor has **no height term at all**:
+
+- `configs/velociraptor/stage1_balance.toml` has no `height_weight` key.
+- `raptor_env.py` references pelvis height only for logging (`info["pelvis_height"]`,
+  twice) and for the shared height/tilt *termination* — there is no `target_z`,
+  no `height_frac`, no `reward_height`. Five height mentions in total, none of
+  them a reward term; `trex_env.py` has 21.)
+
+So the raptor has the poor geometry but nothing pulling on it. Its documented
+jitter (r = 0.925, ~53° of knee per step — *worse* than the T-Rex's 31°) is
+real, but the height-term mechanism cannot be its cause.
+
+**Recommendation: do not port the stance fix on the strength of the T-Rex
+result.** Diagnose the raptor's excursions on their own terms first. And note
+that §3.2 blocks a stance change anyway: you cannot meaningfully re-pose a limb
+whose stance is partly held up by a spring anchored at an unrelated angle.
+
+### 3.6 `natural_pitch` is stale by 4.0°, and it is not free reward
+
+`RaptorEnv.natural_pitch` defaults to **0.35 rad** (20.05°) and
+`mjx_config._NATURAL_PITCH` matches it. The plant settles at **0.4200 rad
+(24.06°)**, sd 0.0002 — a **+4.01°** mismatch.
+
+Unlike the T-Rex, the raptor *does* set `posture_target_forward_z`, so the
+posture reward is centred on the stale angle and the animal is penalised for
+standing in its own natural pose. Measured over a settled episode at the
+committed stage-1 weights (`posture_weight = 1.5`, `nosedive_weight = 1.5`):
+
+| | `natural_pitch` 0.35 | corrected to 0.42 |
+|---|---|---|
+| nosedive | **−97.3 / episode** | −0.1 |
+| posture | −7.3 / episode | −0.0 |
+| total reward | 1.745 / step | **1.850 / step (+6.0%)** |
+
+**~104 reward per episode of pure shaping error**, dominated by the nosedive
+term. It also shifts the nosedive *termination* boundary, costing ~4° of
+forward-pitch headroom.
+
+**This one is free.** I verified it: applying the change and running
+`python -m environments.shared.plant_contract --check` reports "Plant manifest
+is current" — no fingerprint moves, so no checkpoint is invalidated and no
+curriculum re-run is forced. The raptor's stage-1 gate is the placeholder
+`min_avg_reward = 100.0`, so there is nothing to re-derive either.
+
+One caveat that is the owner's call, not mine: `mjx_config.py` deliberately
+pins `natural_forward_z=-0.342` with the comment "Preserve the existing rounded
+nosedive baseline so reward shaping does not move the termination boundary in
+this isolated experiment." Someone froze that on purpose. Correcting
+`natural_pitch` retires that freeze.
+
+---
+
+## 4. SB3 / MJX parity
+
+### 4.1 The two paths terminate on different things
+
+| | SB3 (`raptor_env.py`) | MJX (`mjx_config.py`) |
+|---|---|---|
+| floor contact terminates | torso, neck, head, tail_3, tail_4, tail_5 | — |
+| body-height terminates | — | tail_3 0.05, tail_4 0.04, tail_5 0.03 |
+| site-height terminates | — | `None` |
+| healthy z | (0.3, 1.0) | (0.3, 1.0) |
+
+The tail is covered on both paths. **The torso, neck and head are covered only
+on SB3.** On MJX the raptor can put its face on the ground without terminating,
+as long as the pelvis stays above 0.3 m and pitch stays inside the nosedive
+gate (57° nose-down).
+
+For contrast, the T-Rex covers the anterior body on both paths — MJX
+`termination_body_heights` includes `skull: 0.45`, `torso: 0.25`, both thighs,
+and a `head_tip: 0.12` site threshold.
+
+This is the kind of divergence the shared `test_species_integration.py`
+`healthy_z_range` test was written to catch for *one* field; the termination
+surface has no equivalent test.
+
+### 4.2 The nosedive termination threshold is hardcoded on one path only
+
+`raptor_env.py:530` hardcodes it:
+
+```python
+if forward_z < self._natural_forward_z - 0.5:
+```
+
+The MJX path reads `nosedive_termination_threshold` from the stage config,
+defaulting to 0.5 (`jax_setup.py`). Today the two agree, because no raptor TOML
+sets the key. But the moment one does, MJX honours it and SB3 silently does
+not. The T-Rex exposes it as a constructor argument and its stage-1 config sets
+it explicitly.
+
+**Low severity today, latent trap.** Cheap to close by promoting it to a
+constructor argument as the T-Rex has.
+
+---
+
+## 5. Recommendations, ranked
+
+| # | Change | Evidence | Blast radius |
+|---|---|---|---|
+| **R1** | Re-derive `min_avg_reward` from the measured statue floor, and re-calibrate `reset_noise_scale`, exactly as the T-Rex config did | §3.0, statue clears the gate 17× at 98% survival | **config only** — no checkpoint cost |
+| **R2** | Set `springref` to the stance **and re-size the leg actuators together** so the plant carries itself | §3.2, 0% survival without the bias; T-Rex control | physics + policy revision; needs its own design pass |
+| **R3** | Correct `natural_pitch` 0.35 → measured 0.42 on both paths | §3.6, ~104 reward/episode | **none** — verified no fingerprint moves |
+| **R4** | Give digit IV and the metatarsus their own touch sites/sensors and sum them, as the T-Rex does | §3.1, sensor sees 55.6% | physics + policy revision |
+| **R5** | Bound the claw motors to the repo's documented `forcerange` convention | §3.3, only unbounded actuators | physics + policy revision |
+| **R6** | Add torso/neck/head termination to the MJX registration | §4.1, code-level asymmetry | config only |
+| **R7** | Promote `nosedive_termination_threshold` to a constructor argument | §4.2 | config only |
+| **R8** | Shorten the metatarsus toward MT III / femur ≈ 0.42–0.51 | §2.2, two independent specimens | physics + policy revision; changes mass/inertia |
+
+**R1 first, and it is urgent rather than merely cheap.** It costs nothing, it
+requires no plant edit, and until it lands every raptor stage-1 run promotes a
+do-nothing policy into stage 2. It also has to be redone after R2, because R2
+moves the statue floor — but doing it now stops the bleeding.
+
+**R2 is the real work** and everything else is small beside it. It is not a
+one-line change: the naive fix collapses the plant (§3.2), so the actuators
+have to be re-sized to take over the load the spring bias is currently
+carrying. Budget it as a design pass with its own before/after baselines, not
+as a bug fix.
+
+**R3 is free and independent** — do it whenever.
+
+**R4 and R5 together** if the raptor's revisions are being bumped at all: both
+are plant edits, both have in-repo precedent, and paying the checkpoint cost
+once is cheaper than twice. Fold them into R2 if R2 is happening.
+
+**R8 belongs with R2.** Both change the limb's static equilibrium, so doing one
+without the other means measuring the stance twice.
+
+### An honest note on ordering
+
+The first draft of this review ranked `springref` last, as a tidiness item, and
+`natural_pitch` first because it was free. That ordering was wrong, and the
+experiment in §3.2 is what corrected it. The lesson generalises: "the plant has
+an odd passive element" and "the plant is being held up by an odd passive
+element" look identical until you delete the element and re-run. Any future
+plant review here should run that counterfactual as a matter of course — it
+cost minutes and it changed the conclusion.
+
+### Explicitly not recommended
+
+- **Do not port the T-Rex stance correction** (`TREX_LEG_FLEXING_PLAN.md`
+  step 5) on the strength of the T-Rex result. The causal mechanism — a live
+  height term serviced through a near-singular knee — does not exist on this
+  species (§3.5).
+- **Do not change tibia:femur.** At 1.110 against a published 1.071 it is
+  within 3.6%, and a tibia longer than the femur is the correct cursorial
+  condition.
+- **Do not make digit II weight-bearing.** Its collision class is correct and
+  matches the prey-restraint interpretation (§2.3).
+
+---
+
+## 6. Open questions this review did not settle
+
+- **What actually causes the raptor's 53°/step knee excursions?** Ruled out:
+  the height-term mechanism (§3.5). Not investigated: the entropy anchor
+  (`docs/investigations/TREX_STAGE1_LEG_JITTER.md` records that raptor S1 was
+  the only stage that annealed `algo_std`), the 65.6 N·m spring load, and the
+  0.8×-kp toe actuators which sit at 10.7% load at rest. Note that §3.0 offers
+  a simpler candidate explanation than any of these: if standing costs nothing,
+  the policy is free to thrash without penalty, because there is no failure
+  mode to punish it.
+- **Can a retuned raptor stand at all?** §3.2 shows the springs are load-bearing
+  and that removing them naively collapses the plant. It does **not** show that
+  a properly re-sized plant can hold the pose — that requires the gain work in
+  R2, and it is possible the actuators need more authority than they currently
+  have. This is the main open risk in R2.
+- **Tail mass fraction.** The tail is 22.2% of body mass. I did not find a
+  published estimate for a dromaeosaurid tail mass fraction to check that
+  against, so it is unassessed rather than endorsed.
+- **Is the metatarsus meant to be load-bearing?** It carries 26.2% of each
+  foot's floor force and contacts at the rear of the support polygon, which
+  sits oddly with the "digitigrade stance" comment on the ankle joint. Whether
+  that is a deliberate ball-of-foot contact or a consequence of the overlong
+  metatarsus (§2.2) is unresolved.
+
+---
+
+## References
+
+1. Persons, W. S. & Currie, P. J. (2016). "An approach to scoring cursorial
+   limb proportions in carnivorous dinosaurs and an attempt to account for
+   allometry." *Scientific Reports* 6:19828. — Table 1, *V. mongoliensis*
+   IGM 100/986: femur 238 mm, tibia 255 mm, metatarsal III 99 mm; low CLP
+   scores for dromaeosaurs.
+2. Norell, M. A. & Makovicky, P. J. (1999). "Important features of the
+   dromaeosaurid skeleton II: information from newly collected specimens of
+   *Velociraptor mongoliensis*." *American Museum Novitates* 3282:1–45. —
+   second specimen, femur ~220 mm, metatarsal IV ~113 mm.
+3. Fowler, D. W., Freedman, E. A., Scannella, J. B. & Kambic, R. E. (2011).
+   "The Predatory Ecology of *Deinonychus* and the Origin of Flapping in
+   Birds." *PLoS ONE* 6(12):e28964. — digit II as an accipitrid-analogous
+   prey-restraint talon; stability-flapping hypothesis for the forelimbs.
+4. Libby, T., Moore, T. Y., Chang-Siu, E., Li, D., Cohen, D. J., Jusufi, A. &
+   Full, R. J. (2012). "Tail-assisted pitch control in lizards, robots and
+   dinosaurs." *Nature* 481:181–184. — active tails stabilising attitude by
+   angular-momentum transfer.
+5. Ostrom, J. H. (1969), on *Deinonychus* — origin of the stiffened-tail
+   "rigid lever" interpretation, since revised by the articulated S-curved
+   *Velociraptor* tail showing lateral flexibility in life.
+6. Volumetric body-mass estimates for *V. mongoliensis* (holotype AMNH 6515):
+   14.1–19.7 kg.
+
+### In-repo cross-references
+
+- `configs/plant_versions.toml` item 3 — the T-Rex foot-sensor repair this
+  review's §3.1 mirrors.
+- `docs/TREX_LEG_FLEXING_PLAN.md` — the stance argument §3.5 declines to port.
+- `docs/investigations/STAGE2_RECOMMENDATIONS.md` R2 — the actuator
+  `forcerange` convention §3.3 says the claws never joined.

--- a/environments/shared/data/plant_manifest.generated.json
+++ b/environments/shared/data/plant_manifest.generated.json
@@ -84,30 +84,30 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:a626ed80300c0575e283661ab4df0ef94c7daf7b20449acefaf7f5957380cf52",
+      "bundle_sha256": "sha256:a07cb824c731349e61506a4165dc8e66f3aa690fe9f7d336f9c2f9705858a94a",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
         "nq": 28,
         "nu": 21,
         "nv": 27,
-        "revision": 4,
+        "revision": 5,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:0c194766307bee3a7c9c555a841687f85e851fa443b57f151d26b4ee472a38cf"
+        "sha256": "sha256:0dc4e7798bad17cfda88ef6d79007cfc7cce31a4cffb972d6e798424b874f541"
       },
       "policy_interface": {
         "action_dim": 21,
         "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 6,
+        "revision": 7,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:db76ea6cb0b9a08d576fe324ec7ad169d15ba24c61daa3f1822259168821f9f2"
+        "sha256": "sha256:5f2ef9adf326ced7600b2bf7849e1971e92db87fb07472eccb8619da07149694"
       },
       "source": {
-        "closure_sha256": "sha256:f499af17638e3c91a24b470c711e9c47ebc94f3576bf321c2cd56a50e12cfa01",
+        "closure_sha256": "sha256:bd63a662293202088b354cb27de8fc52f6f0dfbf379932a60c06984d14c9cbf5",
         "dependencies": [
           {
-            "content_sha256": "sha256:aef603402e5a26ccfbb21540954443672cc285ee0def1ffd0103d98ad99d8242",
+            "content_sha256": "sha256:c64fb09dbe07d8dfc12525a491a4383f0a7e2ba27ef29c3f9946f90f4dbb628c",
             "kind": "mjcf",
             "logical_path": "environments/trex/assets/trex.xml"
           }

--- a/environments/shared/scripts/joint_excursion_report.py
+++ b/environments/shared/scripts/joint_excursion_report.py
@@ -97,9 +97,7 @@ def main(argv: list[str]) -> None:
         vecnorm_path = str(guess) if guess.exists() else None
     normalizer = None
     if vecnorm_path:
-        normalizer = VecNormalize.load(
-            vecnorm_path, DummyVecEnv([lambda: build_env(args.species, args.stage)])
-        )
+        normalizer = VecNormalize.load(vecnorm_path, DummyVecEnv([lambda: build_env(args.species, args.stage)]))
         normalizer.training = False
         normalizer.norm_reward = False
 
@@ -121,8 +119,10 @@ def main(argv: list[str]) -> None:
     ctrl = np.asarray(ctrl_log)
     qpos = np.asarray(qpos_log)
     print(f"\n{args.species} stage {args.stage}: {len(ctrl)} steps over {args.episodes} episodes")
-    print(f"  {'joint':<18}{'cmd p5-p95':>14}{'cmd full':>11}{'achieved':>11}"
-          f"{'ctrl span':>11}{'used':>7}{'delta/step':>12}")
+    print(
+        f"  {'joint':<18}{'cmd p5-p95':>14}{'cmd full':>11}{'achieved':>11}"
+        f"{'ctrl span':>11}{'used':>7}{'delta/step':>12}"
+    )
 
     for a in range(mj.nu):
         name = mujoco.mj_id2name(mj, mujoco.mjtObj.mjOBJ_ACTUATOR, a)
@@ -137,8 +137,10 @@ def main(argv: list[str]) -> None:
         full = c.max() - c.min()
         achieved = q.max() - q.min()
         delta = float(np.sqrt(np.mean(np.diff(c, axis=0) ** 2)))
-        print(f"  {name:<18}{band:11.1f} deg{full:8.1f} deg{achieved:8.1f} deg"
-              f"{span:8.0f} deg{100 * full / span:6.0f}%{delta:9.1f} deg")
+        print(
+            f"  {name:<18}{band:11.1f} deg{full:8.1f} deg{achieved:8.1f} deg"
+            f"{span:8.0f} deg{100 * full / span:6.0f}%{delta:9.1f} deg"
+        )
 
     env.close()
 

--- a/environments/shared/species_catalog.py
+++ b/environments/shared/species_catalog.py
@@ -138,7 +138,11 @@ def _optional_number(value: Any, *, field: str) -> int | float | None:
         return None
     if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
         raise CatalogError(f"{field} must be null or a finite number")
-    return value
+    # Annotated local: the isinstance guard above narrows the value, but mypy
+    # does not carry that narrowing out of an Any-typed parameter, so the bare
+    # ``return value`` trips no-any-return.
+    number: int | float = value
+    return number
 
 
 def _load_environment(entrypoint: str) -> type[Any]:

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -75,8 +75,14 @@ def test_catalog_publishes_layered_plant_contract() -> None:
         "brachiosaurus": "quadrupedal-target/v1",
         "dibothrosuchus": "quadrupedal-target/v1",
     }
-    expected_policy_revisions = {"velociraptor": 6, "trex": 6, "brachiosaurus": 3, "dibothrosuchus": 3}
-    expected_physics_revisions = {"velociraptor": 2, "trex": 4, "brachiosaurus": 1, "dibothrosuchus": 1}
+    # The T-Rex is at policy r7 / physics r5 for the theropod stance correction:
+    # the home keyframe moved off a near-straight knee onto a 135 deg one and
+    # the leg ctrlranges were re-centred on it, so both the compiled dynamics
+    # and the control interface changed. Its visual revision is deliberately
+    # NOT bumped -- the visual layer fingerprints geom/site/material/camera
+    # definitions, all of which are body-local and unchanged by a pose edit.
+    expected_policy_revisions = {"velociraptor": 6, "trex": 7, "brachiosaurus": 3, "dibothrosuchus": 3}
+    expected_physics_revisions = {"velociraptor": 2, "trex": 5, "brachiosaurus": 1, "dibothrosuchus": 1}
     expected_visual_revisions = {"velociraptor": 3, "trex": 4, "brachiosaurus": 1, "dibothrosuchus": 1}
     digest_pattern = re.compile(r"sha256:[0-9a-f]{64}")
     for species in catalog["species"]:
@@ -130,11 +136,13 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
     # Stage-1 reward gates are per-species because only the T-Rex has been
     # calibrated against its zero-action baseline. 100.0 is the original
     # placeholder, which cannot bind: every species' do-nothing policy clears
-    # it by a wide margin, so a statue advances into stage 2. The T-Rex's 1900
-    # sits just above its measured floor of 1800.56 +/- 1267.66
-    # (environments/shared/scripts/zero_action_baseline.py trex). The other
-    # three still need the same treatment.
-    stage_one_min_avg_reward = {"trex": 1900.0, "velociraptor": 100.0, "brachiosaurus": 100.0, "dibothrosuchus": 100.0}
+    # it by a wide margin, so a statue advances into stage 2. The T-Rex's 1840
+    # sits just above its measured floor of 1743.73 +/- 1275.54
+    # (environments/shared/scripts/zero_action_baseline.py trex). That floor
+    # is a property of the plant, so it moved with the theropod stance
+    # correction (from 1800.56) and the gate was re-derived from it at the
+    # same +5.5% margin. The other three still need the same treatment.
+    stage_one_min_avg_reward = {"trex": 1840.0, "velociraptor": 100.0, "brachiosaurus": 100.0, "dibothrosuchus": 100.0}
 
     for species_id, entry in species.items():
         stage_one, stage_two, stage_three = [stage["advancement_gate"] for stage in entry["stages"]]

--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -58,7 +58,7 @@
 
     Approximate dimensions (scaled for simulation, measured from the home keyframe):
       Body length: 1.2m (torso)
-      Hip height: 0.93m (pelvis body at 0.9775m)
+      Hip height: 0.88m (pelvis body at 0.9266m)
       Skull length: 0.5m
       Tail length: 1.5m
       Total mass: 85.7kg (scaled)
@@ -69,12 +69,52 @@
       - Powerful digitigrade hind legs; all three digits bear load
       - Heavy muscular tail as counterbalance to skull (~18% of mass)
       - Vertebral column held roughly horizontal: the PELVIS FRAME IS LEVEL at
-        the home keyframe, and settles ~2.9 deg nose-down under the home
+        the home keyframe, and settles ~1.55 deg nose-down under the home
         controller.  Only the torso capsule slopes (~10 deg).  Reward code
-        reads the pelvis frame, so natural_pitch tracks that 2.9 deg, not the
+        reads the pelvis frame, so natural_pitch tracks that 1.55 deg, not the
         capsule slope.
       - Body pivots at hips, skull and tail balance each other: the CoM sits
-        3mm behind the foot-contact centroid at home
+        3.7mm behind the foot-contact centroid at home
+
+    HIND-LIMB STANCE.  The home keyframe stands the animal on a flexed
+    theropod limb, not a columnar one:
+
+                        home     was      real T. rex
+      knee interior     135.0    172.1    flexed
+      ankle interior    135.7    153.3    flexed
+      femur from vert.   22.5      4.9    subvertical, inclined
+      hip height        0.877    0.928
+
+    135.0 deg is 45 deg of flexion from a fully columnar limb, which is the
+    knee angle Hutchinson, Anderson, Blemker & Delp (2005), "Analysis of
+    hindlimb muscle moment arms in Tyrannosaurus rex using a three-dimensional
+    musculoskeletal computer model", Paleobiology 31(4):676-701, use for T. rex
+    in Fig. 8.  Their Table 1 fixes the convention: "For all joints, 0 deg was
+    fully straightened", and to convert to an interior angle "for the knee
+    subtract the angle here from 180 deg".  The same paper concludes it "seems
+    reasonable to reconstruct T. rex in a more upright (but not completely
+    columnar) pose, rather than a more crouched pose" (p. 692).  Published
+    reconstructions span roughly 110-140 deg interior; 135 is deliberately at
+    the upright end of that spread, which is where this source argues for,
+    rather than the midpoint of it.
+
+    The 172.1 deg it replaces was 7.9 deg from full extension, i.e. inside the
+    singular region for leg-length control: hip-to-ankle distance changes at
+    only 0.024 m/rad there against 0.134 m/rad here, so holding pelvis height
+    cost 23.7 deg of knee travel per centimetre instead of 4.3.  See
+    docs/TREX_LEG_FLEXING_PLAN.md.
+
+    Femur and tibia sit symmetrically 22.5 deg either side of vertical.  That
+    is not a free choice: with this plant's tibia:femur of 1.000 it is the one
+    inclination that keeps the hip vertically above the ankle, so the stance
+    change does not move the body over the feet.  Measured, the CoM still sits
+    33.8% of the way heel-to-toe through the support polygon (34.3% before).
+
+    The three rotations from the reference pose (hip -17.6, knee +35.2,
+    ankle -17.6 deg) sum to zero, so the metatarsus keeps its authored
+    21.8 deg digitigrade slope and the plantar pad and all three digits keep
+    their 0.5 mm floor contact.  Segment vectors, masses and inertias are
+    untouched; only joint values, limits and control ranges moved.
     -->
 
     <body name="pelvis" pos="0 0 0.9795">
@@ -170,11 +210,31 @@
       <!-- ==================== RIGHT LEG ==================== -->
       <!-- Massive, powerful digitigrade legs -->
       <!-- Hip -> Thigh -> Tibia -> Metatarsus -> Toes -->
+      <!--
+      Reading the three stance joints.  ``ref`` and ``springref`` are NOT the
+      same pose here, and the difference is deliberate:
+
+        ref       the joint value at which the bodies sit exactly as the geoms
+                  below author them.  The geoms author the COLUMNAR reference
+                  limb, so ref still reads 15 / -60 / 94.5 and the physical
+                  rotation MuJoCo applies is (qpos - ref).  The home keyframe
+                  holds -17.6 / +35.2 / -17.6 of it; see the stance block at
+                  the top of this file.
+        springref the standing pose, so the passive leg spring (stiffness 40,
+                  leg_joint class) is neutral where the animal actually
+                  stands rather than pulling it back toward a straight leg.
+        range     re-centred on the standing pose, width unchanged.  The knee
+                  gains from this twice over: -74.8..25.2 spans 85..185 deg
+                  of interior angle, where -110..-10 around the columnar pose
+                  spanned 120..220.  Anything past 180 is the knee bending
+                  backwards, so the reachable hyperextension falls from
+                  40.2 deg to 5.0 as a side effect of the re-centring.
+      -->
 
       <body name="r_thigh" pos="-0.05 -0.14 -0.05">
         <!-- Hip: 2 DOF -->
         <joint name="r_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0"
-               range="-50 80" ref="15" springref="15"/>
+               range="-67.6 62.4" ref="15" springref="-2.6"/>
         <joint name="r_hip_roll" class="leg_joint" type="hinge" axis="1 0 0"
                range="-25 25" springref="0"/>
         <geom name="r_thigh_geom" type="capsule" fromto="0 0 0  0.03 0 -0.35" size="0.09"
@@ -183,14 +243,14 @@
         <body name="r_tibia" pos="0.03 0 -0.35">
           <!-- Knee: 1 DOF -->
           <joint name="r_knee" class="leg_joint" type="hinge" axis="0 1 0"
-                 range="-110 -10" ref="-60" springref="-60"/>
+                 range="-74.8 25.2" ref="-60" springref="-24.8"/>
           <geom name="r_tibia_geom" type="capsule" fromto="0 0 0  -0.03 0 -0.35" size="0.07"
                 mass="3.5" material="body_mat"/>
 
           <body name="r_metatarsus" pos="-0.03 0 -0.35">
             <!-- Ankle: 1 DOF (digitigrade stance) -->
             <joint name="r_ankle" class="leg_joint" type="hinge" axis="0 1 0"
-                   range="50 150" ref="94.5" springref="94.5"/>
+                   range="32.4 132.4" ref="94.5" springref="76.9"/>
             <geom name="r_metatarsus_geom" type="capsule" fromto="0 0 0  0.08 0 -0.2" size="0.025"
                   mass="1.2" material="body_mat"/>
             <!-- Thin plantar pad: gives the three digits one load-bearing
@@ -246,7 +306,7 @@
 
       <body name="l_thigh" pos="-0.05 0.14 -0.05">
         <joint name="l_hip_pitch" class="leg_joint" type="hinge" axis="0 1 0"
-               range="-50 80" ref="15" springref="15"/>
+               range="-67.6 62.4" ref="15" springref="-2.6"/>
         <joint name="l_hip_roll" class="leg_joint" type="hinge" axis="1 0 0"
                range="-25 25" springref="0"/>
         <geom name="l_thigh_geom" type="capsule" fromto="0 0 0  0.03 0 -0.35" size="0.09"
@@ -254,13 +314,13 @@
 
         <body name="l_tibia" pos="0.03 0 -0.35">
           <joint name="l_knee" class="leg_joint" type="hinge" axis="0 1 0"
-                 range="-110 -10" ref="-60" springref="-60"/>
+                 range="-74.8 25.2" ref="-60" springref="-24.8"/>
           <geom name="l_tibia_geom" type="capsule" fromto="0 0 0  -0.03 0 -0.35" size="0.07"
                 mass="3.5" material="body_mat"/>
 
           <body name="l_metatarsus" pos="-0.03 0 -0.35">
             <joint name="l_ankle" class="leg_joint" type="hinge" axis="0 1 0"
-                   range="50 150" ref="94.5" springref="94.5"/>
+                   range="32.4 132.4" ref="94.5" springref="76.9"/>
             <geom name="l_metatarsus_geom" type="capsule" fromto="0 0 0  0.08 0 -0.2" size="0.025"
                   mass="1.2" material="body_mat"/>
             <geom name="l_plantar_geom" type="box" pos="0.14 0 -0.218"
@@ -351,20 +411,32 @@
          original 200/250/150 gains let all three stance joints sag by
          16-23 degrees before producing support torque. These gains combine
          mass scaling with the tested stance margin; the existing 1.5x-kp
-         gait headroom remains unchanged. -->
-    <position name="r_hip_pitch_act" joint="r_hip_pitch" kp="1200" forcerange="-1800 1800" ctrlrange="-0.8727 1.3963"/>
+         gait headroom remains unchanged.
+
+         The three stance ctrlranges were re-centred on the theropod home
+         pose, keeping their widths (130/100/100 deg) and the invariant that
+         matters to home-keyframe-residual/v1: the midpoint of each range IS
+         the home control, so residual action zero commands the stance and
+         +-1 reach the endpoints symmetrically.  The ankle keeps its 5.5 deg
+         preload against gravity: its range is centred on the commanded
+         82.4 deg, not on the 76.9 deg the joint holds.  Settled hold torques
+         under these gains are 48.9 / 7.2 / 54.4 N.m against 1800 / 2250 /
+         1350 of authority; the knee's is near zero because the flexed limb
+         puts that joint almost on the line of the vertical ground reaction
+         force, which is the mechanically sound place for it. -->
+    <position name="r_hip_pitch_act" joint="r_hip_pitch" kp="1200" forcerange="-1800 1800" ctrlrange="-1.17984 1.08908"/>
     <position name="r_hip_roll_act" joint="r_hip_roll" kp="150" forcerange="-120 120" ctrlrange="-0.4363 0.4363"/>
-    <position name="r_knee_act" joint="r_knee" kp="1500" forcerange="-2250 2250" ctrlrange="-1.9199 -0.1745"/>
-    <position name="r_ankle_act" joint="r_ankle" kp="900" forcerange="-1350 1350" ctrlrange="0.8727 2.6180"/>
+    <position name="r_knee_act" joint="r_knee" kp="1500" forcerange="-2250 2250" ctrlrange="-1.30550 0.43982"/>
+    <position name="r_ankle_act" joint="r_ankle" kp="900" forcerange="-1350 1350" ctrlrange="0.56549 2.31081"/>
     <position name="r_toe_d2_act" joint="r_toe_d2_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
     <position name="r_toe_d3_act" joint="r_toe_d3_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
     <position name="r_toe_d4_act" joint="r_toe_d4_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
 
     <!-- Left leg -->
-    <position name="l_hip_pitch_act" joint="l_hip_pitch" kp="1200" forcerange="-1800 1800" ctrlrange="-0.8727 1.3963"/>
+    <position name="l_hip_pitch_act" joint="l_hip_pitch" kp="1200" forcerange="-1800 1800" ctrlrange="-1.17984 1.08908"/>
     <position name="l_hip_roll_act" joint="l_hip_roll" kp="150" forcerange="-120 120" ctrlrange="-0.4363 0.4363"/>
-    <position name="l_knee_act" joint="l_knee" kp="1500" forcerange="-2250 2250" ctrlrange="-1.9199 -0.1745"/>
-    <position name="l_ankle_act" joint="l_ankle" kp="900" forcerange="-1350 1350" ctrlrange="0.8727 2.6180"/>
+    <position name="l_knee_act" joint="l_knee" kp="1500" forcerange="-2250 2250" ctrlrange="-1.30550 0.43982"/>
+    <position name="l_ankle_act" joint="l_ankle" kp="900" forcerange="-1350 1350" ctrlrange="0.56549 2.31081"/>
     <position name="l_toe_d2_act" joint="l_toe_d2_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
     <position name="l_toe_d3_act" joint="l_toe_d3_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
     <position name="l_toe_d4_act" joint="l_toe_d4_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
@@ -448,20 +520,39 @@
   </contact>
 
   <!-- ==================== KEYFRAMES ==================== -->
-  <!-- Standing pose with a shallow (0.5 mm) plantar contact. Joint
-       references define the same authored physical stance while placing
-       the lower-body neutral controls at the actuator-range midpoints.
-       The ankle midpoint retains a 5.5 deg preload against gravity. -->
+  <!-- Flexed theropod standing pose with a shallow (0.5 mm) plantar contact,
+       and the lower-body neutral controls on the actuator-range midpoints.
+       The ankle midpoint retains a 5.5 deg preload against gravity.
+
+       Leg qpos, in degrees:  hip -2.6   knee -24.8   ankle 76.9
+       Leg ctrl, in degrees:  hip -2.6   knee -24.8   ankle 82.4
+
+       That is a 135.0 deg interior knee and a 22.5 deg femur inclination;
+       see the HIND-LIMB STANCE block at the top of this file for the source
+       and the derivation.  Root z 0.9266 is the height at which the plantar
+       pads and all six digits sit 0.5 mm into the floor at this pose; it
+       is a consequence of the joint values, not an independent choice, and
+       must be re-solved if they change.
+
+       Under the home controller this settles to pelvis 0.9260 m (sd 0.00001)
+       at forward_z -0.027.  Those two numbers are load-bearing constants
+       elsewhere and must be re-measured together with any edit here:
+         trex_env.py    target_z, natural_pitch, healthy_z_range
+         mjx_config.py  target_standing_z, _NATURAL_PITCH, healthy_z_range
+         configs/trex/stage1_balance.toml
+                        nosedive_termination_threshold, min_avg_reward
+       environments/trex/tests/test_trex_env.py::TestHeightTargetTracksStance
+       pins target_z to the settled stance so it cannot drift silently. -->
 
   <keyframe>
     <key name="home"
-         qpos="0 0 0.9775 1 0 0 0
+         qpos="0 0 0.9266 1 0 0 0
                0 0 0 0 0 0 0
-               0.261799 0 -1.047198 1.649336 0.218166 0.218166 0.218166
-               0.261799 0 -1.047198 1.649336 0.218166 0.218166 0.218166"
+               -0.045379 0 -0.432842 1.342158 0.218166 0.218166 0.218166
+               -0.045379 0 -0.432842 1.342158 0.218166 0.218166 0.218166"
          ctrl="0 0 0
-               0.2618 0 -1.0472 1.74535 0.2182 0.2182 0.2182
-               0.2618 0 -1.0472 1.74535 0.2182 0.2182 0.2182
+               -0.04538 0 -0.43284 1.43815 0.2182 0.2182 0.2182
+               -0.04538 0 -0.43284 1.43815 0.2182 0.2182 0.2182
                0 0 0 0"/>
   </keyframe>
 

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -81,7 +81,7 @@ class TRexEnv(BaseDinoEnv):
         bite_head_proximity_weight: float = 0.0,
         posture_weight: float = 0.2,
         nosedive_weight: float = 0.0,
-        natural_pitch: float = 0.05,
+        natural_pitch: float = 0.027,
         height_weight: float = 0.0,
         gait_symmetry_weight: float = 0.0,
         smoothness_weight: float = 0.05,
@@ -102,18 +102,29 @@ class TRexEnv(BaseDinoEnv):
         prey_distance_range: tuple[float, float] = (3.0, 8.0),
         prey_lateral_range: tuple[float, float] = (-2.0, 2.0),
         # Matches the MJX registration, which is the value the evidence
-        # supports.  The old SB3 floor of 0.50 could essentially never be the
-        # binding termination: tail_3/4/5 are unconditional termination geoms
-        # and the tail reaches the floor at a pelvis height of ~0.55-0.57 in a
-        # level squat, so the plant is already lying down before 0.50 is
-        # reached.  0.75 costs nothing measurable -- healthy full-horizon
-        # episodes bottom out at 0.884 m, 0.134 m of margin, 0/34 false
-        # terminations, and 1/300 stage-1 resets spawn below it (that episode
-        # was not recoverable anyway) -- while ending doomed episodes a median
-        # 74 steps sooner.  It also gives the MJX alive bonus, which scales by
-        # (z - floor) / (ceiling - floor), a 0.266 fraction at settled stance
-        # against the velociraptor's 0.275.
-        healthy_z_range: tuple[float, float] = (0.75, 1.6),
+        # supports.  Both bounds moved down by 0.05 with the theropod stance:
+        # the flexed home keyframe settles at 0.9260 m where the columnar one
+        # settled at 0.9757 (-0.0497).  Translating the whole band by the
+        # measured stance drop is what preserves the three measurements the
+        # old (0.75, 1.6) was sized on, rather than re-guessing them:
+        #   * The tail is the real backstop.  tail_3/4/5 are unconditional
+        #     termination geoms and the tail reaches the floor at a pelvis
+        #     height of ~0.55-0.57 in a level squat, so the plant is already
+        #     lying down below that.  The tail's pose is fixed relative to the
+        #     pelvis and does not move with the legs, so that figure is
+        #     unchanged and 0.70 still clears it by ~0.13.
+        #   * Healthy full-horizon episodes bottomed out 0.134 m above the
+        #     floor (0.884 against 0.75).  0.834 against 0.70 is the same
+        #     margin under a stance that sits 0.0497 lower.
+        #   * The MJX alive bonus scales by (z - floor) / (ceiling - floor),
+        #     which is 0.266 at the settled stance before and after -- that is
+        #     why the ceiling moves too -- against the velociraptor's 0.275.
+        # The spawn tail is preserved too: 2000 resets at reset_noise_scale
+        # = 0.10 put 0.75% below the floor on both plants (0.70 on this one,
+        # 0.75 on the columnar one).  The root-height jitter is a 0.10 m
+        # normal and dominates the joint noise on either stance, so the
+        # translated floor keeps the same share of unrecoverable spawns.
+        healthy_z_range: tuple[float, float] = (0.70, 1.55),
         reset_noise_scale: float = 0.01,
     ):
         model_path = str(Path(__file__).parent.parent / "assets" / "trex.xml")
@@ -142,12 +153,17 @@ class TRexEnv(BaseDinoEnv):
         self.foot_contact_gate = foot_contact_gate
         self.nosedive_termination_threshold = nosedive_termination_threshold
 
-        # Natural forward pitch (~2.9°), measured: the pelvis frame at the home
+        # Natural forward pitch (~1.55°), measured: the pelvis frame at the home
         # keyframe is level, and under the home controller the plant settles at
-        # forward_z ≈ -0.050.  The nosedive penalty and termination are measured
+        # forward_z ≈ -0.027.  The nosedive penalty and termination are measured
         # relative to that neutral pose.  The former 0.17 rad (9.7°) described
         # the torso capsule's built-in slope, not the pelvis frame the reward
         # actually reads, so it granted ~7 deg of unpenalized nose-down pitch.
+        # The theropod stance halved the residual: a flexed limb settles closer
+        # to its commanded pose than a columnar one does, so the plant now
+        # settles 1.55° nose-down where the columnar stance settled 2.9°.
+        # nosedive_termination_threshold in configs/trex/stage1_balance.toml is
+        # calibrated against this number and moved with it.
         # Unlike the raptor, the T-Rex posture reward stays centred on world
         # vertical (see _get_reward_info); the MJX path matches by leaving
         # posture_target_forward_z unset for this species.
@@ -428,13 +444,16 @@ class TRexEnv(BaseDinoEnv):
         # 8c. Height maintenance reward (smooth gradient toward staying upright)
         min_z = self.healthy_z_range[0]
         # Settled pelvis height under the home controller, measured (zero action,
-        # zero reset noise, 600 steps: 0.9757 m, sd 0.0001).  This must track the
+        # zero reset noise, 600 steps: 0.9260 m, sd 0.00001).  This must track the
         # plant: the previous 0.90 was the root height of the PRE-repair plant,
         # and after the July home-equilibrium fix raised the stance to 0.9757 the
         # term saturated at 1.0 everywhere in the healthy band -- a flat constant
         # worth 39% of stage-1 and 10% of stage-2 return that shaped nothing.
-        # ``TestHeightTargetTracksStance`` pins it to the measured stance.
-        target_z = 0.9757
+        # ``TestHeightTargetTracksStance`` pins it to the measured stance, which
+        # is how the 0.9757 -> 0.9260 move under the theropod stance correction
+        # was caught rather than left to drift.  Keep this and
+        # ``target_standing_z`` in environments/trex/mjx_config.py equal.
+        target_z = 0.9260
         height_frac = float(np.clip((pelvis_height - min_z) / (target_z - min_z), 0.0, 1.0))
         reward_height = self.height_weight * height_frac
         info["reward_height"] = reward_height

--- a/environments/trex/mjx_config.py
+++ b/environments/trex/mjx_config.py
@@ -11,12 +11,12 @@ import math
 from environments.shared.mjx_env import register_species_mjx
 
 # Must track ``TRexEnv.__init__``'s ``natural_pitch`` default (trex_env.py).
-# The pelvis frame is level at the home keyframe and settles ~2.9 deg
+# The pelvis frame is level at the home keyframe and settles ~1.55 deg
 # nose-down under the home controller; the nosedive penalty and termination
 # are both measured relative to that pose.  Kept as the angle rather than a
 # rounded forward_z so the two paths derive the same number from the same
 # quantity -- test_mjx_env.test_trex_creation pins them equal.
-_NATURAL_PITCH = 0.05
+_NATURAL_PITCH = 0.027
 
 # Sensor indices match the MJCF sensor definition order:
 # pelvis_gyro(3), pelvis_accel(3), pelvis_orientation(4),
@@ -38,7 +38,7 @@ register_species_mjx(
     action_mapping="home-keyframe-residual/v1",
     frame_skip=5,
     max_episode_steps=1000,
-    healthy_z_range=(0.75, 1.6),
+    healthy_z_range=(0.70, 1.55),
     # Matches the Gymnasium env (the BaseDinoEnv default), which is the value
     # the evidence supports.  max_tilt_angle is the absolute backstop; nosedive
     # is the per-stage tunable pitch gate.  Stages 2 and 3 leave
@@ -58,7 +58,7 @@ register_species_mjx(
     sensor_tail_gyro_start=_SENSOR_TAIL_GYRO_START,
     forward_vel_max=8.0,
     fall_penalty=-100.0,
-    target_standing_z=0.9757,  # SB3 height-maintenance target (trex_env.py); settled stance
+    target_standing_z=0.9260,  # SB3 height-maintenance target (trex_env.py); settled stance
     target_distance_range=(3.0, 8.0),
     target_lateral_range=(-2.0, 2.0),
     target_z=0.5,

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -357,18 +357,18 @@
         "nu": 21,
         "dynamic_mass_kg": 85.72,
         "plant_contract": {
-          "bundle_sha256": "sha256:a626ed80300c0575e283661ab4df0ef94c7daf7b20449acefaf7f5957380cf52",
-          "source_closure_sha256": "sha256:f499af17638e3c91a24b470c711e9c47ebc94f3576bf321c2cd56a50e12cfa01",
+          "bundle_sha256": "sha256:a07cb824c731349e61506a4165dc8e66f3aa690fe9f7d336f9c2f9705858a94a",
+          "source_closure_sha256": "sha256:bd63a662293202088b354cb27de8fc52f6f0dfbf379932a60c06984d14c9cbf5",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 6,
+            "revision": 7,
             "observation_schema": "bipedal-target/v1",
-            "sha256": "sha256:db76ea6cb0b9a08d576fe324ec7ad169d15ba24c61daa3f1822259168821f9f2"
+            "sha256": "sha256:5f2ef9adf326ced7600b2bf7849e1971e92db87fb07472eccb8619da07149694"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",
-            "revision": 4,
-            "sha256": "sha256:0c194766307bee3a7c9c555a841687f85e851fa443b57f151d26b4ee472a38cf"
+            "revision": 5,
+            "sha256": "sha256:0dc4e7798bad17cfda88ef6d79007cfc7cce31a4cffb972d6e798424b874f541"
           },
           "visual": {
             "schema": "mesozoic.mujoco-visual/v1",
@@ -408,7 +408,7 @@
           "config_path": "configs/trex/stage1_balance.toml",
           "timesteps": 6000000,
           "advancement_gate": {
-            "min_avg_reward": 1900.0,
+            "min_avg_reward": 1840.0,
             "min_avg_episode_length": 750,
             "min_avg_forward_velocity": null,
             "min_success_rate": null,


### PR DESCRIPTION
Implements **Option 1** of `docs/TREX_LEG_FLEXING_PLAN.md`.

> ⚠️ **Breaking plant change.** `physics_revision` 4→5 **and** `policy_interface_revision` 6→7. Every existing T-Rex checkpoint is invalidated and stage 1 must be re-run (~13 h curriculum).

## The problem

The home keyframe stood the animal on a **172.1°** interior knee — 7.9° from full extension, i.e. inside the singular region for leg-length control. Hip-to-ankle distance changed at only 0.024 m/rad there, so servicing stage 1's live height term (`height_weight = 1.0`) cost **23.7° of knee travel per centimetre** of pelvis height. That is enough, from geometry alone, to account for the 31°-per-step knee excursions that three `smoothness_weight` escalations (0.1 → 0.7 → 2.0) reduced but could never remove.

## The stance

The knee now sits at **135.0°** interior — 45° of flexion from a fully columnar limb, which is the knee angle used for *T. rex* in Fig. 8 of:

> Hutchinson, J. R., Anderson, F. C., Blemker, S. S., and Delp, S. L. (2005). "Analysis of hindlimb muscle moment arms in *Tyrannosaurus rex* using a three-dimensional musculoskeletal computer model: implications for stance, gait, and speed." *Paleobiology* 31(4):676–701.

converted to an interior angle by that paper's own Table 1 rule — *"for the knee subtract the angle here from 180°"*, with *"0° was fully straightened"*. The same paper concludes it *"seems reasonable to reconstruct T. rex in a more upright (but not completely columnar) pose, rather than a more crouched pose"* (p. 692), so 135° is deliberately the **upright end** of the 110–140° spread reconstructions span, not a silent midpoint between sources.

The femur inclination is not a second free choice. With this plant's tibia:femur of 1.000, femur and tibia symmetric at **22.5°** either side of vertical is the one pose holding the hip above the ankle, so the body does not move over the feet. The alternative was checked: Hutchinson's 15° hip moment-arm optimum puts the hip 8.5 cm forward of the ankle and the model tips onto its face (CoM at 458% of the support polygon).

The three rotations — hip −17.6, knee +35.2, ankle −17.6 — **sum to zero**, so the metatarsus keeps its authored 21.8° digitigrade slope and the plantar pads and all six digits keep their 0.5 mm floor contact. Segment vectors, masses and inertias are untouched.

## Dependent constants

Each was re-measured on the new plant rather than adjusted by eye. The protocol was validated first by reproducing the committed values *exactly* on the pre-change plant (0.97576 → `target_z` 0.9757; 0.0506 rad → `natural_pitch` 0.05; baseline 1800.56 ± 1267.66).

| | before | after |
|---|---|---|
| knee interior | 172.1° | **135.0°** |
| ankle interior | 153.3° | 135.7° |
| femur from vertical | 4.9° | 22.5° |
| leg-length authority | 0.024 m/rad | **0.134 m/rad** |
| knee travel per 1 cm | 23.7° | **4.3°** |
| settled pelvis height | 0.9757 m | 0.9260 m (sd 0.00001) |
| settled pitch | 2.90° nose-down | 1.55° nose-down |
| hip / knee / ankle hold | 52.1 / 49.5 / 58.0 N·m | 48.9 / 7.2 / 54.4 N·m |
| CoM through support polygon | 34.3% heel→toe | 33.8% heel→toe |
| `target_z` / `target_standing_z` | 0.9757 | 0.9260 |
| `natural_pitch` | 0.05 | 0.027 |
| `nosedive_termination_threshold` | 0.47 | 0.493 |
| `healthy_z_range` | (0.75, 1.6) | (0.70, 1.55) |
| `min_avg_reward` | 1900 | 1840 |

- **`nosedive_termination_threshold`** holds the absolute envelope fixed, which is the rule the previous edit set: `0.493 = sin(0.05) + 0.47 − sin(0.027)`, so the plant still terminates at forward_z −0.520 (31.33°).
- **`healthy_z_range`** moves *both* bounds by the measured 0.0497 stance drop. That is what preserves the three measurements the old band was sized on: the tail still reaches the floor at ~0.55–0.57 pelvis height (it does not move with the legs), healthy episodes keep the same 0.134 m bottom-out margin, and the MJX alive bonus still scales to 0.266 at settled stance. Measured over 2000 resets at `reset_noise_scale = 0.10`, **0.75% spawn below the floor on both plants**.
- **Leg `ctrlrange`s** are re-centred on the new pose at unchanged width, preserving the invariant `home-keyframe-residual/v1` depends on: each range midpoint *is* the home control (verified equal to machine precision). The ankle keeps its 5.5° gravity preload. Side effect worth having: reachable knee hyperextension falls from **40.2° to 5.0°**, because the old −110..−10 window reached 40° past straight.

## Validation

- **Zero-action baseline re-run:** `1743.73 ± 1275.54`, 57% full-horizon (was `1800.56 ± 1267.66`, 60%). The gate re-derives to 1840 at the same +5.5% margin over the measured floor that 1900 held over the old one. The plan predicted the statue would fall much faster; it does, but only slightly, because the position servos and their spring references moved with the pose.
- **Plant manifest regenerated**, both fingerprints confirmed changed, and the `--baseline` monotonicity check CI runs on the PR passes.
- **`visual_revision` deliberately left at 4.** The generator initially wanted 5, but that layer fingerprints body-local geom/site/material/camera definitions, none of which a pose edit touches. Bumping it would invalidate cached renders for nothing.
- **1657 tests pass** across all five species suites, plus `ruff check` and the plant-contract integration tests. `TestHeightTargetTracksStance` was confirmed to fail against the stale 0.9757 (0.7797 against a required ≥0.99) *before* being updated — the pin did its job.

## Not done / worth knowing

- **The knee's static hold *fell*, 49.5 → 7.2 N·m.** A properly flexed limb puts that joint almost on the line of the vertical ground reaction force, which is mechanically correct, but the plan's separate "the actuators are idle / 22× authority ratio" observation is **not** addressed by this change.
- **tibia:femur is still exactly 1.000**, which the plan flags as unrealistic for an adult *T. rex*. Correcting it means changing segment lengths and therefore masses and inertias — a wider blast radius than a stance fix, and its own change.
- **Reward weights untouched**, as scoped.
- **The causal claim is still unproven.** The geometry says the columnar knee *forced* the excursions; nothing here demonstrates a policy on the flexed plant actually commands fewer degrees per step. Restored authority permits a smoother solution, it does not compel one.
- Outstanding from the plan's Validation section: `test-jax-cpu` and `test-sb3` (no jax/torch/SB3 in the sandbox — CI only), and the stage-1 curriculum run itself. Recommend taking the plan's step-3 `joint_excursion_report.py` measurement against `20260727_130726/stage1` *before* spending the 13 h — it is ~10 min and it is the only "before" picture that makes the post-run comparison conclusive.