### PR TITLE
NS-1 is a task change, not a reward term; fix the NaN this branch int…

### DIFF
--- a/docs/investigations/TREX_REVIEW_2026_07.md
+++ b/docs/investigations/TREX_REVIEW_2026_07.md
@@ -871,6 +871,25 @@ That contradicts the config's own sizing argument, which expected ~2340 before a
 `diagnostics/action_delta` and `algo_std`, to separate "the penalty bound and the policy
 adapted" from "the penalty never bound". Requires the `diagnostics.npz` files.
 
+**OQ-6 — Brachiosaurus's four foot touch sensors read exactly 0.0 N while its feet are on the
+floor.** Found while measuring the cross-species zero-action floor; **not part of this review's
+scope and not investigated**, but confirmed directly and filed because it is live:
+
+```
+$ # brachiosaurus, zero action, 200 steps settled
+touch sensors: [('fr_foot_touch', 0.0), ('fl_foot_touch', 0.0),
+                ('rr_foot_touch', 0.0), ('rl_foot_touch', 0.0)]
+floor contacts: 9, total normal force: 1733.3 N   (via mj_contactForce)
+```
+
+`configs/brachiosaurus/stage1_balance.toml` keys `foot_contact_gate` and `foot_contact_weight`
+off exactly those sensors on the JAX path, so on MJX its alive bonus would be gated to zero and
+its foot-contact bonus never paid. This is the same defect class as the T-Rex repair in
+`aa87445` and the raptor repair in `aa3395c`. Velociraptor was reported at 0.554 of body weight
+and so is partially affected; I did not verify that number.
+*What would resolve it:* the same investigation `aa87445` did for T-Rex — check whether the
+touch sites sit on a body whose child bodies carry the load-bearing geoms.
+
 **OQ-5 — Do the other three species carry F2's gap?**
 The MJX default of 0.5 is shared and every SB3 default differs (T-Rex 0.62, Dibothrosuchus
 0.55). Not audited — out of scope for this review by instruction.
