### PR TITLE
Add behavior-neutral T. rex stance diagnostics

### DIFF
--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -9,6 +9,12 @@ import math
 from collections import Counter
 from pathlib import Path
 
+from environments.shared.stance_diagnostics import (
+    STANCE_INFO_KEYS,
+    derive_stance_info,
+    has_stance_diagnostics,
+)
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -142,6 +148,7 @@ class DiagnosticsCallback(_BaseCallback):
         "head_food_distance",  # Brachiosaurus
         "torso_height",  # Brachiosaurus
         "jaw_distance",  # T-Rex
+        *STANCE_INFO_KEYS,
     ]
 
     def __init__(
@@ -199,9 +206,13 @@ class DiagnosticsCallback(_BaseCallback):
 
     def _on_step(self) -> bool:
         for info in self.locals.get("infos", []):
+            stance_info = dict(info)
+            if has_stance_diagnostics(info):
+                for key, value in derive_stance_info(info).items():
+                    stance_info.setdefault(key, value)
             for key in self.REWARD_KEYS + self.INFO_KEYS:
-                if key in info:
-                    self._step_infos[key].append(float(info[key]))
+                if key in stance_info:
+                    self._step_infos[key].append(float(stance_info[key]))
             if "termination_reason" in info:
                 self._rollout_terminations[info["termination_reason"]] += 1
         # Accumulate the actions taken this step. self.locals["actions"] is

--- a/environments/shared/evaluation.py
+++ b/environments/shared/evaluation.py
@@ -8,12 +8,19 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Mapping
 
 if TYPE_CHECKING:
     from .plant_contract import PlantIdentity
 
 logger = logging.getLogger(__name__)
+
+TREX_STAGE1_CAMERA_VIEWS: dict[str, dict[str, float]] = {
+    # Fixed view angles make stance comparisons repeatable while preserving
+    # the existing pelvis-tracking camera.
+    "side": {"azimuth": 90.0, "elevation": -8.0, "distance": 3.4},
+    "front": {"azimuth": 180.0, "elevation": -8.0, "distance": 3.4},
+}
 
 try:
     import numpy as _np
@@ -93,6 +100,7 @@ def eval_policy_quality(
         Dict of aggregated eval metrics (prefixed with ``eval_``).
     """
     from .metrics import LocomotionMetrics, env_dt
+    from .stance_diagnostics import STANCE_INFO_KEYS
 
     episode_reports = []
     dt = env_dt(eval_env)
@@ -156,6 +164,16 @@ def eval_policy_quality(
     if "mean_distance_traveled" in agg:
         result["eval_distance_traveled"] = round(agg["mean_distance_traveled"], 4)
 
+    # Reporting-only stance diagnostics. ``mean_mean_*`` is the mean of each
+    # episode's timestep mean; ``std_mean_*`` captures episode variation.
+    for metric in STANCE_INFO_KEYS:
+        mean_key = f"mean_mean_{metric}"
+        std_key = f"std_mean_{metric}"
+        if mean_key in agg:
+            result[f"eval_mean_{metric}"] = round(agg[mean_key], 4)
+        if std_key in agg:
+            result[f"eval_std_{metric}"] = round(agg[std_key], 4)
+
     # Reward component breakdown (cumulative per episode, averaged across episodes)
     for key, value in agg.items():
         if key.startswith("mean_reward_component_"):
@@ -186,12 +204,18 @@ def record_stage_video(
     label: str | None = None,
     plant_identity: PlantIdentity | None = None,
     allow_legacy_plant: bool = False,
+    camera_views: Mapping[str, Mapping[str, float]] | None = None,
+    collect_stance_diagnostics: bool = False,
 ):
     """Record and save a video of the trained policy for a given stage.
 
     When *vecnorm_path* is provided, observations are normalized using the
     saved ``VecNormalize`` running statistics so the policy sees the same
     input distribution it was trained on.
+
+    When *camera_views* is supplied, one additional synchronized video is
+    written per named camera preset. When *collect_stance_diagnostics* is
+    true, a per-frame ``*_stance.csv`` is written beside the replay.
 
     Requires the ``mediapy`` package (``pip install mediapy``).
     """
@@ -247,9 +271,11 @@ def record_stage_video(
 
     obs, _ = render_env.reset(seed=seed + 2000 + stage)
     frames = []
+    named_frames: dict[str, list[Any]] = {name: [] for name in (camera_views or {})}
+    stance_rows: list[dict[str, float]] = []
     episode_reward = 0.0
 
-    for _ in range(max_steps):
+    for step_index in range(max_steps):
         if vec_normalize is not None:
             obs_input = vec_normalize.normalize_obs(obs)
         else:
@@ -257,6 +283,28 @@ def record_stage_video(
         action, _ = model.predict(obs_input, deterministic=True)
         obs, reward, terminated, truncated, info = render_env.step(action)
         frames.append(render_env.render())
+        if collect_stance_diagnostics:
+            from .stance_diagnostics import capture_trex_stance_snapshot
+
+            stance_rows.append(capture_trex_stance_snapshot(render_env, info, step_index + 1))
+        if camera_views:
+            camera = getattr(render_env, "_camera", None)
+            if camera is None:
+                logger.warning("Skipping named camera views: environment did not expose an RGB camera.")
+                camera_views = None
+            else:
+                original_camera = {name: getattr(camera, name) for name in ("azimuth", "elevation", "distance")}
+                try:
+                    for view_name, preset in camera_views.items():
+                        for attr, value in original_camera.items():
+                            setattr(camera, attr, value)
+                        for attr in ("azimuth", "elevation", "distance"):
+                            if attr in preset:
+                                setattr(camera, attr, float(preset[attr]))
+                        named_frames[view_name].append(render_env.render())
+                finally:
+                    for attr, value in original_camera.items():
+                        setattr(camera, attr, value)
         episode_reward += reward
         if terminated or truncated:
             break
@@ -268,6 +316,19 @@ def record_stage_video(
     suffix = f"_{label}" if label else ""
     video_path = str(Path(stage_dir) / f"{species}_{algorithm.lower()}_stage{stage}{suffix}.mp4")
     mediapy.write_video(video_path, frames, fps=50)
+    video_stem = Path(video_path).with_suffix("")
+    for view_name, view_frames in named_frames.items():
+        if not view_frames:
+            continue
+        view_path = str(video_stem.with_name(f"{video_stem.name}_{view_name}").with_suffix(".mp4"))
+        mediapy.write_video(view_path, view_frames, fps=50)
+        logger.info("  Saved %s camera replay to: %s", view_name, view_path)
+    if collect_stance_diagnostics:
+        from .stance_diagnostics import write_stance_diagnostics_csv
+
+        stance_path = video_stem.with_name(f"{video_stem.name}_stance").with_suffix(".csv")
+        if write_stance_diagnostics_csv(stance_path, stance_rows) is not None:
+            logger.info("  Saved stance diagnostics to: %s", stance_path)
     logger.info("Stage %d video: reward=%.2f | %d frames", stage, episode_reward, len(frames))
     logger.info("  Saved to: %s", video_path)
     return video_path, frames

--- a/environments/shared/metrics.py
+++ b/environments/shared/metrics.py
@@ -26,6 +26,11 @@ from typing import Any
 import numpy as np
 
 from environments.shared.diagnostics import DiagnosticsCallback
+from environments.shared.stance_diagnostics import (
+    STANCE_INFO_KEYS,
+    derive_stance_info,
+    has_stance_diagnostics,
+)
 
 
 def env_dt(env: Any, default: float = 0.01) -> float:
@@ -73,6 +78,7 @@ class LocomotionMetrics:
     _pelvis_yaw_velocities: list[float] = field(default_factory=list)
     _distances_traveled: list[float] = field(default_factory=list)
     _reward_components: dict[str, list[float]] = field(default_factory=dict)
+    _stance_metrics: dict[str, list[float]] = field(default_factory=dict)
     # Control timestep in seconds (model timestep x frame_skip).  All current
     # species use 0.002 x 5 = 0.01.  Pass the env's actual ``dt`` (see
     # :func:`env_dt`) so distance / stride-frequency / time-to-target stay
@@ -99,6 +105,7 @@ class LocomotionMetrics:
         self._pelvis_yaw_velocities.clear()
         self._distances_traveled.clear()
         self._reward_components.clear()
+        self._stance_metrics.clear()
         self._termination_reason = None
 
     def record_step(self, info: dict[str, Any], reward: float = 0.0):
@@ -165,6 +172,14 @@ class LocomotionMetrics:
         for key in DiagnosticsCallback.REWARD_KEYS:
             if key in info:
                 self._reward_components.setdefault(key, []).append(float(info[key]))
+
+        stance_info = dict(info)
+        if has_stance_diagnostics(info):
+            for key, value in derive_stance_info(info).items():
+                stance_info.setdefault(key, value)
+        for key in STANCE_INFO_KEYS:
+            if key in stance_info:
+                self._stance_metrics.setdefault(key, []).append(float(stance_info[key]))
 
         # Capture termination reason from the final step
         if "termination_reason" in info:
@@ -322,6 +337,12 @@ class LocomotionMetrics:
                 # Strip "reward_" prefix for cleaner metric names
                 component = key.replace("reward_", "")
                 result[f"reward_component_{component}"] = float(np.sum(values))
+
+        # --- Reporting-only stance quality ---
+        for key, values in self._stance_metrics.items():
+            if values:
+                result[f"mean_{key}"] = float(np.mean(values))
+                result[f"std_{key}"] = float(np.std(values))
 
         # --- Termination reason ---
         if self._termination_reason is not None:

--- a/environments/shared/reporting.py
+++ b/environments/shared/reporting.py
@@ -1408,6 +1408,7 @@ def generate_stage_artifacts(
             from environments.shared.visualization import (
                 plot_diagnostics_graphs,
                 plot_foot_contacts,
+                plot_stance_diagnostics,
                 plot_training_curves,
             )
 
@@ -1438,6 +1439,14 @@ def generate_stage_artifacts(
                 save_path=stage_dir / "foot_contacts.png",
                 show=False,
             )
+            plot_stance_diagnostics(
+                stage_dirs,
+                stage_configs,
+                species,
+                algorithm,
+                save_path=stage_dir / "stance_diagnostics.png",
+                show=False,
+            )
         except ImportError:
             logger.warning("Skipping graph generation (matplotlib not installed).")
         except Exception:
@@ -1450,7 +1459,7 @@ def generate_stage_artifacts(
     from .plant_contract import PlantCompatibilityError, current_plant_identity, validate_model_plant
 
     try:
-        from environments.shared.evaluation import record_stage_video
+        from environments.shared.evaluation import TREX_STAGE1_CAMERA_VIEWS, record_stage_video
         from environments.shared.train_base import _ensure_sb3
 
         sb3 = _ensure_sb3()
@@ -1462,6 +1471,8 @@ def generate_stage_artifacts(
         vecnorm_path = str(model_dir / "best_model_vecnorm.pkl")
         final_path = model_dir / f"stage{stage}_final"
         final_vecnorm_path = str(final_path) + "_vecnorm.pkl"
+        replay_diagnostics = species.lower() == "trex" and stage == 1
+        replay_camera_views = TREX_STAGE1_CAMERA_VIEWS if replay_diagnostics else None
 
         if (model_dir / "best_model.zip").exists():
             best_model = alg_cls.load(str(best_model_path))
@@ -1484,6 +1495,8 @@ def generate_stage_artifacts(
                 label="best",
                 plant_identity=plant_identity,
                 allow_legacy_plant=allow_legacy_plant,
+                camera_views=replay_camera_views,
+                collect_stance_diagnostics=replay_diagnostics,
             )
 
         if (Path(str(final_path) + ".zip")).exists():
@@ -1507,6 +1520,8 @@ def generate_stage_artifacts(
                 label="final",
                 plant_identity=plant_identity,
                 allow_legacy_plant=allow_legacy_plant,
+                camera_views=replay_camera_views,
+                collect_stance_diagnostics=replay_diagnostics,
             )
     except PlantCompatibilityError:
         raise
@@ -1760,6 +1775,9 @@ def save_jax_stage_artifacts(
 
     # 4. Diagnostics NPZ from eval results
     diag_data: dict[str, Any] = {
+        # JAX diagnostics are a contiguous evaluation trace rather than
+        # rollout snapshots. Expose a compatible step axis for dashboards.
+        "timesteps": _np.arange(len(eval_results.diag_tilt), dtype=int),
         "tilt_angle": _np.array(eval_results.diag_tilt),
         "forward_vel": _np.array(eval_results.diag_fwd_vel),
         "pelvis_height": _np.array(eval_results.diag_pelvis_h),
@@ -1770,6 +1788,28 @@ def save_jax_stage_artifacts(
         diag_data["r_foot_contact"] = _np.array(eval_results.diag_r_foot)
     for comp_name, comp_vals in eval_results.diag_reward_components.items():
         diag_data[f"reward_{comp_name}"] = _np.array(comp_vals)
+    if species.lower() == "trex" and stage == 1 and eval_results.diag_l_foot and eval_results.diag_r_foot:
+        from .stance_diagnostics import derive_stance_info
+
+        derived_rows = [
+            derive_stance_info(
+                {
+                    "r_foot_contact": right_force,
+                    "l_foot_contact": left_force,
+                }
+            )
+            for right_force, left_force in zip(
+                eval_results.diag_r_foot,
+                eval_results.diag_l_foot,
+                strict=True,
+            )
+        ]
+        if derived_rows:
+            for diagnostic_name in derived_rows[0]:
+                diag_data[diagnostic_name] = _np.array(
+                    [row[diagnostic_name] for row in derived_rows],
+                    dtype=float,
+                )
 
     diag_path = stage_dir / "diagnostics.npz"
     _np.savez(diag_path, **diag_data)

--- a/environments/shared/stance_diagnostics.py
+++ b/environments/shared/stance_diagnostics.py
@@ -1,0 +1,300 @@
+"""Reporting-only T. rex stance diagnostics.
+
+The helpers in this module derive support and pose measurements without
+changing actions, observations, rewards, reset behavior, or termination.
+Training callbacks store rollout means; evaluation replays can additionally
+write detailed per-frame geometry to CSV.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+# Raw environment measurements and reporting-only values derived from them.
+# Reward-shaped qualities deliberately live outside this module.
+STANCE_INFO_KEYS: tuple[str, ...] = (
+    "r_foot_contact_duty",
+    "l_foot_contact_duty",
+    "bilateral_support_duty",
+    "single_support_duty",
+    "unsupported_duty",
+    "r_foot_load_share",
+    "l_foot_load_share",
+    "foot_load_imbalance",
+    "foot_load_asymmetry",
+    "foot_load_balance",
+    "leg_home_pose_error",
+    "head_tip_z",
+    "head_pelvis_rel_z",
+    "neck_posture_error",
+    "height_error",
+)
+
+# ``bite_success`` already exists on every T. rex reward-info step and
+# distinguishes its biped contacts from similarly named quadruped front-foot
+# contacts without adding a new environment signal.
+STANCE_MARKER_KEYS: tuple[str, ...] = (
+    "bite_success",
+    "leg_home_pose_error",
+    "head_pelvis_rel_z",
+    "neck_posture_error",
+)
+
+_REPLAY_INFO_KEYS: tuple[str, ...] = (
+    "r_foot_contact",
+    "l_foot_contact",
+    "pelvis_height",
+    "tilt_angle",
+    "forward_z",
+    "drift_distance",
+    "pelvis_angular_vel",
+    "pelvis_yaw_vel",
+    "heading_alignment",
+    *STANCE_INFO_KEYS,
+)
+
+_LEG_JOINTS: tuple[tuple[str, str], ...] = (
+    ("hip_pitch", "hip_pitch"),
+    ("hip_roll", "hip_roll"),
+    ("knee", "knee"),
+    ("ankle", "ankle"),
+)
+
+
+def has_stance_diagnostics(info: Mapping[str, Any]) -> bool:
+    """Return whether *info* carries T. rex stance instrumentation."""
+    return any(key in info for key in STANCE_MARKER_KEYS)
+
+
+def derive_stance_info(info: Mapping[str, Any], contact_threshold: float = 0.1) -> dict[str, float]:
+    """Derive instantaneous support and load metrics from foot forces.
+
+    The returned ``*_duty`` fields are binary per timestep. Averaging them in
+    the training callback or episode metrics produces conventional duty
+    fractions. Existing environment-provided values remain authoritative when
+    callers merge the result with ``setdefault``.
+    """
+    if "r_foot_contact" not in info or "l_foot_contact" not in info:
+        return {}
+
+    right_force = max(float(info["r_foot_contact"]), 0.0)
+    left_force = max(float(info["l_foot_contact"]), 0.0)
+    right_supported = right_force > contact_threshold
+    left_supported = left_force > contact_threshold
+    total_force = right_force + left_force
+
+    if total_force > 1e-8:
+        right_share = right_force / total_force
+        left_share = left_force / total_force
+        imbalance = abs(right_force - left_force) / total_force
+        balance = 1.0 - imbalance
+    else:
+        right_share = 0.0
+        left_share = 0.0
+        imbalance = 0.0
+        balance = 0.0
+
+    return {
+        "r_foot_contact_duty": float(right_supported),
+        "l_foot_contact_duty": float(left_supported),
+        "bilateral_support_duty": float(right_supported and left_supported),
+        "single_support_duty": float(right_supported != left_supported),
+        "unsupported_duty": float(not right_supported and not left_supported),
+        "r_foot_load_share": float(right_share),
+        "l_foot_load_share": float(left_share),
+        "foot_load_imbalance": float(imbalance),
+        "foot_load_asymmetry": float(imbalance),
+        "foot_load_balance": float(balance),
+    }
+
+
+def _scalar(value: Any) -> float | None:
+    """Return a finite scalar float, or ``None`` for arrays/non-numbers."""
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _quat_to_euler(quat: Any) -> tuple[float, float, float]:
+    """Convert a MuJoCo ``(w, x, y, z)`` quaternion to XYZ Euler angles."""
+    w, x, y, z = (float(value) for value in quat)
+    roll = math.atan2(2.0 * (w * x + y * z), 1.0 - 2.0 * (x * x + y * y))
+    pitch_term = max(-1.0, min(1.0, 2.0 * (w * y - z * x)))
+    pitch = math.asin(pitch_term)
+    yaw = math.atan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z))
+    return roll, pitch, yaw
+
+
+def _named_id(model: Any, object_type: Any, name: str) -> int:
+    import mujoco
+
+    return int(mujoco.mj_name2id(model, object_type, name))
+
+
+def _site_position(env: Any, name: str) -> np.ndarray | None:
+    try:
+        import mujoco
+
+        site_id = _named_id(env.model, mujoco.mjtObj.mjOBJ_SITE, name)
+        if site_id >= 0:
+            return np.asarray(env.data.site_xpos[site_id], dtype=float)
+    except (AttributeError, ImportError, IndexError, TypeError, ValueError):
+        pass
+    return None
+
+
+def _body_pose(env: Any, name: str) -> tuple[np.ndarray, np.ndarray] | None:
+    try:
+        import mujoco
+
+        body_id = _named_id(env.model, mujoco.mjtObj.mjOBJ_BODY, name)
+        if body_id >= 0:
+            return (
+                np.asarray(env.data.xpos[body_id], dtype=float),
+                np.asarray(env.data.xquat[body_id], dtype=float),
+            )
+    except (AttributeError, ImportError, IndexError, TypeError, ValueError):
+        pass
+    return None
+
+
+def _home_joint_error(env: Any, joint_name: str) -> float | None:
+    try:
+        import mujoco
+
+        joint_id = _named_id(env.model, mujoco.mjtObj.mjOBJ_JOINT, joint_name)
+        if joint_id < 0:
+            return None
+        qpos_index = int(env.model.jnt_qposadr[joint_id])
+        home_id = getattr(env, "home_keyframe_id", None)
+        if home_id is None:
+            home_id = _named_id(env.model, mujoco.mjtObj.mjOBJ_KEY, "home")
+        if int(home_id) < 0:
+            return None
+        return abs(float(env.data.qpos[qpos_index] - env.model.key_qpos[int(home_id), qpos_index]))
+    except (AttributeError, ImportError, IndexError, TypeError, ValueError):
+        return None
+
+
+def capture_trex_stance_snapshot(env: Any, info: Mapping[str, Any], step: int) -> dict[str, float]:
+    """Capture one reporting-only T. rex stance row from a replay environment."""
+    row: dict[str, float] = {"step": float(step)}
+    for key in _REPLAY_INFO_KEYS:
+        if key in info:
+            value = _scalar(info[key])
+            if value is not None:
+                row[key] = value
+    for key, value in derive_stance_info(info).items():
+        row.setdefault(key, value)
+
+    side_errors: dict[str, list[float]] = {"r": [], "l": []}
+    joint_errors: dict[str, list[float]] = {label: [] for label, _ in _LEG_JOINTS}
+    for side in ("r", "l"):
+        for label, joint_suffix in _LEG_JOINTS:
+            error = _home_joint_error(env, f"{side}_{joint_suffix}")
+            if error is None:
+                continue
+            row[f"{side}_{label}_home_error_rad"] = error
+            row[f"{side}_{label}_home_error_deg"] = math.degrees(error)
+            side_errors[side].append(error)
+            joint_errors[label].append(error)
+
+    for side, values in side_errors.items():
+        if values:
+            row[f"{side}_leg_home_error_rad"] = float(np.mean(values))
+            row[f"{side}_leg_home_error_deg"] = math.degrees(row[f"{side}_leg_home_error_rad"])
+    if side_errors["r"] and side_errors["l"]:
+        row["leg_home_error_asymmetry_rad"] = abs(row["r_leg_home_error_rad"] - row["l_leg_home_error_rad"])
+        row["leg_home_error_asymmetry_deg"] = math.degrees(row["leg_home_error_asymmetry_rad"])
+    for label, values in joint_errors.items():
+        if values:
+            row[f"{label}_home_error_rad"] = float(np.mean(values))
+            row[f"{label}_home_error_deg"] = math.degrees(row[f"{label}_home_error_rad"])
+
+    pelvis_pose = _body_pose(env, "pelvis")
+    pelvis_position: np.ndarray | None = None
+    pelvis_z: float | None = None
+    if pelvis_pose is not None:
+        position, quaternion = pelvis_pose
+        pelvis_position = position
+        row["pelvis_x"], row["pelvis_y"], row["pelvis_z"] = (float(value) for value in position)
+        pelvis_z = row["pelvis_z"]
+        row.setdefault("pelvis_height", pelvis_z)
+        roll, pitch, yaw = _quat_to_euler(quaternion)
+        for name, value in (("roll", roll), ("pitch", pitch), ("yaw", yaw)):
+            row[f"pelvis_{name}_rad"] = value
+            row[f"pelvis_{name}_deg"] = math.degrees(value)
+
+    foot_positions: dict[str, np.ndarray] = {}
+    for side in ("r", "l"):
+        foot_position = _site_position(env, f"{side}_foot")
+        if foot_position is None:
+            continue
+        foot_positions[side] = foot_position
+        row[f"{side}_foot_x"], row[f"{side}_foot_y"], row[f"{side}_foot_z"] = (float(value) for value in foot_position)
+
+    if "r" in foot_positions and "l" in foot_positions:
+        right_foot = foot_positions["r"]
+        left_foot = foot_positions["l"]
+        fore_aft_offset = float(right_foot[0] - left_foot[0])
+        support_midpoint = (right_foot + left_foot) / 2.0
+        row["stance_width"] = abs(float(right_foot[1] - left_foot[1]))
+        row["foot_fore_aft_offset"] = fore_aft_offset
+        row["foot_fore_aft_separation"] = abs(fore_aft_offset)
+        row["support_midpoint_x"], row["support_midpoint_y"], row["support_midpoint_z"] = (
+            float(value) for value in support_midpoint
+        )
+        if pelvis_position is not None:
+            pelvis_support_offset = pelvis_position - support_midpoint
+            row["pelvis_support_offset_x"], row["pelvis_support_offset_y"], row["pelvis_support_offset_z"] = (
+                float(value) for value in pelvis_support_offset
+            )
+            row["pelvis_support_offset_xy"] = float(np.linalg.norm(pelvis_support_offset[:2]))
+
+    head_tip = _site_position(env, "head_tip")
+    if head_tip is not None:
+        row["head_tip_x"], row["head_tip_y"], row["head_tip_z"] = (float(value) for value in head_tip)
+        row["head_tip_clearance"] = row["head_tip_z"]
+        if pelvis_z is not None:
+            row["head_pelvis_rel_z"] = row["head_tip_z"] - pelvis_z
+
+    skull_pose = _body_pose(env, "skull")
+    if skull_pose is not None:
+        skull_position, skull_quaternion = skull_pose
+        row["skull_x"], row["skull_y"], row["skull_z"] = (float(value) for value in skull_position)
+        row["skull_clearance"] = row["skull_z"]
+        if pelvis_z is not None:
+            row["skull_pelvis_rel_z"] = row["skull_z"] - pelvis_z
+        _, skull_pitch, _ = _quat_to_euler(skull_quaternion)
+        row["skull_pitch_rad"] = skull_pitch
+        row["skull_pitch_deg"] = math.degrees(skull_pitch)
+
+    tail_tip = _site_position(env, "tail_tip")
+    if tail_tip is not None:
+        row["tail_tip_z"] = float(tail_tip[2])
+        if pelvis_z is not None:
+            row["tail_pelvis_rel_z"] = row["tail_tip_z"] - pelvis_z
+
+    return row
+
+
+def write_stance_diagnostics_csv(path: str | Path, rows: Sequence[Mapping[str, Any]]) -> Path | None:
+    """Write per-frame stance diagnostics, preserving every observed column."""
+    if not rows:
+        return None
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = ["step"]
+    fieldnames.extend(sorted({key for row in rows for key in row if key != "step"}))
+    with output_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+    return output_path

