### PR TITLE
Record the action-saturation finding, and the pre/post-clip metric hazard

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -48,6 +48,76 @@ tolerance) remains the standing recommendation for the divergences above.
 
 ## Training / RL
 
+- **HIGH** — **the reward is computed on unclipped actions, and the policy's raw
+  output runs 6–8× outside the action bound.** `BaseDinoEnv.step` clips for the
+  physics but not for the reward:
+
+  ```python
+  base_env.py:765   ctrl = self._scale_action(action)              # clips to [-1, 1] -> plant
+  base_env.py:783   reward, reward_info = self._get_reward_info(action)   # RAW -> reward
+  ```
+
+  Neither penalty clips internally — `reward_energy` is `sum(action**2) / n`
+  and `reward_action_smoothness` is `sum((action - prev_action)**2)`, both on
+  the raw value. `reward_energy`'s docstring states it "ranges [0, 1] when
+  actions are in [-1, 1]", which is an assumption nothing enforces.
+
+  Measured on T-Rex stage-1 run `20260727_130726` (PPO, 6.0M steps), from its
+  own tensorboard:
+
+  | `diagnostics/` scalar | first | last | mean | max |
+  |---|---|---|---|---|
+  | `action_abs_max` | 4.55 | 6.71 | **6.11** | **7.77** |
+  | `action_std` | 1.00 | 1.93 | 1.42 | 1.93 |
+  | `action_saturation` | 0.32 | **0.68** | 0.49 | 0.68 |
+  | `action_delta` | 21.27 | 6.24 | 15.04 | 21.43 |
+
+  `action_saturation` (fraction of components pinned at the limit, threshold
+  0.99) rose **monotonically** across all 6M steps — 0.32 → 0.68. By the end
+  **68% of action components are clipped at any instant**, and the raw output
+  peaks at 7.77 against a `Box(-1, 1)` action space. Note `train/std` *fell*
+  over the run (1.00 → 0.72) while the empirical `action_std` nearly doubled:
+  the policy is pushing its mean out of bounds, not widening its exploration.
+
+  Two consequences:
+
+  1. **The energy term is inflated ~3.8×.** With `E[a²] = mean² + std² = 3.78`
+     the penalty runs at `0.075 × 3.78 = 0.284`/step ≈ 284/episode, against a
+     ceiling of 75/episode if the action were clipped first. That is ~209/episode,
+     **~7.9% of this run's 2654.66 return**, charged for magnitude the plant
+     never sees.
+  2. **`r` (RMS action change) is partly decoupled from the physics.** `r` is
+     measured in raw action space; the plant sees the clipped action. With 68%
+     of components saturated, a large share of raw-action motion produces *zero*
+     change in `ctrl`, so the policy can lower `sum((Δa)²)` by shrinking raw
+     magnitude inside the saturated region without changing behaviour at all.
+
+  Consequence 2 matters beyond the reward: `r` is the metric
+  [TREX_LEG_FLEXING_PLAN.md](TREX_LEG_FLEXING_PLAN.md) steers by. That document
+  observes `smoothness_weight` 0.1 → 0.7 → 2.0 reliably lowering `r` while the
+  legs still visibly bounce, and extrapolates from an `r ∝ w^-0.16` fit that
+  smoothness would need a weight "in the six figures". **That curve was fitted
+  on a partly-decoupled metric**, so the extrapolation is unsound, and the
+  smoothness penalty was partly free to satisfy. It also fits the measured
+  envelope for the same run: `used` = 100% of range on 20 of 21 actuators with
+  only moderate per-step deltas is what a bang-bang policy looks like.
+
+  **Not shown:** that this *causes* the leg flexing. It is a strong additional
+  hypothesis, not a demonstrated cause, and the stance correction is defensible
+  independently (an 8°-from-singular knee is badly conditioned regardless).
+
+  **Scope:** this is in `base_env.py`, so it affects all four species, and the
+  MJX path should be checked for the same split before either is changed.
+
+  **Fixing it is a reward-shaping change**, not a plant change: no fingerprint
+  moves and no checkpoint is invalidated, but historical reward numbers stop
+  being comparable and every stage gate calibrated against them
+  (`min_avg_reward`) would need re-deriving from a fresh zero-action baseline.
+  Worth deciding deliberately rather than folding into another change. When
+  judging the stance correction, prefer the `achieved` / `used` columns from
+  `joint_excursion_report.py` — those are measured on `qpos` and `ctrl` and are
+  unaffected. (2026-07 T-Rex envelope measurement)
+
 - **LOW** — `BaseDinoEnv.reset` still applies one `reset_noise_scale` scalar to
   the whole of `qvel`, which mixes root linear velocity (m/s), root angular
   velocity (rad/s) and joint velocities (rad/s). This is the same

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -48,75 +48,71 @@ tolerance) remains the standing recommendation for the divergences above.
 
 ## Training / RL
 