@@ -880,19 +899,101 @@ The MJX default of 0.5 is shared and every SB3 default differs (T-Rex 0.62, Dibo
 
 ## 5. Next steps, ranked
 
-**NS-1 — Give stage 1 a term the statue cannot collect. (Addresses F1.)**
-*Change:* add a stance-quality term that a constant action scores near zero on — the
-strongest candidate is a centre-of-pressure / support-polygon margin term, since the plant
-already carries per-digit touch sensors that make CoP computable; a cheaper stand-in is
-re-enabling `reset_noise_scale` sweeps so the reward has to buy recoveries rather than luck.
-*Touches:* `configs/trex/stage1_balance.toml` `[env]`, plus a new helper in
-`environments/shared/reward_functions.py`.
-*Expected:* the zero-action full-horizon score drops well below the trained score; the
-per-step comparison in F1 inverts.
-*Measurement that decides it:* re-run `zero_action_baseline.py trex` and the F1 per-step
-table. Success is the trained per-step return exceeding the standing statue's, on the same
-seed family. Until that inverts, stage 1 is not measuring balance.
-*Note:* this makes future runs incomparable with §2. Do it once, deliberately, and re-baseline.
+**NS-1 — Change the task, not the reward. (Addresses F1.)**
+
+An earlier draft of this item proposed "add a stance-quality term the statue cannot collect,
+strongest candidate a centre-of-pressure / support-polygon margin." **That was wrong, and the
+reason it is wrong is the most useful thing in this section.**
+
+Four candidate designs were built and each attacked by two independent verifiers who
+implemented the proposed term in a standalone rollout and measured it for the statue and for
+`robust_best_model.zip`. **None survived.** Three of the four add a per-step reward term, and
+all three were refuted 2/2 on the same measured failure — the statue collects the term *at
+least as much as* the trained policy:
+
+| candidate | statue (per 1000 standing steps) | trained policy | winner |
+|---|---|---|---|
+| two-sided height error (repair the existing term) | −1.25, and −0.00 in the settled window | −51.57 | statue by 50.32 |
+| capture-point / support-polygon containment | −392.86 | −1792.58 | statue by 1399.72 |
+| potential-based shaping on divergent CoM velocity | +0.99/ep | −1.45/ep | statue by 2.44 |
+
+Three unrelated mathematical families, same result. That is not three tuning failures, it is
+one structural fact: **the plant is passively stable at the home keyframe, and at any static
+equilibrium the centre of pressure lies exactly under the centre of mass** (measured to 0.2 mm
+over 6126 statue steps — it is forced, since at rest the ground reaction must pass through the
+CoM). Any bounded per-step function of the standing state that means "well balanced" is
+therefore *maximised by standing perfectly still*, which is exactly what `action = 0` does
+under `home-keyframe-residual/v1`. **With no disturbance, the optimal balance controller is the
+statue.** You cannot pay a policy to beat it at a game where it is already the optimum.
+
+Two of the three also made F1 numerically worse: the height repair moves the equal-survival
+deficit 333.66 → 381.32 and drops the achievable stage-1 ceiling to 1850.00 against
+`min_avg_reward = 1840.0`, i.e. it would make the shipped gate near-unclearable and halt the
+curriculum at `train_base.py:1292`.
+
+*Change instead:* apply a scheduled external shove — a runtime write to
+`data.xfrc_applied[root, 0:3]` in `BaseDinoEnv.step`, no reward term, no observation change.
+Every ~2 s, push the root horizontally in a uniformly random direction with an impulse sized at
+1.5× the capture-point velocity (≈150 N for 0.20 s on this plant).
+*Touches:* a new `_apply_perturbation()` in `environments/shared/base_env.py` called at the top
+of `step()`, a pure `external_push_force()` kernel in `environments/shared/reward_functions.py`
+so both backends share it, and new `perturbation_*` keys in `configs/trex/stage1_balance.toml`
+`[env]` defaulting to `0.0` everywhere else.
+
+**It must go in `step()`, not `reset()`.** Verified: `plant_contract.py:916` hashes
+`_callable_semantics(env.reset)` into `policy_interface_revision` for every
+`home-keyframe-residual/v1` species, while `step` appears **zero** times in the interface
+payload. A `step()` hook moves no fingerprint and invalidates no checkpoint.
+
+*Measured, 40 episodes, seed 3042, reproduced independently by two verifiers:*
+
+| | statue | trained checkpoint |
+|---|---|---|
+| shipped (no push) | 1743.73, 57% full-horizon | 2489.65, 100% |
+| push on, noise 0.05 | **711.05 ± 403.76, 0 of 40 full-horizon** | 2418.38 ± 357.61, 85% |
+| push on, noise 0.10 | **604.18 ± 483.99, 0 of 40** | **NOT MEASURED** |
+
+The statue does not merely score less — *the standing statue ceases to exist*, so
+`reward_mean_standing` becomes undefined and the F1 comparison has no left-hand side. Gaming
+was hunted hard and found nothing: 13 hand-designed constant stances, two independent CEM
+searches over the full 21-dim constant action space (best holdouts 490.3 and 692.0, both ≤
+zeros), the trained policy's own settled mean action held constant (184.6), and a blind
+clock-driven brace policy (732.8 mean, worse mean-minus-std, 1 of 40 full-horizon).
+
+*The one load-bearing number that does not exist:* the trained checkpoint has never been
+evaluated at noise 0.10 with the push on. That is a ~10-minute eval, not a training run, and it
+gates everything below.
+
+*Mandatory corrections to the proposal as filed* — each measured, not argued:
+
+1. **Do not bundle `reset_noise_scale` 0.10 → 0.05.** At 0.05 with the push off the statue
+   scores 2568.7 at 90% full-horizon against the checkpoint's 2498.8 — the statue wins
+   outright, reversing the shipped config's +660.5 edge to the policy. Keep 0.10.
+2. **Ship the impulse fixed, not ramped.** `set_reward_weight` (`base_env.py:752`) is a bare
+   `setattr`, so a `RewardRampCallback` on `perturbation_delta_v` would be a step function
+   unless the force is recomputed inside `_apply_perturbation` on every call.
+3. **Jitter the interval** (`perturbation_jitter`). The blind-clock brace exploit is weak but
+   real (+17% mean); one line removes it. Re-measure the floor with jitter on.
+4. **Force `perturbation_delta_v = 0.0` in every diagnostic script.** `zero_action_baseline`,
+   `joint_excursion_report`, `action_bound_report`, `actuator_saturation_report` and
+   `observation_ablation_report` all build the env from the TOML and would silently measure a
+   shoved plant.
+5. **Leave `min_avg_reward = 1840.0` alone** (supersedes NS-2 for T-Rex). The "+5.5% over the
+   measured floor" rule dies with the floor: 1840 is 2.6× the pushed statue and the
+   un-retrained checkpoint clears it by ~580. Rewrite the comment block, not the value.
+
+*Honest scope.* This does **not** repair the per-step reward. Under the push the statue still
+earns more shaping per surviving step than the policy (2.680 vs 2.553); all the separation comes
+from termination plus `fall_penalty`. Stage 1 stays a survival test — it becomes a survival test
+a statue fails. Record that in the TOML rather than claiming the reward now measures balance.
+
+*Worth re-testing afterwards, not before:* the support-polygon term was refuted on an
+**undisturbed** plant, where the statue's capture point barely moves. Once a disturbance exists
+the statue no longer stands and a disturbance-rejection term is no longer maximised by
+stillness. It would still need its two real defects fixed first — a single-support exploit (the
+isotropic `patch_radius²·I` floor lets one loaded digit score containment 1.0000) and the fact
+that 90% of its measured statue deficit is a 13.2 mm touch-site placement artefact rather than a
+stance error.
 
 **NS-2 — Re-derive `min_avg_reward` against the *standing* floor, not the falling one —
 for all four species, not just T-Rex.**

--- a/environments/shared/scripts/zero_action_baseline.py
+++ b/environments/shared/scripts/zero_action_baseline.py
@@ -118,8 +118,16 @@ def score(env, episodes: int, seed: int, noise: float | None = None) -> dict:
         # do-nothing policy survives are worth far more than its average.  A
         # gate set above ``reward_mean`` but below this one is cleared by a
         # policy that has learned only "do not fall".
-        "reward_mean_standing": float(rewards_arr[standing].mean()) if standing.any() else float("nan"),
-        "reward_std_standing": float(rewards_arr[standing].std()) if standing.any() else float("nan"),
+        #
+        # ``None``, not NaN, when the statue never reaches the horizon: this
+        # dict is serialised straight into the baseline records the notebook
+        # writes to Drive, and ``json.dumps`` renders a float NaN as a bare
+        # ``NaN`` literal, which RFC 8259 does not allow.  Python and jq accept
+        # it; strict parsers (JavaScript ``JSON.parse``, most Go/Rust decoders)
+        # reject the whole file.  ``None`` serialises to ``null``.  Brachiosaurus
+        # hits this today -- it never survives a full episode under zero action.
+        "reward_mean_standing": float(rewards_arr[standing].mean()) if standing.any() else None,
+        "reward_std_standing": float(rewards_arr[standing].std()) if standing.any() else None,
         "n_standing": int(standing.sum()),
         "length_mean": float(lengths_arr.mean()),
         "full_horizon_share": float(standing.mean()),
@@ -128,6 +136,13 @@ def score(env, episodes: int, seed: int, noise: float | None = None) -> dict:
         "episodes": int(rewards_arr.size),
         "reset_noise_scale": float(env.reset_noise_scale),
     }
