### PR TITLE
Stop reset from generating already-terminal episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Images/` except the `.dockerignore` entry excluding it, now also dropped.
 
 ### Fixed
+- **The curriculum advancement gate now fails closed** (breaking — every stage
+  config must declare `gate_schema_version` and `gate_kind`). The gate plumbing
+  failed *open* in three independent ways, so a stage could advance on evidence
+  nobody had checked. `thresholds_from_configs` copied six known keys out of
+  `[curriculum]` and **silently discarded everything else**, so a config
+  carrying only new-style gate fields produced no thresholds at all and SB3 fell
+  back to `StageThreshold`'s permissive defaults (`min_avg_reward = -inf`,
+  length and success floors `0`) — which advance on any evaluation whatsoever.
+  `jax_curriculum.check_stage_gate` logged a warning and returned `True` when
+  `min_avg_reward` was absent. And neither backend rejected an unrecognised key,
+  so a misspelled threshold name *disabled* that threshold instead of failing.
+  Together these made "no gate" indistinguishable from "gate satisfied", with
+  the permissive reading always winning — which is the wrong default for the
+  mechanism that decides whether a policy is good enough to build the next stage
+  on. A new `environments/shared/curriculum/gate_schema.py` makes the
+  declaration explicit and versioned: unknown keys, unknown gate kinds and
+  unsupported schema versions are **fatal** whenever advancement is enabled, and
+  a threshold field its declared kind does not consume is fatal too, since it
+  implies a gate that is not actually enforced. Running without a gate is still
+  possible, but only by declaring `gate_kind = "none/v1"`, which is recorded in
+  the config and *refuses* to advance rather than passing by default. All twelve
+  stage configs declare `reward_and_length/v1`; the existing tests that asserted
+  the permissive behaviour were updated in the same change, as they were the
+  reason the defect survived. Effective thresholds for all four species are
+  unchanged.
+- **`collapse_peak_floor` no longer inherits `min_avg_reward`**, which coupled
+  an early-stop backstop to an unrelated advancement threshold. The builder
+  chained `collapse_peak_floor` → `min_avg_reward` → `0.0`, and only
+  `configs/trex/stage1_balance.toml` set the key explicitly (1 of 12), so
+  removing a stage's reward gate — which a state-capability gate would do —
+  silently dropped its arming floor to `0.0` and armed collapse detection after
+  *any* positive robust peak. A missing floor now means **never arm**, because a
+  backstop that is not configured should not abort a run; the eleven configs
+  that were relying on the fallback now set the value it produced, so every
+  effective floor is bit-identical (`100.0` everywhere except T-Rex stage 1's
+  `2200.0`). `collapse_smoothing_window` was also readable but undeclared, and
+  is now part of the schema.
 - **Reset can no longer generate an already-terminal episode** (breaking —
   policy interface revision bumps for the three home-keyframe-residual species:
   velociraptor 6 → 7, T-Rex 7 → 8, dibothrosuchus 3 → 4; brachiosaurus does not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Images/` except the `.dockerignore` entry excluding it, now also dropped.
 
 ### Fixed
+- **Reset can no longer generate an already-terminal episode** (breaking —
+  policy interface revision bumps for the three home-keyframe-residual species:
+  velociraptor 6 → 7, T-Rex 7 → 8, dibothrosuchus 3 → 4; brachiosaurus does not
+  carry `home_reset` and is unchanged). The root-height jitter was the **only
+  unbounded term in the reset** — every other one is a bounded uniform — so
+  `BaseDinoEnv.reset` drew `normal(0, height_scale)` with nothing stopping it
+  from placing the root outside `healthy_z_range` before the policy acted.
+  T-Rex is the species it actually broke: a 0.926 m home pelvis sits 0.226 m
+  above the 0.70 m floor, which at σ = 0.10 m is only **2.26σ**, so a predicted
+  **1.19%** of spawns started sub-floor. Measured over seeds 3042–5041, 18/2000
+  spawned below the floor and **16 of those terminated on step 1 whatever the
+  policy did**; a wider scan of 3042–7041 found 43/4000. The draw is now
+  truncated to the distance to the nearer end of `healthy_z_range` less a 0.02 m
+  margin, which takes sub-floor spawns to **0/4000**. The bound is symmetric, so
+  the mean spawn height is unchanged (0.9262 → 0.9261 m over 2000 seeds) while
+  the standard deviation tightens 0.1007 → 0.0980. It binds at 2.07σ for T-Rex
+  (3.9% of draws) against 3.6–3.8σ for velociraptor and dibothrosuchus (~0.02%),
+  so those two move only in the far tail. Dibothrosuchus hit this same defect
+  first and fixed it by decoupling `reset_height_noise_scale`; T-Rex was left
+  coupled and nobody re-checked it.
+
+  **This does not meaningfully move the zero-action baseline, and that is the
+  point.** Re-measured on seeds 3042–3081 the statue is unchanged where it
+  matters — still 23/40 full-horizon, `reward standing` still 3244.04 ± 23.55,
+  unconditional mean 1971.57 → 1976.62 — because a statue fails those seeds
+  anyway. What the defect capped was the **competent** policy: an episode that
+  ends on step 1 regardless of the action is not a policy failure, and counting
+  it as one put an unreachable ceiling on any reliability gate. Seed 3077 is
+  precisely the first failure in the 39/40 evaluation panels that
+  `docs/STAGE1_SPLIT_PLAN.md` §2.3.1 reports, and it is this bug rather than the
+  policy. Existing checkpoints for the three bumped species were trained against
+  a different reset distribution and must be re-baselined before any stage-1
+  gate is calibrated against them.
 - **T-Rex stages 2 and 3 no longer terminate at a different pitch angle on the
   MJX path than on the Gymnasium one**: `nosedive_termination_threshold` is the
   per-stage tunable pitch gate, and only `stage1_balance.toml` sets it. When a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the site and README actually reference. Nothing in the repository referred to
   `Images/` except the `.dockerignore` entry excluding it, now also dropped.
 
+### Added
+- **`foot_sensor_report.py`, and a four-species audit of what the foot touch
+  sensors actually measure.** A MuJoCo touch sensor sums only contacts on geoms
+  belonging to its site's own body, so a site on a parent segment silently
+  misses whatever the child geoms carry — a failure invisible from the reward
+  trace, because a sensor reading zero looks exactly like a foot off the ground.
+  Checking every species against `mj_contactForce` found T-Rex and dibothrosuchus
+  correct (ratio **1.000**) and two species wrong: **velociraptor at 0.553**,
+  missing its `metatarsus` (17.54 N) and lateral `toe_d4` (12.03 N) per foot
+  because the site sits on `toe_d3` alone, and **brachiosaurus at 0.000**, blind
+  to all 1699.2 N of its floor contact. Total floor reaction equals body weight
+  on all four, so the contacts are real and these are sensor-scope defects, not
+  physics ones. Neither reaches a stage-1 reward term today, but both reach the
+  **observation**: brachiosaurus trains with four permanently zero input
+  channels (indices 75–78 of 83) and the raptor's policy sees 55% of true
+  per-foot load. Repairs are per-species MJCF changes and are *not* included
+  here. Recorded in `docs/investigations/FOOT_SENSOR_VERIFICATION.md`, which
+  also corrects the ground-reaction-force reading in `STAGE1_SPLIT_PLAN.md` §6.2:
+  the T-Rex statue's 841 N is *exactly* body weight (840.9 N, ratio 1.002), and
+  the 1483 N that makes it look low is `mj_getTotalmass` counting the 65.45 kg
+  **prey body** — 43% of the model total. A GRF diagnostic must divide by the
+  animal's kinematic subtree or it reports a false 0.57 on a plant standing in
+  perfect equilibrium.
+
 ### Fixed
 - **Being airborne is no longer cheaper than honest single support.**
   `reward_foot_load_balance` computed `|R − L| / (R + L + 1e-8)`, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Images/` except the `.dockerignore` entry excluding it, now also dropped.
 
 ### Fixed
+- **Being airborne is no longer cheaper than honest single support.**
+  `reward_foot_load_balance` computed `|R − L| / (R + L + 1e-8)`, which
+  evaluates to **zero** when both feet read zero — so a plant off the ground
+  scored the same as one standing evenly on both feet, and strictly better than
+  one carrying its weight on a single foot, which pays the full penalty. On the
+  stage-1 weights that ordering was `both feet down +0.600 > airborne 0.000 >
+  single support −0.300`: flight was the second-best available state on the
+  stage whose entire job is to stand still, and a policy off the ground cannot
+  reject a disturbance at all. An unsupported pair now reports maximal
+  imbalance, giving `both feet down +0.600 > single support = airborne −0.300`.
+  A new optional `foot_load_balance_min_support_force` sets the total force
+  below which the pair counts as unsupported; it defaults to `0.0`, which closes
+  only the exact `[0, 0]` case and leaves **every loaded state numerically
+  unchanged**, and can be raised during gate calibration to also deny credit for
+  a token grazing contact. Wired identically through the Gymnasium, MJX and
+  JAX paths, with the `[0, 0]` case now covered in both `test_reward_functions`
+  and `test_trex_mjx_reward_parity` — neither covered it before, which is how
+  the hole survived. Note the two failure states are now *tied* rather than
+  airborne being strictly worst; separating them needs a term this fix does not
+  add.
 - **The curriculum advancement gate now fails closed** (breaking — every stage
   config must declare `gate_schema_version` and `gate_kind`). The gate plumbing
   failed *open* in three independent ways, so a stage could advance on evidence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Images/` except the `.dockerignore` entry excluding it, now also dropped.
 
 ### Added
