### PR TITLE
Gate stage 1a on stance quality instead of return

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Apex Predator. **Specialty:** Head-contact attack task.
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
 |---|---|---:|---:|
-| 1 — Balance | Learn to stand and balance without falling | 6M | reward ≥ 1950; episode length ≥ 950; ≥ 10 episodes/evaluation; 3 consecutive passes |
+| 1 — Balance | Learn to stand and balance without falling | 6M | reward ≥ 1950; full-horizon episodes ≥ 95.0%; unsupported duty ≤ 0.02; unsupported duty 95% upper bound ≤ 0.02; ≥ 40 episodes/evaluation; 3 consecutive passes |
 | 2 — Locomotion | Learn forward walking/running | 8M | reward ≥ 100; episode length ≥ 750; avg. velocity ≥ 2 m/s; ≥ 10 episodes/evaluation; 3 consecutive passes |
 | 3 — Bite | Sprint to prey and make contact with the head bite proxy | 8M | reward ≥ 100; task success ≥ 50.0%; ≥ 10 episodes/evaluation; 3 consecutive passes |
 

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -214,8 +214,11 @@ timesteps = 6000000
 # 1000.0 steps (clearing min_avg_episode_length = 950), which this run's own
 # zero_action_baseline.json reported as "FAILS — a statue clears this gate".
 # Worse, it also passed the policy we actually needed to reject — run
-# 20260801_021545's best checkpoint scored 2347.67 while spending 28.4% of its
-# steps with neither foot loaded.
+# 20260801_021545's best checkpoint, re-rolled on this plant and reward over 40
+# episodes (seeds 3042-3081), reaches the horizon 40/40 and scores 2133.4 while
+# spending 0.319 of its post-settling steps with neither foot loaded. Two
+# earlier figures for it are superseded: 0.284 duty came from an 8-episode
+# sample, and 2347.67 was its evaluation mean under the pre-§14 reward.
 #
 # The gate is NOT trying to beat the statue. STAGE1_SPLIT_PLAN §2.3.1 is
 # explicit that the statue's numbers are what a 1a policy must MATCH, not
@@ -231,8 +234,8 @@ timesteps = 6000000
 min_full_horizon_fraction = 0.95         # Statue: 99.17% pooled over three independent 40-seed blocks (119/120).
                                          # A floor to MATCH, not beat. Replaces min_avg_episode_length = 950, which
                                          # encoded the same §12 requirement through the only field the old gate had.
-max_unsupported_duty = 0.02              # Screening ceiling. Statue 0.000; the chatterer we must reject 0.284, i.e.
-                                         # 14x over. Set well above 0.000 so ordinary weight-shifting is not
+max_unsupported_duty = 0.02              # Screening ceiling. Statue 0.000; the chatterer we must reject 0.319, i.e.
+                                         # 16x over. Set well above 0.000 so ordinary weight-shifting is not
                                          # penalised — note the repaired plant moved raw contact-switch count UP
                                          # (0.86 -> 1.00 /s) while duty went to zero, because the extra switches are
                                          # weight shifts. Gate on duty; switch rate stays diagnostic until it is
@@ -254,7 +257,8 @@ min_eval_episodes = 40                   # The panel size every figure above is 
                                          # describe this gate.
 min_avg_reward = 1950.0                 # Collapse RAIL, not the gate (PLANT_VALIDATION §9/§12): no reward threshold
                                         # can separate a competent policy from a statue, because the statue is the
-                                        # reward optimum (97.0% of the 3.35/step ceiling with zero actuation cost).
+                                        # reward optimum (3271.8 = 97.7% of the 3.35/step ceiling with zero actuation
+                                        # cost; the 97.0% quoted elsewhere is the pre-repair 3250.27 measurement).
                                         # Sized to the one job a rail CAN do — rejecting a policy that discarded
                                         # most of the available return — at 0.60 x the statue's standing reward at
                                         # the 0.05 operating point (3271.8 +/- 12.0, 40 episodes).

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -203,8 +203,55 @@ net_arch = [512, 256]                  # Match SB3 PPO architecture
 
 [curriculum]
 gate_schema_version = 1                 # Fail-closed gate declaration; see
-gate_kind = "reward_and_length/v1"      # environments/shared/curriculum/gate_schema.py
+gate_kind = "stance_quality/v1"         # environments/shared/curriculum/gate_schema.py
 timesteps = 6000000
+
+# ---------------------------------------------------------------------------
+# The 1a gate: physical stance quality, not return.
+#
+# Adopted 2026-08-01, replacing reward_and_length/v1. That gate was passable by
+# doing nothing: the statue scores 3271.8 (clearing min_avg_reward = 1950) at
+# 1000.0 steps (clearing min_avg_episode_length = 950), which this run's own
+# zero_action_baseline.json reported as "FAILS — a statue clears this gate".
+# Worse, it also passed the policy we actually needed to reject — run
+# 20260801_021545's best checkpoint scored 2347.67 while spending 28.4% of its
+# steps with neither foot loaded.
+#
+# The gate is NOT trying to beat the statue. STAGE1_SPLIT_PLAN §2.3.1 is
+# explicit that the statue's numbers are what a 1a policy must MATCH, not
+# beat: it defines the quality ceiling, and 1a's job is to certify a policy
+# has not bought stability with actuation. Robustness belongs to 1b, via
+# declared xfrc_applied perturbations rather than reset noise, where a lucky
+# draw and a good controller are indistinguishable.
+#
+# Duty is derive_stance_info's unsupported_duty at its default 0.1 N contact
+# threshold — deliberately NOT the reward's 42 N min_support_force. Every
+# calibration point below is measured at 0.1 N.
+# ---------------------------------------------------------------------------
+min_full_horizon_fraction = 0.95         # Statue: 99.17% pooled over three independent 40-seed blocks (119/120).
+                                         # A floor to MATCH, not beat. Replaces min_avg_episode_length = 950, which
+                                         # encoded the same §12 requirement through the only field the old gate had.
+max_unsupported_duty = 0.02              # Screening ceiling. Statue 0.000; the chatterer we must reject 0.284, i.e.
+                                         # 14x over. Set well above 0.000 so ordinary weight-shifting is not
+                                         # penalised — note the repaired plant moved raw contact-switch count UP
+                                         # (0.86 -> 1.00 /s) while duty went to zero, because the extra switches are
+                                         # weight shifts. Gate on duty; switch rate stays diagnostic until it is
+                                         # decomposed into bilateral<->single vs bilateral<->airborne.
+max_unsupported_duty_ucb = 0.02          # The CERTIFYING criterion: one-sided 95% UPPER bound on mean duty.
+                                         # Binarising instead costs nearly all the power at this panel size — a
+                                         # binomial LCB95 >= 0.90 at n=40 needs a clean 40/40 and would reject the
+                                         # statue 28% of the time (true rate 0.9917 -> P(40/40) = 71.6%). Duty is
+                                         # continuous with tiny variance, so an interval on it has real power at 40
+                                         # where the pass/fail count has almost none. UCB >= mean by construction,
+                                         # so this subsumes the screening ceiling while both sit at 0.02; both are
+                                         # kept configurable in case a tighter screen than bound is ever wanted.
+settle_steps = 200                       # [inferred], NOT measured. Duty is scored only after this prefix, because
+                                         # a policy that corrects reset randomisation may legitimately move a foot
+                                         # doing it — and settling is the capability 1a exists to certify. 20% of
+                                         # the horizon. Calibrate against rollout data before treating as evidence.
+min_eval_episodes = 40                   # The panel size every figure above is specified at. n_eval_episodes must
+                                         # match: at n=30 the bound's power and the 28%-rejection analysis no longer
+                                         # describe this gate.
 min_avg_reward = 1950.0                 # Collapse RAIL, not the gate (PLANT_VALIDATION §9/§12): no reward threshold
                                         # can separate a competent policy from a statue, because the statue is the
                                         # reward optimum (97.0% of the 3.35/step ceiling with zero actuation cost).
@@ -222,15 +269,17 @@ min_avg_reward = 1950.0                 # Collapse RAIL, not the gate (PLANT_VAL
                                         # is competence-bar reasoning, and §9 is the argument that a competence bar
                                         # cannot work here.
                                         #
-                                        # The real 1a gate is the episode-level stance_success event
-                                        # (STAGE1_SPLIT_PLAN §2.3) over unsupported duty — machinery still to be
-                                        # built. The old 1840 was cleared by the statue itself and certified
-                                        # nothing.
-min_avg_episode_length = 950             # Encodes §12's full-horizon >= 95% in the existing machinery. The statue
-                                        # measures 100% at noise 0.05, so this is a floor a competent policy must
-                                        # MATCH, not beat; the old 750 was calibrated at noise 0.10 where survival
-                                        # and stance quality were inseparable.
-required_consecutive = 3
+                                        # The real 1a gate is now the stance criteria above; this stays purely as a
+                                        # rail. The old 1840 was cleared by the statue itself and certified nothing.
+                                        #
+                                        # Superseded, kept for the record:
+                                        # min_avg_episode_length = 950 — encoded §12's full-horizon >= 95% through
+                                        # the only field reward_and_length/v1 had. min_full_horizon_fraction states
+                                        # the same requirement directly, so the schema now rejects this key for this
+                                        # gate kind rather than letting both express it.
+required_consecutive = 3                # Scheduler hysteresis ONLY. Re-running a deterministic panel is not
+                                        # statistical replication (§3.4 caution 3) — the certified claim comes from
+                                        # the bound above, not from repeating the same evaluation three times.
 collapse_min_evals = 20                 # Backstop early-stop (EvalCollapseEarlyStopCallback): wait ~1M steps before it can fire.
 collapse_patience = 10                  # Require 10 consecutive raw per-eval mean drops so transition turbulence won't abort the stage.
 collapse_drop_fraction = 0.5            # Only raw means >50% below the robust rolling-median peak count. Stage-1 balance learning has a long

--- a/docs/PLANT_VALIDATION_AND_STAGE1_OBJECTIVE.md
+++ b/docs/PLANT_VALIDATION_AND_STAGE1_OBJECTIVE.md
@@ -371,6 +371,12 @@ luck.
 
 **Gate on unsupported duty; treat switch rate as diagnostic** until §11.3 is resolved.
 
+> **DONE for T-Rex 1a, 2026-08-01.** `[implemented]` Shipped as gate kind `stance_quality/v1`:
+> `min_full_horizon_fraction ≥ 0.95`, `max_unsupported_duty ≤ 0.02`, and a one-sided 95% upper
+> bound on mean duty `≤ 0.02`, over a 40-episode panel, with reward demoted to a rail. Switch
+> rate stayed diagnostic as directed. The full `stance_success` quantile conjunction is not
+> built; the two discriminating criteria and the certifying bound are.
+
 Proposed per-species thresholds — **for review, not adopted**:
 
 | species | noise | full-horizon | unsupported duty | contact switches | reward floor |
@@ -672,3 +678,22 @@ above stay a faithful snapshot:
   kind named `reward_and_length/v1`. `collapse_peak_floor` is 0.75 × each statue's standing
   reward, still absolute pending §14 item 3. The `stance_success` machinery and the §14 reward
   changes remain unimplemented — the latter deliberately, per §14's "wait for the fresh run".
+
+  > **SUPERSEDED 2026-08-01 for T-Rex stage 1.** `[implemented]` The §14 reward changes shipped,
+  > and the gate itself moved to a new kind, `stance_quality/v1`
+  > (`environments/shared/curriculum/stance_gate.py`). Three things above no longer describe
+  > T-Rex 1a:
+  >
+  > * `min_avg_episode_length` is **retired** for that stage. `min_full_horizon_fraction = 0.95`
+  >   states the same §12 requirement directly instead of encoding it as a mean step count, and
+  >   the schema now rejects the old key for this gate kind so both cannot express it at once.
+  > * `min_avg_reward = 1950` survives only as a **rail**, not a gate criterion. Run
+  >   `20260801_203206`'s own `zero_action_baseline.json` returned *"FAILS — a statue clears this
+  >   gate"*: the statue scores 3271.8 at 1000.0 steps, clearing both retired criteria.
+  > * `collapse_peak_floor` is no longer absolute — §14 item 3 shipped, and the floor is now
+  >   `0.45 × collapse_peak_floor_reference`.
+  >
+  > The `stance_success` conjunction of quantile criteria is still unbuilt; what shipped is the
+  > two criteria that discriminate, plus the certifying bound. The other three species remain on
+  > `reward_and_length/v1` pending their own calibration, and quadrupeds stay blocked on the
+  > `diag_r_foot`/`diag_l_foot` interleaving defect.

--- a/docs/STAGE1_SPLIT_PLAN.md
+++ b/docs/STAGE1_SPLIT_PLAN.md
@@ -279,9 +279,24 @@ From a randomised initial state, converge to a stable upright pose and hold it t
 passive. That is the intended null for this stage and it is *not* a defect — settling is the
 capability 1a exists to certify.
 
-**What does not pass:** literal zero action, which reaches the full horizon in only 57.5% of
-episodes against the 90% proposed below. The two are often conflated; they are different
-policies with different scores.
+**What does not pass:** *(revision 2 text, now STALE — see the correction below)* literal zero
+action, which reaches the full horizon in only 57.5% of episodes against the 90% proposed below.
+The two are often conflated; they are different policies with different scores.
+
+> **CORRECTED 2026-08-01 — at the adopted 1a operating point, zero action DOES pass.** `[measured]`
+> The 57.5% figure is measured at `reset_noise_scale = 0.10`. §2.3.1 subsequently moved 1a to
+> **0.05**, where the statue reaches the full horizon in **99.17%** of episodes (119/120 pooled
+> over three independent 40-seed blocks) with unsupported duty **0.000**. Against the adopted
+> `min_full_horizon_fraction = 0.95` it passes comfortably.
+>
+> That is intentional, not a hole. §2.3.1 states the position directly: the statue's numbers are
+> what a 1a policy must **match, not beat** — it defines the quality ceiling, and 1a's job is to
+> certify a policy has not bought stability with actuation. The policy the gate must reject is
+> the **chatterer**, not the statue: run `20260801_021545`'s best checkpoint reached the horizon
+> on every rolled-out episode and scored 2347.67 while spending **28.4%** of its steps with
+> neither foot loaded. Robustness is 1b's job, supplied through declared `xfrc_applied`
+> perturbations rather than reset noise, where a lucky draw and a good controller are
+> indistinguishable.
 
 ### 2.2 Configuration
 
@@ -353,10 +368,18 @@ oscillation and large transients — which is precisely the failure mode in §1.
 > 1. **Screening, every evaluation at n=40** — raw fractions, with `required_consecutive` as
 >    scheduler hysteresis ONLY. Re-running a deterministic panel is not statistical
 >    replication (§3.4 caution 3).
-> 2. **The load-bearing bound — one-sided LCB on MEAN UNSUPPORTED DUTY at n=40.** Duty is
+> 2. **The load-bearing bound — one-sided UCB on MEAN UNSUPPORTED DUTY at n=40.** Duty is
 >    continuous with tiny measured variance (the statue sits at 0.000 on all four species), so
 >    an interval on it has real power at 40 episodes where the pass/fail count has almost none.
 >    This is what actually certifies stance quality.
+>
+>    > **CORRECTED 2026-08-01 — this said LCB, which is the wrong direction.** Unsupported duty
+>    > is required to stay *below* a ceiling, so the conservative bound is the **upper** one.
+>    > A lower bound would pass a policy whose mean already exceeded the ceiling whenever the
+>    > panel happened to be noisy, which inverts the gate. The distinction does not apply to
+>    > item 1's `P(stance_success)`, where a lower bound is correct because that quantity must
+>    > stay *above* a floor. Implemented as UCB in
+>    > `environments/shared/curriculum/stance_gate.py`.
 > 3. **Confirmation — one predeclared held-out panel at n≈100–180** for the binary
 >    full-horizon event, run once a candidate qualifies (96/100 certifies `P ≥ 0.911`; 168/179
 >    certifies `P ≥ 0.900`). Evaluation is minutes and training is days, so this is the cheapest
@@ -370,26 +393,63 @@ oscillation and large transients — which is precisely the failure mode in §1.
 > recorded in KNOWN_ISSUES, which must be fixed before this rule can be applied to
 > brachiosaurus or dibothrosuchus.
 
-**This is new machinery, not a config change.** `StageThreshold`
-(`environments/shared/curriculum/manager.py:23-30`) currently supports exactly `min_avg_reward`,
+> **BUILT 2026-08-01 — `stance_quality/v1`.** `[implemented]` The gate now exists as a
+> registered kind in `environments/shared/curriculum/gate_schema.py`, evaluated by
+> `environments/shared/curriculum/stance_gate.py` and run identically by both backends. What
+> shipped is items 1 and 2 of the adopted rule, over the two criteria that discriminate; the
+> richer `stance_success` conjunction below (settling time, tail quantiles on height,
+> orientation, speed and drift) is **not** implemented, and neither is item 3's held-out panel.
+>
+> | criterion | T-Rex 1a | statue | chatterer (`20260801_021545`) |
+> |---|---|---|---|
+> | `min_full_horizon_fraction` | ≥ 0.95 | 0.9917 ✓ | 1.000 ✓ |
+> | `max_unsupported_duty` | ≤ 0.02 | 0.000 ✓ | **0.284 ✗** |
+> | `max_unsupported_duty_ucb` | ≤ 0.02 | 0.000 ✓ | **0.284 ✗** |
+> | `min_avg_reward` (rail) | ≥ 1950 | 3271.8 ✓ | 2347.7 ✓ |
+>
+> Two semantics were decided rather than inferred, and are recorded in the module docstring:
+> **failed episodes are excluded from duty** rather than scored as 1.0 (survival is already
+> gated by the horizon fraction; averaging duty over a failed episode's steps would flatter a
+> policy that faceplanted early), and **duty is measured after `settle_steps = 200`**, which is
+> `[inferred]`, not measured, and should be calibrated against rollout data.
+>
+> Duty is `derive_stance_info`'s `unsupported_duty` at its default **0.1 N** contact threshold,
+> deliberately not the reward's 42 N `min_support_force` — every calibration point above is
+> measured at 0.1 N.
+>
+> **JAX is gate-complete but emitter-incomplete.** `check_stage_gate` evaluates the kind through
+> the same shared function and raises `GateSchemaError` when the trainer supplies no stance
+> metrics, so it cannot half-enforce; the MJX evaluator does not yet emit them, so
+> `stance_quality/v1` stages are SB3-only until it does. Quadrupeds remain blocked on the
+> `diag_r_foot`/`diag_l_foot` interleaving defect.
+
+**This was new machinery, not a config change.** `StageThreshold`
+(`environments/shared/curriculum/manager.py:23-30`) supported exactly `min_avg_reward`,
 `min_avg_episode_length`, `min_avg_forward_vel`, `min_success_rate`, `min_eval_episodes` and
 `required_consecutive`. `[measured]` Revision 1 of this document said the proposed quantities
-"are already logged"; that conflated diagnostic logging with canonical gate evidence. Before any
-of this can gate advancement, the following must be specified and implemented:
+"are already logged"; that conflated diagnostic logging with canonical gate evidence. The
+following had to be specified and implemented — items still open are marked:
 
-* per-step → per-episode → per-evaluation aggregation, explicitly;
-* whether failed episodes contribute, and with what value;
-* the settling and tail window definitions;
-* whether drift means final, maximum, time-averaged or cumulative displacement;
-* per-species thresholds or morphology-normalised ones — `height_error` is currently T-Rex
-  instrumentation, not a four-species advancement metric;
-* SB3 and MJX/JAX parity;
-* persistence through reporting, result bundles, notebook and sweeps.
+* ~~per-step → per-episode → per-evaluation aggregation, explicitly~~ **done** —
+  `summarize_stance_panel` / `stance_panel_from_episode_duties`, the single reduction both
+  backends call;
+* ~~whether failed episodes contribute, and with what value~~ **done** — excluded;
+* the settling window is defined (`settle_steps`, applied before duty is accumulated); the
+  **tail window** for the quantile criteria is not, because those criteria are not built;
+* **open** — whether drift means final, maximum, time-averaged or cumulative displacement;
+* **open** — per-species thresholds or morphology-normalised ones. `height_error` is T-Rex
+  instrumentation, not a four-species advancement metric. Only T-Rex 1a is configured;
+* SB3 and MJX/JAX parity — **criteria done, MJX emitter open** (see the note above);
+* **open** — persistence through reporting, result bundles, notebook and sweeps.
 
-Provisional T-Rex values, to be calibrated rather than adopted: `T_settle` 200 steps,
-`h_max` 0.03 m, `d_max` 0.5 m. `[inferred]`
+Provisional T-Rex values, to be calibrated rather than adopted: `T_settle` 200 steps (adopted as
+`settle_steps`, still `[inferred]`), `h_max` 0.03 m, `d_max` 0.5 m. `[inferred]`
 