--- a/environments/shared/tests/test_diagnostics.py
+++ b/environments/shared/tests/test_diagnostics.py
@@ -80,6 +80,56 @@ class TestOnStep:
         assert callback._step_infos["forward_vel"] == [2.0]
         assert callback._step_infos["prey_distance"] == [5.0]
 
+    def test_derives_trex_contact_duties_and_load_share(self, callback):
+        callback.locals = {
+            "infos": [
+                {
+                    "bite_success": 0.0,
+                    "r_foot_contact": 75.0,
+                    "l_foot_contact": 25.0,
+                }
+            ]
+        }
+        callback._on_step()
+
+        assert callback._step_infos["bilateral_support_duty"] == [1.0]
+        assert callback._step_infos["r_foot_load_share"] == [0.75]
+        assert callback._step_infos["foot_load_imbalance"] == [0.5]
+
+    def test_environment_stance_value_wins_over_derivative(self, callback):
+        callback.locals = {
+            "infos": [
+                {
+                    "bite_success": 0.0,
+                    "r_foot_contact": 75.0,
+                    "l_foot_contact": 25.0,
+                    "foot_load_imbalance": 0.125,
+                }
+            ]
+        }
+        callback._on_step()
+
+        assert callback._step_infos["foot_load_imbalance"] == [0.125]
+
+    def test_does_not_derive_biped_stance_metrics_for_quadruped_contacts(self, callback):
+        callback.locals = {
+            "infos": [
+                {
+                    "r_foot_contact": 75.0,
+                    "l_foot_contact": 25.0,
+                    "rr_foot_contact": 50.0,
+                    "rl_foot_contact": 50.0,
+                }
+            ]
+        }
+        callback._on_step()
+
+        assert callback._step_infos["r_foot_contact"] == [75.0]
+        assert callback._step_infos["rr_foot_contact"] == [50.0]
+        assert callback._step_infos["bilateral_support_duty"] == []
+        assert callback._step_infos["r_foot_load_share"] == []
+        assert callback._step_infos["foot_load_imbalance"] == []
+
     def test_collects_termination_reasons(self, callback):
         callback.locals = {"infos": [{"termination_reason": "fallen"}, {"termination_reason": "fallen"}]}
         callback._on_step()
