### PR TITLE
CI: combine coverage across jobs so the number reflects what CI runs

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -97,7 +97,17 @@ jobs:
           pytest \
             environments/shared/tests/test_plant_contract_*.py \
             environments/shared/tests/test_species_catalog.py \
-            -v --tb=short
+            -v --tb=short --cov=environments --cov-report= --cov-fail-under=0
+        env:
+          COVERAGE_FILE: .coverage.plant-contract
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-plant-contract
+          path: .coverage.*
+          include-hidden-files: true
+          retention-days: 1
 
       - name: Verify plant identity from an installed wheel
         run: |
@@ -140,9 +150,18 @@ jobs:
           pip install -e .[dev]
 
       - name: Run tests with coverage
-        run: pytest environments/shared/tests/ -v --tb=short --cov=environments/shared --cov-report=term-missing
+        run: pytest environments/shared/tests/ -v --tb=short --cov=environments --cov-report= --cov-fail-under=0
         env:
           MUJOCO_GL: osmesa
+          COVERAGE_FILE: .coverage.shared-${{ matrix.python-version }}
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-shared-${{ matrix.python-version }}
+          path: .coverage.*
+          include-hidden-files: true
+          retention-days: 1
 
   test-velociraptor:
     runs-on: ubuntu-latest
@@ -168,9 +187,18 @@ jobs:
           pip install -e .[dev]
 
       - name: Run tests with coverage
-        run: pytest environments/velociraptor/tests/ -v --tb=short --cov=environments/velociraptor --cov-report=term-missing
+        run: pytest environments/velociraptor/tests/ -v --tb=short --cov=environments --cov-report= --cov-fail-under=0
         env:
           MUJOCO_GL: osmesa
+          COVERAGE_FILE: .coverage.velociraptor-${{ matrix.python-version }}
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-velociraptor-${{ matrix.python-version }}
+          path: .coverage.*
+          include-hidden-files: true
+          retention-days: 1
 
   test-brachiosaurus:
     runs-on: ubuntu-latest
@@ -196,9 +224,18 @@ jobs:
           pip install -e .[dev]
 
       - name: Run tests with coverage
-        run: pytest environments/brachiosaurus/tests/ -v --tb=short --cov=environments/brachiosaurus --cov-report=term-missing
+        run: pytest environments/brachiosaurus/tests/ -v --tb=short --cov=environments --cov-report= --cov-fail-under=0
         env:
           MUJOCO_GL: osmesa
+          COVERAGE_FILE: .coverage.brachiosaurus-${{ matrix.python-version }}
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-brachiosaurus-${{ matrix.python-version }}
+          path: .coverage.*
+          include-hidden-files: true
+          retention-days: 1
 
   test-trex:
     runs-on: ubuntu-latest
@@ -224,9 +261,18 @@ jobs:
           pip install -e .[dev]
 
       - name: Run tests with coverage
-        run: pytest environments/trex/tests/ -v --tb=short --cov=environments/trex --cov-report=term-missing
+        run: pytest environments/trex/tests/ -v --tb=short --cov=environments --cov-report= --cov-fail-under=0
         env:
           MUJOCO_GL: osmesa
+          COVERAGE_FILE: .coverage.trex-${{ matrix.python-version }}
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-trex-${{ matrix.python-version }}
+          path: .coverage.*
+          include-hidden-files: true
+          retention-days: 1
 
   test-dibothrosuchus:
     runs-on: ubuntu-latest
@@ -252,9 +298,18 @@ jobs:
           pip install -e .[dev]
 
       - name: Run tests with coverage
-        run: pytest environments/dibothrosuchus/tests/ -v --tb=short --cov=environments/dibothrosuchus --cov-report=term-missing
+        run: pytest environments/dibothrosuchus/tests/ -v --tb=short --cov=environments --cov-report= --cov-fail-under=0
         env:
           MUJOCO_GL: osmesa
+          COVERAGE_FILE: .coverage.dibothrosuchus-${{ matrix.python-version }}
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-dibothrosuchus-${{ matrix.python-version }}
+          path: .coverage.*
+          include-hidden-files: true
+          retention-days: 1
 
   test-sb3:
     runs-on: ubuntu-latest
@@ -327,9 +382,18 @@ jobs:
             environments/shared/tests/test_train_base.py \
             environments/shared/tests/test_sweep_ray_plant_contract.py \
             environments/shared/tests/test_wandb_integration.py \
-            -v --tb=short
+            -v --tb=short --cov=environments --cov-report= --cov-fail-under=0
         env:
           MUJOCO_GL: osmesa
+          COVERAGE_FILE: .coverage.sb3
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-sb3
+          path: .coverage.*
+          include-hidden-files: true
+          retention-days: 1
 
   test-jax-cpu:
     runs-on: ubuntu-latest
@@ -361,7 +425,53 @@ jobs:
             environments/shared/tests/test_jax_*.py \
             environments/shared/tests/test_mjx_env.py \
             environments/shared/tests/test_reward_functions.py \
