### PR TITLE
Fix reset ground placement and two permanent self-collisions; re-baseline Stage 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Swift Bipedal Predator. **Specialty:** Sickle-claw contact attacks.
 | Action dimension / actuators | 22 |
 | Generalized coordinates / velocities | nq=31, nv=30 |
 | Compiled dynamic model mass | 13.5 kg |
-| Plant contract revisions | policy r7; physics r2; visual r3 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r8; physics r2; visual r3 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/velociraptor/assets/raptor.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
@@ -112,7 +112,7 @@ Apex Predator. **Specialty:** Head-contact attack task.
 | Action dimension / actuators | 21 |
 | Generalized coordinates / velocities | nq=28, nv=27 |
 | Compiled dynamic model mass | 85.7 kg |
-| Plant contract revisions | policy r8; physics r5; visual r4 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r9; physics r6; visual r4 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/trex/assets/trex.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
@@ -137,7 +137,7 @@ Gentle Giant Herbivore. **Specialty:** Head-to-food reaching.
 | Action dimension / actuators | 30 |
 | Generalized coordinates / velocities | nq=38, nv=37 |
 | Compiled dynamic model mass | 175.3 kg |
-| Plant contract revisions | policy r3; physics r1; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r4; physics r2; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/brachiosaurus/assets/brachiosaurus.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
@@ -161,7 +161,7 @@ Gracile Erect-Limbed Crocodylomorph. **Specialty:** Snout-contact snap task.
 | Action dimension / actuators | 27 |
 | Generalized coordinates / velocities | nq=35, nv=34 |
 | Compiled dynamic model mass | 8.7 kg |
-| Plant contract revisions | policy r4; physics r1; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r5; physics r1; visual r1 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/dibothrosuchus/assets/dibothrosuchus.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |

--- a/configs/plant_manifest.generated.json
+++ b/configs/plant_manifest.generated.json
@@ -6,30 +6,30 @@
   },
   "plants": {
     "brachiosaurus": {
-      "bundle_sha256": "sha256:243c8a158b88d5199cd0ea05dca518acfd99cf738d7651775eab457ffd5eed13",
+      "bundle_sha256": "sha256:507954e780e5c78d3f75208ca7d9c5dfb64b664f21f2b4397ff1e05ee38a4700",
       "env_entrypoint": "environments.brachiosaurus.envs.brachio_env:BrachioEnv",
       "model_path": "environments/brachiosaurus/assets/brachiosaurus.xml",
       "physics": {
         "nq": 38,
         "nu": 30,
         "nv": 37,
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:9d28ad3609e7ea6cff39fd37d8ab488a2e3390a66575e142f2b0feadb28ecf29"
+        "sha256": "sha256:252077668ac2714ec5af438f434d158d2d8cb8d71b6154c887f76812d4f603d8"
       },
       "policy_interface": {
         "action_dim": 30,
         "observation_dim": 83,
         "observation_schema": "quadrupedal-target/v1",
-        "revision": 3,
+        "revision": 4,
         "schema": "mesozoic.policy-interface/v1",
         "sha256": "sha256:f192ccd9f533fb757aa530b8bda89f9c129f4dc3d4ae34103464d97fdbbf55ec"
       },
       "source": {
-        "closure_sha256": "sha256:586e8c38684b4132c63872662333b37a2471b7740a6bc265def721f86fad1a5b",
+        "closure_sha256": "sha256:239a1db1d399478ca4fd9074be384114aa67f5dd8ba29773b8f2b3c6ec9bd622",
         "dependencies": [
           {
-            "content_sha256": "sha256:75e13dbd28abc3ad4f930eb74b32aa45bdcf9fd77932847359838eeafbe7806d",
+            "content_sha256": "sha256:59dc50391983a25b401c550487cce64b4b277a67d97caa2e3044621af54bcbdf",
             "kind": "mjcf",
             "logical_path": "environments/brachiosaurus/assets/brachiosaurus.xml"
           }
@@ -45,7 +45,7 @@
       }
     },
     "dibothrosuchus": {
-      "bundle_sha256": "sha256:e1956db822d9f019b8d32931712e9a417136be750636538dd59b264ac51ab7d1",
+      "bundle_sha256": "sha256:b95297d3e697744b362a2422117a897ee67a07e7ef0b260eee219fab26b7fee6",
       "env_entrypoint": "environments.dibothrosuchus.envs.dibothrosuchus_env:DibothrosuchusEnv",
       "model_path": "environments/dibothrosuchus/assets/dibothrosuchus.xml",
       "physics": {
@@ -60,9 +60,9 @@
         "action_dim": 27,
         "observation_dim": 77,
         "observation_schema": "quadrupedal-target/v1",
-        "revision": 4,
+        "revision": 5,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:3ce9b5b46e31a55db52a288c64f52dd25a2a7d3b6c1a9b61b68c3a2211a8a474"
+        "sha256": "sha256:13a35afba904f9500aabb7da17426281833a5af749b02ff6926e00148999827e"
       },
       "source": {
         "closure_sha256": "sha256:5532fad56a1613020f09bfa197f14f0916306e664d5cf18609b757d3c5948bc3",
@@ -84,30 +84,30 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:0e3ef817188447729fab0fdc2c1e7a77b4ae1c9868b782908343cbc720146e25",
+      "bundle_sha256": "sha256:1d1ddd1efeceb2a2770079e52387d2fd2f38490a8c4527630ebf597264e9a702",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
         "nq": 28,
         "nu": 21,
         "nv": 27,
-        "revision": 5,
+        "revision": 6,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:0dc4e7798bad17cfda88ef6d79007cfc7cce31a4cffb972d6e798424b874f541"
+        "sha256": "sha256:7dfa00f5b28a5f562170ba0926e6811208354cb6160b524d9ab58412a37bc2f0"
       },
       "policy_interface": {
         "action_dim": 21,
         "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 8,
+        "revision": 9,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:cce25e87bc9bbf67f9e56f4243c532ade26d780de9ee4531d3ae04751c673c78"
+        "sha256": "sha256:bacbb3243a7f84f1379e106dd886279ed247c252c143cb5e86500a50725d7020"
       },
       "source": {
-        "closure_sha256": "sha256:bd63a662293202088b354cb27de8fc52f6f0dfbf379932a60c06984d14c9cbf5",
+        "closure_sha256": "sha256:2ef85b8c9aef05050e7e407ba9cf6a7a6da62e2c14282c5143366dd0575f2571",
         "dependencies": [
           {
-            "content_sha256": "sha256:c64fb09dbe07d8dfc12525a491a4383f0a7e2ba27ef29c3f9946f90f4dbb628c",
+            "content_sha256": "sha256:1362fd47f50233ac4fc87b3e6dbaeefb609f5be76530220d541fb598c704fdd8",
             "kind": "mjcf",
             "logical_path": "environments/trex/assets/trex.xml"
           }
@@ -123,7 +123,7 @@
       }
     },
     "velociraptor": {
-      "bundle_sha256": "sha256:51911dc21d53c60b4885eecb55a6c60abb023ce83518a435b635d77fd74f9b00",
+      "bundle_sha256": "sha256:60b806b9c59172ee1ef7e6b73734f2c590f47b05910006daafe938c0a7342e9d",
       "env_entrypoint": "environments.velociraptor.envs.raptor_env:RaptorEnv",
       "model_path": "environments/velociraptor/assets/raptor.xml",
       "physics": {
@@ -138,9 +138,9 @@
         "action_dim": 22,
         "observation_dim": 67,
         "observation_schema": "bipedal-target/v1",
-        "revision": 7,
+        "revision": 8,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:8897d9705fd27a7dfd09fc6277f5918af87707fdffd653707a2117e7bcbfd53a"
+        "sha256": "sha256:1fa480739251a23fdf1b9a43f25b02b2f32c082b906dcb31f70ca59dfbb59f6f"
       },
       "source": {
         "closure_sha256": "sha256:ae2ebacf577a7247484e8954fecce421b007246ead904a83ce319babb1efdec5",

--- a/configs/plant_versions.toml
+++ b/configs/plant_versions.toml
@@ -67,9 +67,51 @@ canonical_mujoco_version = "3.10.0"
 #    are trained against a different task and the zero-action baseline must be
 #    re-measured before any stage-1 gate is calibrated against it.
 
+#
+# 6. Reset now settles the animal ON the ground, and two permanent
+#    self-collisions were excluded.
+#
+#    BaseDinoEnv.reset placed the root by height alone.  But joint jitter
+#    changes how far the lowest geom sits below the root, so no fixed root
+#    height is right for most sampled poses, and entry 5's bound did not help:
+#    healthy_z_range is a termination predicate on the ROOT and says nothing
+#    about foot-to-floor geometry -- a T-Rex pelvis at 0.739 m is "healthy"
+#    with the toes 0.198 m underground.  Measured over 40 seeds, spawns ranged
+#    from 0.198 m inside the floor to 0.18 m above it; the solver answered
+#    penetration with up to 19x body weight and launched the model 0.52 m
+#    upward to tumble ballistically for ~60 steps before landing nose-down past
+#    the nosedive threshold.  Reset now shifts the root so the lowest body geom
+#    sits at the clearance the HOME KEYFRAME was authored with -- T-Rex's
+#    plantar pad and digits at 0.491 mm of contact, and so on per species.
+#    Settling to the authored depth rather than to a constant keeps the
+#    noise-free reset bit-identical and keeps real foot-floor contact at spawn,
+#    which the species static-balance suites already require.  Because the floor
+#    is a horizontal plane a single shift settles the pose exactly, so no extra
+#    RNG draws are consumed and the reset stays deterministic in its seed.
+#
+#    Separately, two MJCF geom pairs overlapped in the home pose and injected a
+#    constant, pose-independent force into every step of every episode ever
+#    run: trex tail_1_geom against both thigh capsules (18.8 mm, 8143 N per
+#    side = 16.3 kN = 11x body weight) and brachiosaurus torso_main against
+#    tail_2_geom (66.9 mm, 25.9 kN = 12.7x body weight).  Both are now
+#    <exclude>d, matching the existing sibling-toe precedent.  T-Rex sibling
+#    toe pair d2<->d4 was excluded for consistency with d2<->d3 and d3<->d4.
+#
+#    Effect on T-Rex, zero action, 40 seeds: t=0 contact force 16990 N (11.5x
+#    body weight) -> 190 N (0.13x, i.e. resting rather than colliding); stance
+#    duty bilateral 0.983 -> 0.992, single 0.003 -> 0.008, UNSUPPORTED
+#    0.014 -> 0.000; survival 25/40 -> 28/40; mean episode length 683 -> 757.
+#
+#    PHYSICS moves for trex and brachiosaurus (MJCF contact exclusions).  The
+#    POLICY INTERFACE moves for every species, since reset placement is
+#    fingerprinted through home_reset and the settling applies to all four.
+#    Every existing checkpoint is trained against a different task: the
+#    zero-action baseline, the stage-1 operating point and any gate calibrated
+#    against them must all be re-measured.
+
 [plants.velociraptor]
 physics_revision = 2
-policy_interface_revision = 7
+policy_interface_revision = 8
 visual_revision = 3
 observation_schema = "bipedal-target/v1"
 
@@ -96,19 +138,19 @@ observation_schema = "bipedal-target/v1"
 #    commands under home-keyframe-residual/v1 -- moved with them.  Every
 #    existing T-Rex checkpoint is invalidated.
 [plants.trex]
-physics_revision = 5
-policy_interface_revision = 8
+physics_revision = 6
+policy_interface_revision = 9
 visual_revision = 4
 observation_schema = "bipedal-target/v1"
 
 [plants.brachiosaurus]
-physics_revision = 1
-policy_interface_revision = 3
+physics_revision = 2
+policy_interface_revision = 4
 visual_revision = 1
 observation_schema = "quadrupedal-target/v1"
 
 [plants.dibothrosuchus]
 physics_revision = 1
-policy_interface_revision = 4
+policy_interface_revision = 5
 visual_revision = 1
 observation_schema = "quadrupedal-target/v1"

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -48,6 +48,73 @@ tolerance) remains the standing recommendation for the divergences above.
 
 ## Training / RL
 
+<!-- The six items below come from the 2026-07-31 plant validation pass; full
+     evidence in PLANT_VALIDATION_AND_STAGE1_OBJECTIVE.md. The reset and
+     self-collision defects that pass also found are FIXED in PR #479 and so
+     are deliberately not listed here. -->
+
+- **HIGH** — **the stage-1 objective's global optimum is the zero-action
+  policy, so no reward threshold can gate it.** Summing the positive T-Rex
+  stage-1 weights gives 3.35/step = 3350; the statue collects 3250.27 = **97.0%**
+  of it with `energy` and `smoothness` at exactly zero. Every active policy pays
+  both — the 7/31 run paid 0.30/step on smoothness alone — so a policy's ceiling
+  sits *below* the statue's score. Set a threshold above the statue and stage 1
+  is unpassable; below, and a statue passes. Needs the episode-level
+  `stance_success` gate (STAGE1_SPLIT_PLAN §2.3), not a better number.
+  (PLANT_VALIDATION §9)
+
+- **HIGH** — **all four stage-1 `min_avg_reward` values are cleared by their own
+  species' statue**: trex 1840 vs 2243.12; velociraptor, brachiosaurus and
+  dibothrosuchus all 100, vs 1746 / 163 / 1834. The gates certify nothing today.
+  Cheap to fix and independent of any training run. (PLANT_VALIDATION §6)
+
+- **HIGH** — **brachiosaurus stage 1 is not a balance task.** Its zero-action
+  baseline scores **0/40** full-horizon at a mean length of 130.7
+  (`fallen` 34, `tail_contact` 6) — the statue falls every time, so there is no
+  "do not fall" floor to beat and no brachiosaurus stage-1 result is
+  interpretable. Pre-existing; verified identical before and after the PR #479
+  plant repair. Mechanism not diagnosed. (PLANT_VALIDATION §6)
+
+- **HIGH** — **`foot_load_balance_min_support_force = 0.0` makes the §7.1
+  airborne repair a no-op.** `derive_stance_info` and `reward_foot_load_balance`
+  differ only in the near-zero branch, yet produced bit-identical output over all
+  709 logged rollouts (`max |diff| = 0.000000`, correlation `1.000000`) spanning
+  30–67% unsupported duty. The sum of two touch-sensor readings is essentially
+  never exactly `0.0`, so the airborne branch never fires. The duty metrics use
+  `> 0.1 N` per foot, so a foot at 0.001 N is *unsupported* in the diagnostic and
+  *supported* in the reward. Needs a real threshold and a **monotone** ordering
+  (airborne strictly worse than single support, not equal). `derive_stance_info`
+  still scores true-airborne as perfect balance for the same reason.
+  (PLANT_VALIDATION §11.1)
+
+- **MEDIUM** — **`smoothness_weight` penalises action-delta magnitude, not
+  frequency, and cannot see a high-frequency limit cycle.** From the 7/31 run's
+  best to final checkpoint, `action_delta` *fell* 12.0 → 10.5 and the smoothness
+  penalty *improved* −0.286 → −0.250, while toe-motion power above 4 Hz
+  **doubled** 35% → 71%. The policy got smoother by the metric while getting
+  buzzier in fact. Needs a contact-switch-rate cost or smoothness on the second
+  difference of actions. (PLANT_VALIDATION §11.2)
+
+- **MEDIUM** — **`collapse_peak_floor` is an absolute reward value and cannot
+  survive a reward-function edit.** Calibrated at 2200 against the 7/29 run
+  (rolling-median peak 2496), it left the 7/31 run (peak **1934.1**) permanently
+  disarmed through a **−59%** collapse (2148.3 → 888.0; full-horizon 93% → 7%).
+  Simulation confirms it never armed; it also confirms that even armed at the old
+  inherited 1840 floor, `drop_fraction=0.5` + `patience=10` would not have fired.
+  Make the floor relative to the zero-action standing baseline and tighten the
+  drop/patience pair independently. (PLANT_VALIDATION §11.4)
+
+- **LOW** — **contact-switch rate conflates bilateral↔single with
+  bilateral↔airborne.** The PR #479 plant repair moved T-Rex's raw switch count
+  *up* (0.86 → 1.00 /s) while unsupported duty went to **zero** — the extra
+  switches are ordinary weight-shifting. Do not gate on it until decomposed;
+  gate on unsupported duty instead. (PLANT_VALIDATION §11.3)
+
+- **LOW** — **four stage-1 reward terms are saturated and contribute no
+  gradient**: `head_clearance` pinned at exactly its full 0.350 weight in every
+  measured window, `height` 0.578 of 0.6, `neck_posture` 0.173 of 0.2,
+  `leg_home_pose` 0.312 of 0.5. (PLANT_VALIDATION §14)
+
 - **MEDIUM** — **the policy saturates its action bound, and the
   `diagnostics/action_*` family mixes pre-clip and post-clip quantities.**
   Measured on T-Rex stage-1 run `20260727_130726` (PPO, 6.0M steps), from its

--- a/docs/PLANT_VALIDATION_AND_STAGE1_OBJECTIVE.md
+++ b/docs/PLANT_VALIDATION_AND_STAGE1_OBJECTIVE.md
@@ -1,0 +1,536 @@
+# Plant Validation and the Stage 1 Objective
+
+> **Date:** 2026-07-31
+> **Status:** Design — Part I/II landed in [PR #479](https://github.com/kuds/mesozoic-labs/pull/479); Parts IV–V open
+> **Baseline commit:** `ca56f6c` (measurements), `0384fca` (the run analysed)
+> **Related:** [STAGE1_SPLIT_PLAN.md](STAGE1_SPLIT_PLAN.md) §2.3.1 (operating point),
+> [investigations/TREX_REVIEW_2026_07.md](investigations/TREX_REVIEW_2026_07.md) §NS-1,
+> [investigations/FOOT_SENSOR_VERIFICATION.md](investigations/FOOT_SENSOR_VERIFICATION.md)
+
+Every claim carries a label from the ledger in §19.
+
+---
+
+## 1. Summary
+
+Three findings, in the order they have to be understood.
+
+**The plant was invalid.** Every reset of every training run to date started with the animal
+intersecting the floor — up to 0.198 m — and with geom pairs permanently overlapping inside the
+body. The contact solver responded with up to 19× body weight, ejecting the model into a
+ballistic arc that no policy could influence. This is fixed.
+
+**The objective is degenerate.** On Stage 1 as configured, doing nothing is the *global optimum*:
+the zero-action policy collects 97.0% of the theoretical maximum return while paying exactly zero
+energy and smoothness cost. No reward threshold can admit a competent policy and exclude a
+passive one, because a competent policy scores *lower*. This is not a calibration problem.
+
+**The instrumentation could not see either.** Four separate metrics were structurally incapable
+of reporting the failure they were built to catch — including two repairs that shipped as no-ops.
+
+The consequence for the Stage 1a/1b split is not that it was wrong. It is that its motivating
+evidence was measured through a broken plant, and the case for it is now both stronger and
+differently shaped.
+
+---
+
+## Part I — The plant was invalid
+
+### 2. Reset interpenetration  `[measured]`
+
+`BaseDinoEnv.reset` placed the root by height alone. Joint jitter changes how far the lowest
+geom sits below the root, so no fixed root height is correct for most sampled poses.
+
+Measured over 40 T-Rex seeds on the pre-fix plant:
+
+| quantity | value |
+|---|---|
+| deepest floor penetration | **−0.198 m** (median −0.022 m) |
+| resets exceeding 2× body weight at t=0 | **40 / 40** |
+| contact force at t=0 | median 16,990 N (**11.5× weight**), max 28,517 N (**19×**) |
+| mean penetration, resets that later failed | −0.088 m |
+| mean penetration, resets that survived | −0.034 m |
+
+The failure mechanism, traced step by step on seed 2:
+
+```
+t= 0  pelvis 0.746  feet 5777.6 / 6033.7 N   spawned inside the floor
+t= 6  pelvis 0.927  feet    0.0 /    0.0 N   ejected, airborne
+t=30  pelvis 1.255  feet    0.0 /    0.0 N   apex, +0.52 m
+t=60  pelvis 0.879  feet 1638.2 / 1334.5 N   lands
+t=66  forward_z -0.530                       nosedive termination
+```
+
+The episode opens with a catapult, ~60 ballistic steps with zero ground contact, and a
+nose-first landing past the 0.493 nosedive threshold.
+
+Spawns went the other way too: seed 0 started at pelvis 1.107 m with **no floor contact at all**
+— 0.18 m in the air, opening with a free fall. The reset distribution spanned "0.20 m buried" to
+"0.18 m airborne".
+
+**Two controller sweeps confirmed the diagnosis by failing.** A PD controller on trunk pitch
+driving ankle and hip (70 gain combinations, both signs, with and without a derivative term) and
+a static posture sweep (75 combinations on ankle/hip/knee) both failed to beat zero action at
+*every* setting. That is the signature of a failure occurring where control does not exist: for
+the first ~60 steps there is nothing to push against.
+
+### 3. Permanent self-collisions  `[measured]`
+
+Two MJCF geom pairs overlapped in the home pose, injecting a constant, **pose-independent** force
+into every step of every episode ever run:
+
+| species | pair | depth | force |
+|---|---|---|---|
+| trex | `tail_1_geom` ↔ `r_thigh_geom` / `l_thigh_geom` | 18.8 mm | 8,143 N each = **16.3 kN** (11.0× weight) |
+| brachiosaurus | `torso_main` ↔ `tail_2_geom` | 66.9 mm | **25.9 kN** (12.7× weight) |
+
+Both tail chains already excluded *adjacent* links (`torso`↔`tail_1`, `tail_1`↔`tail_2`); both
+bodies are long enough to reach two links back. The repo already carried the identical fix and
+its rationale for the sibling toe capsules — the precedent existed and was not generalised.
+
+Beyond corrupting the solver, this pollutes every contact-force reward and diagnostic in the
+system.
+
+### 4. Why the earlier repair missed it  `[measured]`
+
+STAGE1_SPLIT_PLAN §7.5 identified "~1% of episodes terminal at generation", bounded the
+root-height draw against `healthy_z_range`, and reported 43/4000 → 0/4000. That measurement was
+correct and beside the point.
+
+`healthy_z_range` is a **termination predicate on the root**. It constrains nothing about
+foot-to-floor geometry. A pelvis at 0.739 m is comfortably "healthy" while the toes are 0.198 m
+underground.
+
+The generalisable lesson: *a bound expressed in the same variable as a termination rule validates
+the termination rule, not the physics.* The right invariant was geometric — where is the lowest
+body geom relative to the ground — and it was never checked. The measurement that looked like
+validation (43/4000 → 0/4000) was real, specific, and answered a question nobody needed answered.
+
+### 5. The repair, and what is now asserted  `[measured]`
+
+`reset()` shifts the root so the lowest body geom sits at the clearance **the home keyframe was
+authored with** — 0.491 mm of contact on T-Rex, per species elsewhere. Settling to the authored
+depth rather than to a constant keeps the noise-free reset bit-identical and preserves real
+foot-floor contact at spawn, which the species static-balance suites already require. Because the
+floor is a horizontal plane, one shift settles the pose exactly: no iteration, no extra RNG draws,
+determinism preserved.
+
+An earlier draft settled to a fixed +2 mm clearance and turned four existing `test_static_balance`
+suites red, because they assert the home pose has real foot-floor contact. That is the existing
+suite doing its job, and it is why the settle target is the authored clearance.
+
+T-Rex, zero action, 40 seeds:
+
+| | before | after |
+|---|---|---|
+| t=0 contact force | 16,990 N (11.5× weight) | **190 N** (0.13×) |
+| settled clearance spread across seeds | — | **0.000 mm** |
+| bilateral duty | 0.983 | 0.992 |
+| single-support duty | 0.003 | 0.008 |
+| unsupported duty | 0.014 | **0.000** |
+| survival | 25/40 | 28/40 |
+| mean episode length | 683 | 757 |
+
+`environments/shared/tests/test_reset_plant_invariants.py` asserts 8 invariants × 4 species,
+independent of reward, stage and animal: no penetration, no hover, plausible t=0 contact force,
+no home-pose self-collision, real ground contact at spawn, no already-terminal reset, settling
+consumes no RNG, settle target does not drift.
+
+**On first run they failed on brachiosaurus**, surfacing the `torso_main` overlap, which had not
+been reported before.
+
+---
+
+## Part II — What the repaired plant measures
+
+### 6. Statue baselines, all four species  `[measured]`
+
+`zero_action_baseline.py`, seed 3042, 40 episodes, each species' configured stage-1 noise:
+
+| species | noise | reward | mean−std | standing | full-horizon | terminations |
+|---|---|---|---|---|---|---|
+| trex | 0.10 | 2243.12 ± 1375.90 | 867.21 | 3250.27 ± 24.49 | 26/40 (65%) | fallen 2, nosedive 12, trunc 26 |
+| velociraptor | 0.05 | 1745.84 ± 5.03 | 1740.81 | 1745.84 ± 5.03 | **40/40 (100%)** | trunc 40 |
+| dibothrosuchus | 0.30 | 1833.53 ± 1163.36 | 670.18 | 2595.03 ± 3.29 | 28/40 (70%) | trunc 28, excessive_tilt 10, tail_contact 2 |
+| brachiosaurus | 0.05 | 163.35 ± 81.40 | 81.95 | **never** | **0/40 (0%)** | fallen 34, tail_contact 6 |
+
+T-Rex before → after the repair: reward 1974.74 → **2243.12**, mean−std 492.94 → **867.21**,
+full-horizon 57.5% → **65%**, episode length 640.85 → **716.5**.
+
+Three things fall out.
+
+**The trained policy is now below do-nothing.** Run `20260731_132102` peaked at **1992.7** mean
+evaluation reward against the repaired statue's **2243.12** — while clearing
+`min_avg_reward = 1840` sixteen times, including an eight-evaluation streak.
+`[artifact-derived]`
+
+**Every species' stage-1 gate is cleared by its own statue**: trex 1840 vs 2243; velociraptor,
+brachiosaurus and dibothrosuchus all 100, vs 1746 / 163 / 1834.
+
+**Brachiosaurus stage 1 is not a balance task.** Its statue falls on 40 of 40 episodes at a mean
+length of 130.7. There is no "do not fall" floor to beat, so no brachiosaurus stage-1 result is
+interpretable. Verified identical before and after the repair — pre-existing, not a regression.
+
+**Velociraptor is the species to prototype gates on**: 40/40 at ± **5.03**. That variance gives a
+paired test real power at n=40; T-Rex's ± 24.49 (standing) / ± 1375.90 (overall) does not.
+
+### 7. Reset noise is the 1a/1b dial  `[measured]`
+
+`zero_action_baseline.py trex --sweep-noise`, 40 episodes each:
+
+| reset noise | reward | mean−std | standing | ep length | full-horizon |
+|---|---|---|---|---|---|
+| 0.01 | 3287.9 | 3286.3 | 3287.9 | 1000.0 | **100%** |
+| 0.05 | 3271.8 | 3259.7 | 3271.8 | 1000.0 | **100%** |
+| **0.10** ← stage-1 default | 2243.1 | 867.2 | 3250.3 | 716.5 | 65% |
+| 0.15 | 1348.2 | −96.9 | 3209.9 | 465.7 | 38% |
+| 0.20 | 845.4 | −411.7 | 3166.9 | 324.4 | 22% |
+
+The `standing` column is nearly flat (3288 → 3167) while `full-horizon` collapses 100% → 22%.
+
+**Reset noise does not make standing harder. It decides how often you get to stand at all.**
+
+Stage 1 sits exactly on the knee between 0.05 and 0.10, which is why survival and stance quality
+have been inseparable in every measurement to date, and why a single scalar gate over both has
+never been able to say anything useful.
+
+### 8. Statue stance quality at the proposed 1a point  `[measured]`
+
+`stance_quality_baseline.py 0.05 40` — the companion that measures duty rather than reward:
+
+| species | full-horizon | all-feet duty | unsupported duty | contact switches | standing reward |
+|---|---|---|---|---|---|
+| trex | 100% | 0.998 | 0.000 | 0.09 /s | 3271.8 ± 12.0 |
+| velociraptor | 100% | 1.000 | 0.000 | 0.00 /s | 1745.8 ± 5.0 |
+| dibothrosuchus | 100% | 0.997 | 0.000 | 0.14 /s | 2598.3 ± 0.9 |
+| brachiosaurus | 0% | 0.000 | 0.885 | 0.00 /s | never |
+
+---
+
+## Part III — The objective is degenerate
+
+### 9. The statue is the global optimum  `[measured]`
+
+Summing the positive T-Rex stage-1 weights:
+
+| term | weight |
+|---|---|
+| `alive_bonus` | 1.00 |
+| `height_weight` | 0.60 |
+| `bilateral_support_weight` | 0.60 |
+| `leg_home_pose_weight` | 0.50 |
+| `head_clearance_weight` | 0.35 |
+| `neck_posture_weight` | 0.20 |
+| `heading_weight` | 0.10 |
+| **theoretical maximum** | **3.35 / step = 3350** |
+
+The statue collects **3250.27 = 97.0%** of it, with `energy` and `smoothness` at exactly zero.
+
+Any active policy pays both. Run `20260731_132102` paid **0.30/step on smoothness alone** — a
+300-point handicap before anything else. A policy's realistic ceiling is therefore *below* the
+statue's score.
+
+**Consequence: no reward threshold separates a competent policy from a passive one.** Set it
+above the statue and Stage 1 is unpassable; set it below and a statue passes. This retires reward
+thresholds for 1a rather than asking for better numbers, and it is a stronger statement than
+STAGE1_SPLIT_PLAN STAGE1_SPLIT_PLAN §1.3's "the stance reward saturates against a statue."
+
+### 10. The expectation tie  `[measured]`
+
+Worse than a ceiling problem, the objective is *flat* across the two behaviours we care about
+distinguishing:
+
+| | reward per surviving episode | survival | expected return |
+|---|---|---|---|
+| zero-action statue (pre-repair) | 3243.1 | 57.5% | **1974.7** |
+| trained policy @ 4.10M | 2054.0 | 93% | **1992.7** |
+
+**0.9% apart.** "Quiet but fragile" and "buzzy but robust" are worth the same to this objective.
+There is no gradient preferring the good one, and PPO landed in the buzzy basin. As long as
+chatter can buy back its cost in survival probability, the policy will keep paying — which means
+an airborne penalty alone will not fix it. Breaking the tie is the design requirement.
+
+---
+
+## Part IV — The instrumentation could not see the failure
+
+## 11. Metrics that cannot report their own failure mode
+
+Four metrics were structurally incapable of reporting what they were built to catch. Two were
+repairs that shipped as no-ops.
+
+### 11.1 `foot_load_balance` shipped inert  `[measured]`
+
+STAGE1_SPLIT_PLAN §7.1's repair set `foot_load_balance_min_support_force = 0.0`, intending airborne to cost the
+same as single support. `derive_stance_info` and `reward_foot_load_balance` differ *only* in the
+near-zero branch, so if the airborne branch ever fired the two would diverge. Over all **709**
+logged PPO rollouts, spanning 30–67% unsupported duty:
+
+```
+max |reward_imbalance - diag_imbalance| = 0.000000
+correlation                              = 1.000000
+```
+
+Neither branch ever fires. The sum of two MuJoCo touch-sensor readings is essentially never
+exactly `0.0`, so `total > 0.0` never selects the airborne case. Meanwhile the *duty* metrics use
+`force > 0.1 N` per foot. A foot registering 0.001 N counts as **unsupported** in the diagnostic
+and **supported** in the reward.
+
+`derive_stance_info` also still carries the original defect it was meant to expose: true-airborne
+yields `imbalance = 0.0`, i.e. *perfect balance*. It simply never triggers either.
+
+### 11.2 `smoothness_weight` is blind to frequency  `[measured]`
+
+It penalises action-delta *magnitude*. From the best checkpoint to the final one:
+
+| | best (4.65M) | final (6.0M) |
+|---|---|---|
+| `action_delta` | 12.0 | **10.5** |
+| smoothness penalty | −0.286 | **−0.250** |
+| toe-motion power > 4 Hz | 35% | **71%** |
+
+The policy got *smoother by the metric* while getting buzzier in fact. A small-amplitude
+high-frequency limit cycle is nearly free under this term.
+
+### 11.3 Contact-switch rate conflates two states  `[measured]`
+
+The plant repair moved T-Rex's raw switch count **up** (0.86 → 1.00 /s) while unsupported duty
+went to **zero**. The extra switches are bilateral↔single weight-shifting, not bilateral↔airborne
+chatter. The metric cannot tell them apart and must not be gated on until decomposed.
+
+### 11.4 The collapse detector was disarmed by a reward-scale change  `[measured]`
+
+`collapse_peak_floor = 2200` was calibrated against the 7/29 run, whose rolling-median peak
+reached 2496. The reward-scale shift lowered the 7/31 run's peak to **1934.1**, below the floor.
+The detector never armed, and watched a **−59%** collapse (2148.3 → 888.0, full-horizon 93% → 7%)
+without firing.
+
+Simulated against the actual series:
+
+| config | max rolling-median peak | armed | stopped |
+|---|---|---|---|
+| `peak_floor=2200` (shipped) | 1934.1 | **never** | never |
+| `peak_floor=1840` (pre-SPLIT_PLAN §7.4) | 1934.1 | 2.9M | never |
+
+Note the second row: even armed, `drop_fraction=0.5` + `patience=10` would not have caught it.
+**An absolute reward floor cannot survive a reward-function edit** — it needs to be relative to
+the zero-action standing baseline, and the drop/patience pair needs tightening independently.
+
+### 11.5 What the diagnostics did say, and how it misled  `[measured]`
+
+Through the entire collapse, training-rollout diagnostics looked healthy or improving: per-step
+reward flat (1.670 → 1.795 → 1.741), support duty improving (bilateral 0.482 → 0.567, unsupported
+0.381 → 0.300), posture stable, and PPO textbook-healthy (`approx_kl` 0.0123 → 0.0113 against a
+0.03 target, `clip_fraction` 0.138 → 0.123, `explained_variance` 0.938 → **0.983**, policy std
+decaying smoothly 0.818 → 0.743).
+
+The collapse was **entirely episode-length driven** and visible only in deterministic evaluation.
+Healthy training rollouts plus failing deterministic eval is a real signature and none of the
+existing dashboards surface it.
+
+### 11.6 Video analysis  `[measured]`
+
+Frame-by-frame measurement of `trex_ppo_stage1_best.mp4` / `_final_side.mp4`. **The renders are
+1000 frames at 50 fps for a 1000-step episode at 100 Hz control — 2× slow motion.** Figures below
+are real-time.
+
+| | best (4.65M) | final (6.0M) |
+|---|---|---|
+| episode survived | 20.0 s (full) | 8.5 s (fell) |
+| toe lift-downs / sec | ~15 | ~14 |
+| dominant fast frequency | 4.3 Hz | **13.5 Hz** |
+| power above 4 Hz | 35% | **71%** |
+| unsupported duty | 0.351 | 0.300 |
+
+Two superimposed oscillations: **~15 toe lift-downs per second** (~7 control steps per cycle —
+a control-bandwidth limit cycle, not a gait) and a **~0.6–1.0 Hz whole-body crouch↔extend bob**,
+~30 cm peak-to-peak.
+
+Stance breakdown at the best checkpoint: **bilateral 52.1% / airborne 35.1% / single 12.8%**.
+Single support is the *rarest* state. A walk alternates bilateral↔single; this alternates
+bilateral↔airborne.
+
+The posture itself is not wrong — horizontal spine, counterbalancing tail, digitigrade stance is
+the correct modern reconstruction, and pelvis height sits on target. The defect is the
+oscillation.
+
+---
+
+## Part V — Design response
+
+### 12. What Stage 1a must be
+
+The measurements in §7 hand the split its operating point directly.
+
+**Run 1a at reset noise ≤ 0.05**, where a statue reaches 100% full-horizon and survival is not
+the binding constraint. Only then does a stance-quality gate measure stance quality rather than
+luck.
+
+**Gate on the episode-level `stance_success` event** (STAGE1_SPLIT_PLAN §2.3), not on reward.
+§9 makes this mandatory, not preferable.
+
+**Gate on unsupported duty; treat switch rate as diagnostic** until §11.3 is resolved.
+
+Proposed per-species thresholds — **for review, not adopted**:
+
+| species | noise | full-horizon | unsupported duty | contact switches | reward floor |
+|---|---|---|---|---|---|
+| trex | 0.05 | ≥ 95% | ≤ 0.02 | ≤ 1.0 /s | ≥ 2900 (0.89 × statue) |
+| velociraptor | 0.05 | ≥ 95% | ≤ 0.02 | ≤ 1.0 /s | ≥ 1550 |
+| dibothrosuchus | 0.05 | ≥ 95% | ≤ 0.02 | ≤ 1.0 /s | ≥ 2300 |
+| brachiosaurus | — | **blocked** — §6 | | | |
+
+The reward floor is a **sanity rail, not the gate**. It sits *below* the statue on purpose,
+because above it is unreachable; its only job is to reject a policy that has discarded most of
+the available return. The 0.89 multiplier is a round number chosen to clear the ~0.30/step
+smoothness cost a reasonable active policy pays. It is `[inferred]`, not measured, and should be
+revisited once anything clears 1a.
+
+Duty and switch ceilings sit well above the statue's measured 0.000 and 0.00–0.14 /s so that
+normal weight-shifting is not penalised.
+
+### 13. What Stage 1b must be
+
+1b supplies robustness through `xfrc_applied` perturbations at a declared magnitude — **not**
+through reset noise, where a lucky draw and a good controller are indistinguishable (§7).
+
+1b is also where the *discrimination* happens. A statue passes 1a by construction, and that is
+correct: 1a certifies a policy has not bought stability with actuation. A statue cannot recover
+from a shove, so 1b is where a policy must demonstrate it has learned something a statue has not.
+Its gate must be measured against **the statue under the same perturbation schedule**, which
+requires the perturbation mechanism to land first.
+
+### 14. What must change in the reward
+
+Ordered by confidence, all currently unimplemented:
+
+1. **Give `foot_load_balance_min_support_force` a real value.** As shipped it is a no-op (§11.1).
+   It must be consistent with the duty metrics' 0.1 N/foot threshold, or better, a fraction of
+   body weight (~40 N ≈ 5% for the T-Rex subtree excluding the 65.45 kg prey body). And the
+   ordering must be **monotone** — airborne strictly worse than single support, not equal to it,
+   which is a flat region with no gradient out of the air.
+2. **Add a frequency-aware cost.** Penalise contact-state switching rate directly, or put
+   smoothness on the second difference of actions. The current term cannot see a 15 Hz buzz
+   (§11.2).
+3. **Make `collapse_peak_floor` relative** to the zero-action standing baseline, and tighten
+   `drop_fraction`/`patience` independently (§11.4).
+4. **Fix `derive_stance_info`'s airborne branch** so the diagnostic can report the difference the
+   reward is trying to create (§11.1).
+5. **Unsaturate the dead terms.** `head_clearance` sits pinned at exactly its full weight (0.350)
+   in every measured window; `height` 0.578 of 0.6; `neck_posture` 0.173 of 0.2. Saturated terms
+   contribute no gradient.
+
+**These should wait for the fresh run in §18**, for the reason in §16. Two confident reward-side diagnoses in this
+investigation turned out to be wrong, both because the environment underneath was lying.
+
+---
+
+## Part VI — Method
+
+## 15. How each probe was run
+
+Each probe, with what makes it reproducible. The pattern worth keeping: **the negative results
+were the informative ones.**
+
+| probe | tool | what it establishes |
+|---|---|---|
+| statue baseline | `zero_action_baseline.py <species>` | the floor every run must clear |
+| noise sweep | `zero_action_baseline.py trex --sweep-noise` | separates survival from stance quality |
+| stance quality | `stance_quality_baseline.py <noise> <episodes>` | duty and switch rate, not reward |
+| plant invariants | `pytest environments/shared/tests/test_reset_plant_invariants.py` | reset geometry, all species |
+| controller sweeps | scratch (§2) | *negative* result localising the failure outside control |
+| video measurement | scratch — silhouette + floor-reflection tracking | frequency content the duty ratios cannot show |
+
+Three methodological notes worth carrying forward:
+
+**A same-seed control run is worth more than any absolute number.** The 7/29 run had identical
+reward weights, hyperparameters, seed, and budget — differing only in the two changes under test.
+Without it, "reward 1900" means nothing. *Check that the comparator is the same stage*: an early
+comparison in this investigation was accidentally made against a stage-3 bite run and produced a
+confidently wrong conclusion.
+
+**When every setting of a controller sweep fails, suspect the plant.** 70 PD gains and 75 static
+postures, none beating zero action, is not a tuning problem.
+
+**Live artifacts tear.** `evaluations.npz` downloaded mid-write produced a byte-stitched file
+whose reward array was silently garbage past eval 57 while its headers and other members parsed
+cleanly. Verify CRCs; do not disable them to force a read.
+
+---
+
+## Part VII — What is not known
+
+## 16. Open empirical questions
+
+Stated explicitly so it is not mistaken for settled.
+
+**How much of the chatter survives on the repaired plant.** A substantial share of the airborne
+duty may have been *learned from the broken reset* — if episodes routinely opened with a catapult
+and ~60 ballistic steps, airborne-tolerant behaviour is exactly what training rewarded. The
+behaviour may be a rational response to a broken environment rather than a reward-design flaw.
+**Unmeasured.** This is the single highest-information open question.
+
+**Why the 7/31 run underperformed the 7/29 control.** With `foot_load_balance` proven inert
+(§11.1), the only remaining delta is the reset height clip — which folded the Gaussian tails onto
+the clip boundary, redistributing exactly the penetration depth that drove failure. Plausible
+mechanism, `[inferred]`, not demonstrated. n=1 seed either way.
+
+**Whether a controller exists that is both quiet and reset-robust.** Zero action on the repaired
+plant reaches 78% survival at 0.2% airborne duty, but still fails 9/40 — residual nosedive, 12 of
+14 failures at noise 0.10. That residual is the legitimate 1a target, and no controller has yet
+been shown to close it.
+
+**Whether the proposed 1a thresholds are achievable.** They are derived from the statue, which is
+an upper bound on quality and a *lower* bound on difficulty. Nothing has yet cleared them.
+
+**Brachiosaurus's collapse mechanism.** Confirmed 0/40, confirmed pre-existing, not diagnosed.
+
+---
+
+## Part VIII — Decisions required
+
+## 17. Decisions that need a human call
+
+Not recommendations — these need a human call.
+
+1. **The four `min_avg_reward` values.** Every one is cleared by its own statue. Whatever replaces
+   them, the current values certify nothing. Cheap, independent of any run.
+2. **1a's operating noise.** §7 argues ≤ 0.05. This changes what Stage 1 *is*, so it is a design
+   decision, not a tuning one.
+3. **Whether the reward floor rail (§12) is worth having at all**, given it cannot be the gate.
+4. **Whether to fix brachiosaurus's stance before or after the T-Rex path clears.** It blocks
+   only brachiosaurus.
+
+## 18. Recommended sequence
+
+1. **Fix the four gate values** and **fix brachiosaurus's stance.** Neither needs GPU time.
+2. **Run a fresh T-Rex stage-1 pilot on the repaired plant — 3M steps, not 6M.** It answers §16's
+   headline question: does the chatter survive? The prior run reached 93% survival by 4.6M, so
+   the trend is visible well before the endgame. Judge it on **airborne duty and switch rate, not
+   reward** — a good policy will still score below the statue (§9), and that is expected, not a
+   failure.
+3. **Then** the reward changes in §14, informed by what that run shows.
+4. Perturbation mechanism, then 1b's gate against the statue-under-perturbation.
+
+## 19. Claim ledger
+
+| label | meaning |
+|---|---|
+| `measured` | reproduced directly against `ca56f6c` for this document |
+| `artifact-derived` | from run `20260731_132102` / `20260729_151044` artifacts; not re-run |
+| `inferred` | reasoning, not measurement |
+
+**`measured`:** every figure in Parts I, II and III; the `foot_load_balance` inertness proof over
+709 rollouts; the smoothness and switch-rate blindness; the collapse-detector simulation; the
+video frequency analysis; the four-species statue and stance-quality baselines; the noise sweep;
+the positive-weight sum and the 97.0% figure.
+
+**`artifact-derived`:** the 7/31 run's evaluation series and per-term diagnostics; the 7/29
+control run's series; the expectation-tie table in §10.
+
+**`inferred`:** the proposed 1a thresholds and the 0.89 reward-floor multiplier; the reset-clip
+mechanism for the 7/29→7/31 regression; the claim that airborne duty was partly learned from the
+broken reset.
+
+**Not claimed:** any statement that the repaired plant produces better *training* outcomes. No
+training run has been performed on it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,8 @@ past a couple of files get their own subdirectory with a short README index
 | [MJX_CONVERSION_PLAN.md](MJX_CONVERSION_PLAN.md) | 2026-07-13 | Implemented design record — current divergences live in KNOWN_ISSUES and the JAX guide |
 | [WEBSITE_PLAN.md](WEBSITE_PLAN.md) | — | Active — Docusaurus site improvements |
 | [BALANCE_REWARD_METRICS.md](BALANCE_REWARD_METRICS.md) | 2026-03-16 | Proposed — composite ASHA metric for stage-1 sweeps |
+| [PLANT_VALIDATION_AND_STAGE1_OBJECTIVE.md](PLANT_VALIDATION_AND_STAGE1_OBJECTIVE.md) | 2026-07-31 | Active — **read before any stage-1 work.** Why every reset was geometrically invalid, why the stage-1 objective's optimum is the zero-action policy, and what replaces the reward gate |
+| [STAGE1_SPLIT_PLAN.md](STAGE1_SPLIT_PLAN.md) | 2026-07-31 | Active (rev 5) — design proposal splitting balance into 1a stance / 1b recovery |
 | [REFACTORING.md](REFACTORING.md) | 2026-03-19 | **Complete** — v0.3.0 consolidation plan |
 | [CODE_CONSOLIDATION.md](CODE_CONSOLIDATION.md) | 2026-03-19 | **Complete** — v0.3.0 implementation record |
 

--- a/docs/STAGE1_SPLIT_PLAN.md
+++ b/docs/STAGE1_SPLIT_PLAN.md
@@ -13,7 +13,20 @@ Revision 3 incorporated two rounds of review feedback on
 identified has been fixed. §11 records what changed and why. Every claim below carries a label
 from the ledger in §11.
 
-## Status of the blocking prerequisites — all landed
+**Revision 5 (`ca56f6c`) reports the re-baseline.** It changes three things materially:
+
+* **§7.5 fixed the wrong invariant.** The real reset defect was geometric interpenetration on
+  *every* episode, not a ~1% terminal tail. With it fixed the statue baseline rose to 2243.12,
+  which puts the trained stage-1 policy's best evaluation (1992.7) **below do-nothing**.
+* **No reward threshold can gate 1a.** The statue collects 97.0% of the theoretical maximum
+  return with zero actuation cost, so it is the optimum, and a policy's ceiling is strictly
+  below it. §2.3's `stance_success` event is the only viable gate.
+* **Reset noise is the 1a/1b dial**, measured: 100% statue full-horizon at ≤ 0.05, 65% at the
+  configured 0.10, 22% at 0.20, with the *standing* score nearly flat throughout.
+
+§2.3.1 carries the measurements and per-species gate proposals for review.
+
+## Status of the blocking prerequisites — all landed, one superseded
 
 Revision 3 opened by saying these defects "must be fixed before any gate in this document can
 mean anything," and §10 called them "not optional preliminaries — they are the work." They
@@ -21,7 +34,9 @@ landed in [PR #478](https://github.com/kuds/mesozoic-labs/pull/478):
 
 | § | defect | status on `34a7002` |
 |---|---|---|
-| 7.5 | ~1% of episodes terminal at generation | **fixed** — 0/4000, `71a91b7` |
+| 7.5 | ~1% of episodes terminal at generation | **superseded** — right fix, wrong invariant; see §2.3.1 and `ca56f6c` |
+| — | every reset interpenetrates the floor (≤ 0.198 m, ≤ 19× body weight) | **fixed** — `ca56f6c` |
+| — | two permanent home-pose self-collisions (16.3 kN trex, 25.9 kN brachiosaurus) | **fixed** — `ca56f6c` |
 | 5.2 | gate plumbing fails open on both backends | **fixed** — both reject, `17ca4e5` |
 | 7.4 | `collapse_peak_floor` inherits `min_avg_reward` | **fixed** — decoupled, `17ca4e5` |
 | 7.1 | `[0, 0]` scores airborne as perfectly balanced | **fixed** — reports 1.0, `c667938` |
@@ -167,7 +182,46 @@ while per-panel reward means ranged **1884.71 to 2157.53**. The physical result 
 the reward scalar attached to it is not stable enough to gate on. This is the empirical case for
 making stance a *state-capability* gate rather than a reward gate.
 
-### 1.5 The observed policy appears to hop rather than stand  `[measured diagnostics, inferred behaviour]`
+### 1.5 The observed policy hops rather than stands — confirmed on video  `[measured]`
+
+> **UPGRADED from inferred to measured.** Frame-by-frame analysis of
+> `trex_ppo_stage1_best.mp4` / `_final_side.mp4` from run `20260731_132102` confirms the
+> behaviour this section inferred from duty ratios, and resolves it into **two** superimposed
+> oscillations. Note the renders are 1000 frames at 50 fps for a 1000-step episode at a 100 Hz
+> control rate, i.e. **2× slow motion** — frequencies below are real-time.
+>
+> | | best (4.65M) | final (6.0M) |
+> |---|---|---|
+> | episode survived | 20.0 s (full) | 8.5 s (fell) |
+> | toe lift-downs / sec | ~15 | ~14 |
+> | dominant fast frequency | 4.3 Hz | **13.5 Hz** |
+> | toe-motion power > 2 Hz (real-time > 4 Hz) | 35% | **71%** |
+> | unsupported duty | 0.351 | 0.300 |
+>
+> 1. **Fast toe chatter, ~15 lift-downs per second** — at 100 Hz control that is ~7 control
+>    steps per cycle, i.e. a control-bandwidth limit cycle, not a gait.
+> 2. **A slow whole-body crouch↔extend bob at ~0.6–1.0 Hz**, ~30 cm peak-to-peak in the
+>    silhouette centroid.
+>
+> Stance breakdown at the best checkpoint: **bilateral 52% / airborne 35% / single 13%**. Single
+> support is the *rarest* state. A walk alternates bilateral↔single; this alternates
+> bilateral↔airborne.
+>
+> The collapse between the two checkpoints is the same chatter with the slow postural control
+> stripped out: identical lift-down rate, double the high-frequency share.
+>
+> **`smoothness_weight` cannot see this.** It penalises action-delta *magnitude*, not frequency.
+> From best to final, `action_delta` **fell** 12.0 → 10.5 and the smoothness penalty *improved*
+> (−0.286 → −0.250) while high-frequency power doubled. The policy got smoother by the metric
+> while getting buzzier in fact. Any fix needs a frequency-aware or contact-switch-rate cost —
+> see §7.1's successor.
+>
+> Caveat carried forward: a large share of the airborne duty was **learned from the broken
+> reset** (§2.3.1) — if episodes routinely opened with a catapult and ~60 ballistic steps,
+> airborne-tolerant behaviour is what training rewarded. How much of the chatter survives on the
+> repaired plant is unmeasured, and needs a fresh run.
+
+Original inference, retained:
 
 Final stage-1 diagnostics from run `20260729_151044` (6,004,736 steps):
 
@@ -299,6 +353,155 @@ Provisional T-Rex values, to be calibrated rather than adopted: `T_settle` 200 s
 
 #### 2.3.1 The statistical operating point must be declared  `[measured]`
 
+> **RE-BASELINED on `ca56f6c`.** Step 6 of §10 is done for the baseline half. Everything from
+> here to the end of this subsection is measured on the repaired plant; the pre-`ca56f6c`
+> numbers that used to head this section are retained below only as the *before* column.
+
+##### The reset defect was misdiagnosed, and §7.5 fixed the wrong invariant  `[measured]`
+
+§7.5 bounded the root-height draw against `healthy_z_range` and reported 43/4000 → 0/4000
+already-terminal spawns. That measurement was correct and it was beside the point.
+`healthy_z_range` is a **termination predicate on the root**; it says nothing about
+foot-to-floor geometry. A T-Rex pelvis at 0.739 m is "healthy" while the toes are 0.198 m
+underground.
+
+Measured over 40 seeds on the pre-fix plant, spawns ranged from **0.198 m inside the floor** to
+**0.18 m above it**, and the solver answered penetration with up to **19× body weight**:
+
+```
+seed 2:  t= 0  pelvis 0.746  feet 5777.6 / 6033.7 N   <- spawned inside the floor
+         t=30  pelvis 1.255  feet    0.0 /    0.0 N   <- ejected 0.52 m, ballistic
+         t=60  pelvis 0.879  forward_z -0.440         <- lands nose-first
+         t=66         forward_z -0.530                <- nosedive termination
+```
+
+Penetration depth predicted failure: failed resets averaged −0.088 m, survivors −0.034 m.
+Two independent controller sweeps confirmed the diagnosis by failing — no PD gain on trunk
+pitch (70 combinations, both signs) and no static posture offset (75 combinations) beat zero
+action, because for the first ~60 steps there is no ground contact to act against.
+
+Separately, two MJCF geom pairs overlapped in the home pose and injected a constant,
+**pose-independent** force into every step of every episode in every run to date:
+`trex tail_1_geom` against both thighs (18.8 mm, 16.3 kN = 11.0× weight) and
+`brachiosaurus torso_main` against `tail_2_geom` (66.9 mm, 25.9 kN = 12.7× weight).
+
+Both are fixed in `ca56f6c`; `environments/shared/tests/test_reset_plant_invariants.py` asserts
+the invariants for all four species. T-Rex t=0 contact force went 16990 N → 190 N.
+
+##### Re-measured statue baseline  `[measured]`
+
+Same protocol as before — `zero_action_baseline.py`, seed 3042, 40 episodes, noise 0.10:
+
+| | before (broken plant) | after (`ca56f6c`) |
+|---|---|---|
+| reward mean | 1974.74 | **2243.12** |
+| reward mean − std | 492.94 | **867.21** |
+| reward standing | 3243.10 ± 23.65 | 3250.27 ± 24.49 |
+| episodes reaching horizon | 23/40 (57.5%) | **26/40 (65%)** |
+| episode length | 640.85 | **716.5** |
+| terminations | fallen 3, nosedive 14, trunc 23 | fallen 2, nosedive 12, trunc 26 |
+
+**The trained stage-1 policy is now worse than doing nothing.** Run `20260731_132102` peaked at
+**1992.7** mean eval reward; the repaired statue scores **2243.12**. That run cleared
+`min_avg_reward = 1840` sixteen times, including an eight-evaluation streak, while sitting 250
+points below the do-nothing floor. `[artifact-derived]`
+
+Nosedive remains 12 of 14 failures, so the catapult was not the only source — a residual pitch
+instability in the home pose survives at noise 0.10. That is a real Stage 1a target; it was
+previously masked.
+
+##### The operating point: reset noise is the 1a/1b dial  `[measured]`
+
+`zero_action_baseline.py trex --sweep-noise`, 40 episodes each:
+
+| reset noise | reward | mean−std | standing | ep length | full-horizon |
+|---|---|---|---|---|---|
+| 0.01 | 3287.9 | 3286.3 | 3287.9 | 1000.0 | **100%** |
+| 0.05 | 3271.8 | 3259.7 | 3271.8 | 1000.0 | **100%** |
+| **0.10** ← stage-1 default | 2243.1 | 867.2 | 3250.3 | 716.5 | 65% |
+| 0.15 | 1348.2 | −96.9 | 3209.9 | 465.7 | 38% |
+| 0.20 | 845.4 | −411.7 | 3166.9 | 324.4 | 22% |
+
+`standing` is nearly flat across the whole sweep (3288 → 3167) while `full-horizon` collapses
+100% → 22%. Reset noise does not make standing *harder*; it decides how often you get to stand
+at all. Stage 1 currently sits exactly on the knee, which is why survival and stance quality
+have been inseparable in every measurement to date.
+
+This is the split, quantified. **1a belongs at noise ≤ 0.05**, where a statue is at 100%
+full-horizon and survival is not the binding constraint, so the gate can be about stance
+quality. **1b supplies robustness through `xfrc_applied` perturbations** (§3.2) at a declared
+magnitude, rather than through reset noise where a lucky draw and a good controller are
+indistinguishable.
+
+##### No reward threshold can separate a statue from a policy  `[measured]`
+
+§1.3 asserted the stance reward "saturates against a statue". It is stronger than that: on
+stage 1 as configured, **the statue is the global optimum**.
+
+Summing the positive T-Rex stage-1 weights — `alive_bonus` 1.00, `height` 0.60,
+`bilateral_support` 0.60, `leg_home_pose` 0.50, `head_clearance` 0.35, `neck_posture` 0.20,
+`heading` 0.10 — gives a theoretical maximum of **3.35/step = 3350** over the horizon. The
+statue collects **3250.27 = 97.0%** of it, with `energy` and `smoothness` at exactly zero. Any
+active policy pays both; run `20260731_132102` paid 0.30/step on smoothness alone, which alone
+is a 300-point handicap.
+
+So a policy's realistic ceiling is *below* the statue's score, and there is no threshold that
+admits a competent policy and excludes a passive one. This is not a calibration problem to be
+solved with a better number — it retires reward thresholds for 1a entirely, and it is why §2.3
+gates on the episode-level `stance_success` event instead.
+
+##### Proposed per-species 1a operating point — FOR REVIEW, not adopted  `[measured baseline, inferred thresholds]`
+
+Statue stance quality at the proposed 1a noise of 0.05, 40 episodes from seed 3042:
+
+| species | full-horizon | all-feet duty | unsupported duty | contact switches | standing reward |
+|---|---|---|---|---|---|
+| trex | 100% | 0.998 | 0.000 | 0.09 /s | 3271.8 ± 12.0 |
+| velociraptor | 100% | 1.000 | 0.000 | 0.00 /s | 1745.8 ± 5.0 |
+| dibothrosuchus | 100% | 0.997 | 0.000 | 0.14 /s | 2598.3 ± 0.9 |
+| brachiosaurus | **0%** | 0.000 | 0.885 | 0.00 /s | never reaches horizon |
+
+These are the numbers a 1a policy must **match**, not beat — the statue defines the quality
+ceiling, and 1a's job is to certify a policy has not bought stability with actuation. Proposed
+per-species thresholds:
+
+| species | noise | full-horizon | unsupported duty | contact switches | reward floor |
+|---|---|---|---|---|---|
+| trex | 0.05 | ≥ 95% | ≤ 0.02 | ≤ 1.0 /s | ≥ 2900 (0.89 × statue) |
+| velociraptor | 0.05 | ≥ 95% | ≤ 0.02 | ≤ 1.0 /s | ≥ 1550 (0.89 × statue) |
+| dibothrosuchus | 0.05 | ≥ 95% | ≤ 0.02 | ≤ 1.0 /s | ≥ 2300 (0.89 × statue) |
+| brachiosaurus | — | **blocked** — see below | | | |
+
+Three notes on these, all of which need a decision rather than adoption:
+
+* The reward floor is a **sanity rail, not the gate**. It is set *below* the statue on purpose,
+  because above it is unreachable; its only job is to reject a policy that has thrown away most
+  of the available return. The `stance_success` event of §2.3 remains the actual gate. The
+  0.89 multiplier is a round number chosen to sit clear of the ~0.30/step smoothness cost a
+  reasonable active policy pays; it is **not** measured and should be revisited once any policy
+  clears 1a.
+* The unsupported-duty and switch-rate ceilings are set well above the statue's measured 0.000
+  and 0.00–0.14 /s so that normal weight-shifting is not penalised. Note the switch metric
+  conflates bilateral↔single with bilateral↔airborne; the repaired plant moved T-Rex's raw
+  switch count *up* (0.86 → 1.00 /s) while unsupported duty went to zero, because the extra
+  switches are weight-shifting. **Gate on unsupported duty; treat switch rate as diagnostic**
+  until it is decomposed.
+* Every current stage-1 `min_avg_reward` is cleared by a statue: trex 1840 vs 2243, and 100 vs
+  1746 / 163 / 1834 for the other three. Whatever is decided for 1a, those four values are
+  wrong today.
+
+**Brachiosaurus stage 1 is not currently a balance task.** The statue scores 0/40 full-horizon,
+mean length 130.7, terminations `fallen 34, tail_contact 6` — it falls every single time. There
+is no "do not fall" floor to beat, so no brachiosaurus stage-1 result is interpretable. Verified
+identical before and after `ca56f6c`, so this is pre-existing and not a regression. It needs its
+own stance fix before any gate is set for it, and it is a new blocking item — see §10 step 7.
+
+**Velociraptor is the best species to prototype the 1a gate on**: 40/40 at 1745.84 ± **5.03**.
+That variance is small enough that a paired test against the statue has real power at n=40,
+which is not true for T-Rex (± 24.49 on standing, ± 1375.90 overall).
+
+##### Power table — arithmetic, unchanged
+
 Interval method: **exact one-sided 95% Clopper-Pearson**. With that fixed, `LCB95 ≥ 0.90`
 implies these cutoffs and these chances of a *good* policy passing:
 
@@ -327,6 +530,14 @@ theoretical concern" on the grounds that the current checkpoint scored 39/40, 39
 > With it removed the checkpoint may well be 40/40 on all four, in which case `LCB95 ≥ 0.90` at
 > n=40 is *not* the impractical rule this section makes it out to be, and the case for n=179
 > weakens considerably.
+>
+> **AMENDED on `ca56f6c`.** The above reasoning was right in shape and wrong in magnitude. Seed
+> 3077 was not one instance of a ~1% tail; it was one instance of a defect affecting **every
+> reset**, which the height bound did not address because it checked the root against a
+> termination range rather than against floor geometry. See the re-baseline at the top of this
+> subsection. The panels still need re-measuring and the conclusion about n is still open, but
+> the premise is now "the plant was wrong for every episode", not "1% of episodes were
+> unwinnable".
 >
 > **The power table above is arithmetic and stands.** What is stale is the empirical premise
 > that a good policy fails the cutoff. Nothing here should be read as settled until the panels
@@ -850,7 +1061,15 @@ disabled" does not make an inherited threshold inert.
 > again after the resolver was extracted in `e3958f9`. `collapse_smoothing_window` was readable
 > but undeclared and is now part of the gate schema.
 
-### 7.5 Reset-validity preflight — LANDED  `[measured]`
+### 7.5 Reset-validity preflight — LANDED, then SUPERSEDED by `ca56f6c`  `[measured]`
+
+> **This section fixed the wrong invariant.** The height bound below is real and still in place,
+> but `healthy_z_range` is a termination predicate on the *root* and constrains nothing about
+> foot-to-floor geometry. The actual defect was geometric interpenetration on **every** reset
+> (up to 0.198 m, answered by up to 19× body weight), plus two permanent home-pose
+> self-collisions. Both are fixed in `ca56f6c` and asserted by
+> `environments/shared/tests/test_reset_plant_invariants.py`. Read §2.3.1 for the measurement;
+> the "~1%" framing below understates the problem by two orders of magnitude.
 
 **About 1% of episodes are unwinnable at generation.** Reset randomisation
 (`reset_noise_scale = 0.10`) can place the pelvis below the height termination floor, so the
@@ -963,14 +1182,21 @@ they required no part of the split — which is why they went first and shipped 
 **Remaining, in order.** Step 6 is new in revision 4 and comes first because everything
 downstream calibrates against it.
 
-6. **Re-baseline.** Re-measure the four 40-seed panels on the repaired reset (§8.7) and
-   re-derive the §2.3.1 operating point from the result rather than from the pre-fix panels.
-   Three species' checkpoints are interface-invalid and were trained on the old reset
-   distribution, so this needs a fresh stage-1 run, not just an evaluation. Nothing below should
-   be calibrated until it lands.
+6. **Re-baseline** — **baseline half done, `ca56f6c`.** The plant defects that made the old
+   panels meaningless are fixed (geometric reset settling, two home-pose self-collisions), and
+   the statue baselines and noise sweep are re-measured for all four species in §2.3.1. What
+   remains is the *policy* half: every checkpoint is now interface-invalid and was trained on a
+   different task, so the four 40-seed panels (§8.7) need a fresh stage-1 run, not an
+   evaluation. Nothing below should be calibrated until that lands.
+6a. **Re-derive the four stage-1 `min_avg_reward` values.** Every one is currently cleared by a
+   statue — trex 1840 vs 2243, and 100 vs 1746 / 163 / 1834. §2.3.1 carries proposals for
+   review. Cheap, and independent of the fresh run.
+6b. **Fix brachiosaurus's stance collapse.** Its statue scores 0/40 full-horizon (mean length
+   130.7, `fallen` 34), so brachiosaurus stage 1 is not a balance task and no result for it is
+   interpretable. Pre-existing, not a regression. Blocks any brachiosaurus gate.
 7. **Repair the velociraptor and brachiosaurus foot sensors** (§7.2) — per-species MJCF changes.
    Not on the T-Rex critical path, but they gate enabling either stage for those species, and
-   both invalidate that species' checkpoints, so they are cheapest done alongside step 6.
+   both invalidate that species' checkpoints, so they are cheapest done alongside step 6b.
 8. §3.2 task fingerprint and load modes; §4 executable stage manifest with backward readers.
 9. §2.3 episode-level gate metrics, implemented and parity-tested.
 10. **Gate resolver (§5)** — before, or atomically with, any executable stage that depends on it.

--- a/environments/brachiosaurus/assets/brachiosaurus.xml
+++ b/environments/brachiosaurus/assets/brachiosaurus.xml
@@ -381,8 +381,12 @@
     <exclude body1="neck_3" body2="neck_4"/>
     <exclude body1="neck_4" body2="head"/>
 
-    <!-- Tail chain -->
+    <!-- Tail chain.  The chain excludes adjacent links, but torso_main is long
+         enough to reach two links back: it overlapped tail_2_geom by 66.9 mm in
+         the home pose, injecting 25.9 kN — 12.7x body weight — of constant
+         self-contact into every reset.  Same defect as tail_1<->thigh on T-Rex. -->
     <exclude body1="torso" body2="tail_1"/>
+    <exclude body1="torso" body2="tail_2"/>
     <exclude body1="tail_1" body2="tail_2"/>
     <exclude body1="tail_2" body2="tail_3"/>
     <exclude body1="tail_3" body2="tail_4"/>

--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -62,6 +62,13 @@ _GROUND_PROBE_DISTANCE = 10.0
 class BaseDinoEnv(gym.Env, ABC):
     """Abstract base class for dinosaur locomotion environments."""
 
+    # Ground-settling caches, all derived from the model and so fixed for the
+    # lifetime of the instance.  Declared here rather than assigned via getattr
+    # so their types are visible; see _settle_root_on_ground.
+    _root_subtree_geom_ids: "np.ndarray | None" = None
+    _static_floor_geom_ids: "np.ndarray | None" = None
+    _home_ground_clearance_m: float | None = None
+
     metadata = {
         "render_modes": ["human", "rgb_array"],
         "render_fps": 50,
@@ -879,9 +886,8 @@ class BaseDinoEnv(gym.Env, ABC):
         else does: prey, food and other spawned props hang off the world or
         their own joints, so they must not take part in ground settling.
         """
-        cached = getattr(self, "_root_subtree_geom_ids", None)
-        if cached is not None:
-            return cached
+        if self._root_subtree_geom_ids is not None:
+            return self._root_subtree_geom_ids
         free = [j for j in range(self.model.njnt) if self.model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE]
         if not free:
             ids = np.empty(0, dtype=np.int32)
@@ -900,9 +906,8 @@ class BaseDinoEnv(gym.Env, ABC):
 
     def _static_floor_geoms(self) -> "np.ndarray":
         """Geom IDs of the static ground the animal is expected to stand on."""
-        cached = getattr(self, "_static_floor_geom_ids", None)
-        if cached is not None:
-            return cached
+        if self._static_floor_geom_ids is not None:
+            return self._static_floor_geom_ids
         ids = np.array(
             [
                 g
@@ -942,9 +947,8 @@ class BaseDinoEnv(gym.Env, ABC):
         species' authored contact, and still removes the pose-dependent error
         that joint jitter introduces.
         """
-        cached = getattr(self, "_home_ground_clearance_m", None)
-        if cached is not None:
-            return cached
+        if self._home_ground_clearance_m is not None:
+            return self._home_ground_clearance_m
         scratch = mujoco.MjData(self.model)
         if self.model.nkey > 0:
             keyframe = int(getattr(self, "_reset_keyframe_id", 0))

--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -47,6 +47,17 @@ from .reward_functions import reward_speed_penalty as _reward_speed_penalty_pure
 # See BaseDinoEnv._bounded_reset_height_delta.
 _RESET_HEIGHT_TERMINATION_MARGIN = 0.02
 
+# Fallback settle target in METRES, used only when a species has no keyframe to
+# read an authored contact depth from.  Reset normally settles to the home
+# keyframe's OWN clearance so the noise-free reset stays bit-identical and each
+# species keeps the resting contact depth its MJCF was authored with.
+_RESET_GROUND_CLEARANCE = 0.0
+
+# Upper bound in METRES on the body-to-floor distance probe.  Only the sign and
+# small magnitudes matter for settling, so this just has to exceed any plausible
+# spawn offset; mj_geomDistance saturates beyond it.
+_GROUND_PROBE_DISTANCE = 10.0
+
 
 class BaseDinoEnv(gym.Env, ABC):
     """Abstract base class for dinosaur locomotion environments."""
@@ -861,6 +872,131 @@ class BaseDinoEnv(gym.Env, ABC):
         bound = max(headroom, 0.0)
         return float(np.clip(delta, -bound, bound))
 
+    def _root_subtree_geoms(self) -> "np.ndarray":
+        """Geom IDs belonging to the animal, i.e. the free-joint root's subtree.
+
+        Everything the reset translates vertically moves together, and nothing
+        else does: prey, food and other spawned props hang off the world or
+        their own joints, so they must not take part in ground settling.
+        """
+        cached = getattr(self, "_root_subtree_geom_ids", None)
+        if cached is not None:
+            return cached
+        free = [j for j in range(self.model.njnt) if self.model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE]
+        if not free:
+            ids = np.empty(0, dtype=np.int32)
+        else:
+            root = int(self.model.jnt_bodyid[free[0]])
+            bodies = {root}
+            for b in range(root + 1, self.model.nbody):
+                if int(self.model.body_parentid[b]) in bodies:
+                    bodies.add(b)
+            ids = np.array(
+                [g for g in range(self.model.ngeom) if int(self.model.geom_bodyid[g]) in bodies],
+                dtype=np.int32,
+            )
+        self._root_subtree_geom_ids = ids
+        return ids
+
+    def _static_floor_geoms(self) -> "np.ndarray":
+        """Geom IDs of the static ground the animal is expected to stand on."""
+        cached = getattr(self, "_static_floor_geom_ids", None)
+        if cached is not None:
+            return cached
+        ids = np.array(
+            [
+                g
+                for g in range(self.model.ngeom)
+                if int(self.model.geom_bodyid[g]) == 0
+                and self.model.geom_type[g] in (mujoco.mjtGeom.mjGEOM_PLANE, mujoco.mjtGeom.mjGEOM_HFIELD)
+            ],
+            dtype=np.int32,
+        )
+        self._static_floor_geom_ids = ids
+        return ids
+
+    def lowest_ground_clearance(self, data: "mujoco.MjData | None" = None) -> float:
+        """Signed distance from the animal's lowest geom to the ground, in METRES.
+
+        Negative means the pose is interpenetrating the floor.  Requires the
+        caller to have run ``mj_forward`` (or ``mj_kinematics``) first.
+        """
+        data = self.data if data is None else data
+        body_geoms, floor_geoms = self._root_subtree_geoms(), self._static_floor_geoms()
+        if not len(body_geoms) or not len(floor_geoms):
+            return float("inf")
+        worst = float("inf")
+        for g in body_geoms:
+            for f in floor_geoms:
+                d = mujoco.mj_geomDistance(self.model, self.data, int(g), int(f), _GROUND_PROBE_DISTANCE, None)
+                worst = min(worst, float(d))
+        return worst
+
+    def home_ground_clearance(self) -> float:
+        """The ground clearance the unperturbed home keyframe was authored with.
+
+        Species author a deliberate resting contact depth into the keyframe --
+        T-Rex's plantar pad and digits sit 0.5 mm into the floor, for instance.
+        Settling every reset back to *this* value rather than to an arbitrary
+        constant keeps the noise-free reset bit-identical, preserves each
+        species' authored contact, and still removes the pose-dependent error
+        that joint jitter introduces.
+        """
+        cached = getattr(self, "_home_ground_clearance_m", None)
+        if cached is not None:
+            return cached
+        scratch = mujoco.MjData(self.model)
+        if self.model.nkey > 0:
+            keyframe = int(getattr(self, "_reset_keyframe_id", 0))
+            if not 0 <= keyframe < self.model.nkey:
+                keyframe = 0
+            mujoco.mj_resetDataKeyframe(self.model, scratch, keyframe)
+        else:
+            mujoco.mj_resetData(self.model, scratch)
+        mujoco.mj_forward(self.model, scratch)
+        saved, self.data = self.data, scratch
+        try:
+            value = self.lowest_ground_clearance()
+        finally:
+            self.data = saved
+        if not np.isfinite(value):
+            value = _RESET_GROUND_CLEARANCE
+        self._home_ground_clearance_m = float(value)
+        return self._home_ground_clearance_m
+
+    def _settle_root_on_ground(self, clearance: float | None = None) -> float:
+        """Translate the root vertically so the animal starts *on* the ground.
+
+        The reset perturbs joint angles and root height independently, but the
+        two are not independent in the world: bending the legs changes how far
+        the feet sit below the root, so any fixed root height is wrong for most
+        sampled poses.  Left uncorrected on T-Rex this spawned the model up to
+        0.198 m inside the floor, and the contact solver answered with ~19x body
+        weight, launching it 0.5 m into the air to tumble ballistically for ~60
+        steps before landing nose-down — an "episode" whose outcome no policy
+        could influence.  The same jitter spawned other seeds 0.18 m *above* the
+        floor, opening the episode with a free fall instead.
+
+        Because the ground is a horizontal plane, translating the root changes
+        every body-to-floor distance by exactly the same amount, so a single
+        shift settles the pose exactly — no iteration, no extra RNG draws, and
+        the reset stays deterministic in the seed.
+
+        The settle target is the home keyframe's own clearance, so a noise-free
+        reset is a no-op and each species keeps its authored resting contact.
+
+        Returns the applied shift in metres (positive = raised).
+        """
+        target = self.home_ground_clearance() if clearance is None else clearance
+        mujoco.mj_forward(self.model, self.data)
+        worst = self.lowest_ground_clearance()
+        if not np.isfinite(worst):
+            return 0.0
+        shift = target - worst
+        self.data.qpos[2] += shift
+        mujoco.mj_forward(self.model, self.data)
+        return float(shift)
+
     def reset(
         self,
         seed: int | None = None,
@@ -900,6 +1036,14 @@ class BaseDinoEnv(gym.Env, ABC):
 
         # Randomize target position (species-specific)
         self._spawn_target()
+
+        # Place the animal ON the ground.  This has to come after BOTH the joint
+        # jitter and the height jitter, since either one changes how far the
+        # lowest geom sits below the root.  _bounded_reset_height_delta above
+        # keeps the spawn inside healthy_z_range, but that is a termination
+        # predicate on the ROOT and says nothing about foot-to-floor geometry —
+        # a pelvis at 0.739 m is "healthy" with the toes 0.198 m underground.
+        self._settle_root_on_ground()
 
         # Forward pass to update derived quantities
         mujoco.mj_forward(self.model, self.data)

--- a/environments/shared/data/plant_manifest.generated.json
+++ b/environments/shared/data/plant_manifest.generated.json
@@ -6,30 +6,30 @@
   },
   "plants": {
     "brachiosaurus": {
-      "bundle_sha256": "sha256:243c8a158b88d5199cd0ea05dca518acfd99cf738d7651775eab457ffd5eed13",
+      "bundle_sha256": "sha256:507954e780e5c78d3f75208ca7d9c5dfb64b664f21f2b4397ff1e05ee38a4700",
       "env_entrypoint": "environments.brachiosaurus.envs.brachio_env:BrachioEnv",
       "model_path": "environments/brachiosaurus/assets/brachiosaurus.xml",
       "physics": {
         "nq": 38,
         "nu": 30,
         "nv": 37,
-        "revision": 1,
+        "revision": 2,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:9d28ad3609e7ea6cff39fd37d8ab488a2e3390a66575e142f2b0feadb28ecf29"
+        "sha256": "sha256:252077668ac2714ec5af438f434d158d2d8cb8d71b6154c887f76812d4f603d8"
       },
       "policy_interface": {
         "action_dim": 30,
         "observation_dim": 83,
         "observation_schema": "quadrupedal-target/v1",
-        "revision": 3,
+        "revision": 4,
         "schema": "mesozoic.policy-interface/v1",
         "sha256": "sha256:f192ccd9f533fb757aa530b8bda89f9c129f4dc3d4ae34103464d97fdbbf55ec"
       },
       "source": {
-        "closure_sha256": "sha256:586e8c38684b4132c63872662333b37a2471b7740a6bc265def721f86fad1a5b",
+        "closure_sha256": "sha256:239a1db1d399478ca4fd9074be384114aa67f5dd8ba29773b8f2b3c6ec9bd622",
         "dependencies": [
           {
-            "content_sha256": "sha256:75e13dbd28abc3ad4f930eb74b32aa45bdcf9fd77932847359838eeafbe7806d",
+            "content_sha256": "sha256:59dc50391983a25b401c550487cce64b4b277a67d97caa2e3044621af54bcbdf",
             "kind": "mjcf",
             "logical_path": "environments/brachiosaurus/assets/brachiosaurus.xml"
           }
@@ -45,7 +45,7 @@
       }
     },
     "dibothrosuchus": {
-      "bundle_sha256": "sha256:e1956db822d9f019b8d32931712e9a417136be750636538dd59b264ac51ab7d1",
+      "bundle_sha256": "sha256:b95297d3e697744b362a2422117a897ee67a07e7ef0b260eee219fab26b7fee6",
       "env_entrypoint": "environments.dibothrosuchus.envs.dibothrosuchus_env:DibothrosuchusEnv",
       "model_path": "environments/dibothrosuchus/assets/dibothrosuchus.xml",
       "physics": {
@@ -60,9 +60,9 @@
         "action_dim": 27,
         "observation_dim": 77,
         "observation_schema": "quadrupedal-target/v1",
-        "revision": 4,
+        "revision": 5,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:3ce9b5b46e31a55db52a288c64f52dd25a2a7d3b6c1a9b61b68c3a2211a8a474"
+        "sha256": "sha256:13a35afba904f9500aabb7da17426281833a5af749b02ff6926e00148999827e"
       },
       "source": {
         "closure_sha256": "sha256:5532fad56a1613020f09bfa197f14f0916306e664d5cf18609b757d3c5948bc3",
@@ -84,30 +84,30 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:0e3ef817188447729fab0fdc2c1e7a77b4ae1c9868b782908343cbc720146e25",
+      "bundle_sha256": "sha256:1d1ddd1efeceb2a2770079e52387d2fd2f38490a8c4527630ebf597264e9a702",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
         "nq": 28,
         "nu": 21,
         "nv": 27,
-        "revision": 5,
+        "revision": 6,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:0dc4e7798bad17cfda88ef6d79007cfc7cce31a4cffb972d6e798424b874f541"
+        "sha256": "sha256:7dfa00f5b28a5f562170ba0926e6811208354cb6160b524d9ab58412a37bc2f0"
       },
       "policy_interface": {
         "action_dim": 21,
         "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 8,
+        "revision": 9,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:cce25e87bc9bbf67f9e56f4243c532ade26d780de9ee4531d3ae04751c673c78"
+        "sha256": "sha256:bacbb3243a7f84f1379e106dd886279ed247c252c143cb5e86500a50725d7020"
       },
       "source": {
-        "closure_sha256": "sha256:bd63a662293202088b354cb27de8fc52f6f0dfbf379932a60c06984d14c9cbf5",
+        "closure_sha256": "sha256:2ef85b8c9aef05050e7e407ba9cf6a7a6da62e2c14282c5143366dd0575f2571",
         "dependencies": [
           {
-            "content_sha256": "sha256:c64fb09dbe07d8dfc12525a491a4383f0a7e2ba27ef29c3f9946f90f4dbb628c",
+            "content_sha256": "sha256:1362fd47f50233ac4fc87b3e6dbaeefb609f5be76530220d541fb598c704fdd8",
             "kind": "mjcf",
             "logical_path": "environments/trex/assets/trex.xml"
           }
@@ -123,7 +123,7 @@
       }
     },
     "velociraptor": {
-      "bundle_sha256": "sha256:51911dc21d53c60b4885eecb55a6c60abb023ce83518a435b635d77fd74f9b00",
+      "bundle_sha256": "sha256:60b806b9c59172ee1ef7e6b73734f2c590f47b05910006daafe938c0a7342e9d",
       "env_entrypoint": "environments.velociraptor.envs.raptor_env:RaptorEnv",
       "model_path": "environments/velociraptor/assets/raptor.xml",
       "physics": {
@@ -138,9 +138,9 @@
         "action_dim": 22,
         "observation_dim": 67,
         "observation_schema": "bipedal-target/v1",
-        "revision": 7,
+        "revision": 8,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:8897d9705fd27a7dfd09fc6277f5918af87707fdffd653707a2117e7bcbfd53a"
+        "sha256": "sha256:1fa480739251a23fdf1b9a43f25b02b2f32c082b906dcb31f70ca59dfbb59f6f"
       },
       "source": {
         "closure_sha256": "sha256:ae2ebacf577a7247484e8954fecce421b007246ead904a83ce319babb1efdec5",

--- a/environments/shared/scripts/stance_quality_baseline.py
+++ b/environments/shared/scripts/stance_quality_baseline.py
@@ -1,60 +1,119 @@
 """Statue stance-quality baseline at a candidate Stage 1a operating point.
 
-Companion to zero_action_baseline.py, which scores the do-nothing policy on
+Companion to ``zero_action_baseline.py``, which scores the do-nothing policy on
 REWARD.  Stage 1a cannot gate on reward: summing the positive stage-1 weights
 gives a ceiling of 3.35/step for T-Rex and the statue collects 97.0% of it with
 energy and smoothness at exactly zero, so the statue IS the optimum and every
-active policy scores below it.  See docs/STAGE1_SPLIT_PLAN.md 2.3.1.
+active policy scores below it.  See
+docs/PLANT_VALIDATION_AND_STAGE1_OBJECTIVE.md section 9.
 
 What 1a can gate on is stance QUALITY, and these are the numbers a policy has to
-MATCH rather than beat.  Usage:
+MATCH rather than beat.  Usage::
 
     python -m environments.shared.scripts.stance_quality_baseline [noise] [episodes]
 """
-import sys, warnings
-import numpy as np, tomllib
-warnings.filterwarnings('ignore')
-from environments.trex.envs.trex_env import TRexEnv
-from environments.velociraptor.envs.raptor_env import RaptorEnv
+
+from __future__ import annotations
+
+import sys
+import tomllib
+import warnings
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
 from environments.brachiosaurus.envs.brachio_env import BrachioEnv
 from environments.dibothrosuchus.envs.dibothrosuchus_env import DibothrosuchusEnv
+from environments.trex.envs.trex_env import TRexEnv
+from environments.velociraptor.envs.raptor_env import RaptorEnv
 
-SPECIES = [(TRexEnv,'trex'),(RaptorEnv,'velociraptor'),(BrachioEnv,'brachiosaurus'),(DibothrosuchusEnv,'dibothrosuchus')]
+warnings.filterwarnings("ignore")
 
-def feet(info):
-    keys = [k for k in info if k.endswith('_foot_contact')]
-    return [float(info[k]) for k in sorted(keys)]
+SPECIES: list[tuple[type, str]] = [
+    (TRexEnv, "trex"),
+    (RaptorEnv, "velociraptor"),
+    (BrachioEnv, "brachiosaurus"),
+    (DibothrosuchusEnv, "dibothrosuchus"),
+]
 
-def run(cls, sp, noise, seeds):
-    cfg = dict(tomllib.load(open(f'configs/{sp}/stage1_balance.toml','rb'))['env'])
-    cfg['reset_noise_scale'] = noise
-    env = cls(**cfg)
-    z = np.zeros(env.action_space.shape, dtype=np.float32)
-    full = 0; stand = []; duty = []; switch = []
-    for s in seeds:
-        env.reset(seed=int(s)); n = 0; R = 0.0; sup = []; 
-        for _ in range(1000):
-            _, r, term, trunc, info = env.step(z); n += 1; R += r
-            f = feet(info)
-            sup.append(sum(1 for v in f if v > 0.1))
-            if term or trunc: break
-        sup = np.array(sup); nf = len(feet(info))
-        duty.append(((sup == 0).mean(), (sup == nf).mean()))
-        allsup = (sup == nf).astype(int)
-        switch.append(np.abs(np.diff(allsup)).mean() / env.dt if len(allsup) > 1 else 0.0)
-        if n >= 1000: full += 1; stand.append(R)
-    d = np.array(duty)
-    return dict(full=full/len(seeds), unsup=d[:,0].mean(), allsup=d[:,1].mean(),
-                switch=float(np.mean(switch)), stand=float(np.mean(stand)) if stand else float('nan'),
-                stand_sd=float(np.std(stand)) if stand else float('nan'), n=len(seeds))
+CONFIG_ROOT = Path(__file__).resolve().parents[3] / "configs"
+HORIZON = 1000
+CONTACT_THRESHOLD = 0.1
 
-if __name__ == '__main__':
-    noise = float(sys.argv[1]) if len(sys.argv) > 1 else 0.05
-    seeds = range(3042, 3042 + (int(sys.argv[2]) if len(sys.argv) > 2 else 40))
-    print(f"statue stance quality at reset_noise={noise}, {len(list(seeds))} episodes")
+
+def foot_forces(info: dict[str, Any]) -> list[float]:
+    """Per-foot contact forces, in a stable order, for however many feet exist."""
+    return [float(info[key]) for key in sorted(k for k in info if k.endswith("_foot_contact"))]
+
+
+def measure(env_cls: type, species: str, noise: float, seeds: range) -> dict[str, float]:
+    """Run the zero-action policy and summarise its stance rather than its return."""
+    with open(CONFIG_ROOT / species / "stage1_balance.toml", "rb") as handle:
+        config = dict(tomllib.load(handle)["env"])
+    config["reset_noise_scale"] = noise
+    env = env_cls(**config)
+    neutral = np.zeros(env.action_space.shape, dtype=np.float32)
+
+    full_horizon = 0
+    standing_returns: list[float] = []
+    unsupported: list[float] = []
+    all_feet: list[float] = []
+    switches: list[float] = []
+
+    for seed in seeds:
+        env.reset(seed=int(seed))
+        supported_count: list[int] = []
+        steps = 0
+        episode_return = 0.0
+        info: dict[str, Any] = {}
+        for _ in range(HORIZON):
+            _, reward, terminated, truncated, info = env.step(neutral)
+            steps += 1
+            episode_return += float(reward)
+            supported_count.append(sum(1 for force in foot_forces(info) if force > CONTACT_THRESHOLD))
+            if terminated or truncated:
+                break
+
+        counts = np.array(supported_count)
+        n_feet = len(foot_forces(info))
+        unsupported.append(float((counts == 0).mean()))
+        all_feet.append(float((counts == n_feet).mean()))
+        fully_supported = (counts == n_feet).astype(int)
+        switch_rate = float(np.abs(np.diff(fully_supported)).mean() / env.dt) if len(fully_supported) > 1 else 0.0
+        switches.append(switch_rate)
+        if steps >= HORIZON:
+            full_horizon += 1
+            standing_returns.append(episode_return)
+
+    return {
+        "full_horizon": full_horizon / len(seeds),
+        "all_feet": float(np.mean(all_feet)),
+        "unsupported": float(np.mean(unsupported)),
+        "switches": float(np.mean(switches)),
+        "standing": float(np.mean(standing_returns)) if standing_returns else float("nan"),
+        "standing_sd": float(np.std(standing_returns)) if standing_returns else float("nan"),
+    }
+
+
+def main(argv: list[str]) -> None:
+    noise = float(argv[1]) if len(argv) > 1 else 0.05
+    episodes = int(argv[2]) if len(argv) > 2 else 40
+    seeds = range(3042, 3042 + episodes)
+
+    print(f"statue stance quality at reset_noise={noise}, {episodes} episodes")
     print(f"{'species':>15} {'full-hz':>8} {'all-feet':>9} {'unsup':>7} {'switch/s':>9} {'standing reward':>18}")
-    for cls, sp in SPECIES:
-        r = run(cls, sp, noise, seeds)
-        sd = f"+/-{r['stand_sd']:.1f}" if r['stand_sd'] == r['stand_sd'] else ""
-        print(f"{sp:>15} {r['full']:>7.0%} {r['allsup']:>9.3f} {r['unsup']:>7.3f} {r['switch']:>9.2f} "
-              f"{r['stand']:>12.1f} {sd:>5}")
+    for env_cls, species in SPECIES:
+        result = measure(env_cls, species, noise, seeds)
+        standing_sd = result["standing_sd"]
+        spread = f"+/-{standing_sd:.1f}" if standing_sd == standing_sd else ""
+        print(
+            f"{species:>15} {result['full_horizon']:>7.0%} {result['all_feet']:>9.3f} "
+            f"{result['unsupported']:>7.3f} {result['switches']:>9.2f} "
+            f"{result['standing']:>12.1f} {spread:>5}"
+        )
+    print("  a 1a policy must MATCH these, not beat them -- the statue is the quality ceiling")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/environments/shared/scripts/stance_quality_baseline.py
+++ b/environments/shared/scripts/stance_quality_baseline.py
@@ -1,0 +1,60 @@
+"""Statue stance-quality baseline at a candidate Stage 1a operating point.
+
+Companion to zero_action_baseline.py, which scores the do-nothing policy on
+REWARD.  Stage 1a cannot gate on reward: summing the positive stage-1 weights
+gives a ceiling of 3.35/step for T-Rex and the statue collects 97.0% of it with
+energy and smoothness at exactly zero, so the statue IS the optimum and every
+active policy scores below it.  See docs/STAGE1_SPLIT_PLAN.md 2.3.1.
+
+What 1a can gate on is stance QUALITY, and these are the numbers a policy has to
+MATCH rather than beat.  Usage:
+
+    python -m environments.shared.scripts.stance_quality_baseline [noise] [episodes]
+"""
+import sys, warnings
+import numpy as np, tomllib
+warnings.filterwarnings('ignore')
+from environments.trex.envs.trex_env import TRexEnv
+from environments.velociraptor.envs.raptor_env import RaptorEnv
+from environments.brachiosaurus.envs.brachio_env import BrachioEnv
+from environments.dibothrosuchus.envs.dibothrosuchus_env import DibothrosuchusEnv
+
+SPECIES = [(TRexEnv,'trex'),(RaptorEnv,'velociraptor'),(BrachioEnv,'brachiosaurus'),(DibothrosuchusEnv,'dibothrosuchus')]
+
+def feet(info):
+    keys = [k for k in info if k.endswith('_foot_contact')]
+    return [float(info[k]) for k in sorted(keys)]
+
+def run(cls, sp, noise, seeds):
+    cfg = dict(tomllib.load(open(f'configs/{sp}/stage1_balance.toml','rb'))['env'])
+    cfg['reset_noise_scale'] = noise
+    env = cls(**cfg)
+    z = np.zeros(env.action_space.shape, dtype=np.float32)
+    full = 0; stand = []; duty = []; switch = []
+    for s in seeds:
+        env.reset(seed=int(s)); n = 0; R = 0.0; sup = []; 
+        for _ in range(1000):
+            _, r, term, trunc, info = env.step(z); n += 1; R += r
+            f = feet(info)
+            sup.append(sum(1 for v in f if v > 0.1))
+            if term or trunc: break
+        sup = np.array(sup); nf = len(feet(info))
+        duty.append(((sup == 0).mean(), (sup == nf).mean()))
+        allsup = (sup == nf).astype(int)
+        switch.append(np.abs(np.diff(allsup)).mean() / env.dt if len(allsup) > 1 else 0.0)
+        if n >= 1000: full += 1; stand.append(R)
+    d = np.array(duty)
+    return dict(full=full/len(seeds), unsup=d[:,0].mean(), allsup=d[:,1].mean(),
+                switch=float(np.mean(switch)), stand=float(np.mean(stand)) if stand else float('nan'),
+                stand_sd=float(np.std(stand)) if stand else float('nan'), n=len(seeds))
+
+if __name__ == '__main__':
+    noise = float(sys.argv[1]) if len(sys.argv) > 1 else 0.05
+    seeds = range(3042, 3042 + (int(sys.argv[2]) if len(sys.argv) > 2 else 40))
+    print(f"statue stance quality at reset_noise={noise}, {len(list(seeds))} episodes")
+    print(f"{'species':>15} {'full-hz':>8} {'all-feet':>9} {'unsup':>7} {'switch/s':>9} {'standing reward':>18}")
+    for cls, sp in SPECIES:
+        r = run(cls, sp, noise, seeds)
+        sd = f"+/-{r['stand_sd']:.1f}" if r['stand_sd'] == r['stand_sd'] else ""
+        print(f"{sp:>15} {r['full']:>7.0%} {r['allsup']:>9.3f} {r['unsup']:>7.3f} {r['switch']:>9.2f} "
+              f"{r['stand']:>12.1f} {sd:>5}")

--- a/environments/shared/tests/test_reset_plant_invariants.py
+++ b/environments/shared/tests/test_reset_plant_invariants.py
@@ -152,7 +152,11 @@ def test_home_pose_has_no_self_collision(env_cls):
     env = env_cls(reset_noise_scale=0.0)
     env.reset(seed=0)
     mujoco.mj_forward(env.model, env.data)
-    floor = set(int(g) for g in env._static_floor_geoms())
+    floor = {int(g) for g in env._static_floor_geoms()}
+
+    def geom_name(geom_id: int) -> str:
+        return mujoco.mj_id2name(env.model, mujoco.mjtObj.mjOBJ_GEOM, geom_id) or f"geom{geom_id}"
+
     offenders = []
     for i in range(env.data.ncon):
         g1, g2 = int(env.data.contact.geom1[i]), int(env.data.contact.geom2[i])
@@ -160,8 +164,7 @@ def test_home_pose_has_no_self_collision(env_cls):
             continue
         depth = float(env.data.contact.dist[i])
         if depth < -MAX_EXTRA_PENETRATION:
-            name = lambda g: mujoco.mj_id2name(env.model, mujoco.mjtObj.mjOBJ_GEOM, g) or f"geom{g}"
-            offenders.append(f"{name(g1)}<->{name(g2)} ({depth * 1000:.1f} mm)")
+            offenders.append(f"{geom_name(g1)}<->{geom_name(g2)} ({depth * 1000:.1f} mm)")
     assert not offenders, (
         f"{env_cls.__name__} home pose has overlapping geoms: {', '.join(offenders)}. "
         "Exclude the pair in <contact> or fix the geometry — an overlap here is a "

--- a/environments/shared/tests/test_reset_plant_invariants.py
+++ b/environments/shared/tests/test_reset_plant_invariants.py
@@ -1,0 +1,227 @@
+"""Plant-level invariants that every reset must satisfy, for every species.
+
+These assertions are deliberately independent of the reward function, the
+curriculum stage and the animal: a reset either hands the policy a physically
+sane starting state or it does not.  Two real defects motivated them, both
+invisible to every existing test and to every reward-side metric:
+
+1. Reset placed the root by height alone, ignoring that joint jitter changes
+   how far the lowest geom sits below the root.  On T-Rex this spawned the
+   model up to 0.198 m *inside* the floor; the contact solver answered with
+   ~19x body weight and launched it 0.5 m upward to tumble ballistically for
+   ~60 steps before landing nose-down past the nosedive threshold.  Other
+   seeds spawned 0.18 m *above* the floor and opened with a free fall.  The
+   prior guard checked the root against ``healthy_z_range``, which is a
+   termination predicate on the ROOT and says nothing about foot-to-floor
+   geometry — a pelvis at 0.739 m is "healthy" with the toes underground.
+
+2. ``tail_1_geom`` overlapped both thigh capsules in the home pose, injecting
+   16.3 kN — eleven times body weight — of constant self-contact into every
+   reset of every run, identically and independently of the sampled pose.
+
+Both classes are caught here by bounding, at t=0: penetration depth, ground
+clearance, and total contact force as a multiple of body weight.
+"""
+
+from __future__ import annotations
+
+import mujoco
+import numpy as np
+import pytest
+
+from environments.brachiosaurus.envs.brachio_env import BrachioEnv
+from environments.dibothrosuchus.envs.dibothrosuchus_env import DibothrosuchusEnv
+from environments.trex.envs.trex_env import TRexEnv
+from environments.velociraptor.envs.raptor_env import RaptorEnv
+
+SPECIES = [
+    pytest.param(TRexEnv, id="trex"),
+    pytest.param(RaptorEnv, id="velociraptor"),
+    pytest.param(BrachioEnv, id="brachiosaurus"),
+    pytest.param(DibothrosuchusEnv, id="dibothrosuchus"),
+]
+
+# Reset noise large enough to exercise the settling path.  The species configs
+# use 0.05-0.10; 0.10 is the widest any stage ships, so test the worst case.
+RESET_NOISE = 0.10
+SEEDS = range(48)
+
+# Tolerances.  Reset settles to the home keyframe's authored clearance, which is
+# a deliberate shallow contact (0.5 mm on T-Rex), so "no penetration" means "no
+# DEEPER than the authored resting contact" plus solver-scale slop.  A tenth of
+# that budget again is ample; the defect this catches was 0.198 m.
+SETTLE_TOLERANCE = 5e-4
+# Depth beyond the authored home contact that counts as interpenetration.
+MAX_EXTRA_PENETRATION = 2e-3
+# A spawn further above the authored contact than this opens with a free fall.
+MAX_GROUND_CLEARANCE = 0.01
+# Contact force at t=0, as a multiple of body weight.  A body resting on the
+# ground carries ~1x; the solver needs headroom for the settling clearance and
+# for whatever velocity jitter the reset applied.  Anything near 10x is a
+# geometry defect, not a landing.
+MAX_RESET_CONTACT_FORCE_WEIGHTS = 3.0
+
+
+def make_env(cls):
+    return cls(reset_noise_scale=RESET_NOISE)
+
+
+def total_contact_force(env) -> float:
+    """Sum of normal contact-force magnitudes over every active contact."""
+    buf = np.zeros(6)
+    total = 0.0
+    for i in range(env.data.ncon):
+        mujoco.mj_contactForce(env.model, env.data, i, buf)
+        total += abs(float(buf[0]))
+    return total
+
+
+def body_weight(env) -> float:
+    return float(sum(env.model.body_mass) * abs(env.model.opt.gravity[2]))
+
+
+@pytest.mark.parametrize("env_cls", SPECIES)
+def test_reset_never_penetrates_the_floor(env_cls):
+    """No reset may start with a body geom inside the ground."""
+    env = make_env(env_cls)
+    home = env.home_ground_clearance()
+    worst, worst_seed = float("inf"), None
+    for seed in SEEDS:
+        env.reset(seed=seed)
+        mujoco.mj_forward(env.model, env.data)
+        clearance = env.lowest_ground_clearance()
+        if clearance < worst:
+            worst, worst_seed = clearance, seed
+    assert worst > home - MAX_EXTRA_PENETRATION, (
+        f"{env_cls.__name__} spawned {(home - worst) * 1000:.1f} mm deeper than its authored "
+        f"home contact on seed {worst_seed}. The reset must settle the root against floor "
+        "geometry, not against healthy_z_range."
+    )
+
+
+@pytest.mark.parametrize("env_cls", SPECIES)
+def test_reset_never_spawns_airborne(env_cls):
+    """No reset may start the animal dropping from a height."""
+    env = make_env(env_cls)
+    home = env.home_ground_clearance()
+    highest, highest_seed = -float("inf"), None
+    for seed in SEEDS:
+        env.reset(seed=seed)
+        mujoco.mj_forward(env.model, env.data)
+        clearance = env.lowest_ground_clearance()
+        if clearance > highest:
+            highest, highest_seed = clearance, seed
+    assert highest - home < MAX_GROUND_CLEARANCE, (
+        f"{env_cls.__name__} spawned {(highest - home) * 100:.1f} cm above its authored home "
+        f"contact on seed {highest_seed}; the episode would open with a free fall."
+    )
+
+
+@pytest.mark.parametrize("env_cls", SPECIES)
+def test_reset_contact_force_is_physically_plausible(env_cls):
+    """t=0 contact force must look like resting, not like a collision.
+
+    This is the assertion that catches a permanent self-collision: a geom pair
+    overlapping in the home pose shows up as a large, *pose-independent* force
+    that no amount of correct root placement removes.
+    """
+    env = make_env(env_cls)
+    weight = body_weight(env)
+    worst, worst_seed = 0.0, None
+    for seed in SEEDS:
+        env.reset(seed=seed)
+        mujoco.mj_forward(env.model, env.data)
+        force = total_contact_force(env)
+        if force > worst:
+            worst, worst_seed = force, seed
+    assert worst < MAX_RESET_CONTACT_FORCE_WEIGHTS * weight, (
+        f"{env_cls.__name__} starts with {worst:.0f} N of contact force "
+        f"({worst / weight:.1f}x body weight) on seed {worst_seed}. "
+        "A resting body carries ~1x; a large multiple means overlapping geometry."
+    )
+
+
+@pytest.mark.parametrize("env_cls", SPECIES)
+def test_home_pose_has_no_self_collision(env_cls):
+    """The unperturbed keyframe must not have body geoms overlapping.
+
+    Pose-independent by construction — no reset noise — so a failure here is a
+    modelling defect in the MJCF, and it will be present in every single step
+    of every episode rather than only at spawn.
+    """
+    env = env_cls(reset_noise_scale=0.0)
+    env.reset(seed=0)
+    mujoco.mj_forward(env.model, env.data)
+    floor = set(int(g) for g in env._static_floor_geoms())
+    offenders = []
+    for i in range(env.data.ncon):
+        g1, g2 = int(env.data.contact.geom1[i]), int(env.data.contact.geom2[i])
+        if g1 in floor or g2 in floor:
+            continue
+        depth = float(env.data.contact.dist[i])
+        if depth < -MAX_EXTRA_PENETRATION:
+            name = lambda g: mujoco.mj_id2name(env.model, mujoco.mjtObj.mjOBJ_GEOM, g) or f"geom{g}"
+            offenders.append(f"{name(g1)}<->{name(g2)} ({depth * 1000:.1f} mm)")
+    assert not offenders, (
+        f"{env_cls.__name__} home pose has overlapping geoms: {', '.join(offenders)}. "
+        "Exclude the pair in <contact> or fix the geometry — an overlap here is a "
+        "constant force injected into the solver and into every contact-based reward."
+    )
+
+
+@pytest.mark.parametrize("env_cls", SPECIES)
+def test_reset_is_not_already_terminal(env_cls):
+    """A reset must never hand back a state that terminates on the first step.
+
+    An episode whose outcome no action can influence is not a policy failure,
+    and counting it as one puts an unreachable ceiling on any reliability gate.
+    """
+    env = make_env(env_cls)
+    terminal = []
+    for seed in SEEDS:
+        env.reset(seed=seed)
+        _, _, terminated, _, _ = env.step(np.zeros(env.action_space.shape, dtype=np.float32))
+        if terminated:
+            terminal.append(seed)
+    assert not terminal, f"{env_cls.__name__} reset is already terminal on seeds {terminal}"
+
+
+@pytest.mark.parametrize("env_cls", SPECIES)
+def test_settling_keeps_reset_deterministic(env_cls):
+    """Settling must not consume RNG draws: same seed, same state."""
+    a, b = make_env(env_cls), make_env(env_cls)
+    for seed in (0, 17, 41):
+        a.reset(seed=seed)
+        b.reset(seed=seed)
+        np.testing.assert_allclose(a.data.qpos, b.data.qpos, rtol=0, atol=0)
+        np.testing.assert_allclose(a.data.qvel, b.data.qvel, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("env_cls", SPECIES)
+def test_noise_free_reset_keeps_the_authored_home_contact(env_cls):
+    """With noise off, settling is a no-op: the keyframe contact is preserved.
+
+    This is what keeps the species static-balance suites meaningful — they
+    assert the home pose has real foot-floor contact, and settling to an
+    arbitrary positive clearance would leave every animal hovering.
+    """
+    env = env_cls(reset_noise_scale=0.0)
+    env.reset(seed=0)
+    mujoco.mj_forward(env.model, env.data)
+    assert env.lowest_ground_clearance() == pytest.approx(env.home_ground_clearance(), abs=SETTLE_TOLERANCE)
+
+
+@pytest.mark.parametrize("env_cls", SPECIES)
+def test_reset_keeps_feet_on_the_floor(env_cls):
+    """Every reset must produce real foot-floor contact, not a hover."""
+    env = make_env(env_cls)
+    for seed in SEEDS:
+        env.reset(seed=seed)
+        mujoco.mj_forward(env.model, env.data)
+        floor = set(int(g) for g in env._static_floor_geoms())
+        touching = sum(
+            1
+            for i in range(env.data.ncon)
+            if int(env.data.contact.geom1[i]) in floor or int(env.data.contact.geom2[i]) in floor
+        )
+        assert touching > 0, f"{env_cls.__name__} seed {seed} spawned with no ground contact at all"

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -84,9 +84,11 @@ def test_catalog_publishes_layered_plant_contract() -> None:
     #
     # The three home-keyframe-residual species then took one more policy bump
     # for the bounded reset height (plant_versions note 5); brachiosaurus does
-    # not carry home_reset and so stays at r3.
-    expected_policy_revisions = {"velociraptor": 7, "trex": 8, "brachiosaurus": 3, "dibothrosuchus": 4}
-    expected_physics_revisions = {"velociraptor": 2, "trex": 5, "brachiosaurus": 1, "dibothrosuchus": 1}
+    # not carry home_reset and so stayed at r3 for that one.
+    # Ground settling at reset (note 6) then bumped ALL FOUR, brachiosaurus
+    # included: settling applies to every species regardless of keyframe style.
+    expected_policy_revisions = {"velociraptor": 8, "trex": 9, "brachiosaurus": 4, "dibothrosuchus": 5}
+    expected_physics_revisions = {"velociraptor": 2, "trex": 6, "brachiosaurus": 2, "dibothrosuchus": 1}
     expected_visual_revisions = {"velociraptor": 3, "trex": 4, "brachiosaurus": 1, "dibothrosuchus": 1}
     digest_pattern = re.compile(r"sha256:[0-9a-f]{64}")
     for species in catalog["species"]:

--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -505,6 +505,16 @@
     <exclude body1="pelvis" body2="r_thigh"/>
     <exclude body1="pelvis" body2="l_thigh"/>
 
+    <!-- The tail base capsule is anchored 0.2 m behind the pelvis origin and
+         is wide enough (140 mm) to overlap both thighs in the home pose. Left
+         colliding it penetrated 18.8 mm and injected 8143 N per side — 16.3 kN,
+         eleven times body weight — into EVERY reset, identically and
+         independently of the sampled pose, polluting both the solver and every
+         contact-force reward and diagnostic. Same fix, and same reason, as the
+         sibling toe capsules below. -->
+    <exclude body1="tail_1" body2="r_thigh"/>
+    <exclude body1="tail_1" body2="l_thigh"/>
+
     <!-- Arm-torso -->
     <exclude body1="pelvis" body2="r_arm"/>
     <exclude body1="pelvis" body2="l_arm"/>
@@ -515,8 +525,10 @@
          the stance or foot sensors. -->
     <exclude body1="r_toe_d2" body2="r_toe_d3"/>
     <exclude body1="r_toe_d3" body2="r_toe_d4"/>
+    <exclude body1="r_toe_d2" body2="r_toe_d4"/>
     <exclude body1="l_toe_d2" body2="l_toe_d3"/>
     <exclude body1="l_toe_d3" body2="l_toe_d4"/>
+    <exclude body1="l_toe_d2" body2="l_toe_d4"/>
   </contact>
 
   <!-- ==================== KEYFRAMES ==================== -->

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -80,13 +80,13 @@
         "nu": 22,
         "dynamic_mass_kg": 13.5,
         "plant_contract": {
-          "bundle_sha256": "sha256:51911dc21d53c60b4885eecb55a6c60abb023ce83518a435b635d77fd74f9b00",
+          "bundle_sha256": "sha256:60b806b9c59172ee1ef7e6b73734f2c590f47b05910006daafe938c0a7342e9d",
           "source_closure_sha256": "sha256:ae2ebacf577a7247484e8954fecce421b007246ead904a83ce319babb1efdec5",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 7,
+            "revision": 8,
             "observation_schema": "bipedal-target/v1",
-            "sha256": "sha256:8897d9705fd27a7dfd09fc6277f5918af87707fdffd653707a2117e7bcbfd53a"
+            "sha256": "sha256:1fa480739251a23fdf1b9a43f25b02b2f32c082b906dcb31f70ca59dfbb59f6f"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",
@@ -357,18 +357,18 @@
         "nu": 21,
         "dynamic_mass_kg": 85.72,
         "plant_contract": {
-          "bundle_sha256": "sha256:0e3ef817188447729fab0fdc2c1e7a77b4ae1c9868b782908343cbc720146e25",
-          "source_closure_sha256": "sha256:bd63a662293202088b354cb27de8fc52f6f0dfbf379932a60c06984d14c9cbf5",
+          "bundle_sha256": "sha256:1d1ddd1efeceb2a2770079e52387d2fd2f38490a8c4527630ebf597264e9a702",
+          "source_closure_sha256": "sha256:2ef85b8c9aef05050e7e407ba9cf6a7a6da62e2c14282c5143366dd0575f2571",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 8,
+            "revision": 9,
             "observation_schema": "bipedal-target/v1",
-            "sha256": "sha256:cce25e87bc9bbf67f9e56f4243c532ade26d780de9ee4531d3ae04751c673c78"
+            "sha256": "sha256:bacbb3243a7f84f1379e106dd886279ed247c252c143cb5e86500a50725d7020"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",
-            "revision": 5,
-            "sha256": "sha256:0dc4e7798bad17cfda88ef6d79007cfc7cce31a4cffb972d6e798424b874f541"
+            "revision": 6,
+            "sha256": "sha256:7dfa00f5b28a5f562170ba0926e6811208354cb6160b524d9ab58412a37bc2f0"
           },
           "visual": {
             "schema": "mesozoic.mujoco-visual/v1",
@@ -570,18 +570,18 @@
         "nu": 30,
         "dynamic_mass_kg": 175.3,
         "plant_contract": {
-          "bundle_sha256": "sha256:243c8a158b88d5199cd0ea05dca518acfd99cf738d7651775eab457ffd5eed13",
-          "source_closure_sha256": "sha256:586e8c38684b4132c63872662333b37a2471b7740a6bc265def721f86fad1a5b",
+          "bundle_sha256": "sha256:507954e780e5c78d3f75208ca7d9c5dfb64b664f21f2b4397ff1e05ee38a4700",
+          "source_closure_sha256": "sha256:239a1db1d399478ca4fd9074be384114aa67f5dd8ba29773b8f2b3c6ec9bd622",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 3,
+            "revision": 4,
             "observation_schema": "quadrupedal-target/v1",
             "sha256": "sha256:f192ccd9f533fb757aa530b8bda89f9c129f4dc3d4ae34103464d97fdbbf55ec"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",
-            "revision": 1,
-            "sha256": "sha256:9d28ad3609e7ea6cff39fd37d8ab488a2e3390a66575e142f2b0feadb28ecf29"
+            "revision": 2,
+            "sha256": "sha256:252077668ac2714ec5af438f434d158d2d8cb8d71b6154c887f76812d4f603d8"
           },
           "visual": {
             "schema": "mesozoic.mujoco-visual/v1",
@@ -766,13 +766,13 @@
         "nu": 27,
         "dynamic_mass_kg": 8.65,
         "plant_contract": {
-          "bundle_sha256": "sha256:e1956db822d9f019b8d32931712e9a417136be750636538dd59b264ac51ab7d1",
+          "bundle_sha256": "sha256:b95297d3e697744b362a2422117a897ee67a07e7ef0b260eee219fab26b7fee6",
           "source_closure_sha256": "sha256:5532fad56a1613020f09bfa197f14f0916306e664d5cf18609b757d3c5948bc3",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 4,
+            "revision": 5,
             "observation_schema": "quadrupedal-target/v1",
-            "sha256": "sha256:3ce9b5b46e31a55db52a288c64f52dd25a2a7d3b6c1a9b61b68c3a2211a8a474"
+            "sha256": "sha256:13a35afba904f9500aabb7da17426281833a5af749b02ff6926e00148999827e"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",


### PR DESCRIPTION
Every episode of every training run to date has started with the animal intersecting the floor, and with two geom pairs permanently overlapping inside the body. This fixes both, adds plant-level invariant tests for all four species, and re-measures the Stage 1 baselines that were calibrated against the broken plant.

## The defect

`reset()` placed the root by height alone. Joint jitter changes how far the lowest geom sits below the root, so no fixed root height is right for most sampled poses. PR #478 bounded the height draw against `healthy_z_range` — but that is a **termination predicate on the root** and constrains nothing about foot-to-floor geometry. A T-Rex pelvis at 0.739 m is "healthy" with the toes 0.198 m underground.

Measured over 40 T-Rex seeds on the pre-fix plant, spawns ranged from **0.198 m inside the floor** to **0.18 m above it**. The solver answered penetration with up to **19× body weight**:

```
seed 2:  t= 0  pelvis 0.746  feet 5777.6 / 6033.7 N   <- spawned inside the floor
         t=30  pelvis 1.255  feet    0.0 /    0.0 N   <- ejected 0.52 m, ballistic
         t=60  pelvis 0.879  forward_z -0.440         <- lands nose-first
         t=66         forward_z -0.530                <- nosedive termination
```

Penetration depth predicted failure: failed resets averaged −0.088 m, survivors −0.034 m.

Two controller sweeps confirmed the diagnosis by failing. No PD gain on trunk pitch (70 combinations, both signs) and no static posture offset (75 combinations) beat zero action — because for the first ~60 steps there is no ground contact to act against.

Separately, two MJCF geom pairs overlapped in the home pose, injecting a constant, **pose-independent** force into every step of every episode:

| species | pair | depth | force |
|---|---|---|---|
| trex | `tail_1_geom` ↔ both thighs | 18.8 mm | 16.3 kN (11.0× weight) |
| brachiosaurus | `torso_main` ↔ `tail_2_geom` | 66.9 mm | 25.9 kN (12.7× weight) |

Both tail chains already excluded *adjacent* links; both bodies are long enough to reach two links back.

## The fix

`reset()` now shifts the root so the lowest body geom sits at the clearance the **home keyframe was authored with** — 0.491 mm of contact on T-Rex, per species elsewhere. Settling to the authored depth rather than to a constant keeps the noise-free reset bit-identical and keeps real foot-floor contact at spawn, which the species static-balance suites already require. The floor is a horizontal plane, so a single shift settles the pose exactly: no iteration, no extra RNG draws, and the reset stays deterministic in its seed.

The two overlapping pairs are `<exclude>`d, matching the existing sibling-toe precedent in both files.

T-Rex, zero action, 40 seeds:

| | before | after |
|---|---|---|
| t=0 contact force | 16,990 N (11.5× weight) | **190 N** (0.13×) |
| bilateral duty | 0.983 | 0.992 |
| single-support duty | 0.003 | 0.008 |
| unsupported duty | 0.014 | **0.000** |
| survival | 25/40 | 28/40 |
| mean episode length | 683 | 757 |

## Tests

`environments/shared/tests/test_reset_plant_invariants.py` — 8 invariants × 4 species, deliberately independent of reward, stage and animal:

| test | catches |
|---|---|
| `test_reset_never_penetrates_the_floor` | the 0.198 m spawn |
| `test_reset_never_spawns_airborne` | the 0.18 m spawn |
| `test_reset_contact_force_is_physically_plausible` | ≤ 3× body weight at t=0 |
| `test_home_pose_has_no_self_collision` | pose-independent overlaps, no noise |
| `test_reset_keeps_feet_on_the_floor` | over-correcting into a hover |
| `test_reset_is_not_already_terminal` | the class PR #478 addressed |
| `test_settling_keeps_reset_deterministic` | settling consuming RNG draws |
| `test_noise_free_reset_keeps_the_authored_home_contact` | drift in the settle target |

On first run these failed on **brachiosaurus**, surfacing the `torso_main` ↔ `tail_2_geom` overlap, which had not been reported before. They also caught an over-correction in the first draft of this change: settling to a fixed +2 mm clearance turned four existing `test_static_balance.py` suites red because they assert the home pose has real foot-floor contact.

## Re-baselined Stage 1

`zero_action_baseline.py`, seed 3042, 40 episodes, noise 0.10:

| | before | after |
|---|---|---|
| reward mean | 1974.74 | **2243.12** |
| reward mean − std | 492.94 | **867.21** |
| reward standing | 3243.10 ± 23.65 | 3250.27 ± 24.49 |
| full-horizon | 23/40 (57.5%) | **26/40 (65%)** |
| episode length | 640.85 | **716.5** |

**The trained Stage 1 policy is now below do-nothing.** Run `20260731_132102` peaked at 1992.7 mean eval reward against the repaired statue's 2243.12, having cleared `min_avg_reward = 1840` sixteen times including an eight-evaluation streak.

Nosedive remains 12 of 14 failures, so a residual pitch instability survives at noise 0.10. That is a real Stage 1a target; it was previously masked.

### Reset noise is the 1a/1b dial

| reset noise | reward | mean−std | standing | ep length | full-horizon |
|---|---|---|---|---|---|
| 0.01 | 3287.9 | 3286.3 | 3287.9 | 1000.0 | **100%** |
| 0.05 | 3271.8 | 3259.7 | 3271.8 | 1000.0 | **100%** |
| **0.10** ← default | 2243.1 | 867.2 | 3250.3 | 716.5 | 65% |
| 0.15 | 1348.2 | −96.9 | 3209.9 | 465.7 | 38% |
| 0.20 | 845.4 | −411.7 | 3166.9 | 324.4 | 22% |

`standing` is nearly flat (3288 → 3167) while full-horizon collapses 100% → 22%. Noise does not make standing harder; it decides how often you get to stand at all. Stage 1 sits exactly on the knee, which is why survival and stance quality have been inseparable in every measurement so far.

### No reward threshold can gate 1a

Summing the positive T-Rex Stage 1 weights gives a ceiling of **3.35/step = 3350**. The statue collects **3250.27 = 97.0%** of it with `energy` and `smoothness` at exactly zero. Any active policy pays both — run `20260731_132102` paid 0.30/step on smoothness alone. A policy's ceiling is therefore *below* the statue's score, and no threshold admits a competent policy while excluding a passive one.

This is stronger than §1.3's "saturates against a statue" and retires reward thresholds for 1a rather than asking for better numbers.

## Documentation

`STAGE1_SPLIT_PLAN.md` revision 5 records the above in §2.3.1, adds per-species 1a threshold proposals **explicitly for review rather than adopted**, marks §7.5 superseded (right fix, wrong invariant), and upgrades §1.5 from inferred to measured against the run's video — the hop resolves into ~15 toe lift-downs/sec plus a ~0.6–1.0 Hz body bob, and `smoothness_weight` is structurally blind to it (`action_delta` *fell* 12.0 → 10.5 from best to final checkpoint while high-frequency power doubled).

Two new blocking items in §10: re-derive all four `min_avg_reward` values (every one is cleared by its own statue), and fix brachiosaurus's stance collapse.

Adds `stance_quality_baseline.py`, the companion to `zero_action_baseline.py` that measures duty and switch rate rather than reward.

## Known-unfixed

**Brachiosaurus Stage 1 is not currently a balance task.** Its statue scores 0/40 full-horizon (mean length 130.7, terminations `fallen 34, tail_contact 6`) — it falls every time, so there is no "do not fall" floor to beat and no result for it is interpretable. Verified identical before and after this change, so pre-existing and not a regression. Tracked as §10 step 6b.

## Compatibility

Plant revisions bumped: **physics** for trex and brachiosaurus (contact exclusions), **policy interface** for all four (reset placement is fingerprinted through `home_reset`). Every existing checkpoint is trained against a different task — the zero-action baseline, the Stage 1 operating point, and any gate calibrated against them must be re-measured. Manifests and species catalog regenerated.

## Verification

- `environments/shared/tests` — full suite green
- `environments/trex environments/brachiosaurus environments/velociraptor environments/dibothrosuchus` — 278 tests green
- New invariant module — 32 tests green across all four species

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaSz93Ko1EJ9P9D8GbHAEE

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaSz93Ko1EJ9P9D8GbHAEE)_