@@ -108,6 +158,13 @@ class TestOnStep:
         callback._on_step()
         assert callback._step_infos["forward_vel"] == [1.0, 2.0, 3.0]
         assert callback._step_infos["reward_forward"] == [0.5, 1.0, 1.5]
+
+    def test_diagnostics_add_no_stance_reward_components(self, callback):
+        assert "reward_bilateral_support" not in callback.REWARD_KEYS
+        assert "reward_foot_load_balance" not in callback.REWARD_KEYS
+        assert "reward_leg_home_pose" not in callback.REWARD_KEYS
+        assert "reward_head_clearance" not in callback.REWARD_KEYS
+        assert "reward_neck_posture" not in callback.REWARD_KEYS
 
     def test_empty_infos(self, callback):
         callback.locals = {"infos": []}

--- a/environments/shared/tests/test_evaluation.py
+++ b/environments/shared/tests/test_evaluation.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from environments.shared.evaluation import eval_policy, evaluate, record_stage_video
+from environments.shared.evaluation import eval_policy, eval_policy_quality, evaluate, record_stage_video
 from environments.shared.plant_contract import PlantCompatibilityError, PlantIdentity, attach_plant_identity
 
 
@@ -129,6 +129,63 @@ class TestEvalPolicy:
         assert fwd_vels[0] == 0.0
 
 
