### PR TITLE
Cover the unified training entry point (0% → 95%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   across jobs. `harnesses/` and the mjlab adapter stay omitted, now with
   accurate reasons — hand-run, and GPU-only with no job able to reach it.
 
+  The combined gate reports **80% over 11,071 statements**. On the comparable
+  `environments/shared` slice that is 78.07% over 9,987 statements against the
+  old 79.57% over 7,652 — the figure barely moves while the denominator grows
+  31%, which was the point. `fail_under` stays at 70 rather than being tuned to
+  the result. The combine log reads `Combined 15 files, skipped 3` against 18
+  artifacts: coverage.py content-hashes each data file and skips one whose
+  bytes match a file already combined, so three matrix runs that produced
+  identical data to a sibling Python version contributed nothing new. No data
+  is dropped.
+
 ### Removed
 - **The top-level `Images/` directory** (25 MB): its three GIFs were
   byte-identical to the copies under `website/static/img/`, which are the ones
@@ -269,6 +279,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already terminated.
 
 ### Added
+- **Tests for the unified training entry point** (`environments/shared/train.py`),
+  which the newly-honest combined coverage showed at **0%** — the module was
+  never imported by any test. It is the `--species` shim in front of
+  `train_base.main`, so a break there takes out every documented
+  `python -m environments.shared.train ...` invocation while the species
+  packages stay green. 13 tests cover both validation exits, the argv rewrite
+  (species pair at the front, middle and end; `argv[0]` preserved), the
+  hand-off to `get_species_config`/`main`, and an unknown species propagating
+  the registry's `ValueError` rather than being swallowed. The `sys.path`
+  bootstrap is pinned against repository landmarks rather than its
+  `parents[2]` arithmetic — the same depth-counting failure that produced the
+  provenance-root bug on this branch — and the `__main__` guard is exercised
+  end to end as a subprocess. 0% → 95%, the remainder being the guard body
+  itself, which only runs out of process. All nine mutations of the module
+  (both exit codes, the argv slice bounds, the parent depth, the guarded
+  `sys.path` insert, and swallowing the registry error) turn the suite red.
+
 - **New species: *Dibothrosuchus elaphros*** (77 obs / 27 actuators / 8.65 kg
   / nq=35, nv=34) — a sphenosuchian crocodylomorph and the first non-dinosaur
   in the project. It is a small, gracile quadruped that held its limbs erect

--- a/environments/shared/tests/test_train_entry_point.py
+++ b/environments/shared/tests/test_train_entry_point.py
@@ -1,0 +1,172 @@
+"""Unit tests for the unified training entry point (``environments/shared/train.py``).
+
+The module is a thin argv shim: it pulls ``--species <name>`` out of ``sys.argv``,
+resolves the species config, and hands the remainder to
+:func:`environments.shared.train_base.main`.  It deliberately defers those two
+imports to call time so that ``--help``-style misuse fails fast without dragging
+in the training stack.
+
+That deferral is also what makes these tests cheap: patching ``main`` and
+``get_species_config`` on their *owning modules* is enough, because the
+function-level ``from ... import`` statements read the attributes fresh on every
+call.  No stable-baselines3 required, and no training is ever started.
+"""
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from environments.shared import train as train_entry
+
+
+@pytest.fixture
+def recorded_run(monkeypatch):
+    """Replace the two names ``_main`` imports, recording what they receive.
+
+    ``argv_at_main`` is captured inside the fake rather than after ``_main``
+    returns, because ``_main`` mutates ``sys.argv`` in place and the assertion
+    that matters is what the downstream argparse would have seen.
+    """
+    calls: dict = {}
+
+    def fake_get_species_config(species):
+        calls["species"] = species
+        return f"config-for-{species}"
+
+    def fake_main(config):
+        calls["config"] = config
+        calls["argv_at_main"] = list(sys.argv)
+
+    monkeypatch.setattr("environments.shared.species_registry.get_species_config", fake_get_species_config)
+    monkeypatch.setattr("environments.shared.train_base.main", fake_main)
+    return calls
+
+
+class TestSpeciesFlagValidation:
+    """Misuse of --species must fail loudly instead of reaching train_base."""
+
+    def test_missing_species_flag_exits_with_usage(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["train.py", "train", "--stage", "1"])
+
+        with pytest.raises(SystemExit) as excinfo:
+            train_entry._main()
+
+        assert excinfo.value.code == 1
+        stderr = capsys.readouterr().err
+        assert "--species" in stderr
+        # The usage text is the only place a user learns the valid names.
+        for name in ("velociraptor", "trex", "brachiosaurus", "dibothrosuchus"):
+            assert name in stderr
+
+    def test_species_flag_without_a_value_exits(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["train.py", "train", "--species"])
+
+        with pytest.raises(SystemExit) as excinfo:
+            train_entry._main()
+
+        assert excinfo.value.code == 1
+        assert "requires a value" in capsys.readouterr().err
+
+    def test_validation_failure_does_not_reach_train_base(self, monkeypatch, recorded_run):
+        monkeypatch.setattr(sys, "argv", ["train.py", "train"])
+
+        with pytest.raises(SystemExit):
+            train_entry._main()
+
+        assert recorded_run == {}
+
+
+class TestHandoffToTrainBase:
+    """The species is resolved, and the flag pair is removed before hand-off."""
+
+    def test_species_is_resolved_and_its_config_passed_to_main(self, monkeypatch, recorded_run):
+        monkeypatch.setattr(sys, "argv", ["train.py", "--species", "velociraptor", "train", "--stage", "1"])
+
+        train_entry._main()
+
+        assert recorded_run["species"] == "velociraptor"
+        assert recorded_run["config"] == "config-for-velociraptor"
+
+    def test_species_pair_is_stripped_before_main_parses_argv(self, monkeypatch, recorded_run):
+        monkeypatch.setattr(sys, "argv", ["train.py", "--species", "velociraptor", "train", "--stage", "1"])
+
+        train_entry._main()
+
+        assert recorded_run["argv_at_main"] == ["train.py", "train", "--stage", "1"]
+
+    def test_species_pair_is_stripped_from_the_middle_of_argv(self, monkeypatch, recorded_run):
+        monkeypatch.setattr(sys, "argv", ["train.py", "curriculum", "--species", "trex", "--n-envs", "4"])
+
+        train_entry._main()
+
+        assert recorded_run["argv_at_main"] == ["train.py", "curriculum", "--n-envs", "4"]
+
+    def test_species_pair_is_stripped_from_the_end_of_argv(self, monkeypatch, recorded_run):
+        monkeypatch.setattr(sys, "argv", ["train.py", "curriculum", "--species", "dibo"])
+
+        train_entry._main()
+
+        assert recorded_run["argv_at_main"] == ["train.py", "curriculum"]
+
+    def test_program_name_survives_the_rewrite(self, monkeypatch, recorded_run):
+        """argv[0] feeds argparse's usage line, so it must not be dropped."""
+        monkeypatch.setattr(sys, "argv", ["/path/to/train.py", "--species", "trex", "train"])
+
+        train_entry._main()
+
+        assert recorded_run["argv_at_main"][0] == "/path/to/train.py"
+
+    def test_an_unknown_species_propagates_the_registry_error(self, monkeypatch):
+        """No blanket except: a typo'd species surfaces the registry's message."""
+        monkeypatch.setattr(sys, "argv", ["train.py", "--species", "stegosaurus", "train"])
+
+        with pytest.raises(ValueError, match="Unknown species"):
+            train_entry._main()
+
+
+class TestRepositoryRootBootstrap:
+    """``_repo_root`` is computed from ``__file__`` by parent depth.
+
+    Depth-counted paths silently change meaning when a module moves, so pin the
+    resolved directory against landmarks rather than trusting the arithmetic.
+    """
+
+    def test_repo_root_resolves_to_the_repository(self):
+        root = Path(train_entry._repo_root)
+
+        assert (root / "pyproject.toml").is_file()
+        assert (root / "environments" / "shared" / "train.py").is_file()
+
+    def test_repo_root_is_on_sys_path(self):
+        assert train_entry._repo_root in sys.path
+
+    def test_repo_root_is_inserted_when_it_is_missing(self, monkeypatch):
+        """The guarded insert is a no-op under pytest, where the root is already
+        importable.  It earns its keep for ``python environments/shared/train.py``,
+        so drive that branch by reloading with the root taken off ``sys.path``.
+        """
+        root = train_entry._repo_root
+        monkeypatch.setattr(sys, "path", [entry for entry in sys.path if entry != root])
+        assert root not in sys.path
+
+        importlib.reload(train_entry)
+
+        assert sys.path[0] == root
+
+
+class TestModuleExecution:
+    """The ``__main__`` guard is the real entry point; exercise it as one."""
+
+    def test_running_the_module_without_species_fails_with_usage(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "environments.shared.train", "train"],
+            capture_output=True,
+            text=True,
+            cwd=train_entry._repo_root,
+        )
+
+        assert result.returncode == 1
+        assert "--species" in result.stderr


