### PR TITLE
Widen the MJX/CPU foot-contact tolerance to a float32 solver residual

### DIFF
--- a/environments/shared/tests/test_mjx_env.py
+++ b/environments/shared/tests/test_mjx_env.py
@@ -493,7 +493,26 @@ class TestHomeKeyframeActionMapping:
         cpu_data = mujoco.MjData(ctx.mj_model)
         reset_mujoco_data_to_home(ctx.mj_model, cpu_data)
         mujoco.mj_forward(ctx.mj_model, cpu_data)
-        np.testing.assert_allclose(foot_sensors, cpu_data.sensordata[10:12], rtol=1e-5, atol=1e-3)
+        # Unlike the pad+digit sum above -- which re-adds the *same* float32
+        # numbers and so is legitimately tight -- this compares two independent
+        # constraint solves: MJX in float32 against MuJoCo CPU in float64.  The
+        # residual is dominated by float32 reduction order, which varies with
+        # the host's SIMD width, so it is a property of the machine rather than
+        # of the plant.  Measured on the same commit:
+        #     GitHub runner (pass)   <= 1.3e-05 relative
+        #     dev container          3.3e-05 relative (0.0122 N of 366 N)
+        #     GitHub runner (fail)   4.3e-04 relative (0.1560 N of 366 N)
+        # a 33x spread across three hosts.  rtol 1e-5 only ever passed on the
+        # lucky end of that: it fails deterministically on some machines, so
+        # this assertion was a hardware lottery rather than a flaky test.
+        #
+        # 5e-3 clears the worst observed residual by ~12x while still catching
+        # everything this assertion exists to catch, all of which is structural
+        # and an order of magnitude larger: a dropped digit is ~22% of the foot
+        # force, a wrong sensor index is orders of magnitude, and the July 2026
+        # stance correction -- the smallest real plant divergence on record --
+        # moved this reading 388.37 -> 366.41 N, 5.7%, still 11x this bound.
+        np.testing.assert_allclose(foot_sensors, cpu_data.sensordata[10:12], rtol=5e-3, atol=1e-3)
 
         assert env.config.action_mapping == "home-keyframe-residual/v1"
         assert env.config.reward_weights["foot_contact_gate"] == pytest.approx(1.0)


### PR DESCRIPTION
Fixes the `test-jax-cpu` failure seen on #464. One assertion, one number, plus a comment recording the measurements behind it.

## It is not a flaky test — it is a hardware lottery

`test_mjx_env.py::TestHomeKeyframeActionMapping::test_trex_stage1_factory_preserves_contact_physics_and_rewards` compares a **float32 MJX** constraint solve against a **float64 MuJoCo CPU** one and asserted `rtol=1e-5` — agreement to 0.0037 N on a 366 N contact force.

Measured on a single commit across three hosts:

| host | relative discrepancy | vs `rtol=1e-5` |
|---|---|---|
| GitHub runner | ≤1.3e-05 | pass |
| dev container | **3.3e-05** (0.0122 N of 366 N) | **fail** |
| GitHub runner | **4.3e-04** (0.1560 N of 366 N) | **fail** |

A **33× spread**. The residual is dominated by float32 reduction order, which varies with the host's SIMD width — so it is a property of the machine, not of the plant. It reproduces **deterministically** in the dev container, which is what distinguishes this from intermittency: the assertion has presumably been failing for anyone whose machine sits off the lucky end.

## Why `5e-3`

It clears the worst observed residual by ~12× while keeping everything the assertion actually guards against, all of which is structural and an order of magnitude larger:

| real divergence this still catches | magnitude |
|---|---|
| a dropped digit in the foot sum | ~22% of transmitted force |
| a wrong sensor index | orders of magnitude |
| the July 2026 stance correction — the smallest real plant divergence on record | 388.37 → 366.41 N = **5.7%**, still **11×** this bound |

The structural checks in the same test (`solver`, `iterations`, `ls_iterations`, `disableflags` equality) are untouched and remain exact.

## Deliberately not changed

The pad+digit assertion higher up in the same class:

```python
np.testing.assert_allclose(foot_observation, expected, rtol=1e-5, atol=1e-3)
```

That one re-adds the **same float32 numbers** — once inside the jitted observation builder, once in numpy — so its ~1 ULP residual and its tight tolerance are both correct, and it passes. Only the cross-precision comparison needed widening. (An earlier comment of mine on #464 suggested loosening both; reading the surrounding code showed that was wrong.)

## History

The current `1e-5` came from a5225b3, *"Use a float32 summation tolerance for the MJX foot-contact assertions"* — the right diagnosis, one notch too tight for the cross-precision case.

## Verification

Ran the exact `test-jax-cpu` selection locally on CPU JAX:

```
pytest environments/shared/tests/test_jax_*.py \
       environments/shared/tests/test_mjx_env.py \
       environments/shared/tests/test_reward_functions.py
```

**217 passed.** CI's last run of the same selection was 216 passed / 1 failed, the failure being this assertion. `ruff check` and `ruff format --check` clean on the changed file.

Worth noting the dev container reproduces the failure before the change and passes after, so this is verified against a real failing host rather than only argued from the CI log.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3UatsZPweofe5WjEEkCYA)_