-- **HIGH** — **the reward is computed on unclipped actions, and the policy's raw
-  output runs 6–8× outside the action bound.** `BaseDinoEnv.step` clips for the
-  physics but not for the reward:
-
-  ```python
-  base_env.py:765   ctrl = self._scale_action(action)              # clips to [-1, 1] -> plant
-  base_env.py:783   reward, reward_info = self._get_reward_info(action)   # RAW -> reward
-  ```
-
-  Neither penalty clips internally — `reward_energy` is `sum(action**2) / n`
-  and `reward_action_smoothness` is `sum((action - prev_action)**2)`, both on
-  the raw value. `reward_energy`'s docstring states it "ranges [0, 1] when
-  actions are in [-1, 1]", which is an assumption nothing enforces.
-
+- **MEDIUM** — **the policy saturates its action bound, and the
+  `diagnostics/action_*` family mixes pre-clip and post-clip quantities.**
   Measured on T-Rex stage-1 run `20260727_130726` (PPO, 6.0M steps), from its
   own tensorboard:
 
-  | `diagnostics/` scalar | first | last | mean | max |
-  |---|---|---|---|---|
-  | `action_abs_max` | 4.55 | 6.71 | **6.11** | **7.77** |
-  | `action_std` | 1.00 | 1.93 | 1.42 | 1.93 |
-  | `action_saturation` | 0.32 | **0.68** | 0.49 | 0.68 |
-  | `action_delta` | 21.27 | 6.24 | 15.04 | 21.43 |
+  | `diagnostics/` scalar | first | last | mean | max | measured on |
+  |---|---|---|---|---|---|
+  | `action_abs_max` | 4.55 | 6.71 | **6.11** | **7.77** | pre-clip |
+  | `action_std` | 1.00 | 1.93 | 1.42 | 1.93 | pre-clip |
+  | `action_saturation` | 0.32 | **0.68** | 0.49 | 0.68 | pre-clip |
+  | `action_delta` | 21.27 | 6.24 | 15.04 | 21.43 | post-clip |
 
-  `action_saturation` (fraction of components pinned at the limit, threshold
-  0.99) rose **monotonically** across all 6M steps — 0.32 → 0.68. By the end
-  **68% of action components are clipped at any instant**, and the raw output
+  `action_saturation` (fraction of components at or beyond 0.99) rose
+  **monotonically** across all 6M steps — 0.32 → 0.68. The policy's raw output
   peaks at 7.77 against a `Box(-1, 1)` action space. Note `train/std` *fell*
-  over the run (1.00 → 0.72) while the empirical `action_std` nearly doubled:
-  the policy is pushing its mean out of bounds, not widening its exploration.
+  over the run (1.00 → 0.72) while empirical `action_std` nearly doubled: the
+  policy is pushing its **mean** out of bounds, not widening its exploration.
 
-  Two consequences:
+  **What this is not: the reward is not inflated.** Both training paths clip
+  before stepping the environment, so `_get_reward_info` receives an in-bound
+  action and both penalties are computed on it:
 