### PR DESCRIPTION
## Summary

The combined coverage gate from #476 landed `environments/shared/train.py` at **0%** — not thinly covered, *never imported by any test*. This is the first thing that gate surfaced, and it's the follow-up work #476 deferred.

The module is the `--species` shim in front of `train_base.main`. Every documented invocation goes through it:

```
python -m environments.shared.train --species velociraptor train --stage 1
python -m environments.shared.train --species trex curriculum --n-envs 4
```

A break in the argv rewrite takes all of those out while every species package stays green, because nothing else imports it.

## The tests

13 tests in `environments/shared/tests/test_train_entry_point.py`. No stable-baselines3 required and no training is ever started: the module defers its two imports to call time, so patching `main` and `get_species_config` on their *owning* modules is enough — the function-level `from ... import` re-reads the attribute on every call.

- Both validation exits — no `--species`, and `--species` with no value — plus a test that neither reaches `train_base`.
- The argv rewrite with the species pair at the **front**, **middle** and **end**, and `argv[0]` preserved (it feeds argparse's usage line).
- The hand-off: species resolved, its config passed to `main`, and the argv `main` would actually parse.
- An unknown species propagating the registry's `ValueError` rather than being swallowed.

Two pins are deliberate:

**The `sys.path` bootstrap is checked against repository landmarks, not its `parents[2]` arithmetic.** Depth-counted paths are byte-identical across a move and change meaning silently — that is exactly how the provenance repository-root bug got into #475 and past an AST-level verbatim audit. So the test asserts the resolved directory actually holds `pyproject.toml` and the module's own file.

**The guarded insert is driven by reloading with the root taken off `sys.path`.** It is a no-op under pytest, where the root is always importable, but it is the entire point of the block for `python environments/shared/train.py`. Without this the branch is untestable dead weight in the report.

The `__main__` guard runs end to end as a subprocess.

## Result

| | before | after |
|---|---|---|
| `environments/shared/train.py` | 22 stmts, **0%** | 22 stmts, **95%** |

The remaining statement is line 46 — `_main()` under the `__main__` guard — which cannot execute in-process. It is covered behaviourally by the subprocess test, just not measurably.

## Mutation testing

All nine mutations of `train.py` turn the suite red:

| mutation | killed by |
|---|---|
| no `--species`: `sys.exit(1)` → `sys.exit(0)` | ✅ |
| no `--species`: `sys.exit(1)` → `return` | ✅ |
| `--species` w/o value: `sys.exit(1)` → `sys.exit(0)` | ✅ |
| argv slice `idx + 2` → `idx + 1` | ✅ |
| drop `argv[0]` from the rewrite | ✅ |
| `parents[2]` → `parents[3]` | ✅ |
| disable the guarded `sys.path` insert | ✅ |
| missing-value bound `idx + 1` → `idx + 2` | ✅ |
| swallow the registry's `ValueError` | ✅ |

`train.py` itself is unchanged — `git status` clean against origin after the run.

## Verification

Locally:
- 13 new tests pass in isolation.
- No cross-test interference from the reload, checked in **both** orderings against `test_species_registry`, `test_cli`, `test_config`, `test_file_io`.
- Full `environments/shared/tests/` suite: **1,543 passed, 30 skipped**, exit 0 — reproduced identically across two independent runs.
- `ruff check`, `ruff format --check` and `mypy` clean repo-wide.

On CI: `lint`, `build`, `plant-contract`, `test-sb3`, `test-shared` on 3.11/3.12/3.13, and all four species jobs on all three versions are **green**. That covers the two tests most likely to behave differently on a clean checkout — the subprocess invocation and the `importlib.reload` — so they hold up without an editable install. `test-jax-cpu` and the dependent combined `coverage` job were still running when this was written.

**Correction to the first version of this description.** I wrote that the full-suite log "lost its tail" and that I could not quote pass/skip counts. That was wrong, and the cause is worth recording: `addopts` in `pyproject.toml` already contains `-q`, so passing `-q` again made it `-qq`, which suppresses pytest's summary line entirely. Nothing was truncated — both runs completed and agree exactly.

## Not in scope

Two things found and deliberately left alone, since this PR is scoped to the coverage zero:

- `--species=trex` (equals form) is not recognised; it falls through to the "Usage:" message, which reads as though the flag were missing entirely.
- `plant_contract/__main__.py` is still at 0% (29 statements) — the other zero the combine surfaced.