+class TestEvalPolicyQuality:
+    def test_exports_raw_stance_means_and_episode_variation(self):
+        env = MagicMock()
+        env.reset.return_value = np.zeros(10)
+        env.step.side_effect = [
+            (
+                np.zeros(10),
+                np.array([1.0]),
+                [True],
+                [
+                    {
+                        "bite_success": 0.0,
+                        "r_foot_contact": 75.0,
+                        "l_foot_contact": 25.0,
+                    }
+                ],
+            ),
+            (
+                np.zeros(10),
+                np.array([1.0]),
+                [True],
+                [
+                    {
+                        "bite_success": 0.0,
+                        "r_foot_contact": 50.0,
+                        "l_foot_contact": 50.0,
+                    }
+                ],
+            ),
+        ]
+        model = MagicMock()
+        model.predict.return_value = (np.array([0.0]), None)
+
+        result = eval_policy_quality(model, env, success_keys=[], n_episodes=2)
+
+        assert result["eval_mean_bilateral_support_duty"] == 1.0
+        assert result["eval_mean_r_foot_load_share"] == pytest.approx(0.625)
+        assert result["eval_std_r_foot_load_share"] == pytest.approx(0.125)
+
+    def test_omits_stance_metrics_without_trex_marker(self):
+        env = MagicMock()
+        env.reset.return_value = np.zeros(10)
+        env.step.return_value = (
+            np.zeros(10),
+            np.array([1.0]),
+            [True],
+            [{"r_foot_contact": 75.0, "l_foot_contact": 25.0}],
+        )
+        model = MagicMock()
+        model.predict.return_value = (np.array([0.0]), None)
+
+        result = eval_policy_quality(model, env, success_keys=[], n_episodes=1)
+
+        assert "eval_mean_bilateral_support_duty" not in result
+        assert "eval_mean_r_foot_load_share" not in result
+
+
 class TestRecordStageVideo:
     """Test record_stage_video with mocked dependencies."""
 