+- **`stance_duty_validation.py`, which shows the support-duty metrics measure
+  what they claim.** `unsupported_duty` and its siblings classify each step by
+  thresholding the foot touch sensors at 0.1 N, and that reading is the evidence
+  behind the claim that the stage-1 policy is off the ground ~21% of the time —
+  a sensor that under-reports contact looks exactly like a foot in flight. The
+  static check above covers one operating point; this sweeps driver policies
+  producing **3% to 67%** airtime and compares the sensors against both
+  `mj_contactForce` over foot-geom contacts and `mj_geomDistance` from every
+  foot geom to the floor, the latter computed from geometry alone and so
+  independent of the sensor path. The metric tracks kinematic truth to within
+  **0.52%** of steps across the whole range (2.6% only under uniform-random
+  actuation, which no policy occupies), and the two error directions nearly
+  cancel. The decisive row is low-amplitude jitter — **16.07% true airtime
+  against 16.21% reported**, straddling the figure under dispute. Combined with
+  the 0.1 N threshold sitting against ~421 N per foot in quiet stance, the
+  sensor-artifact explanation for `STAGE1_SPLIT_PLAN.md` §1.5 is exhausted and
+  its hopping reading can be relied on. This validates the *instrument*, not the
+  policy: the checkpoint was not replayed, and the causal half of §1.5 ("the
+  reward caused the hop") still needs a counterfactual run.
 - **`foot_sensor_report.py`, and a four-species audit of what the foot touch
   sensors actually measure.** A MuJoCo touch sensor sums only contacts on geoms
   belonging to its site's own body, so a site on a parent segment silently

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Swift Bipedal Predator. **Specialty:** Sickle-claw contact attacks.
 | Action dimension / actuators | 22 |
 | Generalized coordinates / velocities | nq=31, nv=30 |
 | Compiled dynamic model mass | 13.5 kg |
-| Plant contract revisions | policy r6; physics r2; visual r3 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r7; physics r2; visual r3 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/velociraptor/assets/raptor.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
@@ -112,7 +112,7 @@ Apex Predator. **Specialty:** Head-contact attack task.
 | Action dimension / actuators | 21 |
 | Generalized coordinates / velocities | nq=28, nv=27 |
 | Compiled dynamic model mass | 85.7 kg |
-| Plant contract revisions | policy r7; physics r5; visual r4 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r8; physics r5; visual r4 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/trex/assets/trex.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
@@ -161,7 +161,7 @@ Gracile Erect-Limbed Crocodylomorph. **Specialty:** Snout-contact snap task.
 | Action dimension / actuators | 27 |
 | Generalized coordinates / velocities | nq=35, nv=34 |
 | Compiled dynamic model mass | 8.7 kg |
-| Plant contract revisions | policy r3; physics r1; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r4; physics r1; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/dibothrosuchus/assets/dibothrosuchus.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |

--- a/configs/brachiosaurus/stage1_balance.toml
+++ b/configs/brachiosaurus/stage1_balance.toml
@@ -87,8 +87,13 @@ init_yaw_noise = 0.1                    # Yaw rotation perturbation at reset (ra
 net_arch = [512, 256]
 
 [curriculum]
+gate_schema_version = 1                 # Fail-closed gate declaration; see
+gate_kind = "reward_and_length/v1"      # environments/shared/curriculum/gate_schema.py
 timesteps = 6000000
 min_avg_reward = 100.0
+collapse_peak_floor = 100.0    # Explicit: this used to fall back to min_avg_reward, coupling an
+                                        # early-stop backstop to an unrelated advancement threshold. Set to
+                                        # the value that fallback produced, so behaviour is unchanged.
 min_avg_episode_length = 750
 required_consecutive = 3
 collapse_min_evals = 20                 # Backstop early-stop (EvalCollapseEarlyStopCallback): wait ~1M steps before it can fire.

--- a/configs/brachiosaurus/stage2_locomotion.toml
+++ b/configs/brachiosaurus/stage2_locomotion.toml
@@ -96,8 +96,13 @@ ramp_start_fraction = 0.16             # Match SB3 sweep winner — gentler star
 net_arch = [512, 256]
 
 [curriculum]
+gate_schema_version = 1                 # Fail-closed gate declaration; see
+gate_kind = "reward_and_length/v1"      # environments/shared/curriculum/gate_schema.py
 timesteps = 16000000                   # Reverted to 16M: 20M run (03-22) showed late-training collapse (2396→809). 16M was sufficient for the only S2 pass.
 min_avg_reward = 100.0
+collapse_peak_floor = 100.0    # Explicit: this used to fall back to min_avg_reward, coupling an
+                                        # early-stop backstop to an unrelated advancement threshold. Set to
+                                        # the value that fallback produced, so behaviour is unchanged.
 min_avg_episode_length = 750
 min_avg_forward_vel = 0.75             # Gate on actual locomotion; without this, a standing-still policy passes on alive_bonus alone. Realistic walking speed for a heavy sauropod.
 required_consecutive = 3

--- a/configs/brachiosaurus/stage3_food_reach.toml
+++ b/configs/brachiosaurus/stage3_food_reach.toml
@@ -89,8 +89,13 @@ ramp_start_fraction = 0.2
 net_arch = [512, 256]
 
 [curriculum]
+gate_schema_version = 1                 # Fail-closed gate declaration; see
+gate_kind = "reward_and_length/v1"      # environments/shared/curriculum/gate_schema.py
 timesteps = 12000000                   # Extended from 8M: best model was at 3.9M and policy degraded after — more time with stable config gives room to recover and converge
 min_avg_reward = 100.0                  # Minimum average reward to confirm food-reaching behavior
+collapse_peak_floor = 100.0    # Explicit: this used to fall back to min_avg_reward, coupling an
+                                        # early-stop backstop to an unrelated advancement threshold. Set to
+                                        # the value that fallback produced, so behaviour is unchanged.
 min_success_rate = 0.5                 # At least 50% food reach success — confirms behavior emerged
 required_consecutive = 3
 warmup_timesteps = 300000               # Tripled from 100k: agent needs more time to adapt from locomotion to food-reach reward landscape without losing walking ability

--- a/configs/dibothrosuchus/stage1_balance.toml
+++ b/configs/dibothrosuchus/stage1_balance.toml
@@ -107,8 +107,13 @@ init_yaw_noise = 0.1                    # Yaw rotation perturbation at reset (ra
 net_arch = [512, 256]
 
 [curriculum]
+gate_schema_version = 1                 # Fail-closed gate declaration; see
+gate_kind = "reward_and_length/v1"      # environments/shared/curriculum/gate_schema.py
 timesteps = 6000000
 min_avg_reward = 100.0
+collapse_peak_floor = 100.0    # Explicit: this used to fall back to min_avg_reward, coupling an
+                                        # early-stop backstop to an unrelated advancement threshold. Set to
+                                        # the value that fallback produced, so behaviour is unchanged.
 min_avg_episode_length = 750
 required_consecutive = 3
 collapse_min_evals = 20                 # Backstop early-stop (EvalCollapseEarlyStopCallback): wait ~1M steps before it can fire.

--- a/configs/dibothrosuchus/stage2_locomotion.toml
+++ b/configs/dibothrosuchus/stage2_locomotion.toml
@@ -94,8 +94,13 @@ ramp_start_fraction = 0.16
 net_arch = [512, 256]
 
 [curriculum]
+gate_schema_version = 1                 # Fail-closed gate declaration; see
+gate_kind = "reward_and_length/v1"      # environments/shared/curriculum/gate_schema.py
 timesteps = 12000000
 min_avg_reward = 100.0
+collapse_peak_floor = 100.0    # Explicit: this used to fall back to min_avg_reward, coupling an
+                                        # early-stop backstop to an unrelated advancement threshold. Set to
+                                        # the value that fallback produced, so behaviour is unchanged.
 min_avg_episode_length = 750
 min_avg_forward_vel = 0.9              # Gate on actual locomotion; without it a standing-still policy passes on alive_bonus alone.
                                        # 0.9 m/s is ~0.7 body lengths/s — a real walk for a gracile 1.24 m cursor.

--- a/configs/dibothrosuchus/stage3_snap.toml
+++ b/configs/dibothrosuchus/stage3_snap.toml
@@ -86,8 +86,13 @@ ramp_start_fraction = 0.1
 net_arch = [512, 256]
 
 [curriculum]
+gate_schema_version = 1                 # Fail-closed gate declaration; see
+gate_kind = "reward_and_length/v1"      # environments/shared/curriculum/gate_schema.py
 timesteps = 8000000
 min_avg_reward = 100.0
+collapse_peak_floor = 100.0    # Explicit: this used to fall back to min_avg_reward, coupling an
+                                        # early-stop backstop to an unrelated advancement threshold. Set to
+                                        # the value that fallback produced, so behaviour is unchanged.
 min_success_rate = 0.5                # At least 50% snap success — confirms the hunting behaviour emerged
 required_consecutive = 3
 warmup_timesteps = 200000               # Constrain policy updates while the critic adapts (PPO only)

--- a/configs/plant_manifest.generated.json
+++ b/configs/plant_manifest.generated.json
@@ -45,7 +45,7 @@
       }
     },
     "dibothrosuchus": {
-      "bundle_sha256": "sha256:a1cd823c627c5b243eb58757c487c68410ffae491442927cd012fb55fa008495",
+      "bundle_sha256": "sha256:e1956db822d9f019b8d32931712e9a417136be750636538dd59b264ac51ab7d1",
       "env_entrypoint": "environments.dibothrosuchus.envs.dibothrosuchus_env:DibothrosuchusEnv",
       "model_path": "environments/dibothrosuchus/assets/dibothrosuchus.xml",
       "physics": {
@@ -60,9 +60,9 @@
         "action_dim": 27,
         "observation_dim": 77,
         "observation_schema": "quadrupedal-target/v1",
-        "revision": 3,
+        "revision": 4,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:ebaa8846cfe572e69fb0dde92c3724d83717fd078e2f8935809f7599b77ff2d3"
+        "sha256": "sha256:3ce9b5b46e31a55db52a288c64f52dd25a2a7d3b6c1a9b61b68c3a2211a8a474"
       },
       "source": {
         "closure_sha256": "sha256:5532fad56a1613020f09bfa197f14f0916306e664d5cf18609b757d3c5948bc3",
@@ -84,7 +84,7 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:a07cb824c731349e61506a4165dc8e66f3aa690fe9f7d336f9c2f9705858a94a",
+      "bundle_sha256": "sha256:0e3ef817188447729fab0fdc2c1e7a77b4ae1c9868b782908343cbc720146e25",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
@@ -99,9 +99,9 @@
         "action_dim": 21,
         "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 7,
+        "revision": 8,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:5f2ef9adf326ced7600b2bf7849e1971e92db87fb07472eccb8619da07149694"
+        "sha256": "sha256:cce25e87bc9bbf67f9e56f4243c532ade26d780de9ee4531d3ae04751c673c78"
       },
       "source": {
         "closure_sha256": "sha256:bd63a662293202088b354cb27de8fc52f6f0dfbf379932a60c06984d14c9cbf5",
@@ -123,7 +123,7 @@
       }
     },
     "velociraptor": {
-      "bundle_sha256": "sha256:9841757f572a06864478219cae05b25107aa393511c64bb265c2053564394d83",
+      "bundle_sha256": "sha256:51911dc21d53c60b4885eecb55a6c60abb023ce83518a435b635d77fd74f9b00",
       "env_entrypoint": "environments.velociraptor.envs.raptor_env:RaptorEnv",
       "model_path": "environments/velociraptor/assets/raptor.xml",
       "physics": {
@@ -138,9 +138,9 @@
         "action_dim": 22,
         "observation_dim": 67,
         "observation_schema": "bipedal-target/v1",
-        "revision": 6,
+        "revision": 7,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:cd69b759369f88ad43324a61069dfeb37f4fde5e1c15ba8d042c2b031f76e2eb"
+        "sha256": "sha256:8897d9705fd27a7dfd09fc6277f5918af87707fdffd653707a2117e7bcbfd53a"
       },
       "source": {
         "closure_sha256": "sha256:ae2ebacf577a7247484e8954fecce421b007246ead904a83ce319babb1efdec5",

--- a/configs/plant_versions.toml
+++ b/configs/plant_versions.toml
@@ -41,10 +41,35 @@ canonical_mujoco_version = "3.10.0"
 #    unchanged.  build_mjx_observation is fingerprinted directly and had to
 #    learn to sum, so every species' policy interface revision increments;
 #    only the T-Rex's observation values actually change.
+#
+# 5. Reset can no longer generate an already-terminal state.  The root-height
+#    jitter was the only UNBOUNDED term in the reset -- every other one is a
+#    bounded uniform -- so BaseDinoEnv.reset now truncates it to the distance to
+#    the nearer end of healthy_z_range, less a 0.02 m margin.  This is
+#    fingerprinted through home_reset, so the three home-keyframe-residual
+#    species increment and brachiosaurus does not.
+#
+#    Only T-Rex was actually broken.  Its 0.926 m home pelvis sits 0.226 m above
+#    the 0.70 m floor, which at sigma 0.10 m is a 2.26 sigma margin, so 1.19% of
+#    spawns landed below the floor and terminated on step 1 whatever the policy
+#    did (measured: 18/2000 sub-floor spawns over seeds 3042-5041, 16 of them
+#    terminal; 43/4000 over the wider range).  Those episodes are not policy
+#    failures, and counting them as such caps any reliability gate near 99% for
+#    reasons unrelated to the policy -- they are the direct cause of the 39/40
+#    evaluation panels.  The bound binds at 2.07 sigma for T-Rex (3.9% of draws)
+#    against 3.6-3.8 sigma for velociraptor and dibothrosuchus (~0.02%), so the
+#    latter two change only in the far tail.
+#
+#    The bound is symmetric, so the mean spawn height is unchanged (0.9262 ->
+#    0.9261 m over 2000 seeds) while the standard deviation tightens 0.1007 ->
+#    0.0980.  Sub-floor spawns go 18/2000 -> 0/2000 and 43/4000 -> 0/4000.
+#    All three species' reset DISTRIBUTIONS move, so their existing checkpoints
+#    are trained against a different task and the zero-action baseline must be
+#    re-measured before any stage-1 gate is calibrated against it.
 
 [plants.velociraptor]
 physics_revision = 2
-policy_interface_revision = 6
+policy_interface_revision = 7
 visual_revision = 3
 observation_schema = "bipedal-target/v1"
 
@@ -72,7 +97,7 @@ observation_schema = "bipedal-target/v1"
 #    existing T-Rex checkpoint is invalidated.
 [plants.trex]
 physics_revision = 5
-policy_interface_revision = 7
+policy_interface_revision = 8
 visual_revision = 4
 observation_schema = "bipedal-target/v1"
 
@@ -84,6 +109,6 @@ observation_schema = "quadrupedal-target/v1"
 
 [plants.dibothrosuchus]
 physics_revision = 1
-policy_interface_revision = 3
+policy_interface_revision = 4
 visual_revision = 1
 observation_schema = "quadrupedal-target/v1"

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -15,6 +15,13 @@ foot_contact_weight = 0.0                      # Disable the legacy any-foot bon
 bilateral_support_weight = 0.6                 # Reward the weaker-loaded foot, so both feet must carry weight
 foot_contact_saturation_force = 350.0          # N per foot; quiet home support (~421 N/foot) already earns full credit
 foot_load_balance_weight = 0.3                 # Penalize normalized left/right load imbalance
+foot_load_balance_min_support_force = 0.0      # Total foot force below which the pair counts as unsupported, and so
+                                               # maximally imbalanced. 0.0 closes only the exact airborne [0, 0] case,
+                                               # which used to score as perfectly balanced -- making flight cheaper
+                                               # than honest single support (0.000 against -0.300). Every loaded state
+                                               # is numerically unchanged at this setting. Raise it to also deny credit
+                                               # for a token grazing contact; pick the value during gate calibration,
+                                               # against measured flight phases rather than by eye.
 support_conditioned_alive_fraction = 0.5       # Keep recovery headroom while making one-foot survival less profitable
 leg_home_pose_weight = 0.5                     # Softly retain the authored p5 theropod leg stance
 leg_home_pose_tolerance = 0.20                 # rad; broad enough for balancing corrections without joint locking

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -149,6 +149,8 @@ init_yaw_noise = 0.1                   # Yaw rotation perturbation at reset (rad
 net_arch = [512, 256]                  # Match SB3 PPO architecture
 
 [curriculum]
+gate_schema_version = 1                 # Fail-closed gate declaration; see
+gate_kind = "reward_and_length/v1"      # environments/shared/curriculum/gate_schema.py
 timesteps = 6000000
 min_avg_reward = 1840.0                 # Provisional legacy gate only. The stance reward changes the score scale,
                                         # so run Stage 1 pilots without curriculum advancement and recalibrate this

--- a/configs/trex/stage2_locomotion.toml
+++ b/configs/trex/stage2_locomotion.toml
@@ -107,8 +107,13 @@ ramp_start_fraction = 0.2              # Start at 20% of target forward_vel_weig
 net_arch = [512, 256]
 
 [curriculum]
+gate_schema_version = 1                 # Fail-closed gate declaration; see
+gate_kind = "reward_and_length/v1"      # environments/shared/curriculum/gate_schema.py
 timesteps = 8000000                     # Increase from 5M: your best T-Rex stage2 was only at 2M steps and still improving
 min_avg_reward = 100.0
+collapse_peak_floor = 100.0    # Explicit: this used to fall back to min_avg_reward, coupling an
+                                        # early-stop backstop to an unrelated advancement threshold. Set to
+                                        # the value that fallback produced, so behaviour is unchanged.
 min_avg_episode_length = 750            # Reduce from 800: T-Rex best run reached 682, 800 is too strict
 min_avg_forward_vel = 2.0               # Gate on sustained running (matches raptor stage 2 gate)
 required_consecutive = 3

--- a/configs/trex/stage3_bite.toml
+++ b/configs/trex/stage3_bite.toml
@@ -86,8 +86,13 @@ ramp_start_fraction = 0.1              # Start at 10% of target
 net_arch = [512, 256]
 
 [curriculum]
+gate_schema_version = 1                 # Fail-closed gate declaration; see
+gate_kind = "reward_and_length/v1"      # environments/shared/curriculum/gate_schema.py
 timesteps = 8000000
 min_avg_reward = 100.0
+collapse_peak_floor = 100.0    # Explicit: this used to fall back to min_avg_reward, coupling an
+                                        # early-stop backstop to an unrelated advancement threshold. Set to
+                                        # the value that fallback produced, so behaviour is unchanged.
 min_success_rate = 0.5                # At least 50% bite success — confirms hunting behavior emerged
 required_consecutive = 3
 warmup_timesteps = 100000               # Timesteps to constrain policy updates while critic adapts (PPO only)

--- a/configs/velociraptor/stage1_balance.toml
+++ b/configs/velociraptor/stage1_balance.toml
@@ -81,8 +81,13 @@ init_yaw_noise = 0.1                    # Yaw rotation perturbation at reset (ra
 net_arch = [512, 256]
 
 [curriculum]
+gate_schema_version = 1                 # Fail-closed gate declaration; see
+gate_kind = "reward_and_length/v1"      # environments/shared/curriculum/gate_schema.py
 timesteps = 6000000
 min_avg_reward = 100.0
+collapse_peak_floor = 100.0    # Explicit: this used to fall back to min_avg_reward, coupling an
+                                        # early-stop backstop to an unrelated advancement threshold. Set to
+                                        # the value that fallback produced, so behaviour is unchanged.
 min_avg_episode_length = 750
 required_consecutive = 3
 collapse_min_evals = 20                 # Backstop early-stop (EvalCollapseEarlyStopCallback): wait ~1M steps before it can fire.

--- a/configs/velociraptor/stage2_locomotion.toml
+++ b/configs/velociraptor/stage2_locomotion.toml
@@ -94,8 +94,13 @@ ramp_start_fraction = 0.2
 net_arch = [512, 256]
 
 [curriculum]
+gate_schema_version = 1                 # Fail-closed gate declaration; see
+gate_kind = "reward_and_length/v1"      # environments/shared/curriculum/gate_schema.py
 timesteps = 8000000
 min_avg_reward = 100.0
+collapse_peak_floor = 100.0    # Explicit: this used to fall back to min_avg_reward, coupling an
+                                        # early-stop backstop to an unrelated advancement threshold. Set to
+                                        # the value that fallback produced, so behaviour is unchanged.
 min_avg_episode_length = 750
 min_avg_forward_vel = 2.0
 required_consecutive = 3

--- a/configs/velociraptor/stage3_strike.toml
+++ b/configs/velociraptor/stage3_strike.toml
@@ -90,11 +90,16 @@ ramp_start_fraction = 0.1
 net_arch = [512, 256]
 
 [curriculum]
+gate_schema_version = 1                 # Fail-closed gate declaration; see
+gate_kind = "reward_and_length/v1"      # environments/shared/curriculum/gate_schema.py
 timesteps = 12000000                    # Raised from 8M (run 20260721_141523): best checkpoint landed at 7.9M with
                                         # success still climbing (last evals 0.63->0.87->0.77) -- strike discovery
                                         # produced no successes until ~5.5M, leaving only ~2.5M of effective hunting
                                         # curriculum. 12M matches the brachiosaurus stage-3 budget.
 min_avg_reward = 100.0
+collapse_peak_floor = 100.0    # Explicit: this used to fall back to min_avg_reward, coupling an
+                                        # early-stop backstop to an unrelated advancement threshold. Set to
+                                        # the value that fallback produced, so behaviour is unchanged.
 min_success_rate = 0.5                  # At least 50% strike success — confirms hunting behavior emerged
 required_consecutive = 3
 warmup_timesteps = 300000               # Increased from 100k: Stage 3 introduces new reward components, critic needs more adaptation time

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -263,6 +263,34 @@ Neutral-action stability and truly actuator-disabled passive behavior are now
 separate test contracts. Layered policy, physics, visual, and source identities
 are documented in [PLANT_CONTRACT.md](PLANT_CONTRACT.md).
 
+### Foot touch sensors under-report on two species — open (July 2026 sensor audit)
+
+A MuJoCo touch sensor sums only contacts on geoms belonging to its site's **own body**, so a
+site on a parent segment silently misses whatever the child geoms carry. Auditing all four
+species against `mj_contactForce` found T-Rex and dibothrosuchus correct (ratio 1.000) and two
+species wrong:
+
+| species | sensor / measured contact | missing |
+|---|---|---|
+| velociraptor | **0.553** | `metatarsus` 17.54 N + `toe_d4` 12.03 N per foot; the site is on `toe_d3` only |
+| brachiosaurus | **0.000** | everything — 1699.2 N of real floor contact is invisible |
+
+Total floor reaction equals body weight on all four species, so the contacts are real and the
+plants are in equilibrium; these are sensor-scope defects, not physics ones. `aa3395c` fixed the
+raptor site's *size* but not its *body scope*, one repair short of `aa87445`.
+
+Neither defect reaches a stage-1 reward term today — no stage-1 config for either species sets
+`foot_contact_gate`, `foot_contact_weight`, `bilateral_support_weight` or
+`foot_load_balance_weight`, and the raptor's `gait_symmetry_weight` is 0.0. Both reach the
+**observation**: brachiosaurus trains with four permanently zero input channels (indices 75–78
+of 83) and the raptor's policy sees 55% of true per-foot load.
+
+Repair is an MJCF change of the `aa87445` shape — per-geom touch sites and sensors, appended so
+existing sensor indices keep their positions, summed per foot on both backends — and moves that
+species' physics and policy fingerprints. Full evidence, method and reproduction in
+[investigations/FOOT_SENSOR_VERIFICATION.md](investigations/FOOT_SENSOR_VERIFICATION.md);
+re-check any repair with `environments/shared/scripts/foot_sensor_report.py`.
+
 ### Velociraptor plant — open (July 2026 raptor review)
 
 **The stance-referenced-spring migration above never reached the raptor.** It

--- a/docs/investigations/FOOT_SENSOR_VERIFICATION.md
+++ b/docs/investigations/FOOT_SENSOR_VERIFICATION.md
@@ -16,9 +16,10 @@ that nobody had checked, and unfounded for the one it was raised about.
 component of `mj_contactForce` over every floor contact, and both against body weight.
 Reproduce with `python environments/shared/scripts/foot_sensor_report.py`.
 
-**Scope.** This is the **static** check. §7.2 also asks for the cross-check *during a policy
-rollout*, against kinematic flight phases; that still needs the checkpoint and is not done
-here. What follows constrains the sensor hypothesis without settling the behavioural one.
+**Scope.** §1–§5 are the **static** check, on a settled plant. §6 is the dynamic half §7.2 also
+asks for — the cross-check against kinematic flight phases — done by sweeping driver policies
+rather than by replaying the trained checkpoint. Read §6 for what that substitution does and
+does not buy.
 
 ## Results  `[measured]`
 
@@ -40,9 +41,8 @@ equals body weight to 0.2%. The post-`aa87445` pad-plus-digits summation is corr
 
 This does not prove the plant hops, but it removes the alternative §7.2 raised: the
 `unsupported_duty = 0.209` reading cannot be explained by sensors failing to see contact,
-because statically they see all of it. §1.5's claim should move from "pending sensor
-verification" to "sensor hypothesis excluded statically" — the outstanding work is the rollout
-comparison against kinematic flight phases, not sensor fidelity.
+because statically they see all of it. §6 then closes the dynamic half, and together they
+exhaust the sensor-artifact explanation.
 
 ## 2. §6.2 reads the GRF invariant backwards  `[correction]`
 
@@ -126,3 +126,63 @@ contacting geom its own touch site and sensor, append them so existing sensor in
 their positions, and sum per foot on both the Gymnasium and MJX paths. Each moves that species'
 physics and policy fingerprints and so belongs in its own change with its own revision bump.
 Both invalidate that species' existing checkpoints, since the observation values change.
+
+## 6. The dynamic half: do the duty metrics track kinematic ground truth?  `[measured]`
+
+§1–§5 verify the sensors at one operating point — quiet bilateral stance, steady load. The
+`unsupported_duty = 0.209` reading comes from a different regime entirely: touchdown transients,
+rapid load transfer, and whatever flight phases exist. A sensor exact at 842 N steady can still
+mis-time the *transitions* that decide how a step is classified.
+
+**Method.** Sweep driver policies that produce airborne fractions from 3% to 67%, and compare
+three signals per timestep — the summed touch sensors, `mj_contactForce` over foot-geom floor
+contacts, and `mj_geomDistance` from every foot geom to the floor. The third is computed from
+geometry alone and never touches the sensor path, so it is the arbiter: if the steps labelled
+`unsupported` are the steps where the feet are genuinely clear of the ground, the metric
+measures what it claims. Reproduce with
+`python environments/shared/scripts/stance_duty_validation.py`.
+
+| regime | airborne (kinematic) | `unsupported_duty` | misclassified |
+|---|---|---|---|
+| drop test (+0.25 m spawn) | 8.17% | 8.17% | **0.000%** |
+| settled stance | 3.37% | 3.51% | 0.137% |
+| low-amplitude jitter | 16.07% | 16.21% | 0.216% |
+| forced hop | 67.25% | 66.74% | 0.515% |
+| random thrash | 64.51% | 63.45% | 2.613% |
+
+**The metric is sound.** Across a twenty-fold range of airtime it tracks kinematic truth to
+within 0.52% of steps, degrading to 2.6% only under uniform-random actuation, which is not a
+regime any policy occupies. The two error directions also very nearly cancel — in the jitter
+band, 9 false-airborne against 2 false-supported out of 5095 steps, a net overstatement of
+0.14%.
+
+The **low-amplitude jitter** row is the one that matters: at 16.07% true airtime against 16.21%
+reported it straddles the 0.209 figure under dispute, and it is the regime whose contact
+transitions most resemble a balancing policy's. Mean sensor-versus-force error there is 4.4 N
+against a 13,079 N peak.
+
+**What this settles.** `unsupported_duty = 0.209` can be taken at face value: the instrument
+producing it is accurate in exactly that band, so the trained policy really is off the ground
+about 21% of the time. Combined with §1 — the sensors see all of the contact statically — and
+with the classifier's 0.1 N threshold against ~421 N per foot in quiet stance, which is far too
+low for partial unloading to manufacture a false `unsupported`, the sensor-artifact explanation
+for §1.5 is exhausted. **§1.5's hopping reading should move from `[inferred]` to `[measured
+instrument, inferred behaviour]`.**
+
+**What this does not settle.** This validates the *instrument* across swept regimes; it does not
+replay the trained policy. The 0.209 figure comes from that run's logged diagnostics, and I have
+not independently reproduced the policy's behaviour — the checkpoint is a 4 MB artifact on Drive
+and could not be pulled into this environment. The remaining claim in §1.5 is causal ("the
+reward *caused* the hop"), which no amount of sensor verification can establish; that needs the
+counterfactual run with the §7.1 repair in place.
+
+**A caution for anyone writing similar diagnostics.** Two bugs surfaced while building this, both
+worth avoiding:
+
+* Comparing the foot sensors against *every* floor contact counts tail and torso strikes as
+  sensor disagreement. Restrict the force reference to foot-geom contacts.
+* Selecting foot geoms by name with a `foot|toe|metatarsus|pad` filter **misses
+  `r_plantar_geom` and `l_plantar_geom`**, which carry the majority of the load — 190–200 kN·steps
+  against 4.6–6.0 kN·steps for the metatarsus across a 15-episode sweep. Enumerate from actual
+  contacts instead. This is the same mistake class as the sensor-scope defects above: a
+  plausible-looking name filter silently omitting the primary load path.

--- a/docs/investigations/FOOT_SENSOR_VERIFICATION.md
+++ b/docs/investigations/FOOT_SENSOR_VERIFICATION.md
@@ -1,0 +1,128 @@
+# Foot touch sensors versus `mj_contactForce`
+
+Discharges the sensor-verification prerequisite (`STAGE1_SPLIT_PLAN.md` §7.2), which gates the
+hopping claim in §1.5, the ground-reaction-force diagnostic in §6.2, and the
+`foot_load_balance` repair in §7.1.
+
+The question §7.2 asks is whether `unsupported_duty = 0.209` on a plant that holds 0.93 m
+pelvis height and never falls is real airtime or a sensor under-reporting. A MuJoCo touch
+sensor sums only contacts on geoms belonging to its site's **own body**, which has already
+produced two silent under-reads here — the T-Rex repair (`aa87445`) and the raptor repair
+(`aa3395c`) — so the concern is well founded. It turns out to be well founded for two species
+that nobody had checked, and unfounded for the one it was raised about.
+
+**Method.** Settle each species 200 zero-action steps from its stage-1 config at
+`reset_noise_scale = 0`, then compare the summed foot touch sensors against the vertical
+component of `mj_contactForce` over every floor contact, and both against body weight.
+Reproduce with `python environments/shared/scripts/foot_sensor_report.py`.
+
+**Scope.** This is the **static** check. §7.2 also asks for the cross-check *during a policy
+rollout*, against kinematic flight phases; that still needs the checkpoint and is not done
+here. What follows constrains the sensor hypothesis without settling the behavioural one.
+
+## Results  `[measured]`
+
+| species | touch sensors | `mj_contactForce` | animal weight | sensor / contact | contact / weight |
+|---|---|---|---|---|---|
+| trex | 842.2 N | 842.2 N | 840.9 N | **1.000** | 1.002 |
+| dibothrosuchus | 84.9 N | 84.9 N | 84.9 N | **1.000** | 1.000 |
+| velociraptor | 73.3 N | 132.4 N | 132.4 N | **0.553** | 1.000 |
+| brachiosaurus | **0.0 N** | 1699.2 N | 1719.7 N | **0.000** | 0.988 |
+
+`contact / weight` is 1.00 on all four species, so the contact accounting itself is sound and
+the plants really are standing in equilibrium. Every discrepancy below is a *sensor* defect,
+not a physics one.
+
+## 1. The T-Rex sensors are accurate — which strengthens the hopping reading
+
+T-Rex touch sensors agree with `mj_contactForce` to three decimals, and total floor reaction
+equals body weight to 0.2%. The post-`aa87445` pad-plus-digits summation is correct.
+
+This does not prove the plant hops, but it removes the alternative §7.2 raised: the
+`unsupported_duty = 0.209` reading cannot be explained by sensors failing to see contact,
+because statically they see all of it. §1.5's claim should move from "pending sensor
+verification" to "sensor hypothesis excluded statically" — the outstanding work is the rollout
+comparison against kinematic flight phases, not sensor fidelity.
+
+## 2. §6.2 reads the GRF invariant backwards  `[correction]`
+
+§6.2 proposes alarming when `mean(total_contact_force) / (m·g)` leaves `[0.95, 1.05]`, and says
+"this would already be firing: the statue's static total is 841 N while the policy's logged
+mean is 1460 N" — implying 841 N is the anomaly.
+
+It is not. **841 N is exactly right.** The T-Rex animal masses 85.72 kg, so its weight is
+840.9 N, and the measured static total of 842.2 N gives a ratio of **1.002**.
+
+The 1483 N figure that makes 841 N look low is `mj_getTotalmass`, which includes the **65.45 kg
+prey body** — 43% of the 151.17 kg model total. Any GRF diagnostic must divide by the mass of
+the *animal's* kinematic subtree, or it reports a false 0.57 on a plant standing in perfect
+equilibrium. `foot_sensor_report.py` does this by summing only the subtrees containing
+actuated joints.
+
+So the diagnostic would fire — but on the **policy's** 1460 N, at 1.74× body weight, not on the
+statue. For strictly periodic motion the time-averaged GRF must equal body weight, so a
+sustained 1.74× indicates either a non-periodic average or one conditioned on contact steps.
+Both readings point at intermittent ground contact rather than a steady stance, consistent with
+§1.5 — but 1460 N is `[artifact-derived]`, was not reproduced here, and should be re-measured
+with the corrected denominator before being relied on.
+
+## 3. Velociraptor under-reports foot load by 45%  `[measured, new]`
+
+Not previously filed. Per foot, the floor reaction divides as:
+
+| body | force | seen by sensor |
+|---|---|---|
+| `toe_d3` (primary digit) | 36.64 N | yes |
+| `metatarsus` | 17.54 N | **no** |
+| `toe_d4` (lateral digit) | 12.03 N | **no** |
+| total | 66.21 N | 36.64 N = **55.3%** |
+
+The `r_foot` / `l_foot` touch sites sit on `r_toe_d3` / `l_toe_d3`, and a touch sensor counts
+only contacts on its own body's geoms. `aa3395c` fixed the *site size* — the original r=0.02
+sphere at the capsule midpoint missed both end contacts and read 0 during stance — but not the
+*body scope*, so the secondary digit and the metatarsus remain invisible. Same defect class as
+`aa87445`, one repair short.
+
+This is the species whose **complete** stage-1 gate a zero-action policy clears
+(`STAGE1_SPLIT_PLAN.md` §1.4), so its instrumentation deserves more confidence than it
+currently earns.
+
+## 4. OQ-6 confirmed: brachiosaurus is blind to its own feet  `[measured]`
+
+All four brachiosaurus foot touch sensors read **exactly 0.0 N** while `mj_contactForce`
+reports 1699.2 N over four floor contacts — 98.8% of the animal's 1719.7 N weight. The contacts
+are real and correctly carrying the animal; the sensors do not see them at all.
+
+## 5. Both under-reads are latent in reward and active in observation
+
+PR #471 placed the brachiosaurus defect on the reward path. That is not where it bites today:
+
+* `configs/brachiosaurus/stage1_balance.toml` sets none of `foot_contact_gate`,
+  `foot_contact_weight`, `bilateral_support_weight` or `foot_load_balance_weight`.
+* `configs/velociraptor/stage1_balance.toml` likewise sets none, and `gait_symmetry_weight = 0.0`
+  disables the only other consumer.
+
+So no stage-1 reward term reads these sensors on either species. The **observation** does:
+
+* `BrachioEnv._get_obs` feeds all four sensors into the policy input at indices **75–78** of 83.
+  Verified directly — after 200 settled zero-action steps, exactly four observation channels
+  are zero, at exactly those indices.
+* `RaptorEnv._get_obs` feeds both sensors in, so the raptor policy sees 55% of true per-foot
+  load.
+
+Brachiosaurus therefore trains with four permanently dead input dimensions and no foot-contact
+information whatsoever. That is worth weighing against §9's brachiosaurus risk row, which notes
+zero action never reaches the horizon (0 of 40, `n_standing = 0`) and asks whether the plant is
+corrupt: a policy that cannot perceive ground contact is a plausible partial explanation that
+does not require plant corruption — though it does not establish one either.
+
+Both defects also matter directly for the split. The §7.1 `foot_load_balance` repair and the
+§6.3 support-state transition matrix both key off these sensors, and a stance or recovery gate
+that reads contact state cannot be trusted on a species whose sensors report 0% or 55% of the
+truth.
+
+**Not fixed here.** Both repairs are MJCF changes of the same shape as `aa87445` — give each
+contacting geom its own touch site and sensor, append them so existing sensor indices keep
+their positions, and sum per foot on both the Gymnasium and MJX paths. Each moves that species'
+physics and policy fingerprints and so belongs in its own change with its own revision bump.
+Both invalidate that species' existing checkpoints, since the observation values change.

--- a/docs/investigations/TREX_REVIEW_2026_07.md
+++ b/docs/investigations/TREX_REVIEW_2026_07.md
@@ -876,35 +876,187 @@ The MJX default of 0.5 is shared and every SB3 default differs (T-Rex 0.62, Dibo
 0.55). Not audited — out of scope for this review by instruction.
 *What would resolve it:* running the F2 probe for each species, or the general fix in NS-4.
 
+**OQ-6 — Brachiosaurus's four foot touch sensors read exactly 0.0 N while its feet are on the
+floor.** Found while measuring the cross-species zero-action floor; **not part of this review's
+scope and not investigated**, but confirmed directly and filed because it is live:
+
+```
+$ # brachiosaurus, zero action, 200 steps settled
+touch sensors: [('fr_foot_touch', 0.0), ('fl_foot_touch', 0.0),
+                ('rr_foot_touch', 0.0), ('rl_foot_touch', 0.0)]
+floor contacts: 9, total normal force: 1733.3 N   (via mj_contactForce)
+```
+
+This is the same defect class as the T-Rex repair in `aa87445` and the raptor repair in
+`aa3395c`.
+
+**Since audited across all four species — see
+[FOOT_SENSOR_VERIFICATION.md](FOOT_SENSOR_VERIFICATION.md).** Two claims above need amending:
+
+* The velociraptor number was right and is now verified: **0.553**, because the touch site sits
+  on `toe_d3` alone and misses the `metatarsus` (17.54 N) and lateral `toe_d4` (12.03 N) per
+  foot. `aa3395c` fixed that site's *size*, not its *body scope*.
+* The reward-path claim is **not** correct on current `main`:
+  `configs/brachiosaurus/stage1_balance.toml` sets neither `foot_contact_gate` nor
+  `foot_contact_weight` (nor `bilateral_support_weight` or `foot_load_balance_weight`), so no
+  stage-1 reward term reads these sensors on either affected species. The live impact is on the
+  **observation** — brachiosaurus trains with four permanently zero input channels at indices
+  75–78 of 83, and the raptor policy sees 55% of true per-foot load.
+
+*What resolves it:* the same repair `aa87445` made — per-geom touch sites and sensors, appended
+so existing sensor indices keep their positions, summed per foot on both backends. One change
+per species, each moving that species' physics and policy fingerprints.
+
 ---
 
 ## 5. Next steps, ranked
 
-**NS-1 — Give stage 1 a term the statue cannot collect. (Addresses F1.)**
-*Change:* add a stance-quality term that a constant action scores near zero on — the
-strongest candidate is a centre-of-pressure / support-polygon margin term, since the plant
-already carries per-digit touch sensors that make CoP computable; a cheaper stand-in is
-re-enabling `reset_noise_scale` sweeps so the reward has to buy recoveries rather than luck.
-*Touches:* `configs/trex/stage1_balance.toml` `[env]`, plus a new helper in
-`environments/shared/reward_functions.py`.
-*Expected:* the zero-action full-horizon score drops well below the trained score; the
-per-step comparison in F1 inverts.
-*Measurement that decides it:* re-run `zero_action_baseline.py trex` and the F1 per-step
-table. Success is the trained per-step return exceeding the standing statue's, on the same
-seed family. Until that inverts, stage 1 is not measuring balance.
-*Note:* this makes future runs incomparable with §2. Do it once, deliberately, and re-baseline.
+**NS-1 — Change the task, not the reward. (Addresses F1.)**
 
-**NS-2 — Re-derive `min_avg_reward` against the *standing* floor, not the falling one —
-for all four species, not just T-Rex.**
-*Change:* `configs/*/stage1_balance.toml` `min_avg_reward`. T-Rex's 1840 is +5.5% over the
-all-episode zero-action mean (1743.73); the standing-statue score is 2834.95. The other three
-are still at the default 100.0, which their own statues clear by 17×, 1.1× and 17×.
-*Expected:* a gate that a statue cannot clear even when it survives, on every species.
-*Measurement:* the §3b pre-flight cell should report `OK` for all four. Do NS-1 first —
-raising the gate against today's reward would just fail every run.
-*Note:* this is the single highest-leverage item on the list now that the floor is measured
-across species. Three of four gates currently cannot fail, so three of four stage-1 results
-carry no information.
+An earlier draft of this item proposed "add a stance-quality term the statue cannot collect,
+strongest candidate a centre-of-pressure / support-polygon margin." **That was wrong, and the
+reason it is wrong is the most useful thing in this section.**
+
+Four candidate designs were built and each attacked by two independent verifiers who
+implemented the proposed term in a standalone rollout and measured it for the statue and for
+`robust_best_model.zip`. **None survived.** Three of the four add a per-step reward term, and
+all three were refuted 2/2 on the same measured failure — the statue collects the term *at
+least as much as* the trained policy:
+
+| candidate | statue (per 1000 standing steps) | trained policy | winner |
+|---|---|---|---|
+| two-sided height error (repair the existing term) | −1.25, and −0.00 in the settled window | −51.57 | statue by 50.32 |
+| capture-point / support-polygon containment | −392.86 | −1792.58 | statue by 1399.72 |
+| potential-based shaping on divergent CoM velocity | +0.99/ep | −1.45/ep | statue by 2.44 |
+
+Three unrelated mathematical families, same result. That is not three tuning failures, it is
+one structural fact: **the plant is passively stable at the home keyframe, and at any static
+equilibrium the centre of pressure lies exactly under the centre of mass** (measured to 0.2 mm
+over 6126 statue steps — it is forced, since at rest the ground reaction must pass through the
+CoM). Any bounded per-step function of the standing state that means "well balanced" is
+therefore *maximised by standing perfectly still*, which is exactly what `action = 0` does
+under `home-keyframe-residual/v1`. **With no disturbance, the optimal balance controller is the
+statue.** You cannot pay a policy to beat it at a game where it is already the optimum.
+
+Two of the three also made F1 numerically worse: the height repair moves the equal-survival
+deficit 333.66 → 381.32 and drops the achievable stage-1 ceiling to 1850.00 against
+`min_avg_reward = 1840.0`, i.e. it would make the shipped gate near-unclearable and halt the
+curriculum at `train_base.py:1292`.
+
+*Change instead:* apply a scheduled external shove — a runtime write to
+`data.xfrc_applied[root, 0:3]` in `BaseDinoEnv.step`, no reward term, no observation change.
+Every ~2 s, push the root horizontally in a uniformly random direction with an impulse sized at
+1.5× the capture-point velocity (≈150 N for 0.20 s on this plant).
+*Touches:* a new `_apply_perturbation()` in `environments/shared/base_env.py` called at the top
+of `step()`, a pure `external_push_force()` kernel in `environments/shared/reward_functions.py`
+so both backends share it, and new `perturbation_*` keys in `configs/trex/stage1_balance.toml`
+`[env]` defaulting to `0.0` everywhere else.
+
+**It must go in `step()`, not `reset()`.** Verified: `plant_contract.py:916` hashes
+`_callable_semantics(env.reset)` into `policy_interface_revision` for every
+`home-keyframe-residual/v1` species, while `step` appears **zero** times in the interface
+payload. A `step()` hook moves no fingerprint and invalidates no checkpoint.
+
+*Measured, 40 episodes, seed 3042, reproduced independently by two verifiers:*
+
+| | statue | trained checkpoint |
+|---|---|---|
+| shipped (no push) | 1743.73, 57% full-horizon | 2489.65, 100% |
+| push on, noise 0.05 | **711.05 ± 403.76, 0 of 40 full-horizon** | 2418.38 ± 357.61, 85% |
+| push on, noise 0.10 | **604.18 ± 483.99, 0 of 40** | **NOT MEASURED** |
+
+The statue does not merely score less — *the standing statue ceases to exist*, so
+`reward_mean_standing` becomes undefined and the F1 comparison has no left-hand side. Gaming
+was hunted hard and found nothing: 13 hand-designed constant stances, two independent CEM
+searches over the full 21-dim constant action space (best holdouts 490.3 and 692.0, both ≤
+zeros), the trained policy's own settled mean action held constant (184.6), and a blind
+clock-driven brace policy (732.8 mean, worse mean-minus-std, 1 of 40 full-horizon).
+
+*The one load-bearing number that does not exist:* the trained checkpoint has never been
+evaluated at noise 0.10 with the push on. That is a ~10-minute eval, not a training run, and it
+gates everything below.
+
+> **Staleness warning on the pushed table above.** These figures are `[artifact-derived,
+> unverified]` and **cannot be reproduced from this repository**: the perturbation
+> implementation, the authoritative force conversion, the registered schedule and the raw
+> per-episode outcomes are all absent, and the checkpoint available today differs from the
+> artifact behind the published `2489.65`. They also predate `435f35f`, which changed the
+> stage-1 stance reward — on the undisturbed task that commit moved the statue **+227.84** mean
+> and **+409.09** standing with byte-identical trajectories. Re-measure every one of them on a
+> registered seed schedule once the scheduler lands, before treating any of them as a
+> calibration input. `STAGE1_SPLIT_PLAN.md` §10 step 10 is the experiment that does this.
+>
+> Two statistical corrections to how the table reads: `0 of 40` bounds zero-action survival
+> **above** by 7.216% (exact one-sided 95%), not at zero; and the checkpoint's 85% is 34/40,
+> whose exact one-sided 95% lower bound is 0.72526 — only narrowly above a 0.70 requirement,
+> and measured at noise 0.05 while the config retains 0.10.
+
+*Mandatory corrections to the proposal as filed* — each measured, not argued:
+
+1. **Do not bundle `reset_noise_scale` 0.10 → 0.05.** At 0.05 with the push off the statue
+   scores 2568.7 at 90% full-horizon against the checkpoint's 2498.8 — the statue wins
+   outright, reversing the shipped config's +660.5 edge to the policy. Keep 0.10.
+2. ~~**Ship the impulse fixed, not ramped.** `set_reward_weight` is a bare `setattr`, so a
+   `RewardRampCallback` would be a step function.~~ **This correction was wrong about the
+   mechanism, and is withdrawn.** `RewardRampCallback` already computes linearly interpolated
+   values from global timesteps and propagates them periodically via `env_method`; the setter
+   merely applies what the callback computed, so it does not force a step function. The real
+   gap is a *dynamic perturbation-scale input* with one defined unit across backends and defined
+   resume behaviour. Ramp versus fixed is an open question to be settled by a transfer pilot,
+   not a decision this review can make — see `STAGE1_SPLIT_PLAN.md` §3.3.
+3. **Jitter the interval** (`perturbation_jitter`). The blind-clock brace exploit is weak but
+   real (+17% mean); one line removes it. Re-measure the floor with jitter on.
+4. ~~**Force `perturbation_delta_v = 0.0` in every diagnostic script.**~~ **Superseded.**
+   Forcing the perturbation off everywhere recreates the incompatible-baseline problem it was
+   meant to prevent: a recovery gate must be calibrated against the *pushed* floor, and a tool
+   that silently disables the configured task cannot produce one. Diagnostic tooling needs
+   explicit, persisted task modes instead — `plant_sanity` (perturbation forced off) and
+   `task_gate` (perturbation exactly matching advancement evaluation). See
+   `STAGE1_SPLIT_PLAN.md` §7.3. This item also listed `actuator_saturation_report` in error: it
+   loads raw XML via `mujoco.MjModel.from_xml_string` and steps MuJoCo directly
+   (`environments/shared/scripts/actuator_saturation_report.py:44-76`), so it never builds an
+   env from the TOML and is unaffected. The genuinely affected tools are `zero_action_baseline`,
+   `joint_excursion_report`, `action_bound_report` and `observation_ablation_report`.
+5. **Leave `min_avg_reward = 1840.0` alone.** The "+5.5% over the measured floor" rule dies
+   with the floor: 1840 is 2.6× the pushed statue and the un-retrained checkpoint clears it by
+   ~580. Rewrite the comment block, not the value. NS-2 above is now superseded outright rather
+   than only for T-Rex, so this item no longer contradicts it.
+
+*Honest scope.* This does **not** repair the per-step reward. Under the push the statue still
+earns more shaping per surviving step than the policy (2.680 vs 2.553); all the separation comes
+from termination plus `fall_penalty`. Stage 1 stays a survival test — it becomes a survival test
+a statue fails. Record that in the TOML rather than claiming the reward now measures balance.
+
+*Worth re-testing afterwards, not before:* the support-polygon term was refuted on an
+**undisturbed** plant, where the statue's capture point barely moves. Once a disturbance exists
+the statue no longer stands and a disturbance-rejection term is no longer maximised by
+stillness. It would still need its two real defects fixed first — a single-support exploit (the
+isotropic `patch_radius²·I` floor lets one loaded digit score containment 1.0000) and the fact
+that 90% of its measured statue deficit is a 13.2 mm touch-site placement artefact rather than a
+stance error.
+
+**NS-2 — ~~Re-derive `min_avg_reward` against the *standing* floor~~ — SUPERSEDED.**
+
+> **Do not implement the survivor-conditioned standing floor.** This item, and NS-1
+> correction 5 which contradicts it for T-Rex, are superseded by `STAGE1_SPLIT_PLAN.md` §5.1.
+> The recommendation was to gate on the zero-action mean *conditioned on full-horizon survival*
+> — but the policy is gated on its **unconditional** mean, so the conditioning removes exactly
+> the failure mode the policy is supposed to eliminate. Measured counterexample: over 120
+> seed-matched episodes the trained policy beat zero action by **+568.02** with survival
+> **118/120 against 68/120**, while sitting 677–775 points *below* the survivor-conditioned
+> statue mean. A standing-floor gate would reject a policy that is unambiguously better than
+> doing nothing.
+>
+> The replacement is a **paired** superiority test on identical seeds,
+> `LCB95(mean(R_policy_i − R_zero_i)) ≥ Δ_R`, which is authoritative; any unpaired scalar is
+> for display and screening only and must never override it.
+
+The observation that motivated this item still stands and is still the point: three of four
+stage-1 gates cannot fail. On `48fd90a` a zero-action policy clears the **reward** threshold on
+all four species and clears velociraptor's **complete** reward-plus-length gate outright. What
+changed is the remedy — raising a reward threshold cannot fix a stage where a statue is the
+optimal controller (NS-1), so the answer is a state-capability gate and a disturbance, not a
+bigger number.
 
 **NS-3 — Decide the alive-bonus semantics once, and pin it with a test. (F3.)**
 *Change:* either scale SB3's `_reward_alive` by `height_frac` to match `mjx_env.py:602-613`,
@@ -1001,7 +1153,7 @@ precisely the configuration in which 13 h of training tells you nothing.
 
 | finding | why not |
 |---|---|
-| **F1** | Reward-weight tuning, excluded by instruction, and it makes every run in §2 incomparable. Needs the NS-1/NS-2 pair done together and re-baselined. |
+| **F1** | Reward-weight tuning, excluded by instruction, and it makes every run in §2 incomparable. Now addressed by NS-1 alone — NS-2 is superseded, since no reward threshold can fix a stage where a statue is the optimal controller. Still needs a re-baseline. |
 | **F3** | Either direction changes the reward scale on one backend; a design decision, not a bug fix. |
 | **F4** | Shared code affecting all four species, and the per-stage semantics (chase vs straight-line) are a design call. |
 | **F5** | One-way door — your call by instruction. Also blocked on OQ-1. |

--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -40,6 +40,13 @@ from .reward_functions import reward_nosedive as _reward_nosedive_pure
 from .reward_functions import reward_posture as _reward_posture_pure
 from .reward_functions import reward_speed_penalty as _reward_speed_penalty_pure
 
+# Clearance in METRES kept between a reset spawn and the nearer end of
+# healthy_z_range.  Reset must never generate an already-terminal state: an
+# episode that ends on step 1 regardless of the action is not a policy failure,
+# and counting it as one puts an unreachable ceiling on any reliability gate.
+# See BaseDinoEnv._bounded_reset_height_delta.
+_RESET_HEIGHT_TERMINATION_MARGIN = 0.02
+
 
 class BaseDinoEnv(gym.Env, ABC):
     """Abstract base class for dinosaur locomotion environments."""
@@ -828,6 +835,32 @@ class BaseDinoEnv(gym.Env, ABC):
         """Check if episode should be truncated (time limit)."""
         return self._step_count >= self.max_episode_steps
 
+    def _bounded_reset_height_delta(self, base_z: float, delta: float) -> float:
+        """Bound a reset height perturbation so the spawn is never terminal.
+
+        The root-height jitter is the only UNBOUNDED term in the reset — every
+        other one is a bounded uniform — and an unbounded Gaussian will
+        eventually place the root outside ``healthy_z_range``.  On T-Rex it did
+        so often enough to matter: home pelvis 0.926 m against a 0.70 m floor
+        is a 0.226 m margin, and at sigma 0.10 m that is only 2.26 sigma, so
+        1.19% of spawns landed below the floor.  Measured over seeds 3042-5041,
+        18/2000 spawned sub-floor and 16 of those terminated on the first step
+        whatever the policy did — capping any reliability measurement at ~99%
+        for reasons that have nothing to do with the policy.
+
+        The bound is the distance to the nearer end of ``healthy_z_range``, less
+        a small margin, and is applied symmetrically so the mean spawn height is
+        unchanged.  Clipping rather than resampling keeps the number of RNG
+        draws per reset fixed and the reset deterministic; the cost is a small
+        point mass at each bound (~2% per side on T-Rex).  Species with ample
+        headroom are effectively unaffected, since the bound then sits far out
+        in the tail.
+        """
+        low, high = self.healthy_z_range
+        headroom = min(base_z - low, high - base_z) - _RESET_HEIGHT_TERMINATION_MARGIN
+        bound = max(headroom, 0.0)
+        return float(np.clip(delta, -bound, bound))
+
     def reset(
         self,
         seed: int | None = None,
@@ -861,7 +894,9 @@ class BaseDinoEnv(gym.Env, ABC):
             height_scale = 0.0
             if noise_scale > 0.0:
                 height_scale = noise_scale if self.reset_height_noise_scale is None else self.reset_height_noise_scale
-            self.data.qpos[2] += self.np_random.normal(0, height_scale)
+            base_z = float(self.data.qpos[2])
+            height_delta = self.np_random.normal(0, height_scale)
+            self.data.qpos[2] = base_z + self._bounded_reset_height_delta(base_z, height_delta)
 
         # Randomize target position (species-specific)
         self._spawn_target()

--- a/environments/shared/curriculum/__init__.py
+++ b/environments/shared/curriculum/__init__.py
@@ -39,6 +39,8 @@ training loop can drive the curriculum without importing SB3 at all:
   entropy-coefficient decay
 * :mod:`~environments.shared.curriculum.advancement` — stage entry, reward
   ramping, and gate evaluation
+* :mod:`~environments.shared.curriculum.gate_schema` — the versioned,
+  fail-closed declaration every stage config's gate is validated against
 * :mod:`~environments.shared.curriculum.early_stopping` — abort a stage whose
   evaluation return has collapsed
 * :mod:`~environments.shared.curriculum.checkpoints` — checkpoint selection,
@@ -59,14 +61,24 @@ from .early_stopping import (
     EvalCollapseEarlyStopCallback,
     build_eval_collapse_early_stop_callback,
 )
+from .gate_schema import (
+    GATE_KINDS,
+    GATE_SCHEMA_VERSION,
+    GateSchemaError,
+    validate_gate_config,
+    validate_gate_configs,
+)
 from .manager import CurriculumManager, StageThreshold, thresholds_from_configs
 from .schedules import EntCoefDecayCallback, _ConstantSchedule
 
 __all__ = [
+    "GATE_KINDS",
+    "GATE_SCHEMA_VERSION",
     "CurriculumCallback",
     "CurriculumManager",
     "EntCoefDecayCallback",
     "EvalCollapseEarlyStopCallback",
+    "GateSchemaError",
     "PublishEvalArtifactsCallback",
     "RewardRampCallback",
     "RobustBestModelCallback",
@@ -78,4 +90,6 @@ __all__ = [
     "load_vecnorm_stats",
     "sb3_compat",
     "thresholds_from_configs",
+    "validate_gate_config",
+    "validate_gate_configs",
 ]

--- a/environments/shared/curriculum/early_stopping.py
+++ b/environments/shared/curriculum/early_stopping.py
@@ -34,10 +34,11 @@ class EvalCollapseEarlyStopCallback(BaseCallback):  # type: ignore[misc]
     even though the episode mean remains healthy.
 
     Detection stays disarmed until the rolling-median peak clears
-    ``peak_floor`` (wired to the stage's ``min_avg_reward`` curriculum gate
-    by ``_build_core_callbacks``): a run can only "collapse" from a level
-    that was actually good, so the pre-convergence grind cannot trip the
-    backstop.
+    ``peak_floor``: a run can only "collapse" from a level that was actually
+    good, so the pre-convergence grind cannot trip the backstop. Each stage
+    config sets its own ``collapse_peak_floor``; the value is deliberately not
+    inherited from ``min_avg_reward``, which would couple this backstop to an
+    unrelated advancement threshold.
 
     Args:
         eval_callback: The ``EvalCallback`` whose ``evaluations.npz``
@@ -144,13 +145,24 @@ def build_eval_collapse_early_stop_callback(
     *,
     verbose: int = 0,
 ) -> EvalCollapseEarlyStopCallback:
-    """Build the shared eval-collapse backstop from curriculum settings."""
+    """Build the shared eval-collapse backstop from curriculum settings.
+
+    ``collapse_peak_floor`` is deliberately NOT inherited from
+    ``min_avg_reward``.  It used to chain ``collapse_peak_floor`` ->
+    ``min_avg_reward`` -> ``0.0``, which coupled an early-stop backstop to an
+    unrelated advancement threshold: removing the reward gate from a stage --
+    as a state-capability gate would -- silently dropped the floor to ``0.0``,
+    arming collapse detection after *any* positive robust peak.  A missing
+    floor now means "never arm" instead, because a backstop that is not
+    configured should not abort a run; every stage config sets the value it
+    actually wants.  See docs/STAGE1_SPLIT_PLAN.md section 7.4.
+    """
     return EvalCollapseEarlyStopCallback(
         eval_callback=eval_callback,
         min_evals=int(curriculum_kwargs.get("collapse_min_evals", 12)),
         patience=int(curriculum_kwargs.get("collapse_patience", 8)),
         drop_fraction=float(curriculum_kwargs.get("collapse_drop_fraction", 0.4)),
-        peak_floor=float(curriculum_kwargs.get("collapse_peak_floor", curriculum_kwargs.get("min_avg_reward", 0.0))),
+        peak_floor=float(curriculum_kwargs.get("collapse_peak_floor", float("inf"))),
         verbose=verbose,
         smoothing_window=int(curriculum_kwargs.get("collapse_smoothing_window", 5)),
     )

--- a/environments/shared/curriculum/early_stopping.py
+++ b/environments/shared/curriculum/early_stopping.py
@@ -139,15 +139,14 @@ class EvalCollapseEarlyStopCallback(BaseCallback):  # type: ignore[misc]
         return True
 
 
-def build_eval_collapse_early_stop_callback(
-    eval_callback: Any,
-    curriculum_kwargs: dict[str, Any],
-    *,
-    verbose: int = 0,
-) -> EvalCollapseEarlyStopCallback:
-    """Build the shared eval-collapse backstop from curriculum settings.
+def collapse_settings_from_config(curriculum_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Resolve the eval-collapse backstop's settings from a stage config.
 
-    ``collapse_peak_floor`` is deliberately NOT inherited from
+    Kept separate from the callback so the resolution can be tested without
+    stable-baselines3 installed — it is plain arithmetic on a config dict, and
+    the one rule worth pinning does not need SB3 to state.
+
+    That rule: ``collapse_peak_floor`` is deliberately **not** inherited from
     ``min_avg_reward``.  It used to chain ``collapse_peak_floor`` ->
     ``min_avg_reward`` -> ``0.0``, which coupled an early-stop backstop to an
     unrelated advancement threshold: removing the reward gate from a stage --
@@ -157,12 +156,33 @@ def build_eval_collapse_early_stop_callback(
     configured should not abort a run; every stage config sets the value it
     actually wants.  See docs/STAGE1_SPLIT_PLAN.md section 7.4.
     """
+    return {
+        "min_evals": int(curriculum_kwargs.get("collapse_min_evals", 12)),
+        "patience": int(curriculum_kwargs.get("collapse_patience", 8)),
+        "drop_fraction": float(curriculum_kwargs.get("collapse_drop_fraction", 0.4)),
+        "peak_floor": float(curriculum_kwargs.get("collapse_peak_floor", float("inf"))),
+        "smoothing_window": int(curriculum_kwargs.get("collapse_smoothing_window", 5)),
+    }
+
+
+def build_eval_collapse_early_stop_callback(
+    eval_callback: Any,
+    curriculum_kwargs: dict[str, Any],
+    *,
+    verbose: int = 0,
+) -> EvalCollapseEarlyStopCallback:
+    """Build the shared eval-collapse backstop from curriculum settings.
+
+    See :func:`collapse_settings_from_config` for how the settings resolve, in
+    particular why ``collapse_peak_floor`` does not inherit ``min_avg_reward``.
+    """
+    settings = collapse_settings_from_config(curriculum_kwargs)
     return EvalCollapseEarlyStopCallback(
         eval_callback=eval_callback,
-        min_evals=int(curriculum_kwargs.get("collapse_min_evals", 12)),
-        patience=int(curriculum_kwargs.get("collapse_patience", 8)),
-        drop_fraction=float(curriculum_kwargs.get("collapse_drop_fraction", 0.4)),
-        peak_floor=float(curriculum_kwargs.get("collapse_peak_floor", float("inf"))),
+        min_evals=settings["min_evals"],
+        patience=settings["patience"],
+        drop_fraction=settings["drop_fraction"],
+        peak_floor=settings["peak_floor"],
         verbose=verbose,
-        smoothing_window=int(curriculum_kwargs.get("collapse_smoothing_window", 5)),
+        smoothing_window=settings["smoothing_window"],
     )

--- a/environments/shared/curriculum/gate_schema.py
+++ b/environments/shared/curriculum/gate_schema.py
@@ -1,0 +1,206 @@
+"""Versioned, fail-closed schema for curriculum advancement gates.
+
+The gate plumbing used to fail *open* in three separate ways, so a stage
+could advance on evidence nobody had checked:
+
+1. :func:`~environments.shared.curriculum.manager.thresholds_from_configs`
+   copied six known keys out of ``[curriculum]`` and silently dropped
+   everything else.  A stage config carrying only new-style gate fields
+   therefore produced *no* thresholds at all, and SB3 fell back to
+   :class:`~environments.shared.curriculum.manager.StageThreshold`'s
+   permissive defaults (``min_avg_reward = -inf``, length and success floors
+   ``0``) — which advance on any evaluation whatsoever.
+2. :func:`~environments.shared.jax_curriculum.check_stage_gate` logged a
+   warning and returned ``True`` when ``min_avg_reward`` was absent.
+3. Neither backend rejected an unrecognised key, so a typo in a threshold
+   name disabled that threshold instead of failing.
+
+Together those mean *removing* a gate key is indistinguishable from having
+no gate, and the permissive reading always wins.  That is the wrong default
+for a mechanism whose entire job is to decide whether a policy is good
+enough to build the next stage on.
+
+This module makes the gate explicit and versioned instead.  Every stage
+config declares ``gate_schema_version`` and ``gate_kind``; unknown keys,
+unknown kinds and unsupported versions are **fatal** whenever advancement is
+enabled.  Running without a gate is still possible, but only by declaring
+``gate_kind = "none/v1"``, which is recorded in the config and refuses to
+advance rather than passing by default.
+
+Adding a new gate kind means adding an entry to :data:`GATE_KINDS` and
+teaching both backends to evaluate it — the schema deliberately will not let
+one backend understand a gate the other silently ignores.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+#: Bumped when the meaning of an existing key changes.  Adding a new gate
+#: kind does not require a bump; changing how an existing one is evaluated
+#: does.
+GATE_SCHEMA_VERSION = 1
+
+#: Threshold fields each gate kind consumes.  A stage config may carry only
+#: the threshold keys belonging to the kind it declares, so a field left over
+#: from a different gate is an error rather than dead config.
+GATE_KINDS: dict[str, frozenset[str]] = {
+    # The historical gate: a conjunction of per-evaluation means, repeated
+    # ``required_consecutive`` times.  Named so a future capability gate can
+    # coexist with it rather than silently replace it.
+    "reward_and_length/v1": frozenset(
+        {
+            "min_avg_reward",
+            "min_avg_episode_length",
+            "min_avg_forward_vel",
+            "min_success_rate",
+            "min_eval_episodes",
+            "required_consecutive",
+        }
+    ),
+    # An explicit, recorded non-advancing mode for pilots and diagnostics.
+    # Declaring it is the ONLY supported way to run a stage with no gate, and
+    # it refuses to advance rather than passing by default.
+    "none/v1": frozenset(),
+}
+
+#: Keys that configure the stage's schedule rather than its gate.
+_SCHEDULE_KEYS = frozenset(
+    {
+        "timesteps",
+        "ramp_timesteps",
+        "ramp_start_value",
+        "warmup_timesteps",
+        "warmup_clip_range",
+        "warmup_ent_coef",
+    }
+)
+
+#: Keys that configure collapse/early-stop detection rather than the gate.
+_COLLAPSE_KEYS = frozenset(
+    {
+        "collapse_min_evals",
+        "collapse_patience",
+        "collapse_drop_fraction",
+        "collapse_peak_floor",
+        "collapse_smoothing_window",
+    }
+)
+
+#: The schema's own declaration keys.
+_SCHEMA_KEYS = frozenset({"gate_schema_version", "gate_kind"})
+
+#: Every threshold key any gate kind knows about, used to tell "belongs to a
+#: different gate kind" apart from "not a gate key at all".
+_ALL_THRESHOLD_KEYS = frozenset().union(*GATE_KINDS.values())
+
+
+class GateSchemaError(ValueError):
+    """A stage config's advancement gate is missing, unknown, or malformed."""
+
+
+def _describe(stage: int | str) -> str:
+    return f"stage {stage}"
+
+
+def validate_gate_config(
+    stage: int | str,
+    curriculum_kwargs: Mapping[str, Any],
+    *,
+    advancement_enabled: bool = True,
+) -> str:
+    """Validate one stage's ``[curriculum]`` block and return its gate kind.
+
+    Args:
+        stage: Stage identifier, used only in error messages.
+        curriculum_kwargs: The stage config's ``curriculum_kwargs`` mapping.
+        advancement_enabled: Whether this run may advance between stages.
+            When ``False`` a missing gate declaration is tolerated, because a
+            single-stage pilot has nothing to advance to; every other defect
+            is still fatal, since a malformed gate is a bug either way.
+
+    Returns:
+        The declared gate kind, or ``"none/v1"`` when advancement is disabled
+        and no kind was declared.
+
+    Raises:
+        GateSchemaError: If the block carries an unknown key, declares an
+            unknown gate kind or schema version, carries a threshold field
+            that its declared kind does not consume, or omits the gate
+            declaration entirely while advancement is enabled.
+    """
+    known = _SCHEMA_KEYS | _SCHEDULE_KEYS | _COLLAPSE_KEYS | _ALL_THRESHOLD_KEYS
+    unknown = sorted(set(curriculum_kwargs) - known)
+    if unknown:
+        raise GateSchemaError(
+            f"{_describe(stage)}: unrecognised [curriculum] key(s) {unknown}. "
+            "Unknown keys are rejected rather than ignored, because silently "
+            "dropping a misspelled threshold disables it. Add the key to "
+            "environments/shared/curriculum/gate_schema.py if it is real."
+        )
+
+    declared_kind = curriculum_kwargs.get("gate_kind")
+    declared_version = curriculum_kwargs.get("gate_schema_version")
+
+    if declared_kind is None:
+        if advancement_enabled:
+            raise GateSchemaError(
+                f"{_describe(stage)}: no gate_kind declared, but advancement is "
+                "enabled. A stage with no gate must say so explicitly with "
+                'gate_kind = "none/v1", which refuses to advance; it must not '
+                "advance by default. See docs/STAGE1_SPLIT_PLAN.md §5.2."
+            )
+        return "none/v1"
+
+    if declared_kind not in GATE_KINDS:
+        raise GateSchemaError(
+            f"{_describe(stage)}: unknown gate_kind {declared_kind!r}. "
+            f"Known kinds: {sorted(GATE_KINDS)}. An unknown kind is fatal so a "
+            "backend cannot silently ignore a gate the other backend enforces."
+        )
+
+    if declared_version is None:
+        raise GateSchemaError(
+            f"{_describe(stage)}: gate_kind is declared but gate_schema_version "
+            "is missing; both are required so a config cannot be read under a "
+            "schema it was not written for."
+        )
+    if declared_version != GATE_SCHEMA_VERSION:
+        raise GateSchemaError(
+            f"{_describe(stage)}: gate_schema_version {declared_version!r} is not "
+            f"supported (this build understands {GATE_SCHEMA_VERSION})."
+        )
+
+    allowed = GATE_KINDS[declared_kind]
+    misplaced = sorted((set(curriculum_kwargs) & _ALL_THRESHOLD_KEYS) - allowed)
+    if misplaced:
+        raise GateSchemaError(
+            f"{_describe(stage)}: gate_kind {declared_kind!r} does not consume "
+            f"threshold field(s) {misplaced}. Leaving them in the config implies "
+            "a gate that is not actually enforced."
+        )
+
+    if advancement_enabled and declared_kind == "none/v1":
+        raise GateSchemaError(
+            f'{_describe(stage)}: gate_kind "none/v1" declares a non-advancing '
+            "pilot, so it cannot be used in a run that advances between stages."
+        )
+
+    return str(declared_kind)
+
+
+def validate_gate_configs(
+    configs: Mapping[int, Mapping[str, Any]],
+    *,
+    advancement_enabled: bool = True,
+) -> dict[int, str]:
+    """Validate every stage config, returning each stage's gate kind."""
+    return {
+        stage: validate_gate_config(
+            stage,
+            cfg.get("curriculum_kwargs", {}),
+            advancement_enabled=advancement_enabled,
+        )
+        for stage, cfg in configs.items()
+    }

--- a/environments/shared/curriculum/manager.py
+++ b/environments/shared/curriculum/manager.py
@@ -14,6 +14,8 @@ import numpy as np
 
 from environments.shared.config import load_all_stages
 
+from .gate_schema import validate_gate_config
+
 logger = logging.getLogger(__name__)
 
 
@@ -251,6 +253,8 @@ class CurriculumManager:
 
 def thresholds_from_configs(
     configs: dict[int, dict[str, Any]],
+    *,
+    advancement_enabled: bool = True,
 ) -> dict[int, dict[str, Any]]:
     """Extract stage thresholds from loaded TOML configs.
 
@@ -259,13 +263,25 @@ def thresholds_from_configs(
 
     Args:
         configs: Dict mapping stage number to config dict (from ``load_all_stages``).
+        advancement_enabled: Whether this run may advance between stages. Passed
+            through to :func:`~environments.shared.curriculum.gate_schema.validate_gate_config`,
+            which tolerates a missing gate declaration only when it is ``False``.
 
     Returns:
         Dict mapping stage number to threshold kwargs.
+
+    Raises:
+        GateSchemaError: If any stage's gate declaration is missing, unknown,
+            or malformed.
     """
     thresholds: dict[int, dict[str, Any]] = {}
     for stage, cfg in configs.items():
         cur = cfg.get("curriculum_kwargs", {})
+        # Fail closed. Silently dropping an unrecognised key here is what let a
+        # composite-only gate config produce no thresholds at all, after which
+        # StageThreshold's permissive defaults advanced the stage on any
+        # evaluation whatsoever. See gate_schema for the full failure mode.
+        validate_gate_config(stage, cur, advancement_enabled=advancement_enabled)
         threshold_fields: dict[str, Any] = {}
         if "min_avg_reward" in cur:
             threshold_fields["min_avg_reward"] = cur["min_avg_reward"]

--- a/environments/shared/data/plant_manifest.generated.json
+++ b/environments/shared/data/plant_manifest.generated.json
@@ -45,7 +45,7 @@
       }
     },
     "dibothrosuchus": {
-      "bundle_sha256": "sha256:a1cd823c627c5b243eb58757c487c68410ffae491442927cd012fb55fa008495",
+      "bundle_sha256": "sha256:e1956db822d9f019b8d32931712e9a417136be750636538dd59b264ac51ab7d1",
       "env_entrypoint": "environments.dibothrosuchus.envs.dibothrosuchus_env:DibothrosuchusEnv",
       "model_path": "environments/dibothrosuchus/assets/dibothrosuchus.xml",
       "physics": {
@@ -60,9 +60,9 @@
         "action_dim": 27,
         "observation_dim": 77,
         "observation_schema": "quadrupedal-target/v1",
-        "revision": 3,
+        "revision": 4,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:ebaa8846cfe572e69fb0dde92c3724d83717fd078e2f8935809f7599b77ff2d3"
+        "sha256": "sha256:3ce9b5b46e31a55db52a288c64f52dd25a2a7d3b6c1a9b61b68c3a2211a8a474"
       },
       "source": {
         "closure_sha256": "sha256:5532fad56a1613020f09bfa197f14f0916306e664d5cf18609b757d3c5948bc3",
@@ -84,7 +84,7 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:a07cb824c731349e61506a4165dc8e66f3aa690fe9f7d336f9c2f9705858a94a",
+      "bundle_sha256": "sha256:0e3ef817188447729fab0fdc2c1e7a77b4ae1c9868b782908343cbc720146e25",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
@@ -99,9 +99,9 @@
         "action_dim": 21,
         "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 7,
+        "revision": 8,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:5f2ef9adf326ced7600b2bf7849e1971e92db87fb07472eccb8619da07149694"
+        "sha256": "sha256:cce25e87bc9bbf67f9e56f4243c532ade26d780de9ee4531d3ae04751c673c78"
       },
       "source": {
         "closure_sha256": "sha256:bd63a662293202088b354cb27de8fc52f6f0dfbf379932a60c06984d14c9cbf5",
@@ -123,7 +123,7 @@
       }
     },
     "velociraptor": {
-      "bundle_sha256": "sha256:9841757f572a06864478219cae05b25107aa393511c64bb265c2053564394d83",
+      "bundle_sha256": "sha256:51911dc21d53c60b4885eecb55a6c60abb023ce83518a435b635d77fd74f9b00",
       "env_entrypoint": "environments.velociraptor.envs.raptor_env:RaptorEnv",
       "model_path": "environments/velociraptor/assets/raptor.xml",
       "physics": {
@@ -138,9 +138,9 @@
         "action_dim": 22,
         "observation_dim": 67,
         "observation_schema": "bipedal-target/v1",
-        "revision": 6,
+        "revision": 7,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:cd69b759369f88ad43324a61069dfeb37f4fde5e1c15ba8d042c2b031f76e2eb"
+        "sha256": "sha256:8897d9705fd27a7dfd09fc6277f5918af87707fdffd653707a2117e7bcbfd53a"
       },
       "source": {
         "closure_sha256": "sha256:ae2ebacf577a7247484e8954fecce421b007246ead904a83ce319babb1efdec5",

--- a/environments/shared/jax_curriculum.py
+++ b/environments/shared/jax_curriculum.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from typing import Any
 
 from .config import load_stage_config
+from .curriculum.gate_schema import GateSchemaError, validate_gate_config
 
 _logger = logging.getLogger(__name__)
 
@@ -30,12 +31,23 @@ def check_stage_gate(
 
     Returns:
         ``True`` if the gate is passed and training should advance.
+
+    Raises:
+        GateSchemaError: If the stage's gate declaration is missing, unknown,
+            or malformed. This used to log a warning and return ``True``, so a
+            stage with no reward threshold advanced unconditionally — the same
+            fail-open behaviour the SB3 path had, reached by a different route.
     """
     curriculum = stage_config.get("curriculum_kwargs", {})
+    validate_gate_config(stage_config.get("stage", "?"), curriculum, advancement_enabled=True)
     min_reward = curriculum.get("min_avg_reward")
     if min_reward is None:
-        _logger.warning("Stage config has no curriculum_kwargs.min_avg_reward — gate passes by default.")
-        return True
+        raise GateSchemaError(
+            "stage config declares an advancement gate but sets no "
+            "min_avg_reward, so there is nothing for the JAX path to check. "
+            'Declare gate_kind = "none/v1" for a non-advancing pilot instead of '
+            "leaving the threshold out."
+        )
     # min_avg_reward is an EPISODE-level threshold (shared with the SB3
     # TOMLs, e.g. 100.0).  The trainer's "mean_reward" is the mean PER-STEP
     # rollout reward (~0.5-2 for a good policy), so gating on it would fail

--- a/environments/shared/jax_reward_termination.py
+++ b/environments/shared/jax_reward_termination.py
@@ -139,6 +139,7 @@ def compute_total_reward(
     r_foot_load_balance, _ = reward_foot_load_balance(
         foot_forces[:2],
         reward_cfg.get("foot_load_balance_weight", 0.0),
+        reward_cfg.get("foot_load_balance_min_support_force", 0.0),
     )
 
     # The opt-in path is formula-identical to Gymnasium.  Fraction zero
@@ -384,6 +385,7 @@ def compute_reward_components(
     r_foot_load_balance, foot_load_imbalance = reward_foot_load_balance(
         foot_forces[:2],
         reward_cfg.get("foot_load_balance_weight", 0.0),
+        reward_cfg.get("foot_load_balance_min_support_force", 0.0),
     )
 
     raw_alive = reward_alive(reward_cfg.get("alive_bonus", 0.1))

--- a/environments/shared/mjx_env.py
+++ b/environments/shared/mjx_env.py
@@ -89,6 +89,7 @@ _KNOWN_REWARD_KEYS: frozenset = frozenset(
         "bilateral_support_weight",
         "foot_contact_saturation_force",
         "foot_load_balance_weight",
+        "foot_load_balance_min_support_force",
         "support_conditioned_alive_fraction",
         "leg_home_pose_weight",
         "leg_home_pose_tolerance",
@@ -718,6 +719,7 @@ class MJXDinoEnv:
             r_foot_load_balance, _ = reward_foot_load_balance(
                 foot_forces[:2],
                 weights.get("foot_load_balance_weight", 0.0),
+                weights.get("foot_load_balance_min_support_force", 0.0),
             )
 
             # The opt-in support-conditioned path mirrors the Gymnasium

--- a/environments/shared/reward_functions.py
+++ b/environments/shared/reward_functions.py
@@ -302,16 +302,49 @@ def reward_bilateral_support(
 def reward_foot_load_balance(
     foot_forces: Array,
     weight: float,
+    min_support_force: float = 0.0,
 ) -> tuple[Array, Array]:
     """Penalise unequal loading of a bilateral support pair.
 
+    An unsupported pair is treated as maximally imbalanced rather than
+    perfectly balanced.  The ratio ``|R - L| / (R + L + 1e-8)`` evaluates to
+    **zero** when both feet read zero, so being airborne used to score the same
+    as standing evenly on both feet -- and strictly better than honest single
+    support, which pays the full penalty:
+
+    ======================  =========  ===================  =======
+    state                   bilateral  foot_load_balance    sum
+    ======================  =========  ===================  =======
+    both feet down, even      +0.600              -0.000     +0.600
+    airborne                   0.000              -0.000      0.000
+    one foot carries load      0.000              -0.300     -0.300
+    ======================  =========  ===================  =======
+
+    That ordering makes flight cheaper than single support, which is the one
+    thing a balance stage must never reward -- a policy off the ground cannot
+    reject a disturbance at all.
+
+    Args:
+        foot_forces: ``(right, left)`` normal forces.
+        weight: Penalty weight.
+        min_support_force: Total force below which the pair counts as
+            unsupported.  The default ``0.0`` closes only the exact ``[0, 0]``
+            case and leaves every loaded state numerically unchanged; raise it
+            to also deny credit for a token grazing contact.
+
     Returns:
         ``(reward, normalized_load_imbalance)``.  The diagnostic is zero for
-        equal loads and approaches one when one foot carries all the load.
+        equal loads, approaches one when one foot carries all the load, and is
+        exactly one when the pair is unsupported.
     """
     xp = _array_mod(foot_forces)
     right_force, left_force = foot_forces[0], foot_forces[1]
-    imbalance = xp.abs(right_force - left_force) / (right_force + left_force + 1e-8)
+    total = right_force + left_force
+    imbalance = xp.where(
+        total > min_support_force,
+        xp.abs(right_force - left_force) / (total + 1e-8),
+        1.0,
+    )
     return -weight * imbalance, imbalance
 
 

--- a/environments/shared/scripts/foot_sensor_report.py
+++ b/environments/shared/scripts/foot_sensor_report.py
@@ -1,0 +1,172 @@
+"""Cross-check foot touch sensors against ``mj_contactForce`` and body weight.
+
+A MuJoCo touch sensor sums only contacts on geoms belonging to its site's OWN
+body, so a sensor mounted on a parent segment silently misses everything the
+child geoms carry.  That has already produced two under-reads in this
+repository -- the T-Rex repair (``aa87445``) and the raptor repair
+(``aa3395c``) -- and it is invisible from the reward trace, because a sensor
+reading zero looks exactly like a foot that is genuinely off the ground.
+
+Two independent checks, both of which must hold on a settled plant:
+
+* **sensor / contact = 1** -- the touch sensors see every floor contact.
+* **contact / weight = 1** -- total floor reaction equals body weight.  This is
+  a physics invariant at rest (and for the time-average of any periodic
+  motion), so a deviation is an accounting bug rather than a policy result.
+
+The weight denominator is the mass of the ANIMAL's kinematic subtree, not
+``mj_getTotalmass``.  Several species carry a prey or food body -- on T-Rex the
+prey is 65.45 kg of a 151.17 kg model total -- so dividing by the model mass
+reports a false 0.57 on a plant standing in perfect equilibrium.
+
+Usage::
+
+    python environments/shared/scripts/foot_sensor_report.py
+    python environments/shared/scripts/foot_sensor_report.py trex brachiosaurus
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+import tomllib
+from pathlib import Path
+
+import numpy as np
+
+_repo_root = str(Path(__file__).resolve().parents[3])
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+SPECIES_ENVS = {
+    "trex": ("environments.trex.envs.trex_env", "TRexEnv"),
+    "velociraptor": ("environments.velociraptor.envs.raptor_env", "RaptorEnv"),
+    "brachiosaurus": ("environments.brachiosaurus.envs.brachio_env", "BrachioEnv"),
+    "dibothrosuchus": ("environments.dibothrosuchus.envs.dibothrosuchus_env", "DibothrosuchusEnv"),
+}
+
+# Keys the TOML [env] block carries for the MJX path only.
+JAX_ONLY_ENV_KEYS = frozenset({"foot_contact_weight", "foot_contact_gate"})
+
+#: Sensor attribute names to try, in order, per species.
+_FOOT_SENSOR_ATTRS = (
+    ("_sensor_r_foot", "_sensor_l_foot"),
+    ("_sensor_fr_foot", "_sensor_fl_foot", "_sensor_rr_foot", "_sensor_rl_foot"),
+)
+
+
+def _foot_sensor_sum(env) -> float | None:
+    """Sum the species' foot touch sensors, including any digit sensors."""
+    import mujoco  # noqa: F401  (imported for parity with the env module)
+
+    if hasattr(env, "_foot_contact_forces"):
+        return float(np.sum(env._foot_contact_forces()))
+    for group in _FOOT_SENSOR_ATTRS:
+        if all(hasattr(env, attr) for attr in group):
+            return float(sum(env.data.sensordata[getattr(env, attr)] for attr in group))
+    return None
+
+
+def _floor_normal_force(env) -> tuple[float, int]:
+    """Total vertical floor reaction over every floor contact."""
+    import mujoco
+
+    ground = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_GEOM, "floor")
+    total, count = 0.0, 0
+    for i in range(env.data.ncon):
+        contact = env.data.contact[i]
+        if ground != -1 and ground not in (contact.geom1, contact.geom2):
+            continue
+        force = np.zeros(6)
+        mujoco.mj_contactForce(env.model, env.data, i, force)
+        frame = np.asarray(contact.frame).reshape(3, 3)
+        total += abs(float((frame.T @ force[:3])[2]))
+        count += 1
+    return total, count
+
+
+def _animal_weight(env) -> float:
+    """Weight of the animal's kinematic subtree, excluding prey/food bodies."""
+
+    model = env.model
+    root_body = model.body_rootid[1] if model.nbody > 1 else 0
+    # The animal is the subtree containing the actuated joints; every other
+    # rooted subtree (prey, food) is scenery.
+    actuated_roots = {int(model.body_rootid[model.jnt_bodyid[model.actuator_trnid[a, 0]]]) for a in range(model.nu)}
+    if not actuated_roots:
+        actuated_roots = {int(root_body)}
+    mass = sum(float(model.body_mass[i]) for i in range(model.nbody) if int(model.body_rootid[i]) in actuated_roots)
+    return mass * 9.81
+
+
+def report(species: str, settle_steps: int = 200) -> dict:
+    module_name, class_name = SPECIES_ENVS[species]
+    env_cls = getattr(importlib.import_module(module_name), class_name)
+
+    config_path = Path(_repo_root) / "configs" / species / "stage1_balance.toml"
+    env_kwargs = {k: v for k, v in tomllib.loads(config_path.read_text())["env"].items() if k not in JAX_ONLY_ENV_KEYS}
+    env_kwargs["reset_noise_scale"] = 0.0
+
+    env = env_cls(**env_kwargs)
+    try:
+        env.reset(seed=0)
+        zero = np.zeros(env.action_space.shape)
+        for _ in range(settle_steps):
+            env.step(zero)
+
+        sensors = _foot_sensor_sum(env)
+        contact, n_contacts = _floor_normal_force(env)
+        weight = _animal_weight(env)
+        return {
+            "species": species,
+            "sensor_total_n": sensors,
+            "contact_total_n": contact,
+            "n_floor_contacts": n_contacts,
+            "animal_weight_n": weight,
+            "sensor_over_contact": (sensors / contact) if (sensors is not None and contact) else None,
+            "contact_over_weight": (contact / weight) if weight else None,
+        }
+    finally:
+        env.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "species",
+        nargs="*",
+        default=[],
+        help=f"species to check (default: all of {', '.join(sorted(SPECIES_ENVS))})",
+    )
+    parser.add_argument("--settle-steps", type=int, default=200)
+    args = parser.parse_args()
+    species_list = args.species or sorted(SPECIES_ENVS)
+    unknown = [s for s in species_list if s not in SPECIES_ENVS]
+    if unknown:
+        parser.error(f"unknown species {unknown}; choose from {sorted(SPECIES_ENVS)}")
+
+    print(f"{'species':16} {'sensors':>10} {'contact':>10} {'weight':>10} {'sens/con':>9} {'con/wt':>8}")
+    bad = []
+    for species in species_list:
+        r = report(species, args.settle_steps)
+        s = "n/a" if r["sensor_total_n"] is None else f"{r['sensor_total_n']:10.1f}"
+        soc = "  n/a" if r["sensor_over_contact"] is None else f"{r['sensor_over_contact']:9.3f}"
+        cow = "  n/a" if r["contact_over_weight"] is None else f"{r['contact_over_weight']:8.3f}"
+        print(f"{species:16} {s} {r['contact_total_n']:10.1f} {r['animal_weight_n']:10.1f} {soc} {cow}")
+        if r["sensor_over_contact"] is not None and not 0.95 <= r["sensor_over_contact"] <= 1.05:
+            bad.append(f"{species}: touch sensors see {r['sensor_over_contact']:.1%} of measured floor contact")
+        if r["contact_over_weight"] is not None and not 0.95 <= r["contact_over_weight"] <= 1.05:
+            bad.append(f"{species}: floor reaction is {r['contact_over_weight']:.1%} of body weight")
+
+    if bad:
+        print("\nFAILED invariants:")
+        for line in bad:
+            print(f"  {line}")
+        return 1
+    print("\nAll species: touch sensors agree with mj_contactForce, and floor reaction equals body weight.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/environments/shared/scripts/stance_duty_validation.py
+++ b/environments/shared/scripts/stance_duty_validation.py
@@ -1,0 +1,218 @@
+"""Validate the support-duty metrics against kinematic ground truth.
+
+``bilateral_support_duty`` / ``single_support_duty`` / ``unsupported_duty``
+(``stance_diagnostics.derive_stance_info``) classify each step by thresholding
+the foot touch sensors at 0.1 N.  Those readings are the evidence behind the
+claim that the stage-1 policy spends ~21% of its steps off the ground, so the
+metric needs to be shown accurate before the behaviour is argued from it -- a
+sensor that under-reports contact looks exactly like a foot in flight.
+
+``foot_sensor_report.py`` checks the sensors on a SETTLED plant.  That is one
+operating point: quiet bilateral stance, steady load.  This script checks the
+regime the duty numbers actually come from -- touchdown transients, rapid load
+transfer, real flight phases -- by sweeping driver policies that produce
+airborne fractions from ~3% to ~67%, and comparing three signals per step, two
+of which never touch the sensor path:
+
+  A. summed foot touch sensors                     (what the duty metric reads)
+  B. ``mj_contactForce`` over foot-geom floor contacts       (force reference)
+  C. ``mj_geomDistance`` from every foot geom to the floor   (KINEMATIC truth)
+
+C is the decisive one: it is computed from geometry alone, so if the steps
+labelled ``unsupported`` are the steps where the feet are genuinely clear of
+the ground, the metric measures what it claims.
+
+Two traps this script exists to avoid, both hit while writing it:
+
+* **Compare against foot contacts only.** Summing every floor contact counts
+  tail and torso strikes as sensor disagreement and produces nonsense.
+* **Enumerate the foot geoms from actual contacts, not from their names.** A
+  ``foot|toe|metatarsus|pad`` name filter misses ``r_plantar_geom`` and
+  ``l_plantar_geom``, which carry most of the load. That is the same mistake
+  class as the sensor-scope defects in FOOT_SENSOR_VERIFICATION.md.
+
+Usage::
+
+    python environments/shared/scripts/stance_duty_validation.py
+    python environments/shared/scripts/stance_duty_validation.py --episodes 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+_repo_root = str(Path(__file__).resolve().parents[3])
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+#: Threshold the duty classifier uses, from ``derive_stance_info``.
+DUTY_THRESHOLD = 0.1
+
+#: Bodies whose geoms make up the feet.  Resolved to geoms at runtime so a
+#: plant revision that adds a digit is picked up without editing a name list.
+FOOT_BODY_MARKERS = ("plantar", "metatarsus", "toe")
+
+
+def _foot_geom_ids(model) -> list[int]:
+    import mujoco
+
+    ids = []
+    for gid in range(model.ngeom):
+        body = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, model.geom_bodyid[gid])
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, gid) or ""
+        haystack = f"{body or ''} {name}"
+        if any(marker in haystack for marker in FOOT_BODY_MARKERS):
+            ids.append(gid)
+    return ids
+
+
+def _probe(env, foot_gids, floor_gid):
+    import mujoco
+
+    model, data = env.model, env.data
+    right, left = env._foot_contact_forces()
+
+    foot_force = other_force = 0.0
+    for i in range(data.ncon):
+        contact = data.contact[i]
+        if floor_gid not in (contact.geom1, contact.geom2):
+            continue
+        other = contact.geom2 if contact.geom1 == floor_gid else contact.geom1
+        force = np.zeros(6)
+        mujoco.mj_contactForce(model, data, i, force)
+        fz = abs(float((np.asarray(contact.frame).reshape(3, 3).T @ force[:3])[2]))
+        if other in foot_gids:
+            foot_force += fz
+        else:
+            other_force += fz
+
+    clearance = min(float(mujoco.mj_geomDistance(model, data, gid, floor_gid, 2.0, None)) for gid in foot_gids)
+    return float(right) + float(left), foot_force, other_force, clearance, float(right), float(left)
+
+
+def _collect(driver, episodes, max_steps, spawn_dz=0.0):
+    import mujoco
+
+    from environments.shared.stance_diagnostics import derive_stance_info
+    from environments.trex.envs.trex_env import TRexEnv
+
+    rows = []
+    for episode in range(episodes):
+        env = TRexEnv(reset_noise_scale=0.10)
+        try:
+            floor_gid = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_GEOM, "floor")
+            foot_gids = _foot_geom_ids(env.model)
+            env.reset(seed=1000 + episode)
+            if spawn_dz:
+                env.data.qpos[2] += spawn_dz
+                mujoco.mj_forward(env.model, env.data)
+            rng = np.random.default_rng(episode)
+            for t in range(max_steps):
+                _, _, terminated, truncated, _ = env.step(driver(t, env, rng))
+                sensors, foot_f, other_f, clearance, right, left = _probe(env, foot_gids, floor_gid)
+                stance = derive_stance_info({"r_foot_contact": right, "l_foot_contact": left}, DUTY_THRESHOLD)
+                rows.append((sensors, foot_f, other_f, clearance, stance["unsupported_duty"]))
+                if terminated or truncated:
+                    break
+        finally:
+            env.close()
+    return np.array(rows)
+
+
+def _summarize(label, rows):
+    sensors, foot_f, other_f, clearance = rows[:, 0], rows[:, 1], rows[:, 2], rows[:, 3]
+    unsupported = rows[:, 4].astype(bool)
+    airborne = clearance > 1e-6
+    n = len(rows)
+    peak = max(float(np.max(foot_f)), 1.0)
+    err = np.abs(sensors - foot_f)
+
+    false_airborne = int(np.sum(unsupported & ~airborne))  # overstates airtime
+    false_supported = int(np.sum(~unsupported & airborne))  # understates airtime
+    disagreement = 100 * (false_airborne + false_supported) / n
+
+    print(f"\n=== {label} ===")
+    print(f"  steps {n:6}   kinematically airborne {airborne.mean():7.2%}   duty-unsupported {unsupported.mean():7.2%}")
+    print(
+        f"  sensors vs foot mj_contactForce: mean err {err.mean():8.3f} N, max {err.max():10.1f} N of {peak:.0f} N peak"
+    )
+    if (other_f > 1e-6).any():
+        print(
+            f"  non-foot floor contact on {(other_f > 1e-6).mean():.1%} of steps"
+            f" (max {other_f.max():.1f} N) -- excluded"
+        )
+    print(
+        f"  misclassified: {false_airborne} false-airborne, {false_supported} false-supported"
+        f"  -> {disagreement:.3f}% of steps"
+    )
+    return {
+        "label": label,
+        "steps": n,
+        "airborne": float(airborne.mean()),
+        "unsupported_duty": float(unsupported.mean()),
+        "disagreement_pct": disagreement,
+    }
+
+
+def _zero(t, env, rng):
+    return np.zeros(env.action_space.shape)
+
+
+def _jitter(t, env, rng):
+    """Small fast noise — the near-threshold regime the duty metric lives in."""
+    return rng.uniform(-0.25, 0.25, size=env.action_space.shape)
+
+
+def _hop(t, env, rng):
+    return np.full(env.action_space.shape, 0.9 * np.sin(2 * np.pi * t / 40.0))
+
+
+def _thrash(t, env, rng):
+    return rng.uniform(-1.0, 1.0, size=env.action_space.shape)
+
+
+REGIMES = (
+    ("drop test (zero action, +0.25 m spawn)", _zero, dict(episodes=8, max_steps=300, spawn_dz=0.25)),
+    ("settled stance (zero action)", _zero, dict(episodes=8, max_steps=400)),
+    ("low-amplitude jitter", _jitter, dict(episodes=40, max_steps=1000)),
+    ("forced hop (sinusoidal leg drive)", _hop, dict(episodes=40, max_steps=1000)),
+    ("random thrash", _thrash, dict(episodes=40, max_steps=1000)),
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--episodes", type=int, default=None, help="override per-regime episode count")
+    parser.add_argument(
+        "--max-disagreement",
+        type=float,
+        default=5.0,
+        help="fail if any regime misclassifies more than this %% of steps",
+    )
+    args = parser.parse_args()
+
+    results = []
+    for label, driver, kwargs in REGIMES:
+        if args.episodes is not None:
+            kwargs = {**kwargs, "episodes": args.episodes}
+        results.append(_summarize(label, _collect(driver, **kwargs)))
+
+    worst = max(results, key=lambda r: r["disagreement_pct"])
+    span = (min(r["airborne"] for r in results), max(r["airborne"] for r in results))
+    print(
+        f"\nAirborne fraction swept {span[0]:.1%} to {span[1]:.1%};"
+        f" worst misclassification {worst['disagreement_pct']:.3f}% ({worst['label']})."
+    )
+    if worst["disagreement_pct"] > args.max_disagreement:
+        print("FAILED: the duty metrics do not track kinematic ground truth closely enough.")
+        return 1
+    print("The support-duty metrics track kinematic ground truth across the swept range.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/environments/shared/tests/test_base_env.py
+++ b/environments/shared/tests/test_base_env.py
@@ -485,3 +485,82 @@ class TestScaleActionClipping:
             np.testing.assert_allclose(scaled, ctrl_max, atol=1e-6)
         finally:
             env.close()
+
+
+class TestResetHeightTruncation:
+    """Reset must never generate an already-terminal state.
+
+    The root-height jitter was the only unbounded term in the reset — every
+    other one is a bounded uniform — so an unbounded Gaussian eventually placed
+    the root outside ``healthy_z_range`` before the policy acted.  An episode
+    that ends on step 1 whatever the action is not a policy failure, and
+    counting it as one puts an unreachable ceiling on any reliability gate.
+    """
+
+    def test_delta_is_bounded_by_distance_to_the_floor(self):
+        env = RaptorEnv()
+        try:
+            low, high = env.healthy_z_range
+            base_z = 0.5 * (low + high)
+            headroom = min(base_z - low, high - base_z)
+            huge = 10.0 * (high - low)
+
+            assert env._bounded_reset_height_delta(base_z, huge) < headroom
+            assert env._bounded_reset_height_delta(base_z, -huge) > -headroom
+        finally:
+            env.close()
+
+    def test_bound_is_symmetric_so_the_mean_spawn_height_is_unchanged(self):
+        env = RaptorEnv()
+        try:
+            low, high = env.healthy_z_range
+            base_z = 0.5 * (low + high)
+            for delta in (0.05, 0.2, 5.0):
+                up = env._bounded_reset_height_delta(base_z, delta)
+                down = env._bounded_reset_height_delta(base_z, -delta)
+                assert up == pytest.approx(-down)
+        finally:
+            env.close()
+
+    def test_small_deltas_pass_through_untouched(self):
+        """Species with ample headroom must be unaffected in practice."""
+        env = RaptorEnv()
+        try:
+            low, high = env.healthy_z_range
+            base_z = 0.5 * (low + high)
+            tiny = 1e-4
+            assert env._bounded_reset_height_delta(base_z, tiny) == pytest.approx(tiny)
+        finally:
+            env.close()
+
+    def test_no_headroom_pins_the_spawn_to_the_keyframe(self):
+        """A base height already at the floor yields a deterministic spawn."""
+        env = RaptorEnv()
+        try:
+            low, _ = env.healthy_z_range
+            assert env._bounded_reset_height_delta(low, 1.0) == pytest.approx(0.0)
+            assert env._bounded_reset_height_delta(low, -1.0) == pytest.approx(0.0)
+        finally:
+            env.close()
+
+    @pytest.mark.parametrize("env_cls", [RaptorEnv, BrachioEnv])
+    def test_reset_never_spawns_outside_the_healthy_range(self, env_cls):
+        env = env_cls(reset_noise_scale=0.5)
+        try:
+            low, high = env.healthy_z_range
+            for seed in range(200):
+                env.reset(seed=seed)
+                root_z = float(env.data.qpos[2])
+                assert low < root_z < high, f"seed {seed} spawned at {root_z:.4f}, outside [{low}, {high}]"
+        finally:
+            env.close()
+
+    def test_zero_noise_still_gives_a_deterministic_reset(self):
+        env = RaptorEnv(reset_noise_scale=0.0)
+        try:
+            env.reset(seed=1)
+            first = env.data.qpos.copy()
+            env.reset(seed=999)
+            np.testing.assert_allclose(env.data.qpos, first)
+        finally:
+            env.close()

--- a/environments/shared/tests/test_curriculum_early_stopping.py
+++ b/environments/shared/tests/test_curriculum_early_stopping.py
@@ -9,6 +9,7 @@ from environments.shared.curriculum import (
     EvalCollapseEarlyStopCallback,
     build_eval_collapse_early_stop_callback,
 )
+from environments.shared.curriculum.early_stopping import collapse_settings_from_config
 
 
 class TestEvalCollapseEarlyStopCallback:
@@ -414,18 +415,20 @@ class TestCollapsePeakFloorIsDecoupledFromTheRewardGate:
     """
 
     def test_reward_gate_no_longer_leaks_into_the_floor(self):
-        cb = build_eval_collapse_early_stop_callback(
-            eval_callback=None,
-            curriculum_kwargs={"min_avg_reward": 1840.0},
-        )
-        assert cb.peak_floor != 1840.0
+        settings = collapse_settings_from_config({"min_avg_reward": 1840.0})
+        assert settings["peak_floor"] != 1840.0
 
     def test_missing_floor_never_arms_rather_than_arming_eagerly(self):
         """An unconfigured backstop must not abort a run."""
-        cb = build_eval_collapse_early_stop_callback(eval_callback=None, curriculum_kwargs={})
-        assert cb.peak_floor == float("inf")
+        assert collapse_settings_from_config({})["peak_floor"] == float("inf")
 
     def test_explicit_floor_is_honoured(self):
+        settings = collapse_settings_from_config({"collapse_peak_floor": 2200.0, "min_avg_reward": 1840.0})
+        assert settings["peak_floor"] == 2200.0
+
+    def test_builder_passes_the_resolved_floor_through(self):
+        """Pin the wiring too, where stable-baselines3 is available."""
+        pytest.importorskip("stable_baselines3")
         cb = build_eval_collapse_early_stop_callback(
             eval_callback=None,
             curriculum_kwargs={"collapse_peak_floor": 2200.0, "min_avg_reward": 1840.0},

--- a/environments/shared/tests/test_curriculum_early_stopping.py
+++ b/environments/shared/tests/test_curriculum_early_stopping.py
@@ -7,6 +7,7 @@ import pytest
 
 from environments.shared.curriculum import (
     EvalCollapseEarlyStopCallback,
+    build_eval_collapse_early_stop_callback,
 )
 
 
@@ -399,3 +400,44 @@ class TestEvalCollapseEarlyStopCallback:
             peak_floor=100.0,
         )
         assert fired is not None, "backstop failed to catch a genuine sustained collapse"
+
+
+class TestCollapsePeakFloorIsDecoupledFromTheRewardGate:
+    """``collapse_peak_floor`` must not inherit ``min_avg_reward``.
+
+    The builder used to chain ``collapse_peak_floor`` -> ``min_avg_reward`` ->
+    ``0.0``, coupling an early-stop backstop to an unrelated advancement
+    threshold. Removing the reward gate from a stage -- which a state-capability
+    gate would do -- silently dropped the floor to ``0.0``, arming collapse
+    detection after any positive robust peak. See docs/STAGE1_SPLIT_PLAN.md
+    section 7.4.
+    """
+
+    def test_reward_gate_no_longer_leaks_into_the_floor(self):
+        cb = build_eval_collapse_early_stop_callback(
+            eval_callback=None,
+            curriculum_kwargs={"min_avg_reward": 1840.0},
+        )
+        assert cb.peak_floor != 1840.0
+
+    def test_missing_floor_never_arms_rather_than_arming_eagerly(self):
+        """An unconfigured backstop must not abort a run."""
+        cb = build_eval_collapse_early_stop_callback(eval_callback=None, curriculum_kwargs={})
+        assert cb.peak_floor == float("inf")
+
+    def test_explicit_floor_is_honoured(self):
+        cb = build_eval_collapse_early_stop_callback(
+            eval_callback=None,
+            curriculum_kwargs={"collapse_peak_floor": 2200.0, "min_avg_reward": 1840.0},
+        )
+        assert cb.peak_floor == 2200.0
+
+    def test_every_committed_stage_config_sets_the_floor_explicitly(self):
+        from environments.shared.config import load_all_stages
+
+        for species in ("trex", "velociraptor", "brachiosaurus", "dibothrosuchus"):
+            for stage, cfg in load_all_stages(species).items():
+                cur = cfg.get("curriculum_kwargs", {})
+                assert "collapse_peak_floor" in cur, (
+                    f"{species} stage {stage} relies on the removed min_avg_reward fallback"
+                )

--- a/environments/shared/tests/test_curriculum_manager.py
+++ b/environments/shared/tests/test_curriculum_manager.py
@@ -7,6 +7,18 @@ from environments.shared.curriculum import (
     StageThreshold,
     thresholds_from_configs,
 )
+from environments.shared.curriculum.gate_schema import (
+    GATE_SCHEMA_VERSION,
+    GateSchemaError,
+    validate_gate_configs,
+)
+
+#: The gate declaration every real stage config carries. Tests that exercise a
+#: working gate must include it, because an undeclared gate is now fatal.
+_GATE = {"gate_schema_version": GATE_SCHEMA_VERSION, "gate_kind": "reward_and_length/v1"}
+
+#: The explicit, recorded non-advancing mode.
+_PILOT = {"gate_schema_version": GATE_SCHEMA_VERSION, "gate_kind": "none/v1"}
 
 
 class TestStageThreshold:
@@ -273,27 +285,28 @@ class TestThresholdsFromConfigs:
 
     def test_extracts_reward_threshold(self):
         configs = {
-            1: {"curriculum_kwargs": {"min_avg_reward": 10.0, "required_consecutive": 2}},
-            2: {"curriculum_kwargs": {"min_avg_reward": 50.0}},
-            3: {"curriculum_kwargs": {}},
+            1: {"curriculum_kwargs": dict(_GATE, min_avg_reward=10.0, required_consecutive=2)},
+            2: {"curriculum_kwargs": dict(_GATE, min_avg_reward=50.0)},
+            3: {"curriculum_kwargs": dict(_PILOT)},
         }
-        thresholds = thresholds_from_configs(configs)
+        thresholds = thresholds_from_configs(configs, advancement_enabled=False)
         assert thresholds[1]["min_avg_reward"] == 10.0
         assert thresholds[1]["required_consecutive"] == 2
         assert thresholds[2]["min_avg_reward"] == 50.0
-        assert 3 not in thresholds  # empty curriculum_kwargs -> no entry
+        assert 3 not in thresholds  # declared non-advancing pilot -> no entry
 
     def test_extracts_all_threshold_fields(self):
         configs = {
             1: {
-                "curriculum_kwargs": {
-                    "min_avg_reward": 10.0,
-                    "min_avg_episode_length": 100,
-                    "min_avg_forward_vel": 0.5,
-                    "min_success_rate": 0.3,
-                    "min_eval_episodes": 12,
-                    "required_consecutive": 3,
-                },
+                "curriculum_kwargs": dict(
+                    _GATE,
+                    min_avg_reward=10.0,
+                    min_avg_episode_length=100,
+                    min_avg_forward_vel=0.5,
+                    min_success_rate=0.3,
+                    min_eval_episodes=12,
+                    required_consecutive=3,
+                ),
             },
         }
         thresholds = thresholds_from_configs(configs)
@@ -304,6 +317,42 @@ class TestThresholdsFromConfigs:
     def test_empty_configs(self):
         thresholds = thresholds_from_configs({})
         assert thresholds == {}
+
+    def test_undeclared_gate_is_fatal_when_advancement_is_enabled(self):
+        """Fail closed: a stage with no gate declaration must not advance.
+
+        A composite-only gate config used to have its unknown fields silently
+        discarded here, after which StageThreshold's permissive defaults
+        (min_avg_reward = -inf, length and success floors 0) advanced the stage
+        on any evaluation at all. See docs/STAGE1_SPLIT_PLAN.md section 5.2.
+        """
+        configs = {1: {"curriculum_kwargs": {"min_avg_reward": 10.0}}}
+        with pytest.raises(GateSchemaError, match="no gate_kind declared"):
+            thresholds_from_configs(configs)
+
+    def test_unknown_field_is_fatal_rather_than_silently_dropped(self):
+        configs = {1: {"curriculum_kwargs": dict(_GATE, min_stance_success_lcb=0.90)}}
+        with pytest.raises(GateSchemaError, match="unrecognised"):
+            thresholds_from_configs(configs)
+
+    def test_threshold_belonging_to_another_gate_kind_is_fatal(self):
+        """A leftover threshold implies a gate that is not actually enforced."""
+        configs = {1: {"curriculum_kwargs": dict(_PILOT, min_avg_reward=10.0)}}
+        with pytest.raises(GateSchemaError, match="does not consume"):
+            thresholds_from_configs(configs, advancement_enabled=False)
+
+    def test_non_advancing_pilot_is_rejected_when_advancement_is_enabled(self):
+        configs = {1: {"curriculum_kwargs": dict(_PILOT)}}
+        with pytest.raises(GateSchemaError, match="non-advancing pilot"):
+            thresholds_from_configs(configs)
+
+    def test_every_committed_stage_config_declares_a_valid_gate(self):
+        """The shipped configs must satisfy the schema on every species."""
+        from environments.shared.config import load_all_stages
+
+        for species in ("trex", "velociraptor", "brachiosaurus", "dibothrosuchus"):
+            kinds = validate_gate_configs(load_all_stages(species))
+            assert set(kinds.values()) == {"reward_and_length/v1"}, species
 
     def test_with_real_configs(self):
         """Integration test: extract thresholds from actual TOML configs."""

--- a/environments/shared/tests/test_jax_curriculum.py
+++ b/environments/shared/tests/test_jax_curriculum.py
@@ -5,16 +5,23 @@ These tests run without JAX installed — check_stage_gate is pure Python.
 
 from __future__ import annotations
 
+import pytest
+
+from environments.shared.curriculum.gate_schema import GATE_SCHEMA_VERSION, GateSchemaError
 from environments.shared.jax_curriculum import check_stage_gate
+
+#: The gate declaration every real stage config carries. Tests that exercise a
+#: working gate must include it, because an undeclared gate is now fatal.
+_GATE = {"gate_schema_version": GATE_SCHEMA_VERSION, "gate_kind": "reward_and_length/v1"}
 
 
 class TestCheckStageGate:
     def test_passes_when_reward_meets_threshold(self):
-        stage_config = {"curriculum_kwargs": {"min_avg_reward": 100.0}}
+        stage_config = {"curriculum_kwargs": dict(_GATE, min_avg_reward=100.0)}
         assert check_stage_gate({"mean_episode_return": 150.0}, stage_config) is True
 
     def test_fails_when_reward_below_threshold(self):
-        stage_config = {"curriculum_kwargs": {"min_avg_reward": 100.0}}
+        stage_config = {"curriculum_kwargs": dict(_GATE, min_avg_reward=100.0)}
         assert check_stage_gate({"mean_episode_return": 50.0}, stage_config) is False
 
     def test_reads_curriculum_kwargs_key_from_real_config(self):
@@ -38,17 +45,47 @@ class TestCheckStageGate:
         episode-level, so the gate must use the episode return — gating on
         the per-step value failed every well-trained policy.
         """
-        stage_config = {"curriculum_kwargs": {"min_avg_reward": 100.0}}
+        stage_config = {"curriculum_kwargs": dict(_GATE, min_avg_reward=100.0)}
         realistic_trainer_metrics = {"mean_reward": 1.2, "mean_episode_return": 240.0}
         assert check_stage_gate(realistic_trainer_metrics, stage_config) is True
 
     def test_falls_back_to_mean_reward_when_no_episode_return(self):
-        stage_config = {"curriculum_kwargs": {"min_avg_reward": 100.0}}
+        stage_config = {"curriculum_kwargs": dict(_GATE, min_avg_reward=100.0)}
         assert check_stage_gate({"mean_reward": 150.0}, stage_config) is True
         assert check_stage_gate({"mean_reward": 50.0}, stage_config) is False
 
-    def test_missing_threshold_passes_with_warning(self):
-        # No threshold configured -> gate passes (matches the SB3
-        # CurriculumManager default of -inf), rather than blocking forever.
-        assert check_stage_gate({"mean_reward": 0.0}, {}) is True
-        assert check_stage_gate({"mean_reward": 0.0}, {"curriculum_kwargs": {}}) is True
+    def test_missing_gate_declaration_is_fatal(self):
+        """Fail closed: an undeclared gate must not advance by default.
+
+        This previously logged a warning and returned ``True``, so a stage
+        whose reward threshold had been removed advanced unconditionally.
+        Combined with the SB3 path's permissive StageThreshold defaults, that
+        made "no gate" indistinguishable from "gate satisfied" on both
+        backends. See docs/STAGE1_SPLIT_PLAN.md section 5.2.
+        """
+        with pytest.raises(GateSchemaError, match="no gate_kind declared"):
+            check_stage_gate({"mean_reward": 0.0}, {})
+        with pytest.raises(GateSchemaError, match="no gate_kind declared"):
+            check_stage_gate({"mean_reward": 0.0}, {"curriculum_kwargs": {}})
+
+    def test_declared_gate_without_a_reward_threshold_is_fatal(self):
+        """A declared gate with nothing to check must raise, not pass."""
+        with pytest.raises(GateSchemaError, match="no min_avg_reward"):
+            check_stage_gate({"mean_episode_return": 0.0}, {"curriculum_kwargs": dict(_GATE)})
+
+    def test_non_advancing_pilot_cannot_be_used_to_advance(self):
+        """gate_kind "none/v1" is the recorded way to run without a gate."""
+        pilot = {"curriculum_kwargs": {"gate_schema_version": 1, "gate_kind": "none/v1"}}
+        with pytest.raises(GateSchemaError, match="non-advancing pilot"):
+            check_stage_gate({"mean_episode_return": 1e9}, pilot)
+
+    def test_unknown_gate_kind_is_fatal(self):
+        bogus = {"curriculum_kwargs": {"gate_schema_version": 1, "gate_kind": "made_up/v9"}}
+        with pytest.raises(GateSchemaError, match="unknown gate_kind"):
+            check_stage_gate({"mean_episode_return": 1e9}, bogus)
+
+    def test_misspelled_threshold_is_fatal_rather_than_ignored(self):
+        """A typo used to silently disable the threshold it meant to set."""
+        typo = {"curriculum_kwargs": dict(_GATE, min_avg_rewrad=100.0)}
+        with pytest.raises(GateSchemaError, match="unrecognised"):
+            check_stage_gate({"mean_episode_return": 0.0}, typo)

--- a/environments/shared/tests/test_reward_functions.py
+++ b/environments/shared/tests/test_reward_functions.py
@@ -261,6 +261,41 @@ class TestStageOneStancePrimitives:
         assert unilateral_imbalance == pytest.approx(1.0)
         assert unilateral_reward == pytest.approx(-1.5)
 
+    def test_airborne_is_maximally_imbalanced_not_perfectly_balanced(self):
+        """Regression: ``[0, 0]`` used to return imbalance 0.0.
+
+        ``|R - L| / (R + L + 1e-8)`` evaluates to zero when both feet read
+        zero, so being airborne scored the same as standing evenly and
+        strictly better than honest single support -- which pays the full
+        penalty. On a balance stage that makes flight the cheapest way to
+        avoid the term, and a policy off the ground cannot reject a
+        disturbance at all. See docs/STAGE1_SPLIT_PLAN.md section 7.1.
+        """
+        reward, imbalance = reward_foot_load_balance(np.array([0.0, 0.0]), 1.5)
+        assert imbalance == pytest.approx(1.0)
+        assert reward == pytest.approx(-1.5)
+
+    def test_airborne_is_no_cheaper_than_single_support(self):
+        """The ordering the stage-1 reward depends on."""
+        _, airborne = reward_foot_load_balance(np.array([0.0, 0.0]), 1.5)
+        _, single = reward_foot_load_balance(np.array([80.0, 0.0]), 1.5)
+        _, even = reward_foot_load_balance(np.array([80.0, 80.0]), 1.5)
+        assert even < single <= airborne
+
+    def test_min_support_force_denies_credit_for_a_grazing_contact(self):
+        forces = np.array([0.25, 0.25])
+        _, unguarded = reward_foot_load_balance(forces, 1.5)
+        _, guarded = reward_foot_load_balance(forces, 1.5, 10.0)
+        assert unguarded == pytest.approx(0.0)
+        assert guarded == pytest.approx(1.0)
+
+    def test_default_leaves_every_loaded_state_unchanged(self):
+        """The default 0.0 threshold must close only the exact [0, 0] case."""
+        for forces in ([80.0, 80.0], [80.0, 0.0], [120.0, 40.0], [1e-6, 1e-6]):
+            _, imbalance = reward_foot_load_balance(np.array(forces), 1.0)
+            expected = abs(forces[0] - forces[1]) / (forces[0] + forces[1] + 1e-8)
+            assert imbalance == pytest.approx(expected)
+
     def test_soft_home_pose_reports_rms_and_mean_joint_quality(self):
         tolerance = 0.5
         joint_positions = np.array([0.0, tolerance])

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -75,13 +75,17 @@ def test_catalog_publishes_layered_plant_contract() -> None:
         "brachiosaurus": "quadrupedal-target/v1",
         "dibothrosuchus": "quadrupedal-target/v1",
     }
-    # The T-Rex is at policy r7 / physics r5 for the theropod stance correction:
-    # the home keyframe moved off a near-straight knee onto a 135 deg one and
-    # the leg ctrlranges were re-centred on it, so both the compiled dynamics
-    # and the control interface changed. Its visual revision is deliberately
-    # NOT bumped -- the visual layer fingerprints geom/site/material/camera
-    # definitions, all of which are body-local and unchanged by a pose edit.
-    expected_policy_revisions = {"velociraptor": 6, "trex": 7, "brachiosaurus": 3, "dibothrosuchus": 3}
+    # The T-Rex is at physics r5 for the theropod stance correction: the home
+    # keyframe moved off a near-straight knee onto a 135 deg one and the leg
+    # ctrlranges were re-centred on it, so both the compiled dynamics and the
+    # control interface changed. Its visual revision is deliberately NOT bumped
+    # -- the visual layer fingerprints geom/site/material/camera definitions,
+    # all of which are body-local and unchanged by a pose edit.
+    #
+    # The three home-keyframe-residual species then took one more policy bump
+    # for the bounded reset height (plant_versions note 5); brachiosaurus does
+    # not carry home_reset and so stays at r3.
+    expected_policy_revisions = {"velociraptor": 7, "trex": 8, "brachiosaurus": 3, "dibothrosuchus": 4}
     expected_physics_revisions = {"velociraptor": 2, "trex": 5, "brachiosaurus": 1, "dibothrosuchus": 1}
     expected_visual_revisions = {"velociraptor": 3, "trex": 4, "brachiosaurus": 1, "dibothrosuchus": 1}
     digest_pattern = re.compile(r"sha256:[0-9a-f]{64}")

--- a/environments/shared/tests/test_train_base.py
+++ b/environments/shared/tests/test_train_base.py
@@ -270,14 +270,17 @@ class TestBuildCoreCallbacks:
         assert cb.peak_floor == 42.0
         assert cb.smoothing_window == 3
 
-        # Defaults are lenient (looser than the old hardcoded 8 / 5 / 0.3),
-        # the arming floor falls back to the stage's own reward gate, and the
-        # smoothing window defaults to 5 evals.
+        # Defaults are lenient (looser than the old hardcoded 8 / 5 / 0.3) and
+        # the smoothing window defaults to 5 evals.  The arming floor no longer
+        # falls back to the stage's reward gate: an unconfigured backstop must
+        # not abort a run, and coupling it to min_avg_reward meant removing the
+        # reward gate silently armed collapse detection on any positive peak.
+        # See docs/STAGE1_SPLIT_PLAN.md section 7.4.
         cb_default = _build_collapse_cb({"min_avg_reward": 100.0})
         assert cb_default.min_evals == 12
         assert cb_default.patience == 8
         assert cb_default.drop_fraction == 0.4
-        assert cb_default.peak_floor == 100.0
+        assert cb_default.peak_floor == float("inf")
         assert cb_default.smoothing_window == 5
 
 

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -119,6 +119,7 @@ class TRexEnv(BaseDinoEnv):
         bilateral_support_weight: float = 0.0,
         foot_contact_saturation_force: float = 100.0,
         foot_load_balance_weight: float = 0.0,
+        foot_load_balance_min_support_force: float = 0.0,
         support_conditioned_alive_fraction: float = 0.0,
         leg_home_pose_weight: float = 0.0,
         leg_home_pose_tolerance: float = 0.35,
@@ -185,6 +186,7 @@ class TRexEnv(BaseDinoEnv):
         self.bilateral_support_weight = bilateral_support_weight
         self.foot_contact_saturation_force = foot_contact_saturation_force
         self.foot_load_balance_weight = foot_load_balance_weight
+        self.foot_load_balance_min_support_force = foot_load_balance_min_support_force
         self.support_conditioned_alive_fraction = support_conditioned_alive_fraction
         self.leg_home_pose_weight = leg_home_pose_weight
         self.leg_home_pose_tolerance = leg_home_pose_tolerance
@@ -373,12 +375,16 @@ class TRexEnv(BaseDinoEnv):
         )
         return float(quality)
 
-    @staticmethod
-    def _foot_load_imbalance(right_force: float, left_force: float) -> float:
-        """Return normalized left/right load mismatch in ``[0, 1]``."""
+    def _foot_load_imbalance(self, right_force: float, left_force: float) -> float:
+        """Return normalized left/right load mismatch in ``[0, 1]``.
+
+        An unsupported pair returns ``1.0``, not ``0.0``: airborne is maximally
+        imbalanced, not perfectly balanced.
+        """
         _, imbalance = _reward_foot_load_balance_pure(
             np.asarray((right_force, left_force)),
             1.0,
+            self.foot_load_balance_min_support_force,
         )
         return float(imbalance)
 

--- a/environments/trex/tests/test_trex_env.py
+++ b/environments/trex/tests/test_trex_env.py
@@ -397,3 +397,49 @@ class TestHeightTargetTracksStance:
                 )
         finally:
             env.close()
+
+
+class TestStage1ResetStaysInsideTheHealthyEnvelope:
+    """No stage-1 seed may start already terminated.
+
+    Dibothrosuchus hit this first and fixed it by decoupling
+    ``reset_height_noise_scale`` from the radian-scale joint noise.  T-Rex was
+    left coupled, and at ``reset_noise_scale = 0.10`` its 0.926 m home pelvis
+    sits only 0.226 m — 2.26 sigma — above the 0.70 m floor, so 1.19% of spawns
+    landed below it.  Measured over seeds 3042-5041 before the fix: 18/2000
+    spawned sub-floor and 16 terminated on step 1 whatever the policy did.
+    That is the direct cause of the 39/40 evaluation panels, and it caps any
+    reliability gate below the level a stance gate needs to certify.
+    """
+
+    def test_stage1_reset_never_spawns_out_of_bounds(self):
+        from environments.shared.config import load_stage_config
+
+        kwargs = load_stage_config("trex", 1)["env_kwargs"]
+        kwargs = {k: v for k, v in kwargs.items() if k not in {"foot_contact_weight", "foot_contact_gate"}}
+        env = TRexEnv(**kwargs)
+        try:
+            low, high = env.healthy_z_range
+            for seed in range(3042, 3242):
+                env.reset(seed=seed)
+                pelvis_z = float(env.data.qpos[2])
+                assert low < pelvis_z < high, f"seed {seed} spawned at {pelvis_z:.4f} m, outside [{low}, {high}]"
+                terminated, info = env._is_terminated()
+                assert not terminated, f"seed {seed} starts terminated: {info.get('termination_reason')}"
+        finally:
+            env.close()
+
+    def test_seed_3077_is_no_longer_terminal_on_the_first_step(self):
+        """The specific seed that produced the first failure of a 40-episode panel."""
+        from environments.shared.config import load_stage_config
+
+        kwargs = load_stage_config("trex", 1)["env_kwargs"]
+        kwargs = {k: v for k, v in kwargs.items() if k not in {"foot_contact_weight", "foot_contact_gate"}}
+        env = TRexEnv(**kwargs)
+        try:
+            env.reset(seed=3077)
+            assert float(env.data.qpos[2]) > env.healthy_z_range[0]
+            _, _, terminated, _, _ = env.step(np.zeros(env.action_space.shape))
+            assert not terminated, "seed 3077 must survive one zero-action step"
+        finally:
+            env.close()

--- a/environments/trex/tests/test_trex_mjx_reward_parity.py
+++ b/environments/trex/tests/test_trex_mjx_reward_parity.py
@@ -184,3 +184,50 @@ def test_stage1_factory_enables_stance_terms_without_changing_dimensions():
     assert len(env._leg_home_pose_qpos_indices) == 8
     assert len(env._neck_posture_qpos_indices) == 3
     assert env._head_clearance_site_id is not None
+
+
+@pytest.mark.parametrize("min_support_force", [0.0, 10.0])
+def test_airborne_foot_load_balance_agrees_across_backends(min_support_force):
+    """The ``[0, 0]`` case, which neither backend covered before.
+
+    ``|R - L| / (R + L + 1e-8)`` is zero when both feet read zero, so an
+    airborne plant scored as perfectly balanced -- cheaper than honest single
+    support. Both paths must now report maximal imbalance, and must agree on
+    where the unsupported threshold sits. See docs/STAGE1_SPLIT_PLAN.md
+    section 7.1.
+    """
+    from environments.shared.reward_functions import reward_foot_load_balance
+    from environments.trex.envs.trex_env import TRexEnv
+
+    weight = 0.3
+    env = TRexEnv(foot_load_balance_weight=weight, foot_load_balance_min_support_force=min_support_force)
+    try:
+        sb3_imbalance = env._foot_load_imbalance(0.0, 0.0)
+    finally:
+        env.close()
+
+    jax_reward, jax_imbalance = reward_foot_load_balance(jnp.asarray([0.0, 0.0]), weight, min_support_force)
+    numpy_reward, numpy_imbalance = reward_foot_load_balance(np.asarray([0.0, 0.0]), weight, min_support_force)
+
+    assert sb3_imbalance == pytest.approx(1.0)
+    assert float(jax_imbalance) == pytest.approx(1.0, abs=1e-6)
+    assert float(numpy_imbalance) == pytest.approx(1.0, abs=1e-6)
+    assert float(jax_reward) == pytest.approx(-weight, abs=1e-6)
+    assert float(numpy_reward) == pytest.approx(-weight, abs=1e-6)
+
+
+def test_grazing_contact_threshold_agrees_across_backends():
+    """A token contact is denied credit identically on both paths."""
+    from environments.shared.reward_functions import reward_foot_load_balance
+    from environments.trex.envs.trex_env import TRexEnv
+
+    forces = (0.25, 0.25)
+    env = TRexEnv(foot_load_balance_weight=0.3, foot_load_balance_min_support_force=10.0)
+    try:
+        sb3_imbalance = env._foot_load_imbalance(*forces)
+    finally:
+        env.close()
+
+    _, jax_imbalance = reward_foot_load_balance(jnp.asarray(forces), 0.3, 10.0)
+    assert sb3_imbalance == pytest.approx(1.0)
+    assert float(jax_imbalance) == pytest.approx(1.0, abs=1e-6)

--- a/environments/trex/tests/test_trex_rewards.py
+++ b/environments/trex/tests/test_trex_rewards.py
@@ -323,7 +323,12 @@ class TestStageOneStanceRewardPrimitives:
             ((100.0, 100.0), 0.0),
             ((100.0, 300.0), 0.5),
             ((0.0, 100.0), 1.0),
-            ((0.0, 0.0), 0.0),
+            # Airborne is MAXIMALLY imbalanced, not perfectly balanced. This
+            # case asserted 0.0 until the arithmetic hole was closed, which
+            # made flight (0.000) cheaper than honest single support (-0.300)
+            # on the stage whose entire job is to stand still.
+            # See docs/STAGE1_SPLIT_PLAN.md section 7.1.
+            ((0.0, 0.0), 1.0),
         ],
     )
     def test_foot_load_balance_is_normalized(self, forces, expected_imbalance):

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -80,13 +80,13 @@
         "nu": 22,
         "dynamic_mass_kg": 13.5,
         "plant_contract": {
-          "bundle_sha256": "sha256:9841757f572a06864478219cae05b25107aa393511c64bb265c2053564394d83",
+          "bundle_sha256": "sha256:51911dc21d53c60b4885eecb55a6c60abb023ce83518a435b635d77fd74f9b00",
           "source_closure_sha256": "sha256:ae2ebacf577a7247484e8954fecce421b007246ead904a83ce319babb1efdec5",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 6,
+            "revision": 7,
             "observation_schema": "bipedal-target/v1",
-            "sha256": "sha256:cd69b759369f88ad43324a61069dfeb37f4fde5e1c15ba8d042c2b031f76e2eb"
+            "sha256": "sha256:8897d9705fd27a7dfd09fc6277f5918af87707fdffd653707a2117e7bcbfd53a"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",
@@ -357,13 +357,13 @@
         "nu": 21,
         "dynamic_mass_kg": 85.72,
         "plant_contract": {
-          "bundle_sha256": "sha256:a07cb824c731349e61506a4165dc8e66f3aa690fe9f7d336f9c2f9705858a94a",
+          "bundle_sha256": "sha256:0e3ef817188447729fab0fdc2c1e7a77b4ae1c9868b782908343cbc720146e25",
           "source_closure_sha256": "sha256:bd63a662293202088b354cb27de8fc52f6f0dfbf379932a60c06984d14c9cbf5",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 7,
+            "revision": 8,
             "observation_schema": "bipedal-target/v1",
-            "sha256": "sha256:5f2ef9adf326ced7600b2bf7849e1971e92db87fb07472eccb8619da07149694"
+            "sha256": "sha256:cce25e87bc9bbf67f9e56f4243c532ade26d780de9ee4531d3ae04751c673c78"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",
@@ -766,13 +766,13 @@
         "nu": 27,
         "dynamic_mass_kg": 8.65,
         "plant_contract": {
-          "bundle_sha256": "sha256:a1cd823c627c5b243eb58757c487c68410ffae491442927cd012fb55fa008495",
+          "bundle_sha256": "sha256:e1956db822d9f019b8d32931712e9a417136be750636538dd59b264ac51ab7d1",
           "source_closure_sha256": "sha256:5532fad56a1613020f09bfa197f14f0916306e664d5cf18609b757d3c5948bc3",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 3,
+            "revision": 4,
             "observation_schema": "quadrupedal-target/v1",
-            "sha256": "sha256:ebaa8846cfe572e69fb0dde92c3724d83717fd078e2f8935809f7599b77ff2d3"
+            "sha256": "sha256:3ce9b5b46e31a55db52a288c64f52dd25a2a7d3b6c1a9b61b68c3a2211a8a474"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",


### PR DESCRIPTION
The root-height jitter was the only unbounded term in the reset -- every
other one is a bounded uniform -- so reset drew normal(0, height_scale)
with nothing stopping it from placing the root outside healthy_z_range
before the policy acted.

T-Rex is the species it broke. Its 0.926 m home pelvis sits 0.226 m above
the 0.70 m floor, which at sigma 0.10 m is 2.26 sigma, predicting 1.19% of
spawns below the floor. Measured over seeds 3042-5041: 18/2000 spawned
sub-floor and 16 of those terminated on step 1 whatever the policy did.
A wider scan of 3042-7041 found 43/4000. Every one of those was already
below the floor at spawn -- none became terminal from the step itself --
so bounding the draw removes the whole failure mode rather than most of it.

The draw is now truncated to the distance to the nearer end of
healthy_z_range less a 0.02 m margin: sub-floor spawns go to 0/4000. The
bound is symmetric, so the mean spawn height is unchanged (0.9262 ->
0.9261 m over 2000 seeds) while the standard deviation tightens 0.1007 ->
0.0980. It binds at 2.07 sigma for T-Rex (3.9% of draws) against 3.6-3.8
sigma for velociraptor and dibothrosuchus (~0.02%), so those two move only
in the far tail. Clipping rather than resampling keeps the number of RNG
draws per reset fixed and the reset deterministic, at the cost of a small
point mass at each bound.

Dibothrosuchus hit this same defect first and fixed it by decoupling
reset_height_noise_scale; T-Rex was left coupled and nobody re-checked it.

Reset semantics are fingerprinted through home_reset, so the three
home-keyframe-residual species take a policy interface bump (velociraptor
6 -> 7, trex 7 -> 8, dibothrosuchus 3 -> 4). Brachiosaurus does not carry
home_reset and is unchanged.

This does not meaningfully move the zero-action baseline, and that is the
point: re-measured on seeds 3042-3081 the statue is still 23/40
full-horizon with reward standing 3244.04 +/- 23.55 and an unconditional
mean of 1971.57 -> 1976.62, because a statue fails those seeds anyway.
What the defect capped was the competent policy. Seed 3077 is the first
failure in the 39/40 panels reported in docs/STAGE1_SPLIT_PLAN.md 2.3.1,
and it is this bug rather than the policy. Existing checkpoints for the
three bumped species were trained against a different reset distribution
and must be re-baselined before any stage-1 gate is calibrated on them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GaSz93Ko1EJ9P9D8GbHAEE