+
+
+def _standing_text(result: dict) -> str:
+    """Format the standing score, which is ``None`` when nothing stood."""
+    if result["n_standing"] == 0:
+        return "-"
+    return f"{result['reward_mean_standing']:.1f}"
 
 
 def report(species: str, stage: int, episodes: int, seed: int, sweep: bool) -> None:
@@ -141,7 +156,7 @@ def report(species: str, stage: int, episodes: int, seed: int, sweep: bool) -> N
                 result = score(env, episodes, seed, noise=noise)
                 print(
                     f"  {noise:>7}{result['reward_mean']:>12.1f}{result['reward_mean_minus_std']:>11.1f}"
-                    f"{result['reward_mean_standing']:>11.1f}"
+                    f"{_standing_text(result):>11}"
                     f"{result['length_mean']:>11.1f}{result['full_horizon_share']:>13.0%}"
                 )
             return
@@ -150,8 +165,13 @@ def report(species: str, stage: int, episodes: int, seed: int, sweep: bool) -> N
         print(f"\n{label}: zero-action baseline ({episodes} episodes, reset_noise={env.reset_noise_scale})")
         print(f"  reward             {result['reward_mean']:.2f} +/- {result['reward_std']:.2f}")
         print(f"  reward mean-std    {result['reward_mean_minus_std']:.2f}")