@@ -200,6 +257,66 @@ class TestRecordStageVideo:
 
         # Should have called write_video
         assert mock_mediapy.write_video.called or result is None
+
+    def test_records_named_camera_views_and_stance_csv_without_extra_steps(self, tmp_path):
+        mock_mediapy = MagicMock()
+        mock_env = MagicMock()
+        mock_env._camera = SimpleNamespace(azimuth=135.0, elevation=-20.0, distance=3.0)
+        mock_env.reset.return_value = (np.zeros(10), {})
+        mock_env.step.return_value = (
+            np.zeros(10),
+            1.0,
+            True,
+            False,
+            {"r_foot_contact": 75.0, "l_foot_contact": 25.0},
+        )
+        mock_env.render.return_value = np.zeros((64, 64, 3), dtype=np.uint8)
+        mock_model = MagicMock()
+        mock_model.predict.return_value = (np.array([0.0]), None)
+
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "mediapy":
+                return mock_mediapy
+            return real_import(name, *args, **kwargs)
+
+        with (
+            patch("builtins.__import__", side_effect=mock_import),
+            patch(
+                "environments.shared.train_base._ensure_sb3",
+                return_value={"DummyVecEnv": MagicMock(), "VecNormalize": MagicMock()},
+            ),
+        ):
+            record_stage_video(
+                model=mock_model,
+                env_class=MagicMock(return_value=mock_env),
+                env_kwargs={},
+                stage=1,
+                stage_dir=str(tmp_path),
+                species="dino",
+                label="best",
+                max_steps=1,
+                camera_views={
+                    "side": {"azimuth": 90.0, "elevation": -8.0, "distance": 3.4},
+                    "front": {"azimuth": 180.0, "elevation": -8.0, "distance": 3.4},
+                },
+                collect_stance_diagnostics=True,
+            )
+
+        written_paths = [str(call.args[0]) for call in mock_mediapy.write_video.call_args_list]
+        assert any(path.endswith("_best.mp4") for path in written_paths)
+        assert any(path.endswith("_best_side.mp4") for path in written_paths)
+        assert any(path.endswith("_best_front.mp4") for path in written_paths)
+        assert all(len(call.args[1]) == 1 for call in mock_mediapy.write_video.call_args_list)
+        assert (tmp_path / "dino_ppo_stage1_best_stance.csv").exists()
+        assert mock_model.predict.call_count == 1
+        assert mock_env.step.call_count == 1
+        assert mock_env._camera.azimuth == 135.0
+        assert mock_env._camera.elevation == -20.0
+        assert mock_env._camera.distance == 3.0
 
 
 class TestEvaluateFunction:

--- a/environments/shared/tests/test_metrics.py
+++ b/environments/shared/tests/test_metrics.py
@@ -139,6 +139,50 @@ class TestLocomotionMetrics:
         result = metrics.compute()
         assert "distance_traveled" not in result
 
+    def test_stance_metrics_include_raw_and_derived_signals(self, metrics):
+        metrics.record_step(
+            {
+                "forward_vel": 0.0,
+                "bite_success": 0.0,
+                "r_foot_contact": 75.0,
+                "l_foot_contact": 25.0,
+                "head_tip_z": 0.65,
+            }
+        )
+        result = metrics.compute()
+
+        assert result["mean_bilateral_support_duty"] == pytest.approx(1.0)
+        assert result["mean_r_foot_load_share"] == pytest.approx(0.75)
+        assert result["mean_foot_load_imbalance"] == pytest.approx(0.5)
+        assert result["mean_head_tip_z"] == pytest.approx(0.65)
+
+    def test_stance_metrics_reset(self, metrics):
+        metrics.record_step(
+            {
+                "bite_success": 0.0,
+                "r_foot_contact": 1.0,
+                "l_foot_contact": 1.0,
+            }
+        )
+        metrics.reset()
+
+        assert metrics._stance_metrics == {}
+
+    def test_quadruped_contacts_do_not_create_biped_stance_metrics(self, metrics):
+        metrics.record_step(
+            {
+                "r_foot_contact": 75.0,
+                "l_foot_contact": 25.0,
+                "rr_foot_contact": 50.0,
+                "rl_foot_contact": 50.0,
+            }
+        )
+        result = metrics.compute()
+
+        assert "mean_bilateral_support_duty" not in result
+        assert "mean_r_foot_load_share" not in result
+        assert "mean_foot_load_imbalance" not in result
+
 
 class TestGaitSymmetry:
     """Test gait symmetry computation."""

--- a/environments/shared/tests/test_reporting.py
+++ b/environments/shared/tests/test_reporting.py
@@ -803,7 +803,7 @@ class TestSaveJaxStageArtifacts:
             },
         )
 
-    def _call(self, tmp_path, stage=1, **overrides):
+    def _call(self, tmp_path, stage=1, species="velociraptor", **overrides):
         run_dir = tmp_path / "run"
         run_dir.mkdir(parents=True, exist_ok=True)
         stage_dir = run_dir / f"stage{stage}"
@@ -825,7 +825,7 @@ class TestSaveJaxStageArtifacts:
         )
 
         kwargs = dict(
-            species="velociraptor",
+            species=species,
             stage=stage,
             stage_config=stage_config,
             stage_results=stage_results,
@@ -899,9 +899,46 @@ class TestSaveJaxStageArtifacts:
         paths, _, _ = self._call(tmp_path)
         data = np.load(paths["diagnostics"])
         assert "tilt_angle" in data
+        assert "timesteps" in data
         assert "forward_vel" in data
         assert "l_foot_contact" in data
         assert "reward_forward" in data
+        assert all(len(data[key]) == len(data["timesteps"]) for key in data.files)
+
+    def test_trex_stage1_diagnostics_derive_support_duty_and_load_share(self, tmp_path):
+        from dataclasses import replace
+
+        import numpy as np
+
+        trex_identity = replace(
+            _plant_identity(),
+            species="trex",
+            model_path="environments/trex/assets/trex.xml",
+            physics_revision=5,
+            policy_interface_revision=7,
+            nq=28,
+            nv=27,
+            nu=21,
+            observation_dim=61,
+            action_dim=21,
+        )
+        paths, _, _ = self._call(
+            tmp_path,
+            species="trex",
+            plant_identity=trex_identity,
+        )
+        data = np.load(paths["diagnostics"])
+
+        np.testing.assert_array_equal(data["r_foot_contact_duty"], [0.0, 1.0, 0.0])
+        np.testing.assert_array_equal(data["l_foot_contact_duty"], [1.0, 0.0, 1.0])
+        np.testing.assert_array_equal(data["bilateral_support_duty"], [0.0, 0.0, 0.0])
+        np.testing.assert_array_equal(data["single_support_duty"], [1.0, 1.0, 1.0])
+        np.testing.assert_array_equal(data["unsupported_duty"], [0.0, 0.0, 0.0])
+        np.testing.assert_allclose(data["r_foot_load_share"], [0.0, 1.0, 0.0])
+        np.testing.assert_allclose(data["l_foot_load_share"], [1.0, 0.0, 1.0])
+        np.testing.assert_allclose(data["foot_load_balance"], [0.0, 0.0, 0.0])
+        np.testing.assert_allclose(data["foot_load_asymmetry"], [1.0, 1.0, 1.0])
+        np.testing.assert_allclose(data["foot_load_imbalance"], [1.0, 1.0, 1.0])
 
     def test_diagnostics_npz_no_foot_data(self, tmp_path):
         import numpy as np

--- a/environments/shared/tests/test_stance_diagnostics.py
+++ b/environments/shared/tests/test_stance_diagnostics.py
@@ -1,0 +1,121 @@
+"""Tests for reporting-only T. rex stance diagnostics."""
+
+import csv
+
+import numpy as np
+import pytest
+
+from environments.shared.stance_diagnostics import (
+    capture_trex_stance_snapshot,
+    derive_stance_info,
+    write_stance_diagnostics_csv,
+)
+
+
+def test_derive_stance_info_reports_duty_load_share_and_asymmetry():
+    result = derive_stance_info({"r_foot_contact": 75.0, "l_foot_contact": 25.0})
+
+    assert result["r_foot_contact_duty"] == 1.0
+    assert result["l_foot_contact_duty"] == 1.0
+    assert result["bilateral_support_duty"] == 1.0
+    assert result["single_support_duty"] == 0.0
+    assert result["r_foot_load_share"] == pytest.approx(0.75)
+    assert result["l_foot_load_share"] == pytest.approx(0.25)
+    assert result["foot_load_imbalance"] == pytest.approx(0.5)
+    assert result["foot_load_asymmetry"] == pytest.approx(0.5)
+    assert result["foot_load_balance"] == pytest.approx(0.5)
+
+
+def test_derive_stance_info_distinguishes_single_and_unsupported_contact():
+    single = derive_stance_info({"r_foot_contact": 1.0, "l_foot_contact": 0.0})
+    unsupported = derive_stance_info({"r_foot_contact": 0.0, "l_foot_contact": 0.0})
+
+    assert single["single_support_duty"] == 1.0
+    assert single["bilateral_support_duty"] == 0.0
+    assert unsupported["unsupported_duty"] == 1.0
+    assert unsupported["foot_load_balance"] == 0.0
+
+
+def test_snapshot_gracefully_records_info_without_mujoco_environment():
+    row = capture_trex_stance_snapshot(
+        object(),
+        {
+            "r_foot_contact": 60.0,
+            "l_foot_contact": 40.0,
+            "drift_distance": 0.2,
+            "pelvis_yaw_vel": -0.1,
+        },
+        step=7,
+    )
+
+    assert row["step"] == 7.0
+    assert row["r_foot_load_share"] == pytest.approx(0.6)
+    assert row["drift_distance"] == pytest.approx(0.2)
+    assert row["pelvis_yaw_vel"] == pytest.approx(-0.1)
+
+
+def test_snapshot_records_geometry_without_mutating_simulation_state():
+    from environments.trex.envs.trex_env import TRexEnv
+
+    env = TRexEnv(reset_noise_scale=0.0)
+    try:
+        env.reset(seed=0)
+        _, _, _, _, info = env.step(np.zeros(env.action_space.shape, dtype=np.float32))
+        before = {
+            "qpos": env.data.qpos.copy(),
+            "qvel": env.data.qvel.copy(),
+            "act": env.data.act.copy(),
+            "ctrl": env.data.ctrl.copy(),
+            "time": float(env.data.time),
+        }
+
+        row = capture_trex_stance_snapshot(env, info, step=1)
+
+        right_foot = np.asarray(env.data.site_xpos[env.r_foot_site_id], dtype=float)
+        left_foot = np.asarray(env.data.site_xpos[env.l_foot_site_id], dtype=float)
+        pelvis = np.asarray(env.data.xpos[env.pelvis_id], dtype=float)
+        support_midpoint = (right_foot + left_foot) / 2.0
+        pelvis_support_offset = pelvis - support_midpoint
+
+        assert [row[f"r_foot_{axis}"] for axis in "xyz"] == pytest.approx(right_foot)
+        assert [row[f"l_foot_{axis}"] for axis in "xyz"] == pytest.approx(left_foot)
+        assert row["stance_width"] == pytest.approx(abs(right_foot[1] - left_foot[1]))
+        assert row["foot_fore_aft_offset"] == pytest.approx(right_foot[0] - left_foot[0])
+        assert row["foot_fore_aft_separation"] == pytest.approx(abs(right_foot[0] - left_foot[0]))
+        assert [row[f"support_midpoint_{axis}"] for axis in "xyz"] == pytest.approx(support_midpoint)
+        assert [row[f"pelvis_support_offset_{axis}"] for axis in "xyz"] == pytest.approx(pelvis_support_offset)
+        assert row["pelvis_support_offset_xy"] == pytest.approx(np.linalg.norm(pelvis_support_offset[:2]))
+        assert row["hip_roll_home_error_rad"] == pytest.approx(
+            np.mean(
+                [
+                    row["r_hip_roll_home_error_rad"],
+                    row["l_hip_roll_home_error_rad"],
+                ]
+            )
+        )
+
+        np.testing.assert_array_equal(env.data.qpos, before["qpos"])
+        np.testing.assert_array_equal(env.data.qvel, before["qvel"])
+        np.testing.assert_array_equal(env.data.act, before["act"])
+        np.testing.assert_array_equal(env.data.ctrl, before["ctrl"])
+        assert env.data.time == before["time"]
+    finally:
+        env.close()
+
+
+def test_write_stance_csv_unions_columns(tmp_path):
+    path = tmp_path / "stance.csv"
+    result = write_stance_diagnostics_csv(path, [{"step": 1, "a": 2.0}, {"step": 2, "b": 3.0}])
+
+    assert result == path
+    with path.open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    assert rows[0]["a"] == "2.0"
+    assert rows[1]["b"] == "3.0"
+
+
+def test_write_stance_csv_skips_empty_rows(tmp_path):
+    path = tmp_path / "stance.csv"
+
+    assert write_stance_diagnostics_csv(path, []) is None
+    assert not path.exists()

--- a/environments/shared/tests/test_visualization.py
+++ b/environments/shared/tests/test_visualization.py
@@ -267,3 +267,83 @@ class TestPlotFootContacts:
         )
 
         assert save_path.exists()
+
+
+class TestPlotStanceDiagnostics:
+    def test_saves_stance_dashboard_when_fields_exist(self, tmp_path):
+        matplotlib.use("Agg")
+
+        from environments.shared.visualization import plot_stance_diagnostics
+
+        np.savez(
+            str(tmp_path / "diagnostics.npz"),
+            timesteps=np.array([50000, 100000]),
+            bilateral_support_duty=np.array([0.5, 0.9]),
+            single_support_duty=np.array([0.5, 0.1]),
+            foot_load_imbalance=np.array([0.3, 0.1]),
+            head_tip_z=np.array([0.6, 0.7]),
+            pelvis_height=np.array([0.8, 0.9]),
+            drift_distance=np.array([0.2, 0.1]),
+            pelvis_yaw_vel=np.array([0.1, 0.05]),
+        )
+        save_path = tmp_path / "stance_diagnostics.png"
+        fig = plot_stance_diagnostics(
+            [(1, tmp_path)],
+            {1: {"name": "Balance"}},
+            species="trex",
+            algorithm="ppo",
+            save_path=save_path,
+            show=False,
+        )
+
+        assert fig is not None
+        assert save_path.exists()
+        assert len(fig.axes) == 6
+
+    def test_returns_none_without_stance_fields(self, tmp_path):
+        matplotlib.use("Agg")
+
+        from environments.shared.visualization import plot_stance_diagnostics
+
+        np.savez(
+            str(tmp_path / "diagnostics.npz"),
+            timesteps=np.array([50000, 100000]),
+            r_foot_contact=np.array([1.0, 1.0]),
+            l_foot_contact=np.array([1.0, 1.0]),
+            pelvis_height=np.array([0.8, 0.9]),
+            drift_distance=np.array([0.2, 0.1]),
+        )
+        result = plot_stance_diagnostics(
+            [(1, tmp_path)],
+            {1: {"name": "Balance"}},
+            species="trex",
+            algorithm="ppo",
+            save_path=tmp_path / "stance_diagnostics.png",
+            show=False,
+        )
+
+        assert result is None
+        assert not (tmp_path / "stance_diagnostics.png").exists()
+
+    def test_returns_none_for_other_species_even_with_support_fields(self, tmp_path):
+        matplotlib.use("Agg")
+
+        from environments.shared.visualization import plot_stance_diagnostics
+
+        np.savez(
+            str(tmp_path / "diagnostics.npz"),
+            timesteps=np.array([50000, 100000]),
+            bilateral_support_duty=np.array([0.5, 0.9]),
+            foot_load_imbalance=np.array([0.3, 0.1]),
+        )
+        result = plot_stance_diagnostics(
+            [(1, tmp_path)],
+            {1: {"name": "Balance"}},
+            species="brachiosaurus",
+            algorithm="ppo",
+            save_path=tmp_path / "stance_diagnostics.png",
+            show=False,
+        )
+
+        assert result is None
+        assert not (tmp_path / "stance_diagnostics.png").exists()