-`min_avg_reward` is **unset** for 1a — see §5.2, which makes that safe rather than fail-open.
+`min_avg_reward` is **set but demoted** for 1a, not unset. Revision 2 proposed unsetting it; the
+adopted position keeps it at 1950 (0.60 × the statue's 3271.8) as a *rail* whose only job is
+rejecting a policy that discarded most of the available return. A fail-closed schema makes "no
+reward criterion" something a config must declare deliberately, and a rail two-thirds below the
+achievable optimum cannot act as a competence bar. See §5.2.
 
 #### 2.3.1 The statistical operating point must be declared  `[measured]`
 

--- a/docs/STAGE1_SPLIT_PLAN.md
+++ b/docs/STAGE1_SPLIT_PLAN.md
@@ -293,7 +293,8 @@ The two are often conflated; they are different policies with different scores.
 > what a 1a policy must **match, not beat** — it defines the quality ceiling, and 1a's job is to
 > certify a policy has not bought stability with actuation. The policy the gate must reject is
 > the **chatterer**, not the statue: run `20260801_021545`'s best checkpoint reached the horizon
-> on every rolled-out episode and scored 2347.67 while spending **28.4%** of its steps with
+> on every rolled-out episode and, re-rolled on the current plant and reward over 40 episodes,
+> scores 2133.4 while spending **31.9%** of its post-settling steps with
 > neither foot loaded. Robustness is 1b's job, supplied through declared `xfrc_applied`
 > perturbations rather than reset noise, where a lucky draw and a good controller are
 > indistinguishable.
@@ -403,9 +404,9 @@ oscillation and large transients — which is precisely the failure mode in §1.
 > | criterion | T-Rex 1a | statue | chatterer (`20260801_021545`) |
 > |---|---|---|---|
 > | `min_full_horizon_fraction` | ≥ 0.95 | 0.9917 ✓ | 1.000 ✓ |
-> | `max_unsupported_duty` | ≤ 0.02 | 0.000 ✓ | **0.284 ✗** |
-> | `max_unsupported_duty_ucb` | ≤ 0.02 | 0.000 ✓ | **0.284 ✗** |
-> | `min_avg_reward` (rail) | ≥ 1950 | 3271.8 ✓ | 2347.7 ✓ |
+> | `max_unsupported_duty` | ≤ 0.02 | 0.000 ✓ | **0.319 ✗** |
+> | `max_unsupported_duty_ucb` | ≤ 0.02 | 0.000 ✓ | **0.322 ✗** |
+> | `min_avg_reward` (rail) | ≥ 1950 | 3271.8 ✓ | 2133.4 ✓ |
 >
 > Two semantics were decided rather than inferred, and are recorded in the module docstring:
 > **failed episodes are excluded from duty** rather than scored as 1.0 (survival is already

--- a/environments/shared/curriculum/advancement.py
+++ b/environments/shared/curriculum/advancement.py
@@ -131,6 +131,20 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
         duties = list(histories[n_evals - 1])
         if not duties:
             return None
+        if len(duties) != len(lengths):
+            # The two sources are matched positionally: lengths come from
+            # EvalCallback's npz, duties from the capture callback. If they
+            # disagree, every duty is paired with the wrong episode's length.
+            # Refuse rather than raise, so a training run degrades to "does
+            # not advance" instead of dying mid-stage.
+            logger.warning(
+                "Stage %d stance capture recorded %d episode duties for a %d-episode "
+                "evaluation; refusing to advance rather than pairing them positionally.",
+                self.curriculum_manager.current_stage,
+                len(duties),
+                len(lengths),
+            )
+            return None
 
         return stance_panel_from_episode_duties(
             episode_lengths=lengths,

--- a/environments/shared/curriculum/advancement.py
+++ b/environments/shared/curriculum/advancement.py
@@ -12,12 +12,14 @@ from typing import Any, Callable, Optional
 import numpy as np
 
 from environments.shared.metrics import LocomotionMetrics, env_dt
+from environments.shared.stance_diagnostics import derive_stance_info
 from environments.shared.wandb_integration import log_eval_metrics
 
 from . import sb3_compat
 from .manager import CurriculumManager
 from .sb3_compat import BaseCallback
 from .schedules import _ConstantSchedule
+from .stance_gate import STANCE_GATE_KIND, StancePanel, stance_panel_from_episode_duties
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +106,43 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
             if latest:
                 return latest
         return fallback
+
+    def _stance_panel_for_eval(
+        self,
+        n_evals: int,
+        rewards: list[float],
+        lengths: list[float],
+    ) -> StancePanel | None:
+        """Build this evaluation's stance panel, or ``None`` if unavailable.
+
+        Read from ``StageAwareEvalCallback``'s per-episode capture over the
+        *main* evaluation pass, so the bound is formed at the panel size it is
+        specified for rather than at the 10-episode supplementary sample.
+        Returns ``None`` when the stage does not gate on stance or the
+        callback did not record duties, which makes the gate fail closed
+        rather than advance on evidence nobody collected.
+        """
+        if self.curriculum_manager.current_threshold.gate_kind != STANCE_GATE_KIND:
+            return None
+
+        histories = getattr(self.eval_callback, "evaluations_unsupported_duties", None)
+        if histories is None or n_evals <= 0 or len(histories) < n_evals:
+            return None
+        duties = list(histories[n_evals - 1])
+        if not duties:
+            return None
+
+        return stance_panel_from_episode_duties(
+            episode_lengths=lengths,
+            episode_duties=duties,
+            episode_rewards=rewards,
+            horizon=self._eval_horizon(),
+        )
+
+    def _eval_horizon(self) -> int:
+        """Episode-step count that counts as reaching the horizon."""
+        env_kwargs = self.curriculum_manager.current_config().get("env_kwargs", {})
+        return int(env_kwargs.get("max_episode_steps", 1000))
 
     def _on_step(self) -> bool:
         if (self.num_timesteps - self._last_eval_step) < self.eval_freq:
@@ -268,7 +307,8 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
         # when task success is an active gate for this stage.  Incidental
         # target contacts in balance/locomotion are not stage success.
         success_arg = self._success_rates_for_stage(npz_successes, success_flags or None)
-        if self.curriculum_manager.should_advance(rewards, lengths, fwd_vel_arg, success_arg):
+        stance_panel = self._stance_panel_for_eval(n_evals, rewards, lengths)
+        if self.curriculum_manager.should_advance(rewards, lengths, fwd_vel_arg, success_arg, stance_panel):
             self.ready_to_advance = True
             logger.info(
                 "CurriculumCallback: stage %d thresholds met at step %d. Stopping training for stage advancement.",
@@ -299,6 +339,11 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
         forward_vels: list[float] = []
         success_flags: list[float] = []
         episode_reports: list[dict[str, Any]] = []
+        # Per-episode unsupported duty, so this path can drive
+        # stance_quality/v1 too. Without it a stage on that gate would fail
+        # closed forever here — correct, but a silent dead end.
+        settle_steps = self.curriculum_manager.current_threshold.settle_steps
+        episode_duties: list[float] = []
 
         try:
             eval_dt = env_dt(self.eval_env)
@@ -309,16 +354,23 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
                 episode_length = 0
                 ep_forward_vels: list[float] = []
                 ep_success = 0.0
+                unsupported_steps = 0
+                measured_steps = 0
                 done = False
                 while not done:
                     action, _ = self.model.predict(obs, deterministic=True)
                     obs, reward, dones, infos = self.eval_env.step(action)
                     step_reward = float(reward[0])
                     episode_reward += step_reward
-                    episode_length += 1
                     metrics.record_step(infos[0], step_reward)
                     if "forward_vel" in infos[0]:
                         ep_forward_vels.append(float(infos[0]["forward_vel"]))
+                    if episode_length >= settle_steps:
+                        stance = derive_stance_info(infos[0])
+                        if stance:
+                            measured_steps += 1
+                            unsupported_steps += int(stance["unsupported_duty"])
+                    episode_length += 1
                     for key in ("bite_success", "strike_success", "food_reached"):
                         if infos[0].get(key):
                             ep_success = 1.0
@@ -329,6 +381,7 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
                 if ep_forward_vels:
                     forward_vels.append(float(np.mean(ep_forward_vels)))
                 success_flags.append(ep_success)
+                episode_duties.append(unsupported_steps / measured_steps if measured_steps else float("nan"))
                 episode_reports.append(metrics.compute())
         finally:
             if old_training is not None:
@@ -340,7 +393,15 @@ class CurriculumCallback(BaseCallback):  # type: ignore[misc]
 
         fwd_vel_arg = forward_vels if forward_vels else None
         success_arg = self._success_rates_for_stage(None, success_flags or None)
-        if self.curriculum_manager.should_advance(rewards, lengths, fwd_vel_arg, success_arg):
+        stance_panel = None
+        if self.curriculum_manager.current_threshold.gate_kind == STANCE_GATE_KIND:
+            stance_panel = stance_panel_from_episode_duties(
+                episode_lengths=lengths,
+                episode_duties=episode_duties,
+                episode_rewards=rewards,
+                horizon=self._eval_horizon(),
+            )
+        if self.curriculum_manager.should_advance(rewards, lengths, fwd_vel_arg, success_arg, stance_panel):
             self.ready_to_advance = True
             logger.info(
                 "CurriculumCallback: stage %d thresholds met at step %d. Stopping training for stage advancement.",

--- a/environments/shared/curriculum/gate_schema.py
+++ b/environments/shared/curriculum/gate_schema.py
@@ -37,6 +37,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+from .stance_gate import STANCE_GATE_KIND
+
 #: Bumped when the meaning of an existing key changes.  Adding a new gate
 #: kind does not require a bump; changing how an existing one is evaluated
 #: does.
@@ -59,6 +61,26 @@ GATE_KINDS: dict[str, frozenset[str]] = {
             "required_consecutive",
         }
     ),
+    # Stage 1a's stance-quality gate.  Judges physical stance -- did the body
+    # reach the horizon, and did it keep both feet loaded once settled --
+    # rather than return, because on stage 1 the zero-action statue is the
+    # global optimum and no reward threshold separates it from a competent
+    # policy (docs/STAGE1_SPLIT_PLAN.md 2.3.1).  ``min_avg_reward`` is carried
+    # here too, but as a RAIL set well below the statue: its only job is
+    # rejecting a policy that threw away most of the available return, and it
+    # is deliberately not the gate.  See
+    # :mod:`environments.shared.curriculum.stance_gate` for the statistic.
+    STANCE_GATE_KIND: frozenset(
+        {
+            "min_full_horizon_fraction",
+            "max_unsupported_duty",
+            "max_unsupported_duty_ucb",
+            "settle_steps",
+            "min_avg_reward",
+            "min_eval_episodes",
+            "required_consecutive",
+        }
+    ),
     # An explicit, recorded non-advancing mode for pilots and diagnostics.
     # Declaring it is the ONLY supported way to run a stage with no gate, and
     # it refuses to advance rather than passing by default.
@@ -74,6 +96,18 @@ GATE_KINDS: dict[str, frozenset[str]] = {
 #: two backends agreeing, which is the schema's whole job.
 _REQUIRED_THRESHOLD_KEYS: dict[str, frozenset[str]] = {
     "reward_and_length/v1": frozenset({"min_avg_reward"}),
+    # All three stance criteria are required.  The UCB in particular is the
+    # one that certifies -- omitting it would leave the gate resting on raw
+    # panel fractions, which is the low-power reading this kind exists to
+    # replace.  ``min_avg_reward`` is NOT required: it is a rail, and a config
+    # may legitimately decline to set one.
+    STANCE_GATE_KIND: frozenset(
+        {
+            "min_full_horizon_fraction",
+            "max_unsupported_duty",
+            "max_unsupported_duty_ucb",
+        }
+    ),
     "none/v1": frozenset(),
 }
 

--- a/environments/shared/curriculum/manager.py
+++ b/environments/shared/curriculum/manager.py
@@ -15,18 +15,45 @@ import numpy as np
 from environments.shared.config import load_all_stages
 
 from .gate_schema import validate_gate_config
+from .stance_gate import (
+    STANCE_GATE_KIND,
+    StanceGateThresholds,
+    StancePanel,
+    evaluate_stance_gate,
+)
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class StageThreshold:
-    """Performance thresholds that must be met to advance past a stage."""
+    """Performance thresholds that must be met to advance past a stage.
 
+    Carries the union of every gate kind's fields; ``gate_kind`` selects which
+    subset :meth:`CurriculumManager.should_advance` actually evaluates. The
+    defaults are the permissive ones only for ``reward_and_length/v1``, which
+    is why :func:`thresholds_from_configs` runs the fail-closed schema check
+    before any of them is populated.
+    """
+
+    gate_kind: str = "reward_and_length/v1"
+
+    # reward_and_length/v1
     min_avg_reward: float = -np.inf
     min_avg_episode_length: float = 0.0
     min_avg_forward_vel: float = 0.0
     min_success_rate: float = 0.0
+
+    # stance_quality/v1.  Ceilings default to +inf and the floor to 0.0 so a
+    # field the schema failed to populate cannot silently tighten the gate;
+    # the schema requires all three of the real ones, so these defaults are
+    # only ever seen by a stage using a different kind.
+    min_full_horizon_fraction: float = 0.0
+    max_unsupported_duty: float = np.inf
+    max_unsupported_duty_ucb: float = np.inf
+    settle_steps: int = 0
+
+    # Shared
     min_eval_episodes: int = 10
     required_consecutive: int = 3
 
@@ -103,6 +130,7 @@ class CurriculumManager:
         episode_lengths: list[float],
         forward_velocities: list[float] | None = None,
         success_rates: list[float] | None = None,
+        stance_panel: StancePanel | None = None,
     ) -> dict[str, float]:
         """Record evaluation results for the current stage.
 
@@ -113,6 +141,13 @@ class CurriculumManager:
                 per episode (m/s). Used for locomotion stage gating.
             success_rates: Optional list of per-episode success flags
                 (1.0 if prey contact / food reached, 0.0 otherwise).
+            stance_panel: Optional stance summary for ``stance_quality/v1``.
+                Both backends must build this with
+                :func:`~environments.shared.curriculum.stance_gate.summarize_stance_panel`
+                rather than reducing per-episode traces themselves, so the
+                settling window and the failed-episode rule cannot drift
+                between SB3 and JAX — which is the whole point of the
+                versioned schema.
 
         Returns:
             Summary dict with mean/std statistics.
@@ -128,6 +163,14 @@ class CurriculumManager:
             summary["mean_forward_vel"] = float(np.mean(forward_velocities))
         if success_rates is not None:
             summary["mean_success_rate"] = float(np.mean(success_rates))
+        if stance_panel is not None:
+            # The bound is stored as a scalar rather than the raw duties: it is
+            # a pure function of them, and the history is serialized into run
+            # summaries where per-episode traces would not belong.
+            summary["full_horizon_fraction"] = stance_panel.full_horizon_fraction
+            summary["mean_unsupported_duty"] = stance_panel.mean_unsupported_duty
+            summary["unsupported_duty_ucb"] = stance_panel.unsupported_duty_ucb
+            summary["n_duty_episodes"] = stance_panel.n_duty_episodes
         self._eval_history[self._current_stage].append(summary)
 
         vel_str = ""
@@ -136,8 +179,15 @@ class CurriculumManager:
         success_str = ""
         if "mean_success_rate" in summary:
             success_str = f", success={summary['mean_success_rate']:.0%}"
+        stance_str = ""
+        if "full_horizon_fraction" in summary:
+            stance_str = (
+                f", horizon={summary['full_horizon_fraction']:.1%}"
+                f", duty={summary['mean_unsupported_duty']:.4f}"
+                f" (ucb {summary['unsupported_duty_ucb']:.4f}, n={summary['n_duty_episodes']:.0f})"
+            )
         logger.info(
-            "Stage %d eval: reward=%.2f +/- %.2f, length=%.1f +/- %.1f%s%s (%d eps)",
+            "Stage %d eval: reward=%.2f +/- %.2f, length=%.1f +/- %.1f%s%s%s (%d eps)",
             self._current_stage,
             summary["mean_reward"],
             summary["std_reward"],
@@ -145,6 +195,7 @@ class CurriculumManager:
             summary["std_length"],
             vel_str,
             success_str,
+            stance_str,
             summary["n_episodes"],
         )
         return summary
@@ -155,6 +206,7 @@ class CurriculumManager:
         episode_lengths: list[float] | None = None,
         forward_velocities: list[float] | None = None,
         success_rates: list[float] | None = None,
+        stance_panel: StancePanel | None = None,
     ) -> bool:
         """Check whether performance thresholds are met for advancement.
 
@@ -167,13 +219,15 @@ class CurriculumManager:
             forward_velocities: Per-episode mean forward velocities (m/s).
             success_rates: Per-episode success flags (1.0 if prey contact
                 / food reached, 0.0 otherwise).
+            stance_panel: Stance summary, required by ``stance_quality/v1``.
+                A stage declaring that kind without one fails closed.
 
         Returns:
             True if the current stage thresholds have been met for the
             required number of consecutive evaluations.
         """
         if rewards is not None and episode_lengths is not None:
-            self.record_eval(rewards, episode_lengths, forward_velocities, success_rates)
+            self.record_eval(rewards, episode_lengths, forward_velocities, success_rates, stance_panel)
 
         threshold = self._thresholds[self._current_stage]
         history = self._eval_history[self._current_stage]
@@ -183,21 +237,17 @@ class CurriculumManager:
 
         latest = history[-1]
 
-        passes = (
-            latest["mean_reward"] >= threshold.min_avg_reward
-            and latest["mean_length"] >= threshold.min_avg_episode_length
-            and latest["n_episodes"] >= threshold.min_eval_episodes
-        )
-
-        # Forward velocity gate (only checked when threshold is > 0)
-        if threshold.min_avg_forward_vel > 0.0:
-            mean_vel = latest.get("mean_forward_vel", 0.0)
-            passes = passes and mean_vel >= threshold.min_avg_forward_vel
-
-        # Success rate gate (only checked when threshold is > 0)
-        if threshold.min_success_rate > 0.0:
-            mean_success = latest.get("mean_success_rate", 0.0)
-            passes = passes and mean_success >= threshold.min_success_rate
+        if threshold.gate_kind == "none/v1":
+            # A declared non-advancing pilot. Previously this stage produced no
+            # threshold entry at all and fell through to StageThreshold's
+            # permissive defaults, which pass on any evaluation — the schema
+            # rejects "none/v1" whenever advancement is enabled, so nothing
+            # reached that path, but it was fail-open one config change away.
+            passes = False
+        elif threshold.gate_kind == STANCE_GATE_KIND:
+            passes = self._stance_gate_passes(latest)
+        else:
+            passes = self._reward_and_length_gate_passes(latest, threshold)
 
         if passes:
             self._consecutive_passes[self._current_stage] += 1
@@ -214,6 +264,76 @@ class CurriculumManager:
             )
 
         return met
+
+    def _reward_and_length_gate_passes(self, latest: dict[str, float], threshold: StageThreshold) -> bool:
+        """Evaluate ``reward_and_length/v1`` against one evaluation."""
+        passes = (
+            latest["mean_reward"] >= threshold.min_avg_reward
+            and latest["mean_length"] >= threshold.min_avg_episode_length
+            and latest["n_episodes"] >= threshold.min_eval_episodes
+        )
+
+        # Forward velocity gate (only checked when threshold is > 0)
+        if threshold.min_avg_forward_vel > 0.0:
+            mean_vel = latest.get("mean_forward_vel", 0.0)
+            passes = passes and mean_vel >= threshold.min_avg_forward_vel
+
+        # Success rate gate (only checked when threshold is > 0)
+        if threshold.min_success_rate > 0.0:
+            mean_success = latest.get("mean_success_rate", 0.0)
+            passes = passes and mean_success >= threshold.min_success_rate
+
+        return passes
+
+    def _stance_gate_passes(self, latest: dict[str, float]) -> bool:
+        """Evaluate ``stance_quality/v1`` against one evaluation.
+
+        Reconstructs a :class:`StancePanel` from the recorded summary so the
+        shared criterion logic in
+        :func:`~environments.shared.curriculum.stance_gate.evaluate_stance_gate`
+        is the single implementation both backends run.
+
+        A stage declaring this kind whose evaluation carried no stance panel
+        fails closed and says so once per evaluation, rather than falling
+        through to the reward criteria — advancing on evidence nobody
+        collected is the exact failure mode the versioned schema exists to
+        prevent.
+        """
+        threshold = self._thresholds[self._current_stage]
+
+        if "full_horizon_fraction" not in latest:
+            logger.warning(
+                "Stage %d declares gate_kind %s but the evaluation carried no stance panel; "
+                "refusing to advance. The eval path must build one with "
+                "stance_gate.summarize_stance_panel().",
+                self._current_stage,
+                STANCE_GATE_KIND,
+            )
+            return False
+
+        panel = StancePanel(
+            n_episodes=int(latest["n_episodes"]),
+            full_horizon_fraction=latest["full_horizon_fraction"],
+            mean_reward=latest["mean_reward"],
+            n_duty_episodes=int(latest["n_duty_episodes"]),
+            mean_unsupported_duty=latest["mean_unsupported_duty"],
+            unsupported_duty_ucb=latest["unsupported_duty_ucb"],
+        )
+        passed, failures = evaluate_stance_gate(
+            panel,
+            StanceGateThresholds(
+                min_full_horizon_fraction=threshold.min_full_horizon_fraction,
+                max_unsupported_duty=threshold.max_unsupported_duty,
+                max_unsupported_duty_ucb=threshold.max_unsupported_duty_ucb,
+                settle_steps=threshold.settle_steps,
+                min_eval_episodes=threshold.min_eval_episodes,
+                min_avg_reward=threshold.min_avg_reward,
+                required_consecutive=threshold.required_consecutive,
+            ),
+        )
+        if not passed:
+            logger.info("Stage %d stance gate not met: %s", self._current_stage, "; ".join(failures))
+        return passed
 
     def advance(self) -> int:
         """Advance to the next curriculum stage.
@@ -281,20 +401,25 @@ def thresholds_from_configs(
         # composite-only gate config produce no thresholds at all, after which
         # StageThreshold's permissive defaults advanced the stage on any
         # evaluation whatsoever. See gate_schema for the full failure mode.
-        validate_gate_config(stage, cur, advancement_enabled=advancement_enabled)
-        threshold_fields: dict[str, Any] = {}
-        if "min_avg_reward" in cur:
-            threshold_fields["min_avg_reward"] = cur["min_avg_reward"]
-        if "min_avg_episode_length" in cur:
-            threshold_fields["min_avg_episode_length"] = cur["min_avg_episode_length"]
-        if "min_avg_forward_vel" in cur:
-            threshold_fields["min_avg_forward_vel"] = cur["min_avg_forward_vel"]
-        if "min_success_rate" in cur:
-            threshold_fields["min_success_rate"] = cur["min_success_rate"]
-        if "min_eval_episodes" in cur:
-            threshold_fields["min_eval_episodes"] = cur["min_eval_episodes"]
-        if "required_consecutive" in cur:
-            threshold_fields["required_consecutive"] = cur["required_consecutive"]
-        if threshold_fields:
-            thresholds[stage] = threshold_fields
+        gate_kind = validate_gate_config(stage, cur, advancement_enabled=advancement_enabled)
+        # The kind is carried onto the threshold so ``should_advance`` selects
+        # the same criteria the schema validated, rather than inferring the
+        # gate from which fields happen to be present — inference is how a
+        # dropped field used to become a disabled criterion.
+        threshold_fields: dict[str, Any] = {"gate_kind": gate_kind}
+        for key in (
+            "min_avg_reward",
+            "min_avg_episode_length",
+            "min_avg_forward_vel",
+            "min_success_rate",
+            "min_full_horizon_fraction",
+            "max_unsupported_duty",
+            "max_unsupported_duty_ucb",
+            "settle_steps",
+            "min_eval_episodes",
+            "required_consecutive",
+        ):
+            if key in cur:
+                threshold_fields[key] = cur[key]
+        thresholds[stage] = threshold_fields
     return thresholds

--- a/environments/shared/curriculum/stance_gate.py
+++ b/environments/shared/curriculum/stance_gate.py
@@ -20,11 +20,21 @@ declared ``xfrc_applied`` perturbations rather than through reset noise, where
 a lucky draw and a good controller are indistinguishable.
 
 The policy this gate exists to reject is therefore the **chatterer**.  Run
-``20260801_021545``'s best checkpoint reached the full horizon in every rolled
-out episode and scored 2347.67 -- clearing ``min_avg_reward = 1950`` -- while
-spending **28.4%** of its steps with neither foot bearing load.  Against the
-statue's 0.000 that is the defect stage 1a is supposed to catch, and the
+``20260801_021545``'s best checkpoint, re-rolled on the current plant and
+reward over 40 episodes (seeds 3042-3081), reaches the full horizon **40/40**
+and scores **2133.4** -- clearing ``min_avg_reward = 1950`` -- while spending
+**0.319** of its post-settling steps with neither foot bearing load.  Against
+the statue's 0.000 that is the defect stage 1a is supposed to catch, and the
 reward gate waved it through.
+
+    Two earlier figures for this policy are superseded and should not be
+    quoted.  ``0.284`` duty came from an 8-episode rollout; 40 episodes give
+    0.319, so the small sample understated it.  ``2347.67`` was the run's best
+    *evaluation* mean under the reward in force at the time; under the shipped
+    section 14 reward the same checkpoint scores 2133.4, the ~214-point drop
+    being ``action_jerk_weight`` charging exactly the behaviour it targets.
+    Both revisions strengthen the case rather than weaken it, and the rail is
+    still cleared either way.
 
 The statistic
 -------------
@@ -252,9 +262,28 @@ def stance_panel_from_episode_duties(
 
     ``episode_duties`` is positionally aligned with ``episode_lengths``; use
     ``None`` for an episode whose duty could not be measured.
+
+    Raises:
+        ValueError: If the three sequences are not the same length.  They are
+            matched **positionally**, so a mismatch does not merely lose data
+            -- it pairs each duty with the wrong episode's length, and the
+            gate then certifies a short sample while reporting the full panel
+            size.  Measured: 40 lengths against 5 duties certified stance
+            quality from 5 episodes and passed.  Loud, because a silent
+            truncation here reads as "40 episodes agreed".
     """
     lengths = np.asarray(list(episode_lengths), dtype=float)
     n = lengths.size
+    duty_list = list(episode_duties)
+    reward_list = list(episode_rewards)
+    if len(duty_list) != n or len(reward_list) != n:
+        raise ValueError(
+            "stance panel inputs must be positionally aligned: got "
+            f"{n} episode_lengths, {len(duty_list)} episode_duties, "
+            f"{len(reward_list)} episode_rewards"
+        )
+    episode_duties = duty_list
+    episode_rewards = reward_list
     reached = lengths >= horizon
 
     duties = [
@@ -314,10 +343,39 @@ def evaluate_stance_gate(
     """
     failures: list[str] = []
 
+    # NaN fails every comparison below, so an unchecked NaN passes the entire
+    # gate. Measured on this implementation: a NaN ``mean_reward`` cleared the
+    # rail, and a NaN duty cleared both duty criteria. Reject non-finite
+    # values up front. The legitimate "unmeasurable" sentinel is ``+inf``,
+    # which fails the ceilings the ordinary way.
+    for name, value in (
+        ("full_horizon_fraction", panel.full_horizon_fraction),
+        ("mean_unsupported_duty", panel.mean_unsupported_duty),
+        ("unsupported_duty_ucb", panel.unsupported_duty_ucb),
+        ("mean_reward", panel.mean_reward),
+    ):
+        if math.isnan(value):
+            failures.append(f"{name} is NaN, so the gate cannot be evaluated")
+    if failures:
+        return False, failures
+
     if panel.n_episodes < thresholds.min_eval_episodes:
         failures.append(
             f"n_episodes {panel.n_episodes} < {thresholds.min_eval_episodes} "
             "(the bound's power is specified at this panel size)"
+        )
+
+    # The bound must rest on at least as many episodes as the survival
+    # requirement implies the panel should have produced. Without this a panel
+    # reporting 40 episodes while supplying 5 duties certified stance quality
+    # from those 5 and still cleared the panel-size check on the 40.
+    min_duty_episodes = math.ceil(thresholds.min_eval_episodes * thresholds.min_full_horizon_fraction)
+    if panel.n_duty_episodes < min_duty_episodes:
+        failures.append(
+            f"n_duty_episodes {panel.n_duty_episodes} < {min_duty_episodes} "
+            f"(min_eval_episodes {thresholds.min_eval_episodes} x min_full_horizon_fraction "
+            f"{thresholds.min_full_horizon_fraction:g}); the bound would certify a smaller "
+            "sample than the panel reports"
         )
 
     if panel.full_horizon_fraction < thresholds.min_full_horizon_fraction:
@@ -327,6 +385,10 @@ def evaluate_stance_gate(
 
     if panel.n_duty_episodes == 0:
         failures.append("no full-horizon episode supplied a measurable unsupported duty")
+    elif not 0.0 <= panel.mean_unsupported_duty <= 1.0 and math.isfinite(panel.mean_unsupported_duty):
+        # Outside [0, 1] is not a stricter or looser policy, it is a broken
+        # measurement -- and a negative one sails under every ceiling.
+        failures.append(f"mean_unsupported_duty {panel.mean_unsupported_duty:.4f} is outside [0, 1]")
     else:
         if panel.mean_unsupported_duty > thresholds.max_unsupported_duty:
             failures.append(

--- a/environments/shared/curriculum/stance_gate.py
+++ b/environments/shared/curriculum/stance_gate.py
@@ -1,0 +1,349 @@
+"""The stance-quality advancement gate: per-episode metrics and its bound.
+
+Stage 1a cannot be gated on return.  On stage 1 as configured the zero-action
+statue is the *global optimum* -- it collects 3271.8 of a theoretical 3350
+maximum, with ``energy`` and ``smoothness`` at exactly zero, while any active
+policy pays both.  So a policy's realistic ceiling sits *below* the statue's
+score and no reward threshold admits a competent policy while excluding a
+passive one.  See docs/STAGE1_SPLIT_PLAN.md section 2.3.1.
+
+This module supplies the replacement: a gate on **physical stance quality**,
+which does not rescale when a reward weight changes.
+
+What the gate is for
+--------------------
+Not for beating the statue.  Section 2.3.1 is explicit that the statue's
+numbers are "what a 1a policy must match, not beat" -- the statue defines the
+quality ceiling, and 1a's job is to certify that a policy has *not bought
+stability with actuation*.  Robustness is stage 1b's job, delivered through
+declared ``xfrc_applied`` perturbations rather than through reset noise, where
+a lucky draw and a good controller are indistinguishable.
+
+The policy this gate exists to reject is therefore the **chatterer**.  Run
+``20260801_021545``'s best checkpoint reached the full horizon in every rolled
+out episode and scored 2347.67 -- clearing ``min_avg_reward = 1950`` -- while
+spending **28.4%** of its steps with neither foot bearing load.  Against the
+statue's 0.000 that is the defect stage 1a is supposed to catch, and the
+reward gate waved it through.
+
+The statistic
+-------------
+Three parts, adopted 2026-08-01:
+
+1. **Screening, every evaluation** -- raw fractions: ``full_horizon_fraction``
+   and mean unsupported duty, with ``required_consecutive`` acting as
+   scheduler hysteresis ONLY.  Re-running a deterministic panel is not
+   statistical replication.
+2. **The load-bearing bound** -- a one-sided 95% *upper* confidence bound on
+   mean unsupported duty.  This is what actually certifies stance quality.
+3. **Confirmation** -- one predeclared held-out panel at n ~ 100-180 for the
+   binary full-horizon event, run once a candidate qualifies.  That step is
+   offline and deliberately lives outside this module.
+
+Why a bound on duty rather than on a pass/fail count: binarising costs almost
+all the power available at this panel size.  Measured, a binomial
+``LCB95 >= 0.90`` at n=40 requires a clean 40/40 and **would reject the
+statue 28% of the time** -- pooled over three independent 40-seed blocks the
+zero-action policy scores 119/120 = 99.17%, and at that true rate the chance
+of scoring 40/40 is only 71.6%.  A gate that rejects the theoretical optimum
+more than a quarter of the time is not measuring the policy.  Duty is
+continuous with tiny measured variance, so an interval on it has real power
+at 40 episodes where the count has almost none.
+
+**Direction.** Section 2.3 of STAGE1_SPLIT_PLAN says "one-sided LCB on mean
+unsupported duty".  That is a slip: duty is a quantity we require to stay
+*below* a ceiling, so the conservative direction is the UPPER bound.  A lower
+bound would pass a policy whose mean already exceeded the ceiling whenever the
+panel was noisy enough, which inverts the gate.  This module computes the
+upper bound and the doc has been corrected to match.
+
+Two semantics that had to be decided rather than inferred
+---------------------------------------------------------
+*Failed episodes are excluded from duty*, not scored as duty 1.0.  Survival is
+already gated by ``min_full_horizon_fraction``; folding it into duty as well
+double-counts it.  The alternative -- averaging duty over whatever steps a
+failed episode happened to run -- is actively perverse: a policy that
+faceplants at step 50 would earn a flattering duty score from its 50 cleanest
+steps.  Excluding them keeps the two criteria independent, which is what makes
+the pair readable.
+
+*Duty is measured after a settling window* (``settle_steps``), because a
+policy that corrects reset randomisation may legitimately move a foot doing
+it, and settling is the capability 1a exists to certify.  The 200-step default
+is ``[inferred]``, not measured -- it is 20% of the horizon and should be
+calibrated against rollout data before it is treated as evidence.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import numpy as np
+
+#: The gate kind this module evaluates.  Imported by ``gate_schema`` so the
+#: registry and the implementation cannot drift apart.
+STANCE_GATE_KIND = "stance_quality/v1"
+
+#: One-sided Student-t quantiles at 95%, by degrees of freedom.  Tabulated
+#: rather than taken from ``scipy.stats``: scipy is declared only in the
+#: ``test`` extra (pyproject.toml), and a gate that decides advancement during
+#: a Colab training run must not depend on a package the training extra does
+#: not install.  Interpolation is linear in ``1/dof``, which reproduces the
+#: exact quantile to within 2e-4 over dof 1-5000 -- verified against
+#: ``scipy.stats.t.ppf`` in the tests, where scipy *is* available.  At the
+#: gate's own operating point, dof 39, the table is exact to 5 decimals.  The
+#: residual is not signed (interpolation both over- and under-shoots by up to
+#: 1.4e-4), but it is three orders of magnitude below the duty ceiling this
+#: bound is compared against, so it cannot change a gate decision.
+_T95_BY_DOF: tuple[tuple[float, float], ...] = (
+    (1, 6.3138),
+    (2, 2.9200),
+    (3, 2.3534),
+    (4, 2.1318),
+    (5, 2.0150),
+    (6, 1.9432),
+    (7, 1.8946),
+    (8, 1.8595),
+    (9, 1.8331),
+    (10, 1.8125),
+    (12, 1.7823),
+    (15, 1.7531),
+    (20, 1.7247),
+    (25, 1.7081),
+    (29, 1.6991),
+    (39, 1.6849),
+    (49, 1.6766),
+    (59, 1.6711),
+    (99, 1.6604),
+    (199, 1.6525),
+)
+
+#: The dof -> infinity limit of the one-sided 95% t quantile (the normal z).
+_Z95 = 1.6449
+
+
+@dataclass(frozen=True)
+class StanceGateThresholds:
+    """The ``stance_quality/v1`` thresholds, as declared in ``[curriculum]``."""
+
+    min_full_horizon_fraction: float
+    max_unsupported_duty: float
+    max_unsupported_duty_ucb: float
+    settle_steps: int = 0
+    min_eval_episodes: int = 40
+    min_avg_reward: float = -math.inf
+    required_consecutive: int = 3
+
+
+def one_sided_t95(dof: int) -> float:
+    """Return the one-sided 95% Student-t quantile for ``dof``.
+
+    Interpolates linearly in ``1/dof`` between tabulated values.  Below the
+    table the smallest tabulated dof is used (the most conservative, i.e.
+    largest, quantile); above it the normal limit.
+    """
+    if dof < 1:
+        return math.inf
+    if dof >= _T95_BY_DOF[-1][0]:
+        # Past the table, interpolate toward the normal limit the same way.
+        last_dof, last_t = _T95_BY_DOF[-1]
+        if dof == last_dof:
+            return last_t
+        weight = (1.0 / dof) / (1.0 / last_dof)
+        return _Z95 + weight * (last_t - _Z95)
+    for (lo_dof, lo_t), (hi_dof, hi_t) in zip(_T95_BY_DOF, _T95_BY_DOF[1:]):
+        if lo_dof <= dof <= hi_dof:
+            if dof == lo_dof:
+                return lo_t
+            span = (1.0 / lo_dof) - (1.0 / hi_dof)
+            weight = ((1.0 / dof) - (1.0 / hi_dof)) / span
+            return hi_t + weight * (lo_t - hi_t)
+    return _T95_BY_DOF[0][1]
+
+
+def mean_upper_confidence_bound(values: Sequence[float]) -> float:
+    """One-sided 95% upper confidence bound on the mean of ``values``.
+
+    Returns ``inf`` for fewer than two observations, so an under-powered panel
+    fails the gate rather than passing it on no evidence.
+
+    A zero-variance panel returns the sample mean exactly.  That is the
+    statue's case -- every episode measures 0.000 -- and it is accepted here
+    rather than floored: duty is a physical occupancy fraction measured on a
+    deterministic panel, not the rate of a rare event, so identical
+    observations really are evidence of an identical underlying quantity.
+    """
+    sample = np.asarray(list(values), dtype=float)
+    n = sample.size
+    if n < 2:
+        return math.inf
+    mean = float(sample.mean())
+    # ddof=1: this is an inference about the population mean, not a
+    # description of the panel.
+    std_err = float(sample.std(ddof=1)) / math.sqrt(n)
+    return mean + one_sided_t95(n - 1) * std_err
+
+
+def episode_unsupported_duty(
+    unsupported_flags: Sequence[float] | Sequence[bool],
+    *,
+    settle_steps: int = 0,
+) -> float | None:
+    """Fraction of post-settling steps in which neither foot bore load.
+
+    Args:
+        unsupported_flags: Per-step truthy values, one per environment step of
+            a single episode, true when neither foot is bearing load.
+        settle_steps: Leading steps to discard before measuring.
+
+    Returns:
+        The duty fraction, or ``None`` when the episode is shorter than the
+        settling window and therefore carries no measurable tail.
+    """
+    flags = np.asarray(list(unsupported_flags), dtype=float)
+    if flags.size <= settle_steps:
+        return None
+    return float(flags[settle_steps:].mean())
+
+
+@dataclass(frozen=True)
+class StancePanel:
+    """The per-evaluation summary the gate consumes.
+
+    Deliberately a flat value object of scalars rather than a holder of
+    per-episode traces: it is recorded into ``CurriculumManager``'s evaluation
+    history, which is serialized into run summaries and result bundles, and
+    per-step traces have no business there.  It also means the panel a gate
+    decision was made from round-trips exactly through that history, so the
+    decision can be re-derived after the fact.
+
+    ``mean_unsupported_duty`` and ``unsupported_duty_ucb`` are ``inf`` when
+    the panel could not measure them, which fails the gate rather than
+    passing it on absent evidence.
+    """
+
+    n_episodes: int
+    full_horizon_fraction: float
+    mean_reward: float
+    #: Number of full-horizon episodes that supplied a measurable duty.
+    n_duty_episodes: int
+    mean_unsupported_duty: float
+    unsupported_duty_ucb: float
+
+
+def stance_panel_from_episode_duties(
+    *,
+    episode_lengths: Sequence[float],
+    episode_duties: Sequence[float | None],
+    episode_rewards: Sequence[float],
+    horizon: int,
+) -> StancePanel:
+    """Build the panel from per-episode duties that a caller already reduced.
+
+    The streaming callers -- SB3's evaluation callback and the MJX rollout --
+    accumulate duty per episode as steps arrive rather than retaining a
+    per-step trace for every episode of the panel.  They hand the reduced
+    scalars here so the rules that actually define the gate stay in one place:
+    which episodes count (full-horizon only), how their duties combine, and
+    how the bound is formed.  Only the mechanical act of applying the settling
+    window while streaming happens outside this module.
+
+    ``episode_duties`` is positionally aligned with ``episode_lengths``; use
+    ``None`` for an episode whose duty could not be measured.
+    """
+    lengths = np.asarray(list(episode_lengths), dtype=float)
+    n = lengths.size
+    reached = lengths >= horizon
+
+    duties = [
+        float(duty)
+        for index, duty in enumerate(episode_duties)
+        if index < n and reached[index] and duty is not None and math.isfinite(float(duty))
+    ]
+
+    return StancePanel(
+        n_episodes=int(n),
+        full_horizon_fraction=float(reached.mean()) if n else 0.0,
+        mean_reward=float(np.mean(episode_rewards)) if len(episode_rewards) else -math.inf,
+        n_duty_episodes=len(duties),
+        mean_unsupported_duty=float(np.mean(duties)) if duties else math.inf,
+        unsupported_duty_ucb=mean_upper_confidence_bound(duties) if duties else math.inf,
+    )
+
+
+def summarize_stance_panel(
+    *,
+    episode_lengths: Sequence[float],
+    episode_unsupported: Iterable[Sequence[float] | Sequence[bool]],
+    episode_rewards: Sequence[float],
+    horizon: int,
+    settle_steps: int = 0,
+) -> StancePanel:
+    """Reduce one evaluation's per-episode traces to the gate's panel summary.
+
+    ``episode_unsupported`` yields one per-step flag sequence per episode, in
+    the same order as ``episode_lengths``.  Only episodes that reached
+    ``horizon`` contribute duty -- see the module docstring for why failures
+    are excluded rather than scored as 1.0.
+
+    Both backends must funnel through this function.  It is where the
+    settling window and the failed-episode rule are applied, and a backend
+    that reduced traces itself would be free to disagree with the other one
+    about what the gate means.
+    """
+    return stance_panel_from_episode_duties(
+        episode_lengths=episode_lengths,
+        episode_duties=[episode_unsupported_duty(flags, settle_steps=settle_steps) for flags in episode_unsupported],
+        episode_rewards=episode_rewards,
+        horizon=horizon,
+    )
+
+
+def evaluate_stance_gate(
+    panel: StancePanel,
+    thresholds: StanceGateThresholds,
+) -> tuple[bool, list[str]]:
+    """Check one evaluation panel against the gate.
+
+    Returns:
+        ``(passed, failures)`` where *failures* names every criterion that did
+        not hold, in declaration order, so a near-miss is diagnosable from the
+        log without re-running the evaluation.
+    """
+    failures: list[str] = []
+
+    if panel.n_episodes < thresholds.min_eval_episodes:
+        failures.append(
+            f"n_episodes {panel.n_episodes} < {thresholds.min_eval_episodes} "
+            "(the bound's power is specified at this panel size)"
+        )
+
+    if panel.full_horizon_fraction < thresholds.min_full_horizon_fraction:
+        failures.append(
+            f"full_horizon_fraction {panel.full_horizon_fraction:.4f} < {thresholds.min_full_horizon_fraction:.4f}"
+        )
+
+    if panel.n_duty_episodes == 0:
+        failures.append("no full-horizon episode supplied a measurable unsupported duty")
+    else:
+        if panel.mean_unsupported_duty > thresholds.max_unsupported_duty:
+            failures.append(
+                f"mean_unsupported_duty {panel.mean_unsupported_duty:.4f} > {thresholds.max_unsupported_duty:.4f}"
+            )
+        # The certifying criterion.  Note UCB >= mean by construction, so this
+        # subsumes the screening check whenever both ceilings are equal; both
+        # are kept configurable because a config may legitimately want a tight
+        # screen with a looser certified bound.
+        if panel.unsupported_duty_ucb > thresholds.max_unsupported_duty_ucb:
+            failures.append(
+                f"unsupported_duty_ucb {panel.unsupported_duty_ucb:.4f} > {thresholds.max_unsupported_duty_ucb:.4f}"
+            )
+
+    if panel.mean_reward < thresholds.min_avg_reward:
+        # A rail, not the gate: set well below the statue on purpose, its only
+        # job is rejecting a policy that threw away most of the return.
+        failures.append(f"mean_reward {panel.mean_reward:.1f} < {thresholds.min_avg_reward:.1f} (rail)")
+
+    return (not failures), failures

--- a/environments/shared/eval_diagnostics.py
+++ b/environments/shared/eval_diagnostics.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import numpy as np
 
+from .stance_diagnostics import derive_stance_info
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -53,6 +55,20 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
     Mean forward velocity is also captured for every evaluation episode so
     the plateau diagnostic can follow the Stage 2 locomotion gate without
     launching another evaluation pass.
+
+    Per-episode **unsupported duty** is captured the same way, for the
+    ``stance_quality/v1`` advancement gate.  It has to come from this pass
+    rather than from the small supplementary evaluation: the gate's bound is
+    specified at the full evaluation panel size, and reducing it to the
+    10-episode supplementary sample would throw away most of the power the
+    bound exists to provide.
+
+    The duty signal is :func:`~environments.shared.stance_diagnostics.derive_stance_info`'s
+    ``unsupported_duty`` at its default 0.1 N contact threshold -- deliberately
+    *not* the reward's 42 N ``min_support_force``.  Every calibration point the
+    gate's ceiling rests on is measured at 0.1 N: the statue's 0.000 and run
+    ``20260801_021545``'s 0.284.  Switching thresholds here would silently
+    shift duty upward and invalidate the 0.02 ceiling.
     """
 
     def __init__(
@@ -61,6 +77,7 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         *,
         stage: int,
         success_applicable: bool,
+        settle_steps: int = 0,
         **kwargs: Any,
     ) -> None:
         if not _SB3_AVAILABLE:
@@ -70,18 +87,28 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         super().__init__(eval_env, **kwargs)
         self.stage = stage
         self.success_applicable = success_applicable
+        self.settle_steps = int(settle_steps)
         self.evaluations_forward_velocities: list[list[float]] = []
+        self.evaluations_unsupported_duties: list[list[float]] = []
         self._episode_forward_sums: dict[int, float] = {}
         self._episode_forward_counts: dict[int, int] = {}
         self._current_eval_forward_velocities: list[float] = []
+        self._episode_steps: dict[int, int] = {}
+        self._episode_unsupported: dict[int, int] = {}
+        self._episode_measured: dict[int, int] = {}
+        self._current_eval_unsupported_duties: list[float] = []
 
     def _reset_forward_velocity_capture(self) -> None:
         self._episode_forward_sums.clear()
         self._episode_forward_counts.clear()
         self._current_eval_forward_velocities = []
+        self._episode_steps.clear()
+        self._episode_unsupported.clear()
+        self._episode_measured.clear()
+        self._current_eval_unsupported_duties = []
 
     def _log_success_callback(self, locals_: dict[str, Any], globals_: dict[str, Any]) -> None:
-        """Capture evaluation velocity and conditionally delegate success."""
+        """Capture evaluation velocity and duty, conditionally delegate success."""
 
         info = locals_["info"]
         env_index = int(locals_.get("i", 0))
@@ -92,10 +119,31 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
                 self._episode_forward_sums[env_index] = self._episode_forward_sums.get(env_index, 0.0) + value
                 self._episode_forward_counts[env_index] = self._episode_forward_counts.get(env_index, 0) + 1
 
+        # Duty is accumulated only after the settling window, because a policy
+        # that corrects reset randomisation may legitimately move a foot doing
+        # it -- and settling is the capability stage 1a exists to certify.
+        step_index = self._episode_steps.get(env_index, 0)
+        self._episode_steps[env_index] = step_index + 1
+        if step_index >= self.settle_steps:
+            stance = derive_stance_info(info)
+            if stance:
+                self._episode_measured[env_index] = self._episode_measured.get(env_index, 0) + 1
+                self._episode_unsupported[env_index] = self._episode_unsupported.get(env_index, 0) + int(
+                    stance["unsupported_duty"]
+                )
+
         if locals_["done"]:
             count = self._episode_forward_counts.pop(env_index, 0)
             total = self._episode_forward_sums.pop(env_index, 0.0)
             self._current_eval_forward_velocities.append(total / count if count else float("nan"))
+
+            measured = self._episode_measured.pop(env_index, 0)
+            unsupported = self._episode_unsupported.pop(env_index, 0)
+            self._episode_steps.pop(env_index, None)
+            # NaN for an episode with no measurable tail (shorter than the
+            # settling window, or an env that reports no foot contacts). The
+            # panel builder drops those rather than scoring them as zero.
+            self._current_eval_unsupported_duties.append(unsupported / measured if measured else float("nan"))
 
         if self.success_applicable:
             super()._log_success_callback(locals_, globals_)
@@ -109,6 +157,7 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
 
         if evaluation_due:
             self.evaluations_forward_velocities.append(list(self._current_eval_forward_velocities))
+            self.evaluations_unsupported_duties.append(list(self._current_eval_unsupported_duties))
             if not self.success_applicable and self.verbose >= 1:
                 print(f"Success rate: N/A (not an active Stage {self.stage} gate)")
 
@@ -383,6 +432,11 @@ def build_stage_evaluation_callbacks(
         eval_env,
         stage=stage,
         success_applicable=success_metric_applicable(stage_config),
+        # Taken from the stage's own gate declaration so the duty this
+        # callback measures uses the same settling window the gate compares
+        # it against. Absent (any non-stance gate) it is 0, which measures the
+        # whole episode and costs nothing.
+        settle_steps=int(curriculum_kwargs.get("settle_steps", 0)),
         **eval_callback_kwargs,
     )
     plateau_callback = StageGatePlateauCallback(

--- a/environments/shared/eval_diagnostics.py
+++ b/environments/shared/eval_diagnostics.py
@@ -67,7 +67,7 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
     ``unsupported_duty`` at its default 0.1 N contact threshold -- deliberately
     *not* the reward's 42 N ``min_support_force``.  Every calibration point the
     gate's ceiling rests on is measured at 0.1 N: the statue's 0.000 and run
-    ``20260801_021545``'s 0.284.  Switching thresholds here would silently
+    ``20260801_021545``'s 0.319.  Switching thresholds here would silently
     shift duty upward and invalidate the 0.02 ceiling.
     """
 
@@ -172,6 +172,17 @@ class _GateMetric:
     value: float | None
     sample_count: int
     percent: bool = False
+    #: True when the threshold is an upper bound the metric must stay under
+    #: (``stance_quality/v1``'s duty ceilings) rather than a floor it must
+    #: clear. Without the distinction a ceiling read as a floor inverts:
+    #: a policy chattering at duty 0.3 against a 0.02 ceiling would be
+    #: reported as comfortably passing.
+    ceiling: bool = False
+
+    def is_failing(self) -> bool:
+        if self.value is None:
+            return False
+        return self.value > self.threshold if self.ceiling else self.value < self.threshold
 
 
 class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
@@ -187,9 +198,16 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
     from both curriculum advancement and collapse early stopping.
     """
 
+    # Ordered most behaviourally specific first. The stance metrics sit above
+    # episode length and reward because on a stance-gated stage they ARE the
+    # gate: without them the callback would follow mean_reward and hand out
+    # reward-tuning guidance for a stage whose blocking criterion is foot
+    # contact, which is worse than silence.
     _METRIC_PRIORITY = (
         "mean_success_rate",
         "mean_forward_vel",
+        "mean_unsupported_duty",
+        "full_horizon_fraction",
         "mean_episode_length",
         "mean_reward",
     )
@@ -204,6 +222,14 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         "mean_episode_length": (
             "Inspect termination reasons, posture, and balance stability before tuning the optimizer."
         ),
+        "mean_unsupported_duty": (
+            "Inspect foot contact forces, the action smoothness and jerk penalties, and exploration noise: "
+            "the policy is spending too much time with neither foot loaded."
+        ),
+        "full_horizon_fraction": (
+            "Inspect termination reasons and the reset distribution before tuning the optimizer: "
+            "episodes are ending early rather than degrading in quality."
+        ),
         "mean_reward": (
             "Inspect reward components and policy diagnostics to identify which behavior has stopped improving."
         ),
@@ -217,6 +243,7 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         curriculum_kwargs: dict[str, Any],
         plateau_window: int = 5,
         min_relative_variation: float = 0.05,
+        horizon: int = 1000,
         verbose: int = 0,
     ) -> None:
         if not _SB3_AVAILABLE:
@@ -230,6 +257,7 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
             raise ValueError("min_relative_variation must be non-negative")
         super().__init__(verbose)
         self.eval_callback = eval_callback
+        self.horizon = int(horizon)
         self.stage = stage
         self.curriculum_kwargs = dict(curriculum_kwargs)
         self.plateau_window = plateau_window
@@ -258,14 +286,28 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         velocities = self.eval_callback.evaluations_forward_velocities
         successes = self.eval_callback.evaluations_successes
 
+        duties = getattr(self.eval_callback, "evaluations_unsupported_duties", [])
+
         samples: dict[str, Any | None] = {
             "mean_reward": rewards[index] if index < len(rewards) else None,
             "mean_episode_length": lengths[index] if index < len(lengths) else None,
             "mean_forward_vel": velocities[index] if index < len(velocities) else None,
             "mean_success_rate": successes[index] if index < len(successes) else None,
+            "mean_unsupported_duty": duties[index] if index < len(duties) else None,
         }
         values = {key: self._finite_mean(sample) if sample is not None else None for key, sample in samples.items()}
         counts = {key: self._finite_count(sample) if sample is not None else 0 for key, sample in samples.items()}
+
+        # Derived, not sampled: the fraction of episodes reaching the horizon.
+        # It comes from the same per-episode lengths the length gate uses, so
+        # no extra capture is needed.
+        episode_lengths = samples["mean_episode_length"]
+        if episode_lengths is not None and len(episode_lengths):
+            finite = [float(v) for v in episode_lengths if math.isfinite(float(v))]
+            horizon_fraction = sum(1.0 for v in finite if v >= self.horizon) / len(finite) if finite else None
+            horizon_count = len(finite)
+        else:
+            horizon_fraction, horizon_count = None, 0
 
         configured = (
             _GateMetric(
@@ -282,6 +324,26 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
                 float(self.curriculum_kwargs.get("min_avg_forward_vel", 0.0)),
                 values["mean_forward_vel"],
                 counts["mean_forward_vel"],
+            ),
+            _GateMetric(
+                "mean_unsupported_duty",
+                "unsupported duty",
+                # inf when absent, so the isfinite filter drops it for stages
+                # that do not gate on stance. A ceiling cannot use 0.0 as its
+                # "absent" default the way a floor does -- 0.0 would be the
+                # strictest possible bound, not the loosest.
+                float(self.curriculum_kwargs.get("max_unsupported_duty", math.inf)),
+                values["mean_unsupported_duty"],
+                counts["mean_unsupported_duty"],
+                ceiling=True,
+            ),
+            _GateMetric(
+                "full_horizon_fraction",
+                "full-horizon episodes",
+                float(self.curriculum_kwargs.get("min_full_horizon_fraction", 0.0)),
+                horizon_fraction,
+                horizon_count,
+                percent=True,
             ),
             _GateMetric(
                 "mean_episode_length",
@@ -323,6 +385,8 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
             return f"{value:.3f} m/s"
         if metric.key == "mean_episode_length":
             return f"{value:.1f} steps"
+        if metric.key == "mean_unsupported_duty":
+            return f"{value:.4f}"
         return f"{value:.3f}"
 
     @staticmethod
@@ -349,7 +413,7 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
             assert metric.value is not None
             self._histories[metric.key].append(metric.value)
 
-        failing = [metric for metric in metrics if metric.value is not None and metric.value < metric.threshold]
+        failing = [metric for metric in metrics if metric.is_failing()]
         if not failing:
             self.logger.record("diagnostics/eval_gate_met", 1.0)
             self.logger.record("diagnostics/eval_plateau_active", 0.0)
@@ -445,6 +509,9 @@ def build_stage_evaluation_callbacks(
         curriculum_kwargs=curriculum_kwargs,
         plateau_window=int(curriculum_kwargs.get("diagnostics_plateau_window", 5)),
         min_relative_variation=float(curriculum_kwargs.get("diagnostics_plateau_min_relative_variation", 0.05)),
+        # From [env], not [curriculum]: the horizon defines what "full" means
+        # for the full-horizon fraction, and it is an environment property.
+        horizon=int(stage_config.get("env_kwargs", {}).get("max_episode_steps", 1000)),
         verbose=diagnostics_verbose,
     )
     return eval_callback, plateau_callback

--- a/environments/shared/eval_diagnostics.py
+++ b/environments/shared/eval_diagnostics.py
@@ -90,13 +90,25 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         self.settle_steps = int(settle_steps)
         self.evaluations_forward_velocities: list[list[float]] = []
         self.evaluations_unsupported_duties: list[list[float]] = []
+        # Not a gate criterion -- captured so a run GENERATES the data needed
+        # to set one honestly. The three stance shares sum to 1, so a falling
+        # unsupported duty says nothing about whether the feet are being
+        # planted; that time can land in single support instead. Bounding
+        # bilateral duty is the obvious fix, but the only reference point
+        # available today is the statue's 0.998, and the statue never shifts
+        # weight. A competent active policy legitimately spends some time in
+        # single support, and how much is unmeasured. Recording it every
+        # evaluation is what turns that into evidence instead of a guess.
+        self.evaluations_bilateral_duties: list[list[float]] = []
         self._episode_forward_sums: dict[int, float] = {}
         self._episode_forward_counts: dict[int, int] = {}
         self._current_eval_forward_velocities: list[float] = []
         self._episode_steps: dict[int, int] = {}
         self._episode_unsupported: dict[int, int] = {}
+        self._episode_bilateral: dict[int, int] = {}
         self._episode_measured: dict[int, int] = {}
         self._current_eval_unsupported_duties: list[float] = []
+        self._current_eval_bilateral_duties: list[float] = []
 
     def _reset_forward_velocity_capture(self) -> None:
         self._episode_forward_sums.clear()
@@ -104,8 +116,10 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         self._current_eval_forward_velocities = []
         self._episode_steps.clear()
         self._episode_unsupported.clear()
+        self._episode_bilateral.clear()
         self._episode_measured.clear()
         self._current_eval_unsupported_duties = []
+        self._current_eval_bilateral_duties = []
 
     def _log_success_callback(self, locals_: dict[str, Any], globals_: dict[str, Any]) -> None:
         """Capture evaluation velocity and duty, conditionally delegate success."""
@@ -131,6 +145,9 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
                 self._episode_unsupported[env_index] = self._episode_unsupported.get(env_index, 0) + int(
                     stance["unsupported_duty"]
                 )
+                self._episode_bilateral[env_index] = self._episode_bilateral.get(env_index, 0) + int(
+                    stance["bilateral_support_duty"]
+                )
 
         if locals_["done"]:
             count = self._episode_forward_counts.pop(env_index, 0)
@@ -139,11 +156,13 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
 
             measured = self._episode_measured.pop(env_index, 0)
             unsupported = self._episode_unsupported.pop(env_index, 0)
+            bilateral = self._episode_bilateral.pop(env_index, 0)
             self._episode_steps.pop(env_index, None)
             # NaN for an episode with no measurable tail (shorter than the
             # settling window, or an env that reports no foot contacts). The
             # panel builder drops those rather than scoring them as zero.
             self._current_eval_unsupported_duties.append(unsupported / measured if measured else float("nan"))
+            self._current_eval_bilateral_duties.append(bilateral / measured if measured else float("nan"))
 
         if self.success_applicable:
             super()._log_success_callback(locals_, globals_)
@@ -158,6 +177,7 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         if evaluation_due:
             self.evaluations_forward_velocities.append(list(self._current_eval_forward_velocities))
             self.evaluations_unsupported_duties.append(list(self._current_eval_unsupported_duties))
+            self.evaluations_bilateral_duties.append(list(self._current_eval_bilateral_duties))
             if not self.success_applicable and self.verbose >= 1:
                 print(f"Success rate: N/A (not an active Stage {self.stage} gate)")
 
@@ -404,6 +424,23 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         reward_metric = next((metric for metric in metrics if metric.key == "mean_reward"), None)
         if reward_metric is not None:
             self.logger.record("diagnostics/eval_episode_count", reward_metric.sample_count)
+
+        # Stance shares for EVERY evaluation, recorded before the gate-data
+        # completeness check returns. These are what a later
+        # min_bilateral_support_duty gets calibrated from, and the early part
+        # of a run -- exactly where the panel is most likely to be incomplete
+        # -- is the part that shows whether bilateral duty is climbing at all.
+        # Losing it there would leave only the converged tail.
+        for attribute, scalar in (
+            ("evaluations_unsupported_duties", "diagnostics/eval_unsupported_duty"),
+            ("evaluations_bilateral_duties", "diagnostics/eval_bilateral_support_duty"),
+        ):
+            history = getattr(self.eval_callback, attribute, [])
+            if index < len(history):
+                share = self._finite_mean(history[index])
+                if share is not None:
+                    self.logger.record(scalar, share)
+
         if any(metric.value is None or metric.sample_count < min_eval_episodes for metric in metrics):
             self.logger.record("diagnostics/eval_gate_data_complete", 0.0)
             return

--- a/environments/shared/jax_curriculum.py
+++ b/environments/shared/jax_curriculum.py
@@ -8,11 +8,18 @@ files used by the SB3 path.
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Callable
 from typing import Any
 
 from .config import load_stage_config
 from .curriculum.gate_schema import GateSchemaError, validate_gate_config
+from .curriculum.stance_gate import (
+    STANCE_GATE_KIND,
+    StanceGateThresholds,
+    StancePanel,
+    evaluate_stance_gate,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -39,10 +46,14 @@ def check_stage_gate(
             fail-open behaviour the SB3 path had, reached by a different route.
     """
     curriculum = stage_config.get("curriculum_kwargs", {})
-    validate_gate_config(stage_config.get("stage", "?"), curriculum, advancement_enabled=True)
-    # The schema requires min_avg_reward for every advancing gate kind, so a
-    # validated config always carries it; a KeyError here would mean the two
-    # fell out of sync.
+    gate_kind = validate_gate_config(stage_config.get("stage", "?"), curriculum, advancement_enabled=True)
+
+    if gate_kind == STANCE_GATE_KIND:
+        return _check_stance_gate(eval_metrics, curriculum)
+
+    # reward_and_length/v1 requires min_avg_reward, so a validated config of
+    # that kind always carries it; a KeyError here would mean the schema and
+    # this branch fell out of sync.
     min_reward = curriculum["min_avg_reward"]
     # min_avg_reward is an EPISODE-level threshold (shared with the SB3
     # TOMLs, e.g. 100.0).  The trainer's "mean_reward" is the mean PER-STEP
@@ -76,6 +87,68 @@ def check_stage_gate(
             "gate; emit mean_episode_length from the trainer instead."
         )
     return bool(episode_length >= min_length)
+
+
+#: Metrics the MJX trainer must emit for ``stance_quality/v1``.  Named here so
+#: the error message can say exactly what is missing.
+_STANCE_METRIC_KEYS = (
+    "n_eval_episodes",
+    "full_horizon_fraction",
+    "n_duty_episodes",
+    "mean_unsupported_duty",
+    "unsupported_duty_ucb",
+)
+
+
+def _check_stance_gate(eval_metrics: dict[str, float], curriculum: dict[str, Any]) -> bool:
+    """Evaluate ``stance_quality/v1`` on the JAX path.
+
+    Runs the *same* :func:`~environments.shared.curriculum.stance_gate.evaluate_stance_gate`
+    the SB3 ``CurriculumManager`` runs, on a panel the MJX trainer must supply
+    already reduced -- so the two backends cannot disagree about the criteria.
+
+    Raises:
+        GateSchemaError: If the trainer emitted none of the stance metrics.
+            Deliberately loud rather than a warning-and-pass: a stage that
+            declares this kind and is then gated on nothing is precisely the
+            "one backend silently ignores a gate the other enforces"
+            divergence the versioned schema exists to prevent.
+    """
+    missing = [key for key in _STANCE_METRIC_KEYS if eval_metrics.get(key) is None]
+    if missing:
+        raise GateSchemaError(
+            f"stage declares gate_kind {STANCE_GATE_KIND!r} but eval_metrics is missing "
+            f"{missing}, so stance quality cannot be checked. Passing on the metrics that "
+            "are present would half-enforce the gate. The MJX evaluator must reduce its "
+            "rollout into a StancePanel with stance_gate.summarize_stance_panel() -- "
+            "reconstructing episode boundaries from cumsum(lengths) over the per-step "
+            "diag_* arrays -- and emit these keys. Note that reconstruction is valid for "
+            "BIPEDS only: see the diag_r_foot/diag_l_foot interleaving defect in "
+            "KNOWN_ISSUES, which must be fixed before this gate can be used for "
+            "brachiosaurus or dibothrosuchus."
+        )
+
+    panel = StancePanel(
+        n_episodes=int(eval_metrics["n_eval_episodes"]),
+        full_horizon_fraction=float(eval_metrics["full_horizon_fraction"]),
+        mean_reward=float(eval_metrics.get("mean_episode_return", eval_metrics.get("mean_reward", -math.inf))),
+        n_duty_episodes=int(eval_metrics["n_duty_episodes"]),
+        mean_unsupported_duty=float(eval_metrics["mean_unsupported_duty"]),
+        unsupported_duty_ucb=float(eval_metrics["unsupported_duty_ucb"]),
+    )
+    thresholds = StanceGateThresholds(
+        min_full_horizon_fraction=float(curriculum["min_full_horizon_fraction"]),
+        max_unsupported_duty=float(curriculum["max_unsupported_duty"]),
+        max_unsupported_duty_ucb=float(curriculum["max_unsupported_duty_ucb"]),
+        settle_steps=int(curriculum.get("settle_steps", 0)),
+        min_eval_episodes=int(curriculum.get("min_eval_episodes", 40)),
+        min_avg_reward=float(curriculum.get("min_avg_reward", -math.inf)),
+        required_consecutive=int(curriculum.get("required_consecutive", 3)),
+    )
+    passed, failures = evaluate_stance_gate(panel, thresholds)
+    if not passed:
+        _logger.info("Stance gate not met: %s", "; ".join(failures))
+    return passed
 
 
 def run_curriculum(

--- a/environments/shared/reporting/csv_output.py
+++ b/environments/shared/reporting/csv_output.py
@@ -281,6 +281,12 @@ def build_results_csv_rows(
         row["ep_length_threshold"] = cur.get("min_avg_episode_length", "")
         row["forward_vel_threshold"] = cur.get("min_avg_forward_vel", "")
         row["success_rate_threshold"] = cur.get("min_success_rate", "")
+        # stance_quality/v1. Without these a stance-gated stage exports only
+        # its reward RAIL, reading as though reward were the gate.
+        row["gate_kind"] = cur.get("gate_kind", "")
+        row["full_horizon_fraction_threshold"] = cur.get("min_full_horizon_fraction", "")
+        row["unsupported_duty_ceiling"] = cur.get("max_unsupported_duty", "")
+        row["unsupported_duty_ucb_ceiling"] = cur.get("max_unsupported_duty_ucb", "")
         row["stage_passed"] = r.get("publication_gate_passed", "")
         row["publication_gate_passed"] = r.get("publication_gate_passed", "")
 

--- a/environments/shared/reporting/gates.py
+++ b/environments/shared/reporting/gates.py
@@ -16,6 +16,7 @@ def evaluate_recorded_gate(
     success-rate gate is enabled but that metric was not saved.
     """
     criteria: list[tuple[str, float]] = []
+    ceilings: list[tuple[str, float]] = []
     if curriculum.get("min_avg_reward") is not None:
         criteria.append(("mean_reward", float(curriculum["min_avg_reward"])))
     if curriculum.get("min_avg_episode_length") is not None:
@@ -24,7 +25,16 @@ def evaluate_recorded_gate(
         criteria.append(("mean_forward_vel", float(curriculum["min_avg_forward_vel"])))
     if float(curriculum.get("min_success_rate") or 0.0) > 0.0:
         criteria.append(("mean_success_rate", float(curriculum["min_success_rate"])))
-    if not criteria or not evaluations:
+    # stance_quality/v1. Without these a stance-gated stage would be reported
+    # as gated on its reward RAIL alone -- which is the claim that gate exists
+    # to refute, since the statue clears the rail by 68%.
+    if curriculum.get("min_full_horizon_fraction") is not None:
+        criteria.append(("full_horizon_fraction", float(curriculum["min_full_horizon_fraction"])))
+    if curriculum.get("max_unsupported_duty") is not None:
+        ceilings.append(("mean_unsupported_duty", float(curriculum["max_unsupported_duty"])))
+    if curriculum.get("max_unsupported_duty_ucb") is not None:
+        ceilings.append(("unsupported_duty_ucb", float(curriculum["max_unsupported_duty_ucb"])))
+    if not (criteria or ceilings) or not evaluations:
         return None
 
     min_eval_episodes = int(curriculum.get("min_eval_episodes", 10))
@@ -32,15 +42,17 @@ def evaluate_recorded_gate(
     consecutive = 0
     incomplete = False
     for evaluation in evaluations:
-        required_values = [evaluation.get(key) for key, _ in criteria]
+        required_values = [evaluation.get(key) for key, _ in (*criteria, *ceilings)]
         n_episodes = evaluation.get("n_episodes")
         if any(value is None for value in required_values) or n_episodes is None:
             incomplete = True
             consecutive = 0
             continue
 
-        passes = int(n_episodes) >= min_eval_episodes and all(
-            float(evaluation[key]) >= threshold for key, threshold in criteria
+        passes = (
+            int(n_episodes) >= min_eval_episodes
+            and all(float(evaluation[key]) >= threshold for key, threshold in criteria)
+            and all(float(evaluation[key]) <= ceiling for key, ceiling in ceilings)
         )
         consecutive = consecutive + 1 if passes else 0
         if consecutive >= required_consecutive:

--- a/environments/shared/reporting/stage_artifacts.py
+++ b/environments/shared/reporting/stage_artifacts.py
@@ -124,6 +124,75 @@ def build_stage_results_from_eval_data(
     return result
 
 
+def _write_stance_gate_report(
+    *,
+    species: str,
+    stage: int,
+    stage_config: dict[str, Any],
+    stage_dir: Path,
+    model_dir: Path,
+) -> None:
+    """Score the selected checkpoint against the stance gate, into the run dir.
+
+    Only for stages that actually declare ``stance_quality/v1``: rolling a
+    40-episode panel costs a few minutes, which is nothing beside a multi-hour
+    stage but is pure waste for a stage the criteria do not govern.
+
+    Runs here rather than in the notebook so it happens for every SB3 run and
+    every sweep trial without anyone remembering, and lands beside
+    ``stage_summary.txt`` in the run directory -- which is on Drive, so the
+    verdict survives a lost runtime.
+
+    Deliberately non-fatal. This is a diagnostic; losing it must never cost a
+    completed training run its artifacts, and the checkpoint may legitimately
+    be absent (a stage stopped before its first ``best_model`` was saved).
+    """
+    from environments.shared.curriculum.stance_gate import STANCE_GATE_KIND
+
+    curriculum = stage_config.get("curriculum_kwargs", {})
+    if curriculum.get("gate_kind") != STANCE_GATE_KIND:
+        return
+
+    # Same preference order the trainer uses when it reloads a stage's policy:
+    # the risk-adjusted checkpoint first, SB3's mean-reward one as fallback.
+    for name in ("robust_best_model", "best_model"):
+        model_path = model_dir / f"{name}.zip"
+        if model_path.is_file():
+            break
+    else:
+        logger.warning(
+            "Stance gate report skipped for stage %d: no checkpoint in %s",
+            stage,
+            model_dir,
+        )
+        return
+
+    vecnorm_path = model_dir / f"{model_path.stem}_vecnorm.pkl"
+    try:
+        from environments.shared.scripts.stance_gate_report import (
+            build_stance_gate_report,
+            write_stance_gate_report,
+        )
+
+        report = build_stance_gate_report(
+            species,
+            stage,
+            stage_config=stage_config,
+            model_path=str(model_path),
+            vecnorm_path=str(vecnorm_path) if vecnorm_path.is_file() else None,
+        )
+        written = write_stance_gate_report(stage_dir, report)
+        logger.info(
+            "Stance gate report: %s (duty %.4f, bilateral %.4f) -> %s",
+            "PASS" if report["passed"] else "FAIL",
+            report["metrics"]["mean_unsupported_duty"],
+            report["metrics"]["bilateral_support_duty"],
+            written["stance_gate_report_txt"],
+        )
+    except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
+        logger.warning("Stance gate report failed for stage %d", stage, exc_info=True)
+
+
 def generate_stage_artifacts(
     species_cfg,
     stage_config: dict[str, Any],
@@ -168,6 +237,14 @@ def generate_stage_artifacts(
 
     text_summaries.write_stage_summary(stage_dir, stage_results, species, algorithm)
     logger.info("Stage summary written to: %s", stage_dir / "stage_summary.txt")
+
+    _write_stance_gate_report(
+        species=species,
+        stage=stage,
+        stage_config=stage_config,
+        stage_dir=stage_dir,
+        model_dir=model_dir,
+    )
 
     # ── Generate training graphs ────────────────────────────────────────
     if generate_graphs:

--- a/environments/shared/result_bundle/evidence.py
+++ b/environments/shared/result_bundle/evidence.py
@@ -12,6 +12,7 @@ import math
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from ..curriculum.stance_gate import STANCE_GATE_KIND
 from .errors import ResultBundleError
 
 
@@ -344,6 +345,30 @@ def validate_evaluation_evidence(
         curriculum = config_value.get("curriculum", config_value.get("curriculum_kwargs", {}))
         if not isinstance(curriculum, Mapping):
             raise ResultBundleError(f"publication gate config for stage {stage} must contain a curriculum object")
+        # A stage whose gate this evidence file cannot express must NOT be
+        # certified on whichever thresholds happen to be checkable.
+        #
+        # ``stance_quality/v1`` carries ``min_avg_reward`` only as a rail --
+        # deliberately set below the zero-action statue, which clears it by
+        # 68% -- and states its real criteria as a full-horizon fraction and
+        # two ceilings on unsupported duty. The per-episode evidence CSV has
+        # ``reward`` and ``length`` but no duty column, so evaluating the four
+        # legacy thresholds here would certify the stage on the rail alone:
+        # exactly the "a statue clears this gate" failure the stance gate was
+        # introduced to remove, reappearing in the publication path.
+        gate_kind = curriculum.get("gate_kind")
+        if gate_kind == STANCE_GATE_KIND:
+            raise ResultBundleError(
+                f"stage {stage} declares gate_kind {gate_kind!r}, whose criteria "
+                "(min_full_horizon_fraction, max_unsupported_duty, "
+                "max_unsupported_duty_ucb) cannot be checked from the publication "
+                "evidence file: it records per-episode reward and length but no "
+                "unsupported duty. Certifying on min_avg_reward alone would pass a "
+                "policy this gate exists to reject, so the bundle refuses instead. "
+                "Add a per-episode duty column to evaluation_selected.csv and teach "
+                "this function to evaluate the stance criteria."
+            )
+
         publication_thresholds = {
             "min_avg_reward": "reward",
             "min_avg_episode_length": "episode_length",

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -37,6 +37,7 @@ claims, and the report says so.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -199,6 +200,178 @@ def run_panel(
     }
 
 
+#: Bumped when the JSON report's field meanings change.
+REPORT_SCHEMA = "mesozoic.stance-gate-report/v1"
+
+
+def thresholds_from_curriculum(curriculum: dict[str, Any]) -> StanceGateThresholds:
+    """Read the stance thresholds a stage declares.
+
+    Ceilings default to ``+inf`` and floors to ``0.0`` so a stage that does not
+    gate on stance still produces a readable report rather than a spuriously
+    strict one -- ``0.0`` would be the tightest possible ceiling, not "absent".
+    """
+    return StanceGateThresholds(
+        min_full_horizon_fraction=float(curriculum.get("min_full_horizon_fraction", 0.0)),
+        max_unsupported_duty=float(curriculum.get("max_unsupported_duty", float("inf"))),
+        max_unsupported_duty_ucb=float(curriculum.get("max_unsupported_duty_ucb", float("inf"))),
+        settle_steps=int(curriculum.get("settle_steps", 0)),
+        min_eval_episodes=int(curriculum.get("min_eval_episodes", 40)),
+        min_avg_reward=float(curriculum.get("min_avg_reward", -float("inf"))),
+        required_consecutive=int(curriculum.get("required_consecutive", 3)),
+    )
+
+
+def build_stance_gate_report(
+    species: str,
+    stage: int,
+    *,
+    stage_config: dict[str, Any],
+    model_path: str | None = None,
+    vecnorm_path: str | None = None,
+    zero_action: bool = False,
+    episodes: int | None = None,
+    seed: int = 3042,
+) -> dict[str, Any]:
+    """Roll a policy and return its gate verdict as a serializable dict.
+
+    Importable so the training pipeline can emit the same report it would
+    produce by hand, rather than a second implementation that could disagree.
+    """
+    curriculum = stage_config["curriculum_kwargs"]
+    env_kwargs = dict(stage_config["env_kwargs"])
+    horizon = int(env_kwargs.get("max_episode_steps", 1000))
+    thresholds = thresholds_from_curriculum(curriculum)
+    panel_episodes = episodes or thresholds.min_eval_episodes
+
+    env_class = SPECIES_FACTORIES[species]().env_class
+    if zero_action:
+        probe = env_class(**env_kwargs)
+        zero = np.zeros(probe.action_space.shape[0], dtype=np.float32)
+        probe.close()
+
+        def predict(_obs: np.ndarray) -> np.ndarray:
+            return zero
+
+        description = "zero action (do-nothing reference)"
+    else:
+        if model_path is None:
+            raise ValueError("model_path is required unless zero_action is set")
+        predict, note = _load_policy(model_path, vecnorm_path, lambda: env_class(**env_kwargs))
+        description = f"{Path(model_path).name} — {note}"
+
+    result = run_panel(
+        species,
+        stage,
+        predict=predict,
+        episodes=panel_episodes,
+        seed=seed,
+        settle_steps=thresholds.settle_steps,
+        horizon=horizon,
+        env_kwargs=env_kwargs,
+    )
+    panel = result["panel"]
+    passed, failures = evaluate_stance_gate(panel, thresholds)
+
+    return {
+        "schema": REPORT_SCHEMA,
+        "species": species,
+        "stage": stage,
+        "gate_kind": curriculum.get("gate_kind"),
+        "policy": description,
+        "episodes": panel_episodes,
+        "seed": seed,
+        "settle_steps": thresholds.settle_steps,
+        "horizon": horizon,
+        "passed": passed,
+        "failures": failures,
+        "thresholds": {
+            "min_full_horizon_fraction": thresholds.min_full_horizon_fraction,
+            "max_unsupported_duty": thresholds.max_unsupported_duty,
+            "max_unsupported_duty_ucb": thresholds.max_unsupported_duty_ucb,
+            "min_avg_reward": thresholds.min_avg_reward,
+            "min_eval_episodes": thresholds.min_eval_episodes,
+        },
+        "metrics": {
+            "reward_mean": float(result["rewards"].mean()),
+            "reward_std": float(result["rewards"].std()),
+            "episode_length_mean": float(result["lengths"].mean()),
+            "full_horizon_fraction": panel.full_horizon_fraction,
+            "mean_unsupported_duty": panel.mean_unsupported_duty,
+            "unsupported_duty_ucb": panel.unsupported_duty_ucb,
+            "n_duty_episodes": panel.n_duty_episodes,
+            # Not gated. Reported because the three shares sum to 1, so a
+            # falling unsupported duty does not by itself mean the feet are
+            # being planted -- the time can land in single support instead.
+            "bilateral_support_duty": result["bilateral_duty"],
+            "single_support_duty": result["single_duty"],
+        },
+        "terminations": result["terminations"],
+        "reward_components": result["components"],
+    }
+
+
+def render_stance_gate_report(report: dict[str, Any]) -> str:
+    """Render a report dict as the human-readable text form."""
+    thresholds = report["thresholds"]
+    metrics = report["metrics"]
+    lines: list[str] = []
+    if report["gate_kind"] != STANCE_GATE_KIND:
+        lines.append(
+            f"NOTE: {report['species']} stage {report['stage']} declares gate_kind "
+            f"{report['gate_kind']!r}, not {STANCE_GATE_KIND!r}. The stance criteria "
+            "below are reported but are not what this stage advances on."
+        )
+        lines.append("")
+    measured = report["horizon"] - report["settle_steps"]
+    lines += [
+        f"policy              {report['policy']}",
+        f"stage               {report['species']} stage {report['stage']} ({report['gate_kind']})",
+        f"panel               {report['episodes']} episodes, "
+        f"seeds {report['seed']}-{report['seed'] + report['episodes'] - 1}",
+        f"settle_steps        {report['settle_steps']} (duty measured over the remaining {measured})",
+        "",
+        f"reward                 {metrics['reward_mean']:9.1f} +/- {metrics['reward_std']:.1f}",
+        f"episode length         {metrics['episode_length_mean']:9.1f}",
+        f"full_horizon_fraction  {metrics['full_horizon_fraction']:9.4f}   "
+        f"(>= {thresholds['min_full_horizon_fraction']:.4f})",
+        f"mean_unsupported_duty  {metrics['mean_unsupported_duty']:9.4f}   "
+        f"(<= {thresholds['max_unsupported_duty']:.4f})",
+        f"unsupported_duty_ucb   {metrics['unsupported_duty_ucb']:9.4f}   "
+        f"(<= {thresholds['max_unsupported_duty_ucb']:.4f})",
+        f"duty episodes          {metrics['n_duty_episodes']:9d}   (full-horizon episodes only)",
+        f"  bilateral support    {metrics['bilateral_support_duty']:9.4f}   (statue 0.998, not gated)",
+        f"  single support       {metrics['single_support_duty']:9.4f}   (statue 0.002, not gated)",
+        f"terminations           {report['terminations']}",
+    ]
+    components = report["reward_components"]
+    if components:
+        lines += ["", "reward per episode, by term (largest magnitude first):"]
+        for key in sorted(components, key=lambda k: -abs(components[k])):
+            if abs(components[key]) > 0.05:
+                lines.append(f"  {key:28s} {components[key]:10.2f}")
+    lines += ["", f"GATE: {'PASS' if report['passed'] else 'FAIL'}"]
+    lines += [f"  - {failure}" for failure in report["failures"]]
+    return "\n".join(lines)
+
+
+def write_stance_gate_report(stage_dir: "str | Path", report: dict[str, Any]) -> dict[str, Path]:
+    """Write the report beside the stage's other artifacts.
+
+    Two forms on purpose: the text is what a human opens next to
+    ``stage_summary.txt``, and the JSON is what later tooling can read without
+    parsing prose -- including the per-episode duty evidence the publication
+    gate currently refuses stance-gated bundles for lacking.
+    """
+    directory = Path(stage_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    text_path = directory / "stance_gate_report.txt"
+    json_path = directory / "stance_gate_report.json"
+    text_path.write_text(render_stance_gate_report(report) + "\n", encoding="utf-8")
+    json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return {"stance_gate_report_txt": text_path, "stance_gate_report_json": json_path}
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("species", help="Species id, e.g. trex")
@@ -213,103 +386,39 @@ def main() -> int:
     parser.add_argument("--episodes", type=int, default=None, help="Defaults to the stage's min_eval_episodes")
     parser.add_argument("--seed", type=int, default=3042, help="First evaluation seed (default: publication seed)")
     parser.add_argument("--config", help="Explicit stage TOML path")
+    parser.add_argument("--out-dir", help="Also write stance_gate_report.{txt,json} to this directory")
     args = parser.parse_args()
 
     if not args.zero_action and not args.model:
         parser.error("pass --model, or --zero-action for the do-nothing reference")
 
     stage_config = load_stage_config(args.species, args.stage, config_path=args.config)
-    curriculum = stage_config["curriculum_kwargs"]
-    env_kwargs = dict(stage_config["env_kwargs"])
-    horizon = int(env_kwargs.get("max_episode_steps", 1000))
-
-    gate_kind = curriculum.get("gate_kind")
-    if gate_kind != STANCE_GATE_KIND:
-        print(f"NOTE: {args.species} stage {args.stage} declares gate_kind {gate_kind!r}, not {STANCE_GATE_KIND!r}.")
-        print("      The stance criteria below are reported but are not what this stage advances on.")
-
-    thresholds = StanceGateThresholds(
-        min_full_horizon_fraction=float(curriculum.get("min_full_horizon_fraction", 0.0)),
-        max_unsupported_duty=float(curriculum.get("max_unsupported_duty", float("inf"))),
-        max_unsupported_duty_ucb=float(curriculum.get("max_unsupported_duty_ucb", float("inf"))),
-        settle_steps=int(curriculum.get("settle_steps", 0)),
-        min_eval_episodes=int(curriculum.get("min_eval_episodes", 40)),
-        min_avg_reward=float(curriculum.get("min_avg_reward", -float("inf"))),
-        required_consecutive=int(curriculum.get("required_consecutive", 3)),
-    )
-    episodes = args.episodes or thresholds.min_eval_episodes
-
-    env_class = SPECIES_FACTORIES[args.species]().env_class
-
-    if args.zero_action:
-        probe = env_class(**env_kwargs)
-        zero = np.zeros(probe.action_space.shape[0], dtype=np.float32)
-        probe.close()
-
-        def predict(_obs: np.ndarray) -> np.ndarray:
-            return zero
-
-        description = "zero action (do-nothing reference)"
-    else:
-        predict, description = _load_policy(args.model, args.vecnorm, lambda: env_class(**env_kwargs))
-        description = f"{Path(args.model).name} — {description}"
-
-    result = run_panel(
+    report = build_stance_gate_report(
         args.species,
         args.stage,
-        predict=predict,
-        episodes=episodes,
+        stage_config=stage_config,
+        model_path=args.model,
+        vecnorm_path=args.vecnorm,
+        zero_action=args.zero_action,
+        episodes=args.episodes,
         seed=args.seed,
-        settle_steps=thresholds.settle_steps,
-        horizon=horizon,
-        env_kwargs=env_kwargs,
     )
-    panel = result["panel"]
-    passed, failures = evaluate_stance_gate(panel, thresholds)
+    print()
+    print(render_stance_gate_report(report))
 
-    print()
-    print(f"policy              {description}")
-    print(f"stage               {args.species} stage {args.stage} ({gate_kind})")
-    print(f"panel               {episodes} episodes, seeds {args.seed}-{args.seed + episodes - 1}")
-    print(
-        f"settle_steps        {thresholds.settle_steps} (duty measured over the remaining {horizon - thresholds.settle_steps})"
-    )
-    print()
-    print(f"reward                 {result['rewards'].mean():9.1f} +/- {result['rewards'].std():.1f}")
-    print(f"episode length         {result['lengths'].mean():9.1f}")
-    print(
-        f"full_horizon_fraction  {panel.full_horizon_fraction:9.4f}   (>= {thresholds.min_full_horizon_fraction:.4f})"
-    )
-    print(f"mean_unsupported_duty  {panel.mean_unsupported_duty:9.4f}   (<= {thresholds.max_unsupported_duty:.4f})")
-    print(f"unsupported_duty_ucb   {panel.unsupported_duty_ucb:9.4f}   (<= {thresholds.max_unsupported_duty_ucb:.4f})")
-    print(f"duty episodes          {panel.n_duty_episodes:9d}   (full-horizon episodes only)")
-    # Not gated, but decisive for reading a falling unsupported duty: the
-    # three shares sum to 1, so a policy can cut flight without ever planting
-    # both feet.
-    print(f"  bilateral support    {result['bilateral_duty']:9.4f}   (statue 0.998, not gated)")
-    print(f"  single support       {result['single_duty']:9.4f}   (statue 0.002, not gated)")
-    print(f"terminations           {result['terminations']}")
-    components = result["components"]
-    if components:
-        print()
-        print("reward per episode, by term (largest magnitude first):")
-        for key in sorted(components, key=lambda k: -abs(components[k])):
-            value = components[key]
-            if abs(value) > 0.05:
-                print(f"  {key:28s} {value:10.2f}")
+    if args.out_dir:
+        for path in write_stance_gate_report(args.out_dir, report).values():
+            print(f"written: {path}")
 
-    print()
-    print(f"GATE: {'PASS' if passed else 'FAIL'}")
-    for failure in failures:
-        print(f"  - {failure}")
-    if args.episodes and args.episodes != thresholds.min_eval_episodes:
+    declared = report["thresholds"]["min_eval_episodes"]
+    if args.episodes and args.episodes != declared:
         print()
         print(
             f"WARNING: --episodes {args.episodes} differs from the stage's min_eval_episodes "
-            f"{thresholds.min_eval_episodes}. The bound's power is specified at the latter; "
-            "this panel does not certify what the gate claims."
+            f"{declared}. The bound's power is specified at the latter; this panel does not "
+            "certify what the gate claims."
         )
-    return 0 if passed else 1
+    return 0 if report["passed"] else 1
 
 
 if __name__ == "__main__":

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -139,6 +139,10 @@ def run_panel(
     rewards: list[float] = []
     duties: list[float] = []
     terminations: dict[str, int] = {}
+    # Per-term totals, so a failing panel can be read for *why*. A policy that
+    # keeps paying the airborne penalty is being funded by some other term;
+    # which one is not guessable from the aggregate score.
+    components: dict[str, float] = {}
 
     for index in range(episodes):
         obs, _ = env.reset(seed=seed + index)
@@ -149,6 +153,9 @@ def run_panel(
         while True:
             obs, reward, terminated, truncated, info = env.step(predict(obs))
             total += float(reward)
+            for key, value in info.items():
+                if key.startswith("reward_") and key != "reward_total":
+                    components[key] = components.get(key, 0.0) + float(value)
             stance = derive_stance_info(info)
             if stance and steps >= settle_steps:
                 measured += 1
@@ -173,6 +180,7 @@ def run_panel(
         "lengths": np.asarray(lengths),
         "rewards": np.asarray(rewards),
         "terminations": terminations,
+        "components": {key: value / episodes for key, value in components.items()},
     }
 
 
@@ -261,6 +269,15 @@ def main() -> int:
     print(f"unsupported_duty_ucb   {panel.unsupported_duty_ucb:9.4f}   (<= {thresholds.max_unsupported_duty_ucb:.4f})")
     print(f"duty episodes          {panel.n_duty_episodes:9d}   (full-horizon episodes only)")
     print(f"terminations           {result['terminations']}")
+    components = result["components"]
+    if components:
+        print()
+        print("reward per episode, by term (largest magnitude first):")
+        for key in sorted(components, key=lambda k: -abs(components[k])):
+            value = components[key]
+            if abs(value) > 0.05:
+                print(f"  {key:28s} {value:10.2f}")
+
     print()
     print(f"GATE: {'PASS' if passed else 'FAIL'}")
     for failure in failures:

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -1,0 +1,275 @@
+"""Score a saved checkpoint against its stage's ``stance_quality/v1`` gate.
+
+Answers one question: **would this policy advance?** It rolls the checkpoint
+on the stage's own configured environment, reduces the episodes with the same
+:mod:`~environments.shared.curriculum.stance_gate` code the training loop runs,
+and prints the verdict criterion by criterion.
+
+Why this exists as a script rather than a notebook cell: the gate's verdict is
+the thing runs are judged on, and a verdict computed by hand-rolled
+reimplementation is not the same verdict.  Everything here funnels through
+``summarize_stance_panel`` and ``evaluate_stance_gate``, so what this prints is
+what the curriculum would decide.
+
+It also covers the case the training loop cannot: **an already-finished run**.
+Run ``20260801_203206`` completed stage 1 under the old ``reward_and_length/v1``
+gate and advanced on reward 2313.2 and length 1000 -- both of which a
+zero-action statue clears.  Whether it would have passed the stance gate is a
+question only a rollout can answer, and the checkpoint is a 4 MB binary that
+lives next to the run, not in the repository.
+
+Usage::
+
+    python environments/shared/scripts/stance_gate_report.py trex \\
+        --model  path/to/robust_best_model.zip \\
+        --vecnorm path/to/robust_best_model_vecnorm.pkl
+
+    # the do-nothing reference, for the same panel and seeds
+    python environments/shared/scripts/stance_gate_report.py trex --zero-action
+
+Thresholds come from the stage TOML, so the report re-anchors automatically
+when the gate is retuned.  ``--episodes`` defaults to the stage's own
+``min_eval_episodes``, because that is the panel size the bound's power is
+specified at; overriding it downward makes the bound weaker than the gate
+claims, and the report says so.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+_repo_root = str(Path(__file__).resolve().parents[3])
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from environments.shared.config import load_stage_config  # noqa: E402
+from environments.shared.curriculum.stance_gate import (  # noqa: E402
+    STANCE_GATE_KIND,
+    StanceGateThresholds,
+    evaluate_stance_gate,
+    stance_panel_from_episode_duties,
+)
+from environments.shared.species_registry import SPECIES_FACTORIES  # noqa: E402
+from environments.shared.stance_diagnostics import derive_stance_info  # noqa: E402
+
+
+def _load_policy(model_path: str, vecnorm_path: str | None, env_factory: Any):
+    """Return ``(predict_fn, describe)`` for a saved SB3 checkpoint.
+
+    Observation normalisation is applied from the saved ``VecNormalize``
+    statistics rather than re-estimated: a policy evaluated on unnormalised
+    observations is a *different policy*, and would score arbitrarily badly
+    for reasons that have nothing to do with stance.  That is why a missing
+    or unreadable file is fatal here instead of a warning.
+
+    Loaded through ``VecNormalize.load`` with a throwaway ``DummyVecEnv``,
+    matching the sibling report scripts -- the loader needs a live env to
+    rebuild the wrapper, and hand-unpickling reconstructs a partial object
+    whose ``__setstate__`` expectations drift with the SB3 version.
+    """
+    from stable_baselines3 import PPO
+    from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
+
+    model = PPO.load(model_path, device="cpu")
+
+    if vecnorm_path is None:
+        return (lambda obs: model.predict(obs, deterministic=True)[0]), "no obs normalisation"
+
+    try:
+        normalizer = VecNormalize.load(vecnorm_path, DummyVecEnv([env_factory]))
+    except Exception as exc:  # noqa: BLE001 - the message matters more than the type
+        # A truncated or text-mode-copied .pkl is the usual cause, and the raw
+        # UnpicklingError/KeyError gives no hint that the file rather than the
+        # code is at fault.
+        raise SystemExit(
+            f"cannot read VecNormalize statistics from {vecnorm_path}: "
+            f"{type(exc).__name__}: {exc}. Re-copy the file in binary mode. "
+            "Running without --vecnorm would evaluate the policy on unnormalised "
+            "observations — a different policy — so this is fatal, not a warning."
+        ) from exc
+
+    obs_rms = normalizer.obs_rms
+    if isinstance(obs_rms, dict):
+        # SB3 keeps a per-key RunningMeanStd for Dict observation spaces. Every
+        # species here exposes a flat Box, so a dict means the checkpoint was
+        # trained against a different observation contract than the stage
+        # config builds — normalising with the wrong statistics would silently
+        # score a different policy.
+        raise SystemExit(
+            f"{vecnorm_path} holds per-key statistics for a Dict observation space "
+            f"(keys: {sorted(obs_rms)}), but this stage builds a flat Box observation."
+        )
+    mean = np.asarray(obs_rms.mean, dtype=np.float64)
+    var = np.asarray(obs_rms.var, dtype=np.float64)
+    epsilon = float(normalizer.epsilon)
+    clip = float(normalizer.clip_obs)
+
+    def predict(obs: np.ndarray) -> np.ndarray:
+        normalized = np.clip((obs - mean) / np.sqrt(var + epsilon), -clip, clip).astype(np.float32)
+        return model.predict(normalized, deterministic=True)[0]
+
+    return predict, f"VecNormalize stats applied (clip {clip:g})"
+
+
+def run_panel(
+    species: str,
+    stage: int,
+    *,
+    predict: Any,
+    episodes: int,
+    seed: int,
+    settle_steps: int,
+    horizon: int,
+    env_kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """Roll ``episodes`` deterministic episodes and reduce them for the gate."""
+    env_class = SPECIES_FACTORIES[species]().env_class
+    env = env_class(**env_kwargs)
+
+    lengths: list[float] = []
+    rewards: list[float] = []
+    duties: list[float] = []
+    terminations: dict[str, int] = {}
+
+    for index in range(episodes):
+        obs, _ = env.reset(seed=seed + index)
+        total = 0.0
+        steps = 0
+        unsupported = 0
+        measured = 0
+        while True:
+            obs, reward, terminated, truncated, info = env.step(predict(obs))
+            total += float(reward)
+            stance = derive_stance_info(info)
+            if stance and steps >= settle_steps:
+                measured += 1
+                unsupported += int(stance["unsupported_duty"])
+            steps += 1
+            if terminated or truncated:
+                reason = info.get("termination_reason", "terminated" if terminated else "truncated")
+                terminations[reason] = terminations.get(reason, 0) + 1
+                break
+        lengths.append(float(steps))
+        rewards.append(total)
+        duties.append(unsupported / measured if measured else float("nan"))
+
+    panel = stance_panel_from_episode_duties(
+        episode_lengths=lengths,
+        episode_duties=duties,
+        episode_rewards=rewards,
+        horizon=horizon,
+    )
+    return {
+        "panel": panel,
+        "lengths": np.asarray(lengths),
+        "rewards": np.asarray(rewards),
+        "terminations": terminations,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("species", help="Species id, e.g. trex")
+    parser.add_argument("--stage", type=int, default=1)
+    parser.add_argument("--model", help="Path to a saved SB3 checkpoint (.zip)")
+    parser.add_argument("--vecnorm", help="Path to the checkpoint's VecNormalize .pkl")
+    parser.add_argument(
+        "--zero-action",
+        action="store_true",
+        help="Score the do-nothing policy instead of a checkpoint (the reference the gate is calibrated against)",
+    )
+    parser.add_argument("--episodes", type=int, default=None, help="Defaults to the stage's min_eval_episodes")
+    parser.add_argument("--seed", type=int, default=3042, help="First evaluation seed (default: publication seed)")
+    parser.add_argument("--config", help="Explicit stage TOML path")
+    args = parser.parse_args()
+
+    if not args.zero_action and not args.model:
+        parser.error("pass --model, or --zero-action for the do-nothing reference")
+
+    stage_config = load_stage_config(args.species, args.stage, config_path=args.config)
+    curriculum = stage_config["curriculum_kwargs"]
+    env_kwargs = dict(stage_config["env_kwargs"])
+    horizon = int(env_kwargs.get("max_episode_steps", 1000))
+
+    gate_kind = curriculum.get("gate_kind")
+    if gate_kind != STANCE_GATE_KIND:
+        print(f"NOTE: {args.species} stage {args.stage} declares gate_kind {gate_kind!r}, not {STANCE_GATE_KIND!r}.")
+        print("      The stance criteria below are reported but are not what this stage advances on.")
+
+    thresholds = StanceGateThresholds(
+        min_full_horizon_fraction=float(curriculum.get("min_full_horizon_fraction", 0.0)),
+        max_unsupported_duty=float(curriculum.get("max_unsupported_duty", float("inf"))),
+        max_unsupported_duty_ucb=float(curriculum.get("max_unsupported_duty_ucb", float("inf"))),
+        settle_steps=int(curriculum.get("settle_steps", 0)),
+        min_eval_episodes=int(curriculum.get("min_eval_episodes", 40)),
+        min_avg_reward=float(curriculum.get("min_avg_reward", -float("inf"))),
+        required_consecutive=int(curriculum.get("required_consecutive", 3)),
+    )
+    episodes = args.episodes or thresholds.min_eval_episodes
+
+    env_class = SPECIES_FACTORIES[args.species]().env_class
+
+    if args.zero_action:
+        probe = env_class(**env_kwargs)
+        zero = np.zeros(probe.action_space.shape[0], dtype=np.float32)
+        probe.close()
+
+        def predict(_obs: np.ndarray) -> np.ndarray:
+            return zero
+
+        description = "zero action (do-nothing reference)"
+    else:
+        predict, description = _load_policy(args.model, args.vecnorm, lambda: env_class(**env_kwargs))
+        description = f"{Path(args.model).name} — {description}"
+
+    result = run_panel(
+        args.species,
+        args.stage,
+        predict=predict,
+        episodes=episodes,
+        seed=args.seed,
+        settle_steps=thresholds.settle_steps,
+        horizon=horizon,
+        env_kwargs=env_kwargs,
+    )
+    panel = result["panel"]
+    passed, failures = evaluate_stance_gate(panel, thresholds)
+
+    print()
+    print(f"policy              {description}")
+    print(f"stage               {args.species} stage {args.stage} ({gate_kind})")
+    print(f"panel               {episodes} episodes, seeds {args.seed}-{args.seed + episodes - 1}")
+    print(
+        f"settle_steps        {thresholds.settle_steps} (duty measured over the remaining {horizon - thresholds.settle_steps})"
+    )
+    print()
+    print(f"reward                 {result['rewards'].mean():9.1f} +/- {result['rewards'].std():.1f}")
+    print(f"episode length         {result['lengths'].mean():9.1f}")
+    print(
+        f"full_horizon_fraction  {panel.full_horizon_fraction:9.4f}   (>= {thresholds.min_full_horizon_fraction:.4f})"
+    )
+    print(f"mean_unsupported_duty  {panel.mean_unsupported_duty:9.4f}   (<= {thresholds.max_unsupported_duty:.4f})")
+    print(f"unsupported_duty_ucb   {panel.unsupported_duty_ucb:9.4f}   (<= {thresholds.max_unsupported_duty_ucb:.4f})")
+    print(f"duty episodes          {panel.n_duty_episodes:9d}   (full-horizon episodes only)")
+    print(f"terminations           {result['terminations']}")
+    print()
+    print(f"GATE: {'PASS' if passed else 'FAIL'}")
+    for failure in failures:
+        print(f"  - {failure}")
+    if args.episodes and args.episodes != thresholds.min_eval_episodes:
+        print()
+        print(
+            f"WARNING: --episodes {args.episodes} differs from the stage's min_eval_episodes "
+            f"{thresholds.min_eval_episodes}. The bound's power is specified at the latter; "
+            "this panel does not certify what the gate claims."
+        )
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -138,6 +138,8 @@ def run_panel(
     lengths: list[float] = []
     rewards: list[float] = []
     duties: list[float] = []
+    bilateral_duties: list[float] = []
+    single_duties: list[float] = []
     terminations: dict[str, int] = {}
     # Per-term totals, so a failing panel can be read for *why*. A policy that
     # keeps paying the airborne penalty is being funded by some other term;
@@ -149,6 +151,8 @@ def run_panel(
         total = 0.0
         steps = 0
         unsupported = 0
+        bilateral = 0
+        single = 0
         measured = 0
         while True:
             obs, reward, terminated, truncated, info = env.step(predict(obs))
@@ -160,6 +164,12 @@ def run_panel(
             if stance and steps >= settle_steps:
                 measured += 1
                 unsupported += int(stance["unsupported_duty"])
+                # The gate bounds unsupported duty only. Reporting the full
+                # three-way split shows where recovered airborne time actually
+                # went: a policy that trades flight for SINGLE support drives
+                # the gated number down without ever planting both feet.
+                bilateral += int(stance["bilateral_support_duty"])
+                single += int(stance["single_support_duty"])
             steps += 1
             if terminated or truncated:
                 reason = info.get("termination_reason", "terminated" if terminated else "truncated")
@@ -168,6 +178,9 @@ def run_panel(
         lengths.append(float(steps))
         rewards.append(total)
         duties.append(unsupported / measured if measured else float("nan"))
+        if measured:
+            bilateral_duties.append(bilateral / measured)
+            single_duties.append(single / measured)
 
     panel = stance_panel_from_episode_duties(
         episode_lengths=lengths,
@@ -181,6 +194,8 @@ def run_panel(
         "rewards": np.asarray(rewards),
         "terminations": terminations,
         "components": {key: value / episodes for key, value in components.items()},
+        "bilateral_duty": float(np.mean(bilateral_duties)) if bilateral_duties else float("nan"),
+        "single_duty": float(np.mean(single_duties)) if single_duties else float("nan"),
     }
 
 
@@ -268,6 +283,11 @@ def main() -> int:
     print(f"mean_unsupported_duty  {panel.mean_unsupported_duty:9.4f}   (<= {thresholds.max_unsupported_duty:.4f})")
     print(f"unsupported_duty_ucb   {panel.unsupported_duty_ucb:9.4f}   (<= {thresholds.max_unsupported_duty_ucb:.4f})")
     print(f"duty episodes          {panel.n_duty_episodes:9d}   (full-horizon episodes only)")
+    # Not gated, but decisive for reading a falling unsupported duty: the
+    # three shares sum to 1, so a policy can cut flight without ever planting
+    # both feet.
+    print(f"  bilateral support    {result['bilateral_duty']:9.4f}   (statue 0.998, not gated)")
+    print(f"  single support       {result['single_duty']:9.4f}   (statue 0.002, not gated)")
     print(f"terminations           {result['terminations']}")
     components = result["components"]
     if components:

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -111,7 +111,11 @@ def _load_policy(model_path: str, vecnorm_path: str | None, env_factory: Any):
 
     def predict(obs: np.ndarray) -> np.ndarray:
         normalized = np.clip((obs - mean) / np.sqrt(var + epsilon), -clip, clip).astype(np.float32)
-        return model.predict(normalized, deterministic=True)[0]
+        # np.asarray, not a bare return: SB3's predict() is untyped when
+        # stable-baselines3 is absent (as it is in the lint job), so the value
+        # is Any there and typed here. Coercing makes the annotation true in
+        # both environments instead of only the one that happens to run mypy.
+        return np.asarray(model.predict(normalized, deterministic=True)[0])
 
     return predict, f"VecNormalize stats applied (clip {clip:g})"
 

--- a/environments/shared/species_catalog.py
+++ b/environments/shared/species_catalog.py
@@ -368,6 +368,13 @@ def _build_stages(species_id: str, raw_videos: list[dict[str, Any]]) -> list[dic
                     "min_avg_episode_length": curriculum.get("min_avg_episode_length"),
                     "min_avg_forward_velocity": curriculum.get("min_avg_forward_vel"),
                     "min_success_rate": curriculum.get("min_success_rate"),
+                    # stance_quality/v1. Exported so the published gate is the
+                    # one actually enforced: a stance-gated stage whose only
+                    # listed criterion was its reward rail would read as gated
+                    # on a threshold its own statue clears by 68%.
+                    "min_full_horizon_fraction": curriculum.get("min_full_horizon_fraction"),
+                    "max_unsupported_duty": curriculum.get("max_unsupported_duty"),
+                    "max_unsupported_duty_ucb": curriculum.get("max_unsupported_duty_ucb"),
                     "min_eval_episodes": int(
                         curriculum.get("min_eval_episodes", DEFAULT_STAGE_THRESHOLD.min_eval_episodes)
                     ),
@@ -688,6 +695,12 @@ def _format_advancement_gate(gate: dict[str, Any]) -> str:
         criteria.append(f"avg. velocity ≥ {gate['min_avg_forward_velocity']:g} m/s")
     if gate["min_success_rate"] is not None:
         criteria.append(f"task success ≥ {_format_percent(gate['min_success_rate'])}")
+    if gate.get("min_full_horizon_fraction") is not None:
+        criteria.append(f"full-horizon episodes ≥ {_format_percent(gate['min_full_horizon_fraction'])}")
+    if gate.get("max_unsupported_duty") is not None:
+        criteria.append(f"unsupported duty ≤ {gate['max_unsupported_duty']:g}")
+    if gate.get("max_unsupported_duty_ucb") is not None:
+        criteria.append(f"unsupported duty 95% upper bound ≤ {gate['max_unsupported_duty_ucb']:g}")
     criteria.append(f"≥ {gate['min_eval_episodes']} episodes/evaluation")
     criteria.append(f"{gate['required_consecutive']} consecutive passes")
     return "; ".join(criteria)

--- a/environments/shared/tests/test_curriculum_advancement.py
+++ b/environments/shared/tests/test_curriculum_advancement.py
@@ -138,6 +138,9 @@ class TestCallbackMethodsMocked:
             [1000.0] * 3,
             [1.0, 1.5, 2.0],
             None,
+            # No stance panel: this stage gates on reward_and_length/v1, so
+            # the stance capture is not consulted at all.
+            None,
         )
 
 

--- a/environments/shared/tests/test_curriculum_manager.py
+++ b/environments/shared/tests/test_curriculum_manager.py
@@ -8,6 +8,7 @@ from environments.shared.curriculum import (
     thresholds_from_configs,
 )
 from environments.shared.curriculum.gate_schema import (
+    GATE_KINDS,
     GATE_SCHEMA_VERSION,
     GateSchemaError,
     validate_gate_configs,
@@ -293,7 +294,12 @@ class TestThresholdsFromConfigs:
         assert thresholds[1]["min_avg_reward"] == 10.0
         assert thresholds[1]["required_consecutive"] == 2
         assert thresholds[2]["min_avg_reward"] == 50.0
-        assert 3 not in thresholds  # declared non-advancing pilot -> no entry
+        # A declared non-advancing pilot now gets an explicit entry carrying its
+        # gate kind, rather than no entry at all. The old "no entry" shape left
+        # it on StageThreshold's permissive defaults (min_avg_reward = -inf),
+        # which pass on any evaluation; only the schema's refusal to accept
+        # "none/v1" under advancement kept that from being reachable.
+        assert thresholds[3]["gate_kind"] == "none/v1"
 
     def test_extracts_all_threshold_fields(self):
         configs = {
@@ -363,12 +369,34 @@ class TestThresholdsFromConfigs:
             thresholds_from_configs(configs, advancement_enabled=False)
 
     def test_every_committed_stage_config_declares_a_valid_gate(self):
-        """The shipped configs must satisfy the schema on every species."""
+        """The shipped configs must satisfy the schema on every species.
+
+        Asserts every declared kind is one the registry knows and both
+        backends evaluate, rather than pinning the specific kind each stage
+        uses — pinning the literal made adopting stance_quality/v1 for T-Rex
+        stage 1a look like a regression instead of the intended change.
+        """
         from environments.shared.config import load_all_stages
 
         for species in ("trex", "velociraptor", "brachiosaurus", "dibothrosuchus"):
             kinds = validate_gate_configs(load_all_stages(species))
-            assert set(kinds.values()) == {"reward_and_length/v1"}, species
+            assert set(kinds.values()) <= set(GATE_KINDS), species
+            # "none/v1" refuses to advance, so a shipped curriculum stage must
+            # never declare it.
+            assert "none/v1" not in set(kinds.values()), species
+
+    def test_trex_stage1_gates_on_stance_quality(self):
+        """T-Rex 1a must not be gated on return: a statue is the reward optimum."""
+        from environments.shared.config import load_all_stages
+
+        curriculum = load_all_stages("trex")[1]["curriculum_kwargs"]
+        assert curriculum["gate_kind"] == "stance_quality/v1"
+        # The statue scores 3271.8 at 1000.0 steps, so the retired reward and
+        # length criteria were both cleared by doing nothing.
+        assert curriculum["min_avg_reward"] < 3271.8, "reward must be a rail below the statue, not a gate"
+        assert "min_avg_episode_length" not in curriculum
+        # The bound's power is specified at this panel size.
+        assert curriculum["min_eval_episodes"] == 40
 
     def test_with_real_configs(self):
         """Integration test: extract thresholds from actual TOML configs."""

--- a/environments/shared/tests/test_eval_diagnostics.py
+++ b/environments/shared/tests/test_eval_diagnostics.py
@@ -47,13 +47,16 @@ def _bare_stage_aware_callback(
     callback._is_success_buffer = []
     callback.evaluations_forward_velocities = []
     callback.evaluations_unsupported_duties = []
+    callback.evaluations_bilateral_duties = []
     callback._episode_forward_sums = {}
     callback._episode_forward_counts = {}
     callback._current_eval_forward_velocities = []
     callback._episode_steps = {}
     callback._episode_unsupported = {}
+    callback._episode_bilateral = {}
     callback._episode_measured = {}
     callback._current_eval_unsupported_duties = []
+    callback._current_eval_bilateral_duties = []
     return callback
 
 
@@ -183,6 +186,7 @@ def _plateau_callback(
         evaluations_forward_velocities=[],
         evaluations_successes=[],
         evaluations_unsupported_duties=[],
+        evaluations_bilateral_duties=[],
     )
     callback = object.__new__(StageGatePlateauCallback)
     callback.eval_callback = cast(StageAwareEvalCallback, eval_callback)
@@ -217,11 +221,14 @@ def _add_evaluation(
     forward_vel_episodes: int | None = None,
     success_episodes: int | None = None,
     unsupported_duty: float | None = None,
+    bilateral_duty: float | None = None,
 ) -> None:
     eval_callback.evaluations_results.append([reward] * n_episodes)
     eval_callback.evaluations_length.append([length] * n_episodes)
     if unsupported_duty is not None:
         eval_callback.evaluations_unsupported_duties.append([unsupported_duty] * n_episodes)
+    if bilateral_duty is not None:
+        eval_callback.evaluations_bilateral_duties.append([bilateral_duty] * n_episodes)
     if forward_vel is not None:
         count = n_episodes if forward_vel_episodes is None else forward_vel_episodes
         eval_callback.evaluations_forward_velocities.append([forward_vel] * count)
@@ -500,3 +507,59 @@ class TestStanceGateIsACeilingNotAFloor:
         metric = next(m for m in callback._metrics_for_evaluation(0) if m.key == "full_horizon_fraction")
         assert metric.value == pytest.approx(0.95)
         assert not metric.is_failing()
+
+
+class TestStanceShareCapture:
+    """Bilateral duty is captured to CALIBRATE a future threshold.
+
+    It is not a gate criterion. The three stance shares sum to 1, so a falling
+    unsupported duty says nothing about whether the feet are being planted --
+    that time can land in single support. Bounding bilateral duty is the
+    obvious fix, but the only reference available is the statue's 0.998, and
+    the statue never shifts weight. Recording the share every evaluation is
+    what turns the eventual threshold into evidence instead of a guess.
+    """
+
+    def test_both_shares_are_captured_per_episode(self):
+        callback = _bare_stage_aware_callback(success_applicable=False, settle_steps=0)
+        # Two steps planted on both feet, then one airborne, then done.
+        for forces, done in (((400.0, 400.0), False), ((400.0, 400.0), False), ((0.0, 0.0), True)):
+            callback._log_success_callback(
+                {"i": 0, "done": done, "info": {"r_foot_contact": forces[0], "l_foot_contact": forces[1]}},
+                {},
+            )
+        assert callback._current_eval_unsupported_duties == [pytest.approx(1 / 3)]
+        assert callback._current_eval_bilateral_duties == [pytest.approx(2 / 3)]
+
+    def test_shares_sum_with_single_support(self):
+        """Single support counts toward neither share, which is the point."""
+        callback = _bare_stage_aware_callback(success_applicable=False, settle_steps=0)
+        for forces, done in (((400.0, 0.0), False), ((400.0, 400.0), False), ((0.0, 0.0), True)):
+            callback._log_success_callback(
+                {"i": 0, "done": done, "info": {"r_foot_contact": forces[0], "l_foot_contact": forces[1]}},
+                {},
+            )
+        unsupported = callback._current_eval_unsupported_duties[0]
+        bilateral = callback._current_eval_bilateral_duties[0]
+        assert unsupported == pytest.approx(1 / 3)
+        assert bilateral == pytest.approx(1 / 3)
+        # The missing third is single support — the share a bilateral floor
+        # would catch and an unsupported ceiling would not.
+        assert 1.0 - unsupported - bilateral == pytest.approx(1 / 3)
+
+    def test_shares_are_logged_even_when_the_gate_panel_is_incomplete(self):
+        """The early, incomplete evaluations are the calibration data."""
+        callback, eval_callback = _plateau_callback({"min_avg_reward": 100.0, "min_eval_episodes": 40}, stage=1)
+        _add_evaluation(
+            callback,
+            eval_callback,
+            reward=200.0,
+            length=1000.0,
+            n_episodes=5,  # below min_eval_episodes -> gate data incomplete
+            unsupported_duty=0.19,
+            bilateral_duty=0.66,
+        )
+        recorded = dict(call.args for call in callback.logger.record.call_args_list)
+        assert recorded["diagnostics/eval_gate_data_complete"] == 0.0
+        assert recorded["diagnostics/eval_unsupported_duty"] == pytest.approx(0.19)
+        assert recorded["diagnostics/eval_bilateral_support_duty"] == pytest.approx(0.66)

--- a/environments/shared/tests/test_eval_diagnostics.py
+++ b/environments/shared/tests/test_eval_diagnostics.py
@@ -182,9 +182,11 @@ def _plateau_callback(
         evaluations_length=[],
         evaluations_forward_velocities=[],
         evaluations_successes=[],
+        evaluations_unsupported_duties=[],
     )
     callback = object.__new__(StageGatePlateauCallback)
     callback.eval_callback = cast(StageAwareEvalCallback, eval_callback)
+    callback.horizon = 1000
     callback.stage = stage
     callback.curriculum_kwargs = dict(curriculum_kwargs)
     callback.plateau_window = plateau_window
@@ -214,9 +216,12 @@ def _add_evaluation(
     n_episodes: int = 10,
     forward_vel_episodes: int | None = None,
     success_episodes: int | None = None,
+    unsupported_duty: float | None = None,
 ) -> None:
     eval_callback.evaluations_results.append([reward] * n_episodes)
     eval_callback.evaluations_length.append([length] * n_episodes)
+    if unsupported_duty is not None:
+        eval_callback.evaluations_unsupported_duties.append([unsupported_duty] * n_episodes)
     if forward_vel is not None:
         count = n_episodes if forward_vel_episodes is None else forward_vel_episodes
         eval_callback.evaluations_forward_velocities.append([forward_vel] * count)
@@ -424,3 +429,74 @@ class TestStageGatePlateauCallback:
                 curriculum_kwargs={"min_avg_reward": 100.0},
                 plateau_window=1,
             )
+
+
+class TestStanceGateIsACeilingNotAFloor:
+    """Duty must fail when it is too HIGH, unlike every other gate metric.
+
+    The plateau machinery originally tested ``value < threshold`` for every
+    metric. Read that way a policy chattering at duty 0.30 against a 0.02
+    ceiling looks comfortably passing, and the callback would follow
+    ``mean_reward`` instead -- handing out reward-tuning advice for a stage
+    whose blocking criterion is foot contact.
+    """
+
+    def test_gate_metric_direction(self):
+        floor = eval_diagnostics_module._GateMetric("mean_reward", "reward", 1950.0, 1200.0, 40)
+        assert floor.is_failing()
+        assert not eval_diagnostics_module._GateMetric("mean_reward", "reward", 1950.0, 3271.8, 40).is_failing()
+
+        ceiling = eval_diagnostics_module._GateMetric(
+            "mean_unsupported_duty", "unsupported duty", 0.02, 0.319, 40, ceiling=True
+        )
+        assert ceiling.is_failing()
+        assert not eval_diagnostics_module._GateMetric(
+            "mean_unsupported_duty", "unsupported duty", 0.02, 0.0, 40, ceiling=True
+        ).is_failing()
+
+    def test_missing_value_is_not_failing_in_either_direction(self):
+        for ceiling in (False, True):
+            metric = eval_diagnostics_module._GateMetric("k", "l", 0.02, None, 0, ceiling=ceiling)
+            assert not metric.is_failing()
+
+    def test_duty_blocks_ahead_of_reward_on_a_stance_stage(self, caplog):
+        callback, eval_callback = _plateau_callback(
+            {
+                "min_avg_reward": 1950.0,
+                "min_full_horizon_fraction": 0.95,
+                "max_unsupported_duty": 0.02,
+            },
+            stage=1,
+        )
+        with caplog.at_level("WARNING", logger="environments.shared.eval_diagnostics"):
+            for _ in range(4):
+                # Clears the reward rail and the horizon floor; only duty fails.
+                _add_evaluation(
+                    callback,
+                    eval_callback,
+                    reward=2133.4,
+                    length=1000.0,
+                    unsupported_duty=0.319,
+                )
+        warnings = [r.message for r in caplog.records if "EVALUATION PLATEAU" in r.message]
+        assert len(warnings) == 1
+        assert "unsupported duty" in warnings[0]
+        assert callback._plateau_metric == "mean_unsupported_duty"
+
+    def test_a_stage_without_stance_thresholds_ignores_duty(self):
+        callback, eval_callback = _plateau_callback({"min_avg_reward": 100.0}, stage=2)
+        _add_evaluation(callback, eval_callback, reward=200.0, length=1000.0, unsupported_duty=0.9)
+        keys = {metric.key for metric in callback._metrics_for_evaluation(0)}
+        assert "mean_unsupported_duty" not in keys
+        assert "full_horizon_fraction" not in keys
+
+    def test_full_horizon_fraction_is_derived_from_episode_lengths(self):
+        callback, eval_callback = _plateau_callback(
+            {"min_avg_reward": 1950.0, "min_full_horizon_fraction": 0.95}, stage=1
+        )
+        eval_callback.evaluations_results.append([3271.8] * 40)
+        # 38 reach the 1000-step horizon, 2 fall at 400.
+        eval_callback.evaluations_length.append([1000.0] * 38 + [400.0] * 2)
+        metric = next(m for m in callback._metrics_for_evaluation(0) if m.key == "full_horizon_fraction")
+        assert metric.value == pytest.approx(0.95)
+        assert not metric.is_failing()

--- a/environments/shared/tests/test_eval_diagnostics.py
+++ b/environments/shared/tests/test_eval_diagnostics.py
@@ -33,17 +33,27 @@ class TestSuccessMetricApplicable:
         assert success_metric_applicable(configs[3]) is True
 
 
-def _bare_stage_aware_callback(*, success_applicable: bool) -> StageAwareEvalCallback:
+def _bare_stage_aware_callback(
+    *,
+    success_applicable: bool,
+    settle_steps: int = 0,
+) -> StageAwareEvalCallback:
     if success_applicable:
         pytest.importorskip("stable_baselines3")
     callback = object.__new__(StageAwareEvalCallback)
     callback.stage = 3 if success_applicable else 1
     callback.success_applicable = success_applicable
+    callback.settle_steps = settle_steps
     callback._is_success_buffer = []
     callback.evaluations_forward_velocities = []
+    callback.evaluations_unsupported_duties = []
     callback._episode_forward_sums = {}
     callback._episode_forward_counts = {}
     callback._current_eval_forward_velocities = []
+    callback._episode_steps = {}
+    callback._episode_unsupported = {}
+    callback._episode_measured = {}
+    callback._current_eval_unsupported_duties = []
     return callback
 
 

--- a/environments/shared/tests/test_jax_curriculum.py
+++ b/environments/shared/tests/test_jax_curriculum.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import pytest
 
 from environments.shared.curriculum.gate_schema import GATE_SCHEMA_VERSION, GateSchemaError
+from environments.shared.curriculum.stance_gate import STANCE_GATE_KIND
 from environments.shared.jax_curriculum import check_stage_gate
 
 #: The gate declaration every real stage config carries. Tests that exercise a
@@ -149,12 +150,31 @@ class TestLengthThresholdIsEnforced:
         stage_config = {"curriculum_kwargs": dict(_GATE, min_avg_reward=100.0)}
         assert check_stage_gate({"mean_episode_return": 150.0}, stage_config) is True
 
-    def test_every_stage_one_config_length_gate_binds_on_both_backends(self):
-        """The shipped stage-1 configs all carry the full-horizon floor."""
+    def test_every_stage_one_config_binds_a_full_horizon_floor(self):
+        """Every shipped stage-1 config enforces a full-horizon requirement.
+
+        The two gate kinds express it differently -- ``reward_and_length/v1``
+        as a mean episode-step floor, ``stance_quality/v1`` as a fraction of
+        episodes reaching the horizon -- but neither may be satisfied by
+        unbounded reward alone. That is the property worth pinning: the
+        specific field is an implementation detail of the kind.
+        """
         from environments.shared.config import load_stage_config
 
         for species in ("trex", "velociraptor", "brachiosaurus", "dibothrosuchus"):
             cfg = load_stage_config(species, 1)
-            floor = cfg["curriculum_kwargs"]["min_avg_episode_length"]
-            generous = {"mean_episode_return": 1e9, "mean_episode_length": floor - 1}
+            curriculum = cfg["curriculum_kwargs"]
+            if curriculum["gate_kind"] == STANCE_GATE_KIND:
+                floor = curriculum["min_full_horizon_fraction"]
+                generous = {
+                    "mean_episode_return": 1e9,
+                    "n_eval_episodes": curriculum["min_eval_episodes"],
+                    "full_horizon_fraction": floor - 0.01,
+                    "n_duty_episodes": curriculum["min_eval_episodes"],
+                    "mean_unsupported_duty": 0.0,
+                    "unsupported_duty_ucb": 0.0,
+                }
+            else:
+                floor = curriculum["min_avg_episode_length"]
+                generous = {"mean_episode_return": 1e9, "mean_episode_length": floor - 1}
             assert check_stage_gate(generous, cfg) is False, species

--- a/environments/shared/tests/test_reporting_gates.py
+++ b/environments/shared/tests/test_reporting_gates.py
@@ -30,3 +30,51 @@ class TestStrictRecordedGate:
             {"mean_reward": 90.0, "n_episodes": 10},
         ]
         assert evaluate_recorded_gate(curriculum, evaluations) is False
+
+
+class TestStanceQualityRecordedGate:
+    """The stance criteria are CEILINGS, so the direction has to be right.
+
+    Reporting them as floors, or omitting them, would describe a stance-gated
+    stage as gated on its reward rail alone -- a threshold the statue clears
+    by 68%, which is the claim the gate exists to refute.
+    """
+
+    CURRICULUM = {
+        "min_avg_reward": 1950.0,
+        "min_full_horizon_fraction": 0.95,
+        "max_unsupported_duty": 0.02,
+        "max_unsupported_duty_ucb": 0.02,
+        "min_eval_episodes": 40,
+        "required_consecutive": 2,
+    }
+
+    def _eval(self, duty, ucb=None, horizon=1.0, reward=3271.8):
+        return {
+            "mean_reward": reward,
+            "full_horizon_fraction": horizon,
+            "mean_unsupported_duty": duty,
+            "unsupported_duty_ucb": duty if ucb is None else ucb,
+            "n_episodes": 40,
+        }
+
+    def test_statue_panel_passes(self):
+        assert evaluate_recorded_gate(self.CURRICULUM, [self._eval(0.0)] * 2) is True
+
+    def test_chatterer_panel_fails_despite_clearing_the_reward_rail(self):
+        # Measured: duty 0.319, reward 2133.4 -- above the 1950 rail.
+        history = [self._eval(0.319, ucb=0.322, reward=2133.4)] * 2
+        assert evaluate_recorded_gate(self.CURRICULUM, history) is False
+
+    def test_duty_is_a_ceiling_not_a_floor(self):
+        """A duty far ABOVE the threshold must fail, not pass."""
+        assert evaluate_recorded_gate(self.CURRICULUM, [self._eval(0.9)] * 2) is False
+
+    def test_bound_binds_when_the_raw_mean_would_pass(self):
+        history = [self._eval(0.018, ucb=0.021)] * 2
+        assert evaluate_recorded_gate(self.CURRICULUM, history) is False
+
+    def test_missing_stance_metrics_cannot_prove_a_pass(self):
+        """An old history lacking the stance keys is unprovable, not a pass."""
+        legacy = [{"mean_reward": 3271.8, "n_episodes": 40}] * 2
+        assert evaluate_recorded_gate(self.CURRICULUM, legacy) is None

--- a/environments/shared/tests/test_result_bundle_evidence.py
+++ b/environments/shared/tests/test_result_bundle_evidence.py
@@ -243,6 +243,45 @@ def test_publication_gate_is_recomputed_from_frozen_thresholds(
         )
 
 
+def test_stance_gated_stage_refuses_publication_rather_than_certifying_on_the_rail(
+    tmp_path: Path,
+    stable_provenance: None,
+) -> None:
+    """A gate this evidence file cannot express must not be half-checked.
+
+    stance_quality/v1 carries min_avg_reward only as a RAIL, set below the
+    zero-action statue. The per-episode evidence CSV records reward and
+    length but no unsupported duty, so evaluating the legacy thresholds would
+    certify the stage on the rail alone -- reintroducing exactly the "a statue
+    clears this gate" failure the stance gate was built to remove.
+    """
+    run_dir = tmp_path / "run"
+    stage_results, stage_configs = _complete_bundle_inputs(run_dir, algorithm="PPO")
+    config_path = run_dir / "stage1" / "stage_config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["curriculum_kwargs"]["gate_kind"] = "stance_quality/v1"
+    config["curriculum_kwargs"]["min_full_horizon_fraction"] = 0.95
+    config["curriculum_kwargs"]["max_unsupported_duty"] = 0.02
+    config["curriculum_kwargs"]["max_unsupported_duty_ucb"] = 0.02
+    config_path.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    with pytest.raises(ResultBundleError, match=r"cannot be checked from the publication evidence"):
+        save_result_bundle(
+            stage_results,
+            stage_configs,
+            "velociraptor",
+            "PPO",
+            42,
+            run_dir,
+            backend="stable-baselines3",
+            backend_version="2.7.0",
+            parallel_envs=4,
+            evaluation_episodes=3,
+            evaluation_seeds=[101, 102, 103],
+            plant_identity=_plant_identity(),
+        )
+
+
 def test_final_evaluation_claims_are_bound_to_terminal_episode_evidence(
     tmp_path: Path,
     stable_provenance: None,

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -185,12 +185,12 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
     # the historical default.
     stage_one_eval_episodes = {"trex": 40, "velociraptor": 10, "brachiosaurus": 10, "dibothrosuchus": 10}
     # Only T-Rex 1a declares stance criteria; the rest export nulls.
-    stance_null = {
+    stance_null: dict[str, float | None] = {
         "min_full_horizon_fraction": None,
         "max_unsupported_duty": None,
         "max_unsupported_duty_ucb": None,
     }
-    stage_one_stance = {
+    stage_one_stance: dict[str, dict[str, float | None]] = {
         "trex": {
             "min_full_horizon_fraction": 0.95,
             "max_unsupported_duty": 0.02,

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -175,20 +175,45 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
         "dibothrosuchus": 1560.0,
     }
 
+    # T-Rex 1a has moved to stance_quality/v1, which does not consume
+    # min_avg_episode_length: min_full_horizon_fraction states section 12's
+    # >= 95% requirement directly instead of encoding it as a step count. Its
+    # min_avg_reward stays, demoted to a rail. The other three species are
+    # still on reward_and_length/v1 pending their own stance calibration.
+    stage_one_length = {"trex": None, "velociraptor": 950, "brachiosaurus": 950, "dibothrosuchus": 950}
+    # The stance bound's power is specified at n=40; the other species keep
+    # the historical default.
+    stage_one_eval_episodes = {"trex": 40, "velociraptor": 10, "brachiosaurus": 10, "dibothrosuchus": 10}
+    # Only T-Rex 1a declares stance criteria; the rest export nulls.
+    stance_null = {
+        "min_full_horizon_fraction": None,
+        "max_unsupported_duty": None,
+        "max_unsupported_duty_ucb": None,
+    }
+    stage_one_stance = {
+        "trex": {
+            "min_full_horizon_fraction": 0.95,
+            "max_unsupported_duty": 0.02,
+            "max_unsupported_duty_ucb": 0.02,
+        },
+        "velociraptor": stance_null,
+        "brachiosaurus": stance_null,
+        "dibothrosuchus": stance_null,
+    }
+
     for species_id, entry in species.items():
         stage_one, stage_two, stage_three = [stage["advancement_gate"] for stage in entry["stages"]]
         assert stage_one == {
             "min_avg_reward": stage_one_min_avg_reward[species_id],
-            # Encodes section 12's full-horizon >= 95% floor. Every species'
-            # statue reaches 100% at noise 0.05, so this is a floor a policy
-            # must MATCH; the old 750 was set at operating points where
-            # survival and stance quality were inseparable.
-            "min_avg_episode_length": 950,
+            "min_avg_episode_length": stage_one_length[species_id],
             "min_avg_forward_velocity": None,
             "min_success_rate": None,
-            "min_eval_episodes": 10,
+            "min_eval_episodes": stage_one_eval_episodes[species_id],
             "required_consecutive": 3,
+            **stage_one_stance[species_id],
         }
+        # Stages 2 and 3 stay on reward_and_length/v1, so their stance fields
+        # export as nulls.
         assert stage_two | {"min_avg_forward_velocity": None} == {
             "min_avg_reward": 100.0,
             "min_avg_episode_length": 750,
@@ -196,6 +221,7 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
             "min_success_rate": None,
             "min_eval_episodes": 10,
             "required_consecutive": 3,
+            **stance_null,
         }
         assert stage_three == {
             "min_avg_reward": 100.0,
@@ -204,6 +230,7 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
             "min_success_rate": 0.5,
             "min_eval_episodes": 10,
             "required_consecutive": 3,
+            **stance_null,
         }
 
     assert species["velociraptor"]["stages"][1]["advancement_gate"]["min_avg_forward_velocity"] == 2.0

--- a/environments/shared/tests/test_stance_gate.py
+++ b/environments/shared/tests/test_stance_gate.py
@@ -1,0 +1,316 @@
+"""Tests for the ``stance_quality/v1`` advancement gate.
+
+The measured anchors these assert against, all at reset noise 0.05 and all
+using ``derive_stance_info``'s 0.1 N contact threshold:
+
+* the zero-action statue -- 119/120 = 99.17% full-horizon pooled over three
+  independent 40-seed blocks, unsupported duty 0.000, reward 3271.8 +/- 12.0;
+* run ``20260801_021545``'s best checkpoint -- full-horizon on every rolled
+  out episode, reward 2347.67, unsupported duty **0.284**.
+
+The gate exists to pass the first and reject the second.  The old
+``reward_and_length/v1`` configuration passed both.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from environments.shared.curriculum.stance_gate import (
+    STANCE_GATE_KIND,
+    StanceGateThresholds,
+    episode_unsupported_duty,
+    evaluate_stance_gate,
+    mean_upper_confidence_bound,
+    one_sided_t95,
+    stance_panel_from_episode_duties,
+    summarize_stance_panel,
+)
+
+HORIZON = 1000
+SETTLE = 200
+
+#: The adopted T-Rex 1a thresholds.
+TREX_1A = StanceGateThresholds(
+    min_full_horizon_fraction=0.95,
+    max_unsupported_duty=0.02,
+    max_unsupported_duty_ucb=0.02,
+    settle_steps=SETTLE,
+    min_eval_episodes=40,
+    min_avg_reward=1950.0,
+)
+
+
+def _episode(duty: float, length: int = HORIZON) -> np.ndarray:
+    """A per-step unsupported trace whose post-settle duty is ``duty``."""
+    flags = np.zeros(length)
+    measurable = max(0, length - SETTLE)
+    flags[SETTLE : SETTLE + int(round(duty * measurable))] = 1.0
+    return flags
+
+
+def _panel(duty, reward, *, n=40, full_fraction=1.0, jitter=0.0, seed=0):
+    rng = np.random.default_rng(seed)
+    n_full = int(round(n * full_fraction))
+    lengths = [HORIZON] * n_full + [400] * (n - n_full)
+    traces = [_episode(max(0.0, duty + (rng.normal(0, jitter) if jitter else 0.0)), L) for L in lengths]
+    return summarize_stance_panel(
+        episode_lengths=lengths,
+        episode_unsupported=traces,
+        episode_rewards=[reward] * n,
+        horizon=HORIZON,
+        settle_steps=SETTLE,
+    )
+
+
+class TestDiscrimination:
+    """The gate must separate the two policies the reward gate could not."""
+
+    def test_statue_passes(self):
+        passed, failures = evaluate_stance_gate(_panel(0.000, 3271.8), TREX_1A)
+        assert passed, failures
+
+    def test_statue_passes_with_its_measured_one_in_120_nosedive(self):
+        # 39/40 = 0.975 full-horizon still clears the 0.95 floor, which is the
+        # point of gating on a fraction rather than demanding a clean sweep.
+        passed, failures = evaluate_stance_gate(_panel(0.000, 3250.0, full_fraction=39 / 40), TREX_1A)
+        assert passed, failures
+
+    def test_chatterer_fails_on_duty(self):
+        """Run 20260801_021545's best model: passed the old gate, must fail this one."""
+        panel = _panel(0.284, 2347.7)
+        passed, failures = evaluate_stance_gate(panel, TREX_1A)
+        assert not passed
+        assert any("mean_unsupported_duty" in f for f in failures)
+        assert any("unsupported_duty_ucb" in f for f in failures)
+        # It cleared the retired reward criterion, which is exactly why the
+        # gate had to stop being about reward.
+        assert panel.mean_reward > TREX_1A.min_avg_reward
+        assert panel.full_horizon_fraction >= TREX_1A.min_full_horizon_fraction
+
+    def test_quiet_active_policy_passes(self):
+        passed, failures = evaluate_stance_gate(_panel(0.005, 3100.0, jitter=0.004, seed=3), TREX_1A)
+        assert passed, failures
+
+    def test_reward_rail_rejects_a_policy_that_threw_away_the_return(self):
+        passed, failures = evaluate_stance_gate(_panel(0.001, 1200.0), TREX_1A)
+        assert not passed
+        assert any("rail" in f for f in failures)
+
+    def test_falling_policy_fails_on_horizon(self):
+        passed, failures = evaluate_stance_gate(_panel(0.000, 3000.0, full_fraction=0.5), TREX_1A)
+        assert not passed
+        assert any("full_horizon_fraction" in f for f in failures)
+
+
+class TestFailedEpisodesAreExcludedFromDuty:
+    """Decided 2026-08-01: failures do not contribute duty."""
+
+    def test_short_episode_duty_is_not_counted(self):
+        # One clean full-horizon episode and one that fell at step 400 while
+        # airborne throughout its measurable tail. Scoring the failure would
+        # drag the mean to ~0.5; excluding it leaves the survivor's 0.0.
+        lengths = [HORIZON, 400]
+        traces = [_episode(0.0, HORIZON), _episode(1.0, 400)]
+        panel = stance_panel_from_episode_duties(
+            episode_lengths=lengths,
+            episode_duties=[episode_unsupported_duty(t, settle_steps=SETTLE) for t in traces],
+            episode_rewards=[3271.8, 900.0],
+            horizon=HORIZON,
+        )
+        assert panel.n_duty_episodes == 1
+        assert panel.mean_unsupported_duty == pytest.approx(0.0)
+        assert panel.full_horizon_fraction == pytest.approx(0.5)
+
+    def test_panel_with_no_survivors_fails_closed(self):
+        panel = _panel(0.0, 3000.0, full_fraction=0.0)
+        assert panel.n_duty_episodes == 0
+        assert panel.mean_unsupported_duty == math.inf
+        passed, failures = evaluate_stance_gate(panel, TREX_1A)
+        assert not passed
+        assert any("no full-horizon episode" in f for f in failures)
+
+    def test_unmeasurable_duty_is_dropped_not_zeroed(self):
+        """A NaN duty must not be read as a perfect 0.0."""
+        panel = stance_panel_from_episode_duties(
+            episode_lengths=[HORIZON, HORIZON],
+            episode_duties=[float("nan"), 0.5],
+            episode_rewards=[3000.0, 3000.0],
+            horizon=HORIZON,
+        )
+        assert panel.n_duty_episodes == 1
+        assert panel.mean_unsupported_duty == pytest.approx(0.5)
+
+
+class TestSettlingWindow:
+    def test_duty_before_the_window_is_ignored(self):
+        # Airborne for the whole settling prefix, planted afterwards.
+        flags = np.zeros(HORIZON)
+        flags[:SETTLE] = 1.0
+        assert episode_unsupported_duty(flags, settle_steps=SETTLE) == pytest.approx(0.0)
+
+    def test_duty_after_the_window_is_counted(self):
+        flags = np.zeros(HORIZON)
+        flags[SETTLE:] = 1.0
+        assert episode_unsupported_duty(flags, settle_steps=SETTLE) == pytest.approx(1.0)
+
+    def test_episode_shorter_than_the_window_has_no_measurable_tail(self):
+        assert episode_unsupported_duty(np.zeros(SETTLE), settle_steps=SETTLE) is None
+
+
+class TestConfidenceBound:
+    def test_bound_is_an_upper_bound(self):
+        """Direction matters: STAGE1_SPLIT_PLAN 2.3 says LCB, which is a slip.
+
+        Duty must stay BELOW a ceiling, so the conservative bound is the upper
+        one. A lower bound would pass a policy whose mean already exceeded the
+        ceiling whenever the panel was noisy, inverting the gate.
+        """
+        values = [0.01, 0.02, 0.03, 0.04, 0.05]
+        assert mean_upper_confidence_bound(values) > float(np.mean(values))
+
+    def test_bound_subsumes_the_screening_ceiling(self):
+        panel = _panel(0.019, 3000.0, jitter=0.01, seed=11)
+        assert panel.unsupported_duty_ucb >= panel.mean_unsupported_duty
+
+    def test_noise_can_fail_a_panel_whose_raw_mean_passes(self):
+        """The bound is load-bearing, not decorative.
+
+        Duties alternating 0.008/0.028 have mean 0.018 -- inside the 0.02
+        screening ceiling -- but a spread wide enough that the 95% bound lands
+        above it. The screening check alone would advance this panel.
+        """
+        duties = [0.008, 0.028] * 20
+        panel = stance_panel_from_episode_duties(
+            episode_lengths=[HORIZON] * 40,
+            episode_duties=duties,
+            episode_rewards=[3000.0] * 40,
+            horizon=HORIZON,
+        )
+        assert panel.mean_unsupported_duty == pytest.approx(0.018)
+        assert panel.mean_unsupported_duty <= TREX_1A.max_unsupported_duty
+        assert panel.unsupported_duty_ucb > TREX_1A.max_unsupported_duty_ucb
+        passed, failures = evaluate_stance_gate(panel, TREX_1A)
+        assert not passed
+        assert any("unsupported_duty_ucb" in f for f in failures)
+        assert not any("mean_unsupported_duty" in f for f in failures)
+
+    def test_zero_variance_panel_returns_the_sample_mean(self):
+        assert mean_upper_confidence_bound([0.0] * 40) == pytest.approx(0.0)
+
+    def test_single_observation_fails_closed(self):
+        assert mean_upper_confidence_bound([0.0]) == math.inf
+
+    def test_t_quantile_matches_scipy(self):
+        stats = pytest.importorskip("scipy.stats")
+        for dof in (1, 2, 5, 7, 11, 20, 29, 39, 49, 99, 250, 1000):
+            assert one_sided_t95(dof) == pytest.approx(float(stats.t.ppf(0.95, dof)), abs=2e-4)
+
+    def test_bound_matches_scipy_at_the_operating_point(self):
+        stats = pytest.importorskip("scipy.stats")
+        rng = np.random.default_rng(0)
+        sample = np.abs(rng.normal(0.01, 0.008, 40))
+        expected = sample.mean() + stats.t.ppf(0.95, 39) * sample.std(ddof=1) / math.sqrt(40)
+        # abs, not rel: the table carries the quantile to 5 decimals, which is
+        # three orders of magnitude below the 0.02 ceiling it is compared to.
+        assert mean_upper_confidence_bound(sample) == pytest.approx(float(expected), abs=1e-6)
+
+
+class TestUnderPoweredPanel:
+    def test_thirty_episodes_cannot_certify_a_forty_episode_bound(self):
+        passed, failures = evaluate_stance_gate(_panel(0.000, 3271.8, n=30), TREX_1A)
+        assert not passed
+        assert any("n_episodes" in f for f in failures)
+
+
+class TestBackendParity:
+    """SB3 and JAX must reach the same verdict from the same panel."""
+
+    @pytest.mark.parametrize(
+        "duty,reward,expected",
+        [(0.000, 3271.8, True), (0.284, 2347.7, False), (0.005, 3100.0, True)],
+    )
+    def test_sb3_and_jax_agree(self, duty, reward, expected):
+        from environments.shared.curriculum.manager import CurriculumManager
+        from environments.shared.jax_curriculum import check_stage_gate
+
+        panel = _panel(duty, reward)
+
+        thresholds = {
+            "gate_kind": STANCE_GATE_KIND,
+            "min_full_horizon_fraction": TREX_1A.min_full_horizon_fraction,
+            "max_unsupported_duty": TREX_1A.max_unsupported_duty,
+            "max_unsupported_duty_ucb": TREX_1A.max_unsupported_duty_ucb,
+            "settle_steps": TREX_1A.settle_steps,
+            "min_eval_episodes": TREX_1A.min_eval_episodes,
+            "min_avg_reward": TREX_1A.min_avg_reward,
+            "required_consecutive": 1,
+        }
+        jax_config = {
+            "stage": 1,
+            "curriculum_kwargs": {
+                "gate_schema_version": 1,
+                **thresholds,
+            },
+        }
+        jax_verdict = check_stage_gate(
+            {
+                "n_eval_episodes": panel.n_episodes,
+                "full_horizon_fraction": panel.full_horizon_fraction,
+                "n_duty_episodes": panel.n_duty_episodes,
+                "mean_unsupported_duty": panel.mean_unsupported_duty,
+                "unsupported_duty_ucb": panel.unsupported_duty_ucb,
+                "mean_episode_return": panel.mean_reward,
+            },
+            jax_config,
+        )
+
+        manager = CurriculumManager(species="trex", stage_thresholds={1: thresholds})
+        sb3_verdict = manager.should_advance(
+            [panel.mean_reward] * panel.n_episodes,
+            [float(HORIZON)] * panel.n_episodes,
+            stance_panel=panel,
+        )
+
+        assert jax_verdict is expected
+        assert sb3_verdict is expected
+
+    def test_jax_raises_rather_than_half_enforcing(self):
+        from environments.shared.curriculum.gate_schema import GateSchemaError
+        from environments.shared.jax_curriculum import check_stage_gate
+
+        config = {
+            "stage": 1,
+            "curriculum_kwargs": {
+                "gate_schema_version": 1,
+                "gate_kind": STANCE_GATE_KIND,
+                "min_full_horizon_fraction": 0.95,
+                "max_unsupported_duty": 0.02,
+                "max_unsupported_duty_ucb": 0.02,
+            },
+        }
+        with pytest.raises(GateSchemaError, match="stance quality cannot be checked"):
+            check_stage_gate({"mean_episode_return": 3271.8, "mean_episode_length": 1000.0}, config)
+
+
+class TestManagerFailsClosedWithoutAPanel:
+    def test_declaring_the_kind_without_a_panel_refuses_to_advance(self):
+        from environments.shared.curriculum.manager import CurriculumManager
+
+        manager = CurriculumManager(
+            species="trex",
+            stage_thresholds={
+                1: {
+                    "gate_kind": STANCE_GATE_KIND,
+                    "min_full_horizon_fraction": 0.95,
+                    "max_unsupported_duty": 0.02,
+                    "max_unsupported_duty_ucb": 0.02,
+                    "min_eval_episodes": 40,
+                    "required_consecutive": 1,
+                }
+            },
+        )
+        assert manager.should_advance([3271.8] * 40, [1000.0] * 40) is False

--- a/environments/shared/tests/test_stance_gate.py
+++ b/environments/shared/tests/test_stance_gate.py
@@ -4,9 +4,15 @@ The measured anchors these assert against, all at reset noise 0.05 and all
 using ``derive_stance_info``'s 0.1 N contact threshold:
 
 * the zero-action statue -- 119/120 = 99.17% full-horizon pooled over three
-  independent 40-seed blocks, unsupported duty 0.000, reward 3271.8 +/- 12.0;
-* run ``20260801_021545``'s best checkpoint -- full-horizon on every rolled
-  out episode, reward 2347.67, unsupported duty **0.284**.
+  independent 40-seed blocks (40/40, 40/40, 39/40), unsupported duty 0.000,
+  reward 3271.8;
+* run ``20260801_021545``'s best checkpoint, re-rolled on the current plant
+  and reward over 40 episodes -- full-horizon 40/40, reward **2133.4**,
+  unsupported duty **0.319**.
+
+Both were re-measured against this implementation rather than carried over.
+Two earlier figures for the checkpoint are superseded: 0.284 duty (8-episode
+sample) and 2347.67 reward (evaluation mean under the pre-section-14 reward).
 
 The gate exists to pass the first and reject the second.  The old
 ``reward_and_length/v1`` configuration passed both.
@@ -22,6 +28,7 @@ import pytest
 from environments.shared.curriculum.stance_gate import (
     STANCE_GATE_KIND,
     StanceGateThresholds,
+    StancePanel,
     episode_unsupported_duty,
     evaluate_stance_gate,
     mean_upper_confidence_bound,
@@ -81,7 +88,7 @@ class TestDiscrimination:
 
     def test_chatterer_fails_on_duty(self):
         """Run 20260801_021545's best model: passed the old gate, must fail this one."""
-        panel = _panel(0.284, 2347.7)
+        panel = _panel(0.319, 2133.4)
         passed, failures = evaluate_stance_gate(panel, TREX_1A)
         assert not passed
         assert any("mean_unsupported_duty" in f for f in failures)
@@ -226,12 +233,92 @@ class TestUnderPoweredPanel:
         assert any("n_episodes" in f for f in failures)
 
 
+class TestFailsClosedOnBrokenInput:
+    """Adversarial: every one of these passed the gate before it was hardened.
+
+    NaN loses every comparison, so an unchecked NaN cleared whichever
+    criterion it reached. Positional misalignment let a 5-episode sample be
+    certified while the panel reported 40. A negative duty sailed under every
+    ceiling.
+    """
+
+    @pytest.mark.parametrize(
+        "field,label",
+        [
+            ("mean_reward", "mean_reward"),
+            ("mean_unsupported_duty", "mean_unsupported_duty"),
+            ("unsupported_duty_ucb", "unsupported_duty_ucb"),
+            ("full_horizon_fraction", "full_horizon_fraction"),
+        ],
+    )
+    def test_nan_in_any_criterion_fails_closed(self, field, label):
+        clean = {
+            "n_episodes": 40,
+            "full_horizon_fraction": 1.0,
+            "mean_reward": 3271.8,
+            "n_duty_episodes": 40,
+            "mean_unsupported_duty": 0.0,
+            "unsupported_duty_ucb": 0.0,
+        }
+        panel = StancePanel(**{**clean, field: float("nan")})
+        passed, failures = evaluate_stance_gate(panel, TREX_1A)
+        assert not passed
+        assert any(label in f and "NaN" in f for f in failures)
+
+    def test_misaligned_inputs_raise_rather_than_truncate(self):
+        with pytest.raises(ValueError, match="positionally aligned"):
+            stance_panel_from_episode_duties(
+                episode_lengths=[HORIZON] * 40,
+                episode_duties=[0.0] * 5,
+                episode_rewards=[3271.8] * 40,
+                horizon=HORIZON,
+            )
+
+    def test_short_duty_sample_cannot_certify_a_full_panel(self):
+        # Reports 40 episodes but only 5 supplied a duty: the bound would rest
+        # on 5 while the panel-size check passed on the 40.
+        panel = StancePanel(
+            n_episodes=40,
+            full_horizon_fraction=1.0,
+            mean_reward=3271.8,
+            n_duty_episodes=5,
+            mean_unsupported_duty=0.0,
+            unsupported_duty_ucb=0.0,
+        )
+        passed, failures = evaluate_stance_gate(panel, TREX_1A)
+        assert not passed
+        assert any("n_duty_episodes" in f for f in failures)
+
+    def test_the_legitimate_short_sample_still_passes(self):
+        """38/40 survivors is exactly the survival floor, and must not trip it."""
+        panel = stance_panel_from_episode_duties(
+            episode_lengths=[HORIZON] * 38 + [400.0] * 2,
+            episode_duties=[0.0] * 38 + [float("nan")] * 2,
+            episode_rewards=[3271.8] * 40,
+            horizon=HORIZON,
+        )
+        assert panel.n_duty_episodes == 38
+        passed, failures = evaluate_stance_gate(panel, TREX_1A)
+        assert passed, failures
+
+    def test_out_of_range_duty_fails_closed(self):
+        panel = stance_panel_from_episode_duties(
+            episode_lengths=[HORIZON] * 40,
+            episode_duties=[-1.0] * 40,
+            episode_rewards=[3271.8] * 40,
+            horizon=HORIZON,
+        )
+        passed, failures = evaluate_stance_gate(panel, TREX_1A)
+        assert not passed
+        assert any("outside [0, 1]" in f for f in failures)
+
+
 class TestBackendParity:
     """SB3 and JAX must reach the same verdict from the same panel."""
 
     @pytest.mark.parametrize(
         "duty,reward,expected",
-        [(0.000, 3271.8, True), (0.284, 2347.7, False), (0.005, 3100.0, True)],
+        [(0.000, 3271.8, True), (0.319, 2133.4, False), (0.005, 3100.0, True)],
     )
     def test_sb3_and_jax_agree(self, duty, reward, expected):
         from environments.shared.curriculum.manager import CurriculumManager

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -104,3 +104,153 @@ def test_flat_statistics_are_applied(stub_ppo, monkeypatch) -> None:
 
     _predict, description = stance_gate_report._load_policy("model.zip", "v.pkl", lambda: None)
     assert "VecNormalize stats applied" in description
+
+
+class TestTrainingPipelineHook:
+    """The artifact writer emits the report automatically, and safely.
+
+    Three properties matter more than the report's content, which is covered
+    above and in test_stance_gate.py: it fires only for stages the criteria
+    govern, it prefers the same checkpoint the trainer reloads, and it can
+    never cost a finished run its artifacts.
+    """
+
+    def _stage_config(self, gate_kind: str) -> dict:
+        return {
+            "curriculum_kwargs": {
+                "gate_schema_version": 1,
+                "gate_kind": gate_kind,
+                "min_full_horizon_fraction": 0.95,
+                "max_unsupported_duty": 0.02,
+                "max_unsupported_duty_ucb": 0.02,
+                "min_eval_episodes": 40,
+            },
+            "env_kwargs": {"max_episode_steps": 1000},
+        }
+
+    def test_skipped_for_a_stage_that_does_not_gate_on_stance(self, tmp_path, monkeypatch):
+        from environments.shared.reporting import stage_artifacts
+
+        called = False
+
+        def _boom(*a, **k):
+            nonlocal called
+            called = True
+            raise AssertionError("must not roll a panel for a non-stance stage")
+
+        monkeypatch.setattr(stance_gate_report, "build_stance_gate_report", _boom)
+        stage_artifacts._write_stance_gate_report(
+            species="trex",
+            stage=2,
+            stage_config=self._stage_config("reward_and_length/v1"),
+            stage_dir=tmp_path,
+            model_dir=tmp_path / "models",
+        )
+        assert not called
+        assert not (tmp_path / "stance_gate_report.json").exists()
+
+    def test_missing_checkpoint_is_logged_not_raised(self, tmp_path, caplog):
+        from environments.shared.reporting import stage_artifacts
+
+        with caplog.at_level("WARNING"):
+            stage_artifacts._write_stance_gate_report(
+                species="trex",
+                stage=1,
+                stage_config=self._stage_config("stance_quality/v1"),
+                stage_dir=tmp_path,
+                model_dir=tmp_path / "models",
+            )
+        assert "no checkpoint" in caplog.text
+        assert not (tmp_path / "stance_gate_report.json").exists()
+
+    def test_a_failing_report_does_not_propagate(self, tmp_path, monkeypatch, caplog):
+        """A diagnostic must never sink a completed training run."""
+        from environments.shared.reporting import stage_artifacts
+
+        models = tmp_path / "models"
+        models.mkdir()
+        (models / "robust_best_model.zip").write_bytes(b"not really a checkpoint")
+
+        monkeypatch.setattr(
+            stance_gate_report,
+            "build_stance_gate_report",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("rollout exploded")),
+        )
+        with caplog.at_level("WARNING"):
+            stage_artifacts._write_stance_gate_report(
+                species="trex",
+                stage=1,
+                stage_config=self._stage_config("stance_quality/v1"),
+                stage_dir=tmp_path,
+                model_dir=models,
+            )
+        assert "Stance gate report failed" in caplog.text
+
+    def test_prefers_robust_best_model_and_writes_both_forms(self, tmp_path, monkeypatch):
+        from environments.shared.reporting import stage_artifacts
+
+        models = tmp_path / "models"
+        models.mkdir()
+        (models / "best_model.zip").write_bytes(b"x")
+        (models / "robust_best_model.zip").write_bytes(b"x")
+        seen: dict = {}
+
+        def _fake(species, stage, *, stage_config, model_path, vecnorm_path=None, **kwargs):
+            seen["model_path"] = model_path
+            seen["vecnorm_path"] = vecnorm_path
+            return {
+                "schema": "mesozoic.stance-gate-report/v1",
+                "species": species,
+                "stage": stage,
+                "gate_kind": "stance_quality/v1",
+                "policy": "stub",
+                "episodes": 40,
+                "seed": 3042,
+                "settle_steps": 200,
+                "horizon": 1000,
+                "passed": False,
+                "failures": ["stub"],
+                "thresholds": {
+                    "min_full_horizon_fraction": 0.95,
+                    "max_unsupported_duty": 0.02,
+                    "max_unsupported_duty_ucb": 0.02,
+                    "min_avg_reward": 1950.0,
+                    "min_eval_episodes": 40,
+                },
+                "metrics": {
+                    "reward_mean": 2313.7,
+                    "reward_std": 25.2,
+                    "episode_length_mean": 1000.0,
+                    "full_horizon_fraction": 1.0,
+                    "mean_unsupported_duty": 0.1877,
+                    "unsupported_duty_ucb": 0.1904,
+                    "n_duty_episodes": 40,
+                    "bilateral_support_duty": 0.664,
+                    "single_support_duty": 0.148,
+                },
+                "terminations": {"truncated": 40},
+                "reward_components": {"reward_alive": 832.23},
+            }
+
+        monkeypatch.setattr(stance_gate_report, "build_stance_gate_report", _fake)
+        stage_artifacts._write_stance_gate_report(
+            species="trex",
+            stage=1,
+            stage_config=self._stage_config("stance_quality/v1"),
+            stage_dir=tmp_path,
+            model_dir=models,
+        )
+
+        # robust_best_model wins over SB3's mean-reward best_model, matching
+        # the order the trainer itself reloads in.
+        assert seen["model_path"].endswith("robust_best_model.zip")
+        # Absent vecnorm is passed as None rather than a path that is not there.
+        assert seen["vecnorm_path"] is None
+
+        import json as _json
+
+        text = (tmp_path / "stance_gate_report.txt").read_text()
+        assert "GATE: FAIL" in text
+        assert "bilateral support" in text
+        payload = _json.loads((tmp_path / "stance_gate_report.json").read_text())
+        assert payload["metrics"]["mean_unsupported_duty"] == pytest.approx(0.1877)

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -1,0 +1,106 @@
+"""Error paths of the stance-gate checkpoint report.
+
+Only the hand-written failure handling is covered here. The gate arithmetic
+itself is tested in ``test_stance_gate.py``, and the happy path needs a real
+MuJoCo rollout, which belongs in a manual run rather than the suite.
+
+Both cases below share a rationale: normalising observations with the wrong
+statistics, or not at all, silently evaluates a *different policy*. A report
+that did so would blame the gate for a loading mistake, so each must fail
+loudly rather than degrade.
+"""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+
+import pytest
+
+from environments.shared.scripts import stance_gate_report
+
+
+class _StubModel:
+    """Stands in for a loaded PPO so the tests exercise the vecnorm branch."""
+
+    @classmethod
+    def load(cls, path, device):  # noqa: ARG003 - signature matches PPO.load
+        return cls()
+
+    def predict(self, obs, deterministic=True):  # noqa: ARG002
+        return obs, None
+
+
+@pytest.fixture
+def stub_ppo(monkeypatch):
+    pytest.importorskip("stable_baselines3")
+    import stable_baselines3
+
+    monkeypatch.setattr(stable_baselines3, "PPO", _StubModel)
+    return _StubModel
+
+
+def test_corrupt_vecnorm_is_fatal_with_a_diagnosable_message(stub_ppo, tmp_path: Path) -> None:
+    truncated = tmp_path / "vecnorm.pkl"
+    truncated.write_bytes(pickle.dumps({"obs_rms": None})[:12])
+
+    with pytest.raises(SystemExit) as excinfo:
+        stance_gate_report._load_policy("model.zip", str(truncated), lambda: None)
+
+    message = str(excinfo.value)
+    # Names the file, says why it is fatal, and points at the likely cause.
+    assert str(truncated) in message
+    assert "binary mode" in message
+    assert "different policy" in message
+
+
+def test_no_vecnorm_is_allowed_but_labelled(stub_ppo) -> None:
+    """Running unnormalised is permitted only when explicitly not supplied."""
+    _predict, description = stance_gate_report._load_policy("model.zip", None, lambda: None)
+    assert "no obs normalisation" in description
+
+
+class _FakeObsRms:
+    mean = 0.0
+    var = 1.0
+
+
+class _FakeNormalizer:
+    epsilon = 1e-8
+    clip_obs = 10.0
+
+    def __init__(self, obs_rms):
+        self.obs_rms = obs_rms
+
+
+def test_dict_observation_statistics_are_rejected(stub_ppo, monkeypatch) -> None:
+    """Per-key stats mean the checkpoint used a different observation contract."""
+    from stable_baselines3.common import vec_env as vec_env_module
+
+    monkeypatch.setattr(
+        vec_env_module.VecNormalize,
+        "load",
+        staticmethod(lambda path, venv: _FakeNormalizer({"a": _FakeObsRms(), "b": _FakeObsRms()})),
+    )
+    monkeypatch.setattr(vec_env_module, "DummyVecEnv", lambda fns: None)
+
+    with pytest.raises(SystemExit) as excinfo:
+        stance_gate_report._load_policy("model.zip", "v.pkl", lambda: None)
+
+    message = str(excinfo.value)
+    assert "Dict observation space" in message
+    assert "'a'" in message
+
+
+def test_flat_statistics_are_applied(stub_ppo, monkeypatch) -> None:
+    from stable_baselines3.common import vec_env as vec_env_module
+
+    monkeypatch.setattr(
+        vec_env_module.VecNormalize,
+        "load",
+        staticmethod(lambda path, venv: _FakeNormalizer(_FakeObsRms())),
+    )
+    monkeypatch.setattr(vec_env_module, "DummyVecEnv", lambda fns: None)
+
+    _predict, description = stance_gate_report._load_policy("model.zip", "v.pkl", lambda: None)
+    assert "VecNormalize stats applied" in description

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -145,6 +145,27 @@ def cosine_schedule(initial_lr: float, final_lr: float):
 # ── Environment creation ─────────────────────────────────────────────────
 
 
+#: Evaluation panel size when a stage's gate does not demand a specific one.
+_DEFAULT_EVAL_EPISODES = 30
+
+
+def _eval_episodes_for_stage(stage_config: dict[str, Any]) -> int:
+    """Episodes per evaluation, never fewer than the stage's gate requires.
+
+    A gate that demands ``min_eval_episodes = 40`` against a 30-episode panel
+    can never pass — the panel-size criterion fails at every evaluation and
+    the stage runs to its timestep budget looking like a training failure.
+    Taking the maximum couples the two deliberately: the evaluation is sized
+    to the claim the gate intends to certify.
+
+    It matters for ``stance_quality/v1``, whose bound and whose 28%-rejection
+    analysis are both specified at n=40; at n=30 neither describes the gate
+    being run.
+    """
+    curriculum = stage_config.get("curriculum_kwargs", {})
+    return max(_DEFAULT_EVAL_EPISODES, int(curriculum.get("min_eval_episodes", 0)))
+
+
 def make_env(
     species_cfg: SpeciesConfig,
     stage_configs: dict[int, dict[str, Any]],
@@ -412,7 +433,7 @@ def _build_core_callbacks(
         best_model_save_path=str(model_dir),
         log_path=local_eval_dir,
         eval_freq=eval_freq // n_envs,
-        n_eval_episodes=30,
+        n_eval_episodes=_eval_episodes_for_stage(stage_config),
         deterministic=True,
         render=False,
         verbose=max(verbose, 1),
@@ -1174,7 +1195,7 @@ def train_curriculum(
             curriculum_manager=manager,
             eval_env=eval_env,
             eval_freq=eval_freq,
-            n_eval_episodes=30,
+            n_eval_episodes=_eval_episodes_for_stage(config),
             eval_callback=eval_callback,
             supplementary_episodes=cur_kwargs.get("supplementary_episodes", 10),
         )

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -1408,6 +1408,12 @@ def _record_stage_result(
         "ep_length_threshold": cur_kwargs.get("min_avg_episode_length", ""),
         "forward_vel_threshold": cur_kwargs.get("min_avg_forward_vel", ""),
         "success_rate_threshold": cur_kwargs.get("min_success_rate", ""),
+        # stance_quality/v1. A stance-gated stage otherwise records only its
+        # reward rail, which reads as though reward were the gate.
+        "gate_kind": cur_kwargs.get("gate_kind", ""),
+        "full_horizon_fraction_threshold": cur_kwargs.get("min_full_horizon_fraction", ""),
+        "unsupported_duty_ceiling": cur_kwargs.get("max_unsupported_duty", ""),
+        "unsupported_duty_ucb_ceiling": cur_kwargs.get("max_unsupported_duty_ucb", ""),
         "stage_passed": bool(curriculum_cb is not None and curriculum_cb.ready_to_advance),
     }
     if plant_identity is not None:

--- a/environments/shared/visualization.py
+++ b/environments/shared/visualization.py
@@ -118,6 +118,18 @@ def plot_training_curves(
             axes[0, 0].axhline(y=min_reward, color=color, linestyle="--", alpha=0.5)
         if min_length is not None:
             axes[0, 1].axhline(y=min_length, color=color, linestyle="--", alpha=0.5)
+        elif cur.get("min_full_horizon_fraction") is not None:
+            # stance_quality/v1 states the survival requirement as a fraction
+            # of episodes rather than a mean step count, so the length panel
+            # would otherwise lose its threshold line entirely. Draw the
+            # equivalent step count so the plot still shows what must be met.
+            horizon = stage_configs[stage_num].get("env_kwargs", {}).get("max_episode_steps", 1000)
+            axes[0, 1].axhline(
+                y=float(cur["min_full_horizon_fraction"]) * float(horizon),
+                color=color,
+                linestyle=":",
+                alpha=0.5,
+            )
 
         # Tilt angle and forward velocity from diagnostics
         diag_log = stage_dir / "diagnostics.npz"

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -135,6 +135,9 @@
             "min_avg_episode_length": 950,
             "min_avg_forward_velocity": null,
             "min_success_rate": null,
+            "min_full_horizon_fraction": null,
+            "max_unsupported_duty": null,
+            "max_unsupported_duty_ucb": null,
             "min_eval_episodes": 10,
             "required_consecutive": 3
           },
@@ -162,6 +165,9 @@
             "min_avg_episode_length": 750,
             "min_avg_forward_velocity": 2.0,
             "min_success_rate": null,
+            "min_full_horizon_fraction": null,
+            "max_unsupported_duty": null,
+            "max_unsupported_duty_ucb": null,
             "min_eval_episodes": 10,
             "required_consecutive": 3
           },
@@ -189,6 +195,9 @@
             "min_avg_episode_length": null,
             "min_avg_forward_velocity": null,
             "min_success_rate": 0.5,
+            "min_full_horizon_fraction": null,
+            "max_unsupported_duty": null,
+            "max_unsupported_duty_ucb": null,
             "min_eval_episodes": 10,
             "required_consecutive": 3
           },
@@ -409,10 +418,13 @@
           "timesteps": 6000000,
           "advancement_gate": {
             "min_avg_reward": 1950.0,
-            "min_avg_episode_length": 950,
+            "min_avg_episode_length": null,
             "min_avg_forward_velocity": null,
             "min_success_rate": null,
-            "min_eval_episodes": 10,
+            "min_full_horizon_fraction": 0.95,
+            "max_unsupported_duty": 0.02,
+            "max_unsupported_duty_ucb": 0.02,
+            "min_eval_episodes": 40,
             "required_consecutive": 3
           },
           "video": {
@@ -439,6 +451,9 @@
             "min_avg_episode_length": 750,
             "min_avg_forward_velocity": 2.0,
             "min_success_rate": null,
+            "min_full_horizon_fraction": null,
+            "max_unsupported_duty": null,
+            "max_unsupported_duty_ucb": null,
             "min_eval_episodes": 10,
             "required_consecutive": 3
           },
@@ -466,6 +481,9 @@
             "min_avg_episode_length": null,
             "min_avg_forward_velocity": null,
             "min_success_rate": 0.5,
+            "min_full_horizon_fraction": null,
+            "max_unsupported_duty": null,
+            "max_unsupported_duty_ucb": null,
             "min_eval_episodes": 10,
             "required_consecutive": 3
           },
@@ -618,6 +636,9 @@
             "min_avg_episode_length": 950,
             "min_avg_forward_velocity": null,
             "min_success_rate": null,
+            "min_full_horizon_fraction": null,
+            "max_unsupported_duty": null,
+            "max_unsupported_duty_ucb": null,
             "min_eval_episodes": 10,
             "required_consecutive": 3
           },
@@ -645,6 +666,9 @@
             "min_avg_episode_length": 750,
             "min_avg_forward_velocity": 0.75,
             "min_success_rate": null,
+            "min_full_horizon_fraction": null,
+            "max_unsupported_duty": null,
+            "max_unsupported_duty_ucb": null,
             "min_eval_episodes": 10,
             "required_consecutive": 3
           },
@@ -672,6 +696,9 @@
             "min_avg_episode_length": null,
             "min_avg_forward_velocity": null,
             "min_success_rate": 0.5,
+            "min_full_horizon_fraction": null,
+            "max_unsupported_duty": null,
+            "max_unsupported_duty_ucb": null,
             "min_eval_episodes": 10,
             "required_consecutive": 3
           },
@@ -821,6 +848,9 @@
             "min_avg_episode_length": 950,
             "min_avg_forward_velocity": null,
             "min_success_rate": null,
+            "min_full_horizon_fraction": null,
+            "max_unsupported_duty": null,
+            "max_unsupported_duty_ucb": null,
             "min_eval_episodes": 10,
             "required_consecutive": 3
           },
@@ -838,6 +868,9 @@
             "min_avg_episode_length": 750,
             "min_avg_forward_velocity": 0.9,
             "min_success_rate": null,
+            "min_full_horizon_fraction": null,
+            "max_unsupported_duty": null,
+            "max_unsupported_duty_ucb": null,
             "min_eval_episodes": 10,
             "required_consecutive": 3
           },
@@ -855,6 +888,9 @@
             "min_avg_episode_length": null,
             "min_avg_forward_velocity": null,
             "min_success_rate": 0.5,
+            "min_full_horizon_fraction": null,
+            "max_unsupported_duty": null,
+            "max_unsupported_duty_ucb": null,
             "min_eval_episodes": 10,
             "required_consecutive": 3
           },


### PR DESCRIPTION
## The problem

The T-Rex stage-1 gate was passable by doing nothing. The zero-action statue scores **3271.8** at **1000.0** steps, clearing both `min_avg_reward = 1950` and `min_avg_episode_length = 950` — run `20260801_203206`'s own `zero_action_baseline.json` reported it outright:

```
verdict: "FAILS — a statue clears this gate"
margin_over_standing: -1321.77
```

It also passed the policy we actually needed to reject. Run `20260801_021545`'s best checkpoint reaches the horizon 40/40 and scores 2133.4 — above the 1950 threshold — while spending **31.9%** of its post-settling steps with neither foot bearing load.

No reward threshold can separate the two, because on stage 1 the statue is the **global optimum**: it collects 97.7% of the 3.35/step ceiling with `energy` and `smoothness` at exactly zero, so a competent policy's realistic ceiling sits *below* it.

## The gate

New kind `stance_quality/v1`, judging physical stance:

| criterion | T-Rex 1a | statue | chatterer |
|---|---|---|---|
| `min_full_horizon_fraction` | ≥ 0.95 | 0.9917 ✓ | 1.000 ✓ |
| `max_unsupported_duty` | ≤ 0.02 | 0.000 ✓ | **0.319 ✗** |
| `max_unsupported_duty_ucb` | ≤ 0.02 | 0.000 ✓ | **0.322 ✗** |
| `min_avg_reward` (rail) | ≥ 1950 | 3271.8 ✓ | 2133.4 ✓ |

It is **not** trying to beat the statue. `STAGE1_SPLIT_PLAN` §2.3.1 is explicit that the statue's numbers are what a 1a policy must *match, not beat* — it defines the quality ceiling, and 1a's job is certifying a policy has not bought stability with actuation. Robustness belongs to 1b via declared `xfrc_applied` perturbations, not reset noise, where a lucky draw and a good controller are indistinguishable.

The certifying criterion is a bound on **duty** rather than a pass/fail count: a binomial `LCB95 ≥ 0.90` at n=40 requires a clean 40/40 and would reject the statue 28.4% of the time. Duty is continuous with tiny variance, so an interval on it has power where the count has almost none. §2.3 said LCB, which is the wrong direction for a ceiling metric — corrected to UCB in both doc and implementation.

Two semantics were decided rather than inferred: **failed episodes are excluded from duty** (survival is already gated; averaging over a failed episode's steps flatters an early faceplant), and **duty is measured after `settle_steps = 200`** — `[inferred]`, not measured.

Duty is `derive_stance_info`'s `unsupported_duty` at its default **0.1 N** threshold, not the reward's 42 N `min_support_force`; every calibration point is measured at 0.1 N.

## Fail-open holes closed

Adversarial probing made the gate **pass** four broken inputs — the wrong direction for a fail-closed module:

1. **NaN loses every comparison**, so an unchecked NaN cleared whichever criterion it reached (`mean_reward` cleared the rail; duty cleared both duty criteria).
2. **Panel inputs are matched positionally** with no length check — 40 lengths against 5 duties certified from 5 episodes while reporting 40.
3. Even aligned, a panel could supply far fewer duties than episodes; the bound must now rest on ≥ `min_eval_episodes × min_full_horizon_fraction` (38 of 40).
4. **Negative duty** sailed under every ceiling.

The eval-callback path gets a matching guard: on count mismatch it refuses to advance and logs, rather than raising mid-run.

## Verification

- **Statue re-run on the three seed blocks** reproduces 40/40, 40/40, 39/40 = 119/120 = 0.9917 with duty 0.0000 — including *which* block holds the single nosedive. The gate passes all three, including the 39/40 one.
- **The real checkpoint rolled through the real gate**: 40/40 full-horizon, duty 0.3188, UCB 0.3223 → FAIL on both duty criteria, while the retired reward criterion would have passed it.
- **Every binomial figure recomputed exactly**: `P(40/40 | 0.9917) = 0.7155`; `LCB95(40/40) = 0.9278` vs `LCB95(39/40) = 0.8868`; 96/100 → 0.9108; 168/179 → 0.9003; `P(40/40 | 0.95) = 12.9%`.
- **Production SB3 capture** measures exactly `len − settle_steps` post-settling steps, one duty per episode, aligned with lengths.
- Two figures were corrected by measurement: duty `0.284 → 0.319` (the old value came from an 8-episode rollout) and reward `2347.67 → 2133.4` (the old value was an eval mean under the pre-§14 reward; the ~214-point drop is `action_jerk_weight` charging the behaviour it targets).

## Also in this change

- Eval panel size now derives from the stage's own `min_eval_episodes` (40 for T-Rex 1a) instead of a hardcoded 30, which would have **deadlocked** the gate.
- A declared `none/v1` pilot now refuses to advance instead of falling through to `StageThreshold`'s permissive defaults.
- Reporting and the species catalog publish the stance criteria, so the README no longer advertises the rail as the gate.
- Fixes two documentation defects: §2.1's "zero action reaches the horizon in only 57.5% of episodes" is the noise-0.10 figure and false at the adopted 0.05 operating point (99.17%), and §2.3's LCB/UCB slip.

## Scope limits

- **SB3 only.** `check_stage_gate` evaluates the kind through the same shared function but raises if the MJX trainer emits no panel — loud rather than half-enforcing. The MJX evaluator does not emit it yet.
- **Bipeds only.** Quadrupeds stay blocked on the `diag_r_foot`/`diag_l_foot` interleaving defect in KNOWN_ISSUES.
- The full `stance_success` quantile conjunction and the n≈100–180 confirmation panel remain unbuilt; what ships is the two discriminating criteria plus the certifying bound.
- The other three species stay on `reward_and_length/v1` pending their own calibration.

## Testing

Full suite green (1960 tests, `--ignore=test_jax_viz.py`). 30 new tests in `test_stance_gate.py` including SB3/JAX agreement on identical panels and regressions for all four fail-open holes, plus five for the recorded-gate reporting path which had none. Ruff clean; mypy unchanged (13 pre-existing errors before and after, in files not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017svujdxTHg8fWZunY638hU

---
_Generated by [Claude Code](https://claude.ai/code/session_017svujdxTHg8fWZunY638hU)_