-            -v --tb=short
+            -v --tb=short --cov=environments --cov-report= --cov-fail-under=0
         env:
           JAX_PLATFORMS: cpu
           MUJOCO_GL: osmesa
+          COVERAGE_FILE: .coverage.jax-cpu
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-jax-cpu
+          path: .coverage.*
+          include-hidden-files: true
+          retention-days: 1
+
+  coverage:
+    # The only job that reports a coverage number. Each test job above measures
+    # the whole `environments` tree but exercises only its own slice, so no
+    # single one of them is meaningful alone -- they are combined here and the
+    # union is what `fail_under` gates on.
+    runs-on: ubuntu-latest
+    needs:
+      - plant-contract
+      - test-shared
+      - test-velociraptor
+      - test-brachiosaurus
+      - test-trex
+      - test-dibothrosuchus
+      - test-sb3
+      - test-jax-cpu
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install coverage
+        run: pip install coverage
+
+      - name: Download coverage data from every test job
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+
+      - name: Combine and report
+        run: |
+          coverage combine
+          coverage report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preventing. The coverage `omit` entry added to work around the old naming is
   replaced by one covering the package.
 
+- **CI now measures the coverage it actually produces.** Three jobs ran tests
+  without `--cov` — `test-jax-cpu`, `test-sb3` and `plant-contract` — and those
+  are precisely the jobs carrying the optional dependencies. The only job
+  reporting a number for `environments/shared` was `test-shared`, which installs
+  neither JAX nor SB3, so the modules needing them were omitted from the report
+  as "not available in the standard CI test environment". That stopped being
+  true when `test-jax-cpu` was added: 1,840 statements of JAX/MJX and 495 of
+  `train_base.py` — 23% of the production code in `environments/shared` — were
+  being exercised by CI and excluded from its number, which read 79.57% over the
+  remaining 7,652 statements.
+
+  Deleting the omits alone does not work; it drops `test-shared` to 66%, under
+  the `fail_under = 70` gate, because that job genuinely cannot import those
+  modules. So every test job now writes its own `.coverage.<job>` and uploads
+  it, and a new `coverage` job combines them and gates the union. Per-job
+  reports are suppressed with `--cov-fail-under=0`, since no single job's slice
+  is meaningful alone. `relative_files` is enabled so the combine lines up
+  across jobs. `harnesses/` and the mjlab adapter stay omitted, now with
+  accurate reasons — hand-run, and GPU-only with no job able to reach it.
+
 ### Removed
 - **The top-level `Images/` directory** (25 MB): its three GIFs were
   byte-identical to the copies under `website/static/img/`, which are the ones

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,31 +152,18 @@ known-first-party = ["environments"]
 
 [tool.coverage.run]
 source = ["environments"]
+# Every test job writes its own .coverage.<job>; the `coverage` job combines
+# them and gates on the union. Paths must be relative for that combine to line
+# up across jobs.
+relative_files = true
 omit = [
     "*/tests/*",
     "*/scripts/*",
     # Hand-run smoke-check and viewer harnesses behind the per-species scripts
     # (the scripts themselves are already excluded by */scripts/*).
     "environments/shared/harnesses/*",
-    # Training entry-point infrastructure (equivalent to the per-species scripts
-    # that were already excluded by */scripts/*). Utility helpers in this module
-    # are tested via test_train_base.py.
-    "environments/shared/train_base.py",
-    # JAX/MJX modules require the [jax] optional dependency which is not
-    # available in the standard CI test environment.  These are tested
-    # separately when JAX is installed.
-    "environments/shared/mjx_env.py",
-    "environments/shared/mjx_utils.py",
-    "environments/shared/jax_ppo.py",
-    "environments/shared/jax_training.py",
-    "environments/shared/jax_normalization.py",
-    "environments/shared/jax_curriculum.py",
-    "environments/shared/jax_reward_termination.py",
-    "environments/shared/jax_setup.py",
-    "environments/shared/jax_trainer.py",
-    "environments/*/mjx_config.py",
-    # mjlab adapter — scaffold only, requires the optional [mjlab] extra
-    # and an NVIDIA GPU, so it's excluded from default CI coverage.
+    # mjlab adapter — scaffold only, requires the optional [mjlab] extra and an
+    # NVIDIA GPU, so no CI job can exercise it.
     "environments/shared/mjlab_env.py",
     "environments/*/mjlab_config.py",
 ]


### PR DESCRIPTION
## Summary

Three CI jobs ran tests without `--cov` — `test-jax-cpu`, `test-sb3` and `plant-contract` — and those are exactly the jobs carrying the optional dependencies. The only job reporting a number for `environments/shared` was `test-shared`, which installs neither JAX nor SB3, so the modules needing them were omitted from the report.

The omit list said those modules were *"not available in the standard CI test environment."* That stopped being true when `test-jax-cpu` was added: they are exercised on every run, just never measured.