-  1. **The energy term is inflated ~3.8×.** With `E[a²] = mean² + std² = 3.78`
-     the penalty runs at `0.075 × 3.78 = 0.284`/step ≈ 284/episode, against a
-     ceiling of 75/episode if the action were clipped first. That is ~209/episode,
-     **~7.9% of this run's 2654.66 return**, charged for magnitude the plant
-     never sees.
-  2. **`r` (RMS action change) is partly decoupled from the physics.** `r` is
-     measured in raw action space; the plant sees the clipped action. With 68%
-     of components saturated, a large share of raw-action motion produces *zero*
-     change in `ctrl`, so the policy can lower `sum((Δa)²)` by shrinking raw
-     magnitude inside the saturated region without changing behaviour at all.
+  - SB3 `on_policy_algorithm.py:214-218` — `clipped_actions = np.clip(actions,
+    low, high)` immediately before `env.step(clipped_actions)`; `policies.py:379`
+    does the same inside `predict()`, which is what both eval loops use.
+  - `jax_trainer.py:365` — `actions = jnp.clip(raw_actions, -1.0, 1.0)` before
+    `env.step`; `jax_ppo.sample_action`'s docstring states the contract
+    ("returns the **unclipped** action… callers must clip before sending to the
+    environment").
+  - `base_env.py:_scale_action` says so directly: "SB3 already clips before
+    stepping, but direct callers… would otherwise command out-of-range ctrl."
 
-  Consequence 2 matters beyond the reward: `r` is the metric
-  [TREX_LEG_FLEXING_PLAN.md](TREX_LEG_FLEXING_PLAN.md) steers by. That document
-  observes `smoothness_weight` 0.1 → 0.7 → 2.0 reliably lowering `r` while the
-  legs still visibly bounce, and extrapolates from an `r ∝ w^-0.16` fit that
-  smoothness would need a weight "in the six figures". **That curve was fitted
-  on a partly-decoupled metric**, so the extrapolation is unsound, and the
-  smoothness penalty was partly free to satisfy. It also fits the measured
-  envelope for the same run: `used` = 100% of range on 20 of 21 actuators with
-  only moderate per-step deltas is what a bang-bang policy looks like.
+  **The metric hazard.** `action_mean`, `action_std`, `action_abs_max` and
+  `action_saturation` come from `diagnostics.py:210`, which reads
+  `self.locals["actions"]` — SB3's **pre-clip** Gaussian sample. `action_delta`
+  arrives by a different route: it is returned by `reward_action_smoothness`
+  from *inside* the env, so it is computed on the **post-clip** action. Four
+  scalars in one namespace describe the policy's raw output; the fifth
+  describes what the plant received. Reading the group as one space is an easy
+  and consequential mistake.
 
-  **Not shown:** that this *causes* the leg flexing. It is a strong additional
-  hypothesis, not a demonstrated cause, and the stance correction is defensible
-  independently (an 8°-from-singular knee is badly conditioned regardless).
+  **What is real.** PPO stores the raw action and its `log_prob`, while the
+  environment responds to the clipped one. With 68% of components saturated,
+  most of the policy's output distribution sits where moving the mean further
+  changes the plant not at all — the standard bias from sampling an unbounded
+  Gaussian into a bounded action space, and a plausible contributor to the
+  bang-bang envelope measured on the same run (`used` = 100% of range on 20 of
+  21 actuators). Worth watching `action_saturation` as a first-class health
+  metric rather than as evidence about the reward.
 
-  **Scope:** this is in `base_env.py`, so it affects all four species, and the
-  MJX path should be checked for the same split before either is changed.
+  **Latent trap.** `base_env.py:783` passes the raw `action` to
+  `_get_reward_info` while `ctrl` is clipped separately at line 765. Harmless
+  under SB3 and the JAX trainer today, but any direct caller — a notebook, a
+  custom rollout loop, a diagnostic script — is silently charged energy and
+  smoothness penalties for magnitude the plant never sees. Clipping at line
+  783 would make the two paths agree and moves no fingerprint.
 
-  **Fixing it is a reward-shaping change**, not a plant change: no fingerprint
-  moves and no checkpoint is invalidated, but historical reward numbers stop
-  being comparable and every stage gate calibrated against them
-  (`min_avg_reward`) would need re-deriving from a fresh zero-action baseline.
-  Worth deciding deliberately rather than folding into another change. When
-  judging the stance correction, prefer the `achieved` / `used` columns from
-  `joint_excursion_report.py` — those are measured on `qpos` and `ctrl` and are
-  unaffected. (2026-07 T-Rex envelope measurement)
+  **Explicitly retracted.** An earlier version of this entry claimed the energy
+  term was inflated ~3.8× (~209/episode, ~7.9% of return) and that the
+  `r ∝ w^-0.16` smoothness fit in
+  [TREX_LEG_FLEXING_PLAN.md](TREX_LEG_FLEXING_PLAN.md) was therefore unsound.
+  Both are wrong: the reward saw clipped actions, and `r` derives from
+  `action_delta`, which is post-clip and so is coupled to the physics. That
+  study stands, no `min_avg_reward` gate needs re-deriving, and no historical
+  reward comparison is invalidated. (2026-07 T-Rex telemetry review)
 
 - **LOW** — `BaseDinoEnv.reset` still applies one `reset_noise_scale` scalar to
   the whole of `qvel`, which mixes root linear velocity (m/s), root angular


### PR DESCRIPTION
Documentation only — one MEDIUM entry in `KNOWN_ISSUES.md`.

**This PR previously claimed something false.** It asserted that `BaseDinoEnv.step` passes the raw action to the reward, inflating the energy penalty ~3.8× (~209/episode, ~7.9% of return). That does not happen. Both training paths clip before stepping the env, so the reward has always been computed on an in-bound action:

| path | where it clips |
|---|---|
| SB3 rollout | `on_policy_algorithm.py:214-218` — `clipped_actions = np.clip(actions, low, high)` immediately before `env.step(clipped_actions)` |
| SB3 eval | `policies.py:379` — `predict()` clips for `Box` spaces; both eval loops use it |
| JAX | `jax_trainer.py:365` — `actions = jnp.clip(raw_actions, -1.0, 1.0)` before `env.step`; `jax_ppo.sample_action`'s docstring states the contract |

`base_env._scale_action`'s own docstring already said so: *"SB3 already clips before stepping, but direct callers… would otherwise command out-of-range ctrl."*

## What misled me, which is the finding worth keeping

The `diagnostics/` namespace mixes two action spaces:

| scalar | measured on | source |
|---|---|---|
| `action_mean`, `action_std`, `action_abs_max`, `action_saturation` | **pre-clip** | `diagnostics.py:210` reads `self.locals["actions"]` — SB3's raw Gaussian sample |
| `action_delta` | **post-clip** | returned by `reward_action_smoothness` from *inside* the env |

Four scalars describe the policy's raw output; the fifth describes what the plant received. Reading the group as one space is an easy and consequential mistake.

## What survives

Saturation is real and worth watching. On run `20260727_130726`, `action_saturation` rose monotonically 0.32 → 0.68 across 6M steps, with raw output peaking at 7.77 against `Box(-1, 1)`. `train/std` *fell* (1.00 → 0.72) while empirical `action_std` nearly doubled — the policy is pushing its **mean** out of bounds, not exploring wider.

PPO stores the raw action and its `log_prob` while the env responds to the clipped one, so with 68% of components saturated, most of the output distribution sits where moving the mean does not move the plant. That is the standard bias from sampling an unbounded Gaussian into a bounded action space, and it fits the bang-bang envelope measured on the same run in #466 (`used` = 100% of range on 20 of 21 actuators).

`base_env.py:783` also remains a latent trap: harmless under SB3 and the JAX trainer, but a direct caller is silently charged for magnitude the plant never sees.

## Explicitly retracted

The entry now states the retraction in-line, so a future reader hits it at the same place as the claim:

- No ~3.8× energy inflation, no ~7.9% of return.
- **The `r ∝ w^-0.16` smoothness study in `TREX_LEG_FLEXING_PLAN.md` stands.** `r` derives from `action_delta`, which is post-clip and therefore coupled to the physics. The earlier claim that the fit was "unsound" was wrong and would have retired a valid result.
- No `min_avg_reward` gate needs re-deriving; no historical reward comparison is invalidated.

Severity dropped **HIGH → MEDIUM**. All relative doc links verified.