--- a/environments/shared/visualization.py
+++ b/environments/shared/visualization.py
@@ -619,6 +619,116 @@ def plot_foot_contacts(
     return fig
 
 
+def plot_stance_diagnostics(
+    stage_dirs: StageDirs,
+    stage_configs: dict[int, dict[str, Any]],
+    species: str,
+    algorithm: str,
+    save_path: "str | Path | None" = None,
+    show: bool = True,
+) -> "Any":
+    """Plot reporting-only Stage-1 stance measurements.
+
+    Returns ``None`` when no stance fields have been recorded, so older runs
+    and other species retain their existing artifact set.
+    """
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    from environments.shared.stance_diagnostics import STANCE_INFO_KEYS
+
+    if species.lower() != "trex":
+        return None
+
+    panels: tuple[tuple[str, tuple[str, ...]], ...] = (
+        (
+            "Foot support duty",
+            (
+                "r_foot_contact_duty",
+                "l_foot_contact_duty",
+                "bilateral_support_duty",
+                "single_support_duty",
+                "unsupported_duty",
+            ),
+        ),
+        (
+            "Foot load distribution",
+            (
+                "r_foot_load_share",
+                "l_foot_load_share",
+                "foot_load_balance",
+                "foot_load_imbalance",
+            ),
+        ),
+        ("Leg home pose", ("leg_home_pose_error",)),
+        (
+            "Head / neck posture",
+            ("head_tip_z", "head_pelvis_rel_z", "neck_posture_error"),
+        ),
+        (
+            "Pelvis pose",
+            ("pelvis_height", "tilt_angle", "height_error"),
+        ),
+        (
+            "Drift / yaw",
+            ("drift_distance", "pelvis_yaw_vel", "pelvis_angular_vel"),
+        ),
+    )
+
+    available = False
+    for _, stage_dir in stage_dirs:
+        diag_path = Path(stage_dir) / "diagnostics.npz"
+        if diag_path.exists():
+            with np.load(diag_path) as diag:
+                if any(
+                    key in diag and np.asarray(diag[key]).size > 0 and np.isfinite(diag[key]).any()
+                    for key in STANCE_INFO_KEYS
+                ):
+                    available = True
+                    break
+    if not available:
+        return None
+
+    fig, axes = plt.subplots(2, 3, figsize=(18, 10))
+    fig.suptitle(
+        f"{species.title()} {algorithm} – Stance Diagnostics",
+        fontsize=14,
+        fontweight="bold",
+    )
+
+    for stage_num, stage_dir in stage_dirs:
+        diag_path = Path(stage_dir) / "diagnostics.npz"
+        if not diag_path.exists():
+            continue
+        with np.load(diag_path) as diag:
+            if "timesteps" not in diag or len(diag["timesteps"]) == 0:
+                continue
+            timesteps = diag["timesteps"]
+            stage_name = stage_configs.get(stage_num, {}).get("name", f"Stage {stage_num}")
+            for axis, (title, keys) in zip(axes.flat, panels, strict=True):
+                for key in keys:
+                    if key not in diag:
+                        continue
+                    axis.plot(
+                        timesteps,
+                        _smooth(diag[key]),
+                        label=f"S{stage_num} {key.replace('_', ' ')}",
+                    )
+                axis.set_title(title)
+                axis.set_xlabel("Timesteps")
+                axis.grid(True, alpha=0.3)
+                _safe_legend(axis, fontsize=7)
+            fig.text(0.99, 0.01, f"S{stage_num}: {stage_name}", ha="right", fontsize=8)
+
+    fig.tight_layout()
+    if save_path is not None:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+        logger.info("Stance diagnostics plot saved to: %s", save_path)
+    if not show:
+        plt.close(fig)
+    return fig
+
+
 def plot_trial_comparison(
     analysis_rows: "list[dict[str, Any]]",
     species: str,


### PR DESCRIPTION
## Why

PR #470 currently couples T. rex Stage 1 reward/gate changes with the instrumentation needed to judge them. This extracts the behavior-neutral diagnostics first so the completed baseline, reward-only pilots, perturbation pilots, and hybrid pilots can all be measured with the same tools.

## What changed

- Derive T. rex bilateral-support duty, single/unsupported duty, foot-load shares, and normalized load imbalance from the foot forces already emitted by the environment.
- Record those values in SB3 rollout diagnostics and post-training quality metrics without adding reward components.
- Add per-frame replay CSVs containing foot positions, stance width and fore/aft offset, support midpoint and pelvis offsets, detailed leg home-pose errors, pelvis orientation, and head/skull/tail clearances.
- Add synchronized fixed side and front Stage 1 replay views.
- Add a six-panel stance dashboard for support, load distribution, posture, pelvis pose, and drift/yaw.
- Give JAX diagnostic artifacts a time axis and derive the same support/load series from existing evaluation foot-force traces.

## Behavioral impact

None intended. This PR does not change the T. rex environment, reward functions, Stage 1 configuration, curriculum gates, actions, observations, reset distribution, termination, XML plant, or generated species catalog. Reward-shaped qualities remain in #470.

No retraining is required.

## Validation

- Focused diagnostics/evaluation/reporting/visualization tests passed.
- All shared and T. rex tests passed with the two stale plant-manifest tests deselected after reproducing those exact failures on untouched merged-#472 code.
- `ruff check environments/` passed.
- `ruff format --check environments/` passed.
- `python -m environments.shared.species_catalog --check` passed.
- Five-episode T. rex Stage 1 zero-action comparison was exactly identical to main: reward `1763.89 ± 1309.03`, mean length `644.4`, 60% full horizon, and termination counts `{'truncated': 3, 'nosedive': 2}`.
- Targeted Mypy reports the same 13 pre-existing errors on this branch and untouched #472, with no new errors.

## Follow-up

After this merges, #470 can be rebased and reduced to the unvalidated reward weights, reward-shaped qualities, and advancement-gate changes.