+        standing = (
+            "never reached the horizon"
+            if result["n_standing"] == 0
+            else f"{result['reward_mean_standing']:.2f} +/- {result['reward_std_standing']:.2f}"
+        )
         print(
-            f"  reward standing    {result['reward_mean_standing']:.2f} +/- {result['reward_std_standing']:.2f}"
+            f"  reward standing    {standing}"
             f"   ({result['n_standing']} of {result['episodes']} episodes reached the horizon)"
         )
         print(f"  episode length     {result['length_mean']:.1f} of {result['horizon']}")

--- a/environments/shared/tests/test_zero_action_baseline.py
+++ b/environments/shared/tests/test_zero_action_baseline.py
@@ -1,0 +1,89 @@
+"""Tests for the zero-action baseline diagnostic.
+
+``score()``'s return value is serialised straight into the baseline records the
+training notebook writes to Google Drive, so it has to survive a strict JSON
+round-trip.  It did not: a species whose statue never reaches the horizon
+produced ``float("nan")``, and ``json.dumps`` renders that as a bare ``NaN``
+literal, which RFC 8259 does not permit.  Brachiosaurus hits that case today.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from environments.shared.scripts.zero_action_baseline import score
+
+
+class _StubEnv:
+    """Minimal env stand-in: ``score`` only needs these four members."""
+
+    def __init__(self, lengths, horizon=1000, reset_noise_scale=0.1):
+        self.max_episode_steps = horizon
+        self.reset_noise_scale = reset_noise_scale
+        self.action_space = type("Box", (), {"shape": (3,)})()
+        self._lengths = list(lengths)
+        self._step = 0
+        self._episode = -1
+
+    def reset(self, seed=None):
+        self._episode += 1
+        self._step = 0
+
+    def step(self, action):
+        self._step += 1
+        done = self._step >= self._lengths[self._episode]
+        truncated = done and self._lengths[self._episode] >= self.max_episode_steps
+        info = {} if truncated else {"termination_reason": "fallen"}
+        return None, 1.0, done and not truncated, truncated, info
+
+
+def _strict_json_round_trip(payload):
+    """Serialise and parse with bare NaN/Infinity literals rejected."""
+
+    def _reject(constant):
+        raise ValueError(f"bare {constant} literal is not valid JSON")
+
+    return json.loads(json.dumps(payload), parse_constant=_reject)
+
+
+class TestScoreIsJsonSerialisable:
+    def test_no_standing_episodes_serialises_strictly(self):
+        """The regression: nothing reaches the horizon, so there is no standing score."""
+        result = score(_StubEnv([100, 250, 400]), episodes=3, seed=0)
+
+        assert result["n_standing"] == 0
+        assert result["reward_mean_standing"] is None, (
+            "must be None, not NaN — json.dumps renders NaN as a bare literal that "
+            "strict JSON parsers reject, and this dict is written to Drive"
+        )
+        assert result["reward_std_standing"] is None
+
+        parsed = _strict_json_round_trip(result)
+        assert parsed["reward_mean_standing"] is None
+
+    def test_some_standing_episodes_report_a_number(self):
+        result = score(_StubEnv([100, 1000, 1000]), episodes=3, seed=0)
+
+        assert result["n_standing"] == 2
+        assert result["reward_mean_standing"] == pytest.approx(1000.0)
+        assert result["reward_std_standing"] == pytest.approx(0.0)
+        assert result["full_horizon_share"] == pytest.approx(2 / 3)
+
+        parsed = _strict_json_round_trip(result)
+        assert parsed["reward_mean_standing"] == pytest.approx(1000.0)
+
+    def test_standing_score_exceeds_the_unconditional_mean(self):
+        """The property the number exists for: surviving episodes are worth more."""
+        result = score(_StubEnv([100, 200, 1000, 1000]), episodes=4, seed=0)
+
+        assert result["reward_mean_standing"] > result["reward_mean"], (
+            "a per-step reward makes full-horizon episodes score above the mix, "
+            "which is why a gate calibrated on the unconditional mean under-binds"
+        )
+
+    def test_every_value_is_json_native(self):
+        """No numpy scalars: they serialise inconsistently across versions."""
+        result = score(_StubEnv([100, 1000]), episodes=2, seed=0)
+        for key, value in result.items():
+            assert not isinstance(value, np.generic), f"{key} is a numpy scalar"


### PR DESCRIPTION
…roduced

## The design result

Four candidate stage-1 reward designs were built and each attacked by two independent verifiers who implemented the proposed term in a standalone rollout and measured it for the statue and for robust_best_model.zip. None survived.  Three of the four add a per-step term and all three were refuted 2/2 on the same measured failure -- the statue collects the term at least as much as the trained policy:

  two-sided height error         statue -1.25   policy -51.57
  capture-point containment      statue -392.86 policy -1792.58
  potential-based CoM shaping    statue +0.99   policy -1.45

Three unrelated mathematical families, one result.  The cause is structural: the plant is passively stable at the home keyframe, and at any static equilibrium the centre of pressure lies under the centre of mass (measured to 0.2 mm over 6126 statue steps; it is forced, since at rest the ground reaction must pass through the CoM).  Any bounded per-step function of the standing state that means "well balanced" is therefore maximised by standing perfectly still -- which is what action = 0 does under home-keyframe-residual/v1.  With no disturbance the optimal balance controller IS the statue.

So NS-1 is rewritten: apply a scheduled external shove via data.xfrc_applied in step(), with no reward term at all.  Measured, the statue goes from 1743.73 / 57% full-horizon to 604.18 / 0 of 40 -- the standing statue ceases to exist, so the F1 comparison loses its left-hand side.  Gaming found nothing: 13 constant stances, two CEM searches over the full 21-dim constant action, the policy's own settled mean action, and a blind clock-driven brace all score at or below zeros.

Verified independently rather than taken on trust: plant_contract.py:916 hashes _callable_semantics(env.reset) into policy_interface_revision for every home-keyframe-residual species, while "step" appears zero times in the interface payload.  A step() hook moves no fingerprint.

Recorded with five mandatory corrections (do not bundle the reset-noise change -- at 0.05 the statue beats the checkpoint outright; do not ramp the impulse through set_reward_weight, which is a bare setattr; jitter the interval; force the perturbation off in every diagnostic script; leave min_avg_reward alone), and with the honest scope: this does not repair the per-step reward, it makes stage 1 a survival test a statue fails.  The one load-bearing number that does not exist -- the checkpoint under push at noise 0.10 -- is flagged as a 10-minute eval that gates the rest.

## The bug this branch introduced

zero_action_baseline.score() returned float("nan") for reward_mean_standing when no episode reached the horizon, added two commits ago.  json.dumps renders that as a bare NaN literal, which RFC 8259 does not permit -- Python and jq accept it, JavaScript JSON.parse and most Go/Rust decoders reject the whole file.  The notebook serialises this dict straight into the baseline records it writes to Drive, and brachiosaurus hits the case today: three bare NaN literals were already present in a record written during testing.

Now returns None, which serialises to null, with the print paths guarded. New test_zero_action_baseline.py pins it with a strict round-trip that rejects bare NaN/Infinity; verified to fail on the previous commit with "assert nan is None" and pass after.  T-Rex output is unchanged (1743.73 +/- 1275.54, standing 2834.95 +/- 6.25); brachiosaurus now prints "never reached the horizon" instead of nan.

## Also filed

OQ-6: brachiosaurus's four foot touch sensors read exactly 0.0 N while mj_contactForce reports 9 floor contacts carrying 1733.3 N.  Its stage-1 config keys foot_contact_gate and foot_contact_weight off those sensors on the JAX path.  Same defect class as the T-Rex repair in aa87445 and the raptor repair in aa3395c.  Out of this review's scope, confirmed directly, not investigated.

Green: ruff check, ruff format --check, mypy (the CI commands), environments/trex/tests (77 passed), environments/shared/tests (1438 passed, 73 skipped).