## What the gap actually is

Measured, not estimated:

| | Statements | Tested by | Measured? |
|---|---|---|---|
| `test-shared` reports **79.57%** over | 7,652 | `test-shared` | yes |
| omitted — JAX/MJX stack (9 modules) | 1,840 | `test-jax-cpu` | **no** |
| omitted — `train_base.py` | 495 | `test-sb3` | **no** |
| omitted — `harnesses/` | 268 | hand-run only | correctly omitted |
| omitted — `mjlab` | 39 | nothing (GPU-only) | correctly omitted |

**2,335 statements — 23% of the production code in `environments/shared`** — were exercised by CI and excluded from its number.

## Why deleting the omits isn't the fix

I tried it: `test-shared` drops from **79.57% → 66%**, under the `fail_under = 70` gate. The denominator grows by 2,335 while the numerator doesn't move, because that job genuinely cannot import those modules.

The root cause is this alignment:

| job | installs | measured coverage before |
|---|---|---|
| `test-shared` | `[dev]` | **yes** |
| `test-sb3` | `[train,ray,test]` | no |
| `test-jax-cpu` | `[jax-cpu,test]` | no |
| `plant-contract` | `[test]` | no |

The one job that measured is the one without the dependencies. The omit list was load-bearing given that shape, not sloppiness.

## The change

- Every test job writes `.coverage.<job>` (via `COVERAGE_FILE`) and uploads it as an artifact.
- A new `coverage` job downloads all of them, runs `coverage combine`, and reports — this is now the only job that gates on `fail_under`.
- Per-job reports suppressed and `--cov-fail-under=0` set, since no single job's slice is meaningful alone.
- `--cov=environments` everywhere (rather than per-package) so the combined data is coherent.
- `relative_files = true` so the combine lines up across jobs.
- Stale JAX and `train_base.py` omits dropped. `harnesses/` and `mjlab` stay omitted with accurate reasons — hand-run, and GPU-only with no job able to reach it.

`fail_under` stays at **70** rather than being pre-tuned to whatever the combined number turns out to be. If the combined figure lands below it, that is a finding to report, not a threshold to relax.

## CI results

All **22 checks green** (`deploy` skipped, as expected on a PR). The new `coverage` job combined 18 uploaded data files and reported:

```
TOTAL   11071   2221   80%
```

Comparable slice, before vs after — `environments/shared` only, so the species packages the combined report also spans aren't inflating it:

| | Statements | Missed | Cover |
|---|---|---|---|
| before (`test-shared` alone) | 7,652 | — | 79.57% |
| after (combined) | 9,987 | 2,190 | **78.07%** |
| whole `environments` tree (the gate) | 11,071 | 2,221 | **80%** |

The headline number barely moved, but it is now measured over a denominator **31% larger** — the 2,335 statements that were being skipped turn out to be covered at roughly 73% on their own. That was the point: not to move the number, but to make it mean something. Clears `fail_under = 70` with room, so the "report it or relax it" question doesn't arise.

### What the combine surfaced

Modules that had been invisible, now in the denominator:

| module | stmts | cover |
|---|---|---|
| `shared/train_base.py` | 495 | **29%** |
| `shared/train.py` | 22 | **0%** |
| `shared/plant_contract/__main__.py` | 29 | **0%** |
| `shared/jax_training.py` | 78 | **21%** |
| `shared/jax_trainer.py` | 547 | 60% |
| `shared/jax_viz.py` | 501 | 60% |
| `shared/jax_setup.py` | 284 | 62% |
| `shared/mjx_env.py` | 445 | 84% |
| `shared/jax_ppo.py` | 111 | 96% |

The JAX physics/PPO core is in good shape. The thin CLI/orchestration wrappers around it (`train.py`, `__main__.py`, the top of `train_base.py`) are near-zero — those are entry points no test invokes. Follow-up work, not this PR.

### One log line worth explaining

The `coverage` job prints `Combined 15 files, skipped 3` against 18 downloaded artifacts. That is not data loss: coverage.py content-hashes each data file and skips one whose bytes are identical to a file already combined. Three matrix runs produced byte-identical data to a sibling Python version — verified locally that two identical runs do produce byte-identical `.coverage` files, and read `DataFileClassifier.classify` to confirm skipping is hash-equality only. A skipped file contributes nothing because an identical one is already in the union.

## Verification

Done locally, before CI:
- Combine mechanism proven end to end — two jobs into separate data files, combined, single report.
- Both workflow files parse as valid YAML.
- All 8 test jobs both upload coverage **and** appear in `coverage.needs` — checked programmatically, not by eye.
- `deploy.yml` has no cross-references to these job names; unaffected.
- Test suite unchanged by the config edit.

`test-sb3` and `test-jax-cpu` could not run in the sandbox (no `stable-baselines3`, no JAX/MJX stack installed), and those are precisely the jobs this change exists to surface — so CI was the first place the real combined number appeared. It is reported above.