### PR TITLE
Stop the T-Rex shaking its own legs by 20°, and report when a run is below the do-nothing policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `_build_core_callbacks` takes `species` to construct it, and a test pins that
   `sb3_training.ipynb` passes it, because an optional argument the trainer
   forgets is exactly how the stance gate became dead code on the Colab path.
+### Changed
+- **T-Rex stage 1 entropy now decays to zero, over 70% of the budget rather
+  than 30%** (`ent_coef_end` 0.001 → 0.0, `ent_coef_decay_timesteps` 3M → 7M).
+  Run `20260804_143747` trained the full 10M and finished at 2686.9 against
+  the zero-action statue's 3271.8 — **588 below the do-nothing policy** — with
+  unsupported duty pinned at 0.1668, 8.3× the gate ceiling (issue #486).
+  The cause is measured, not guessed: `ent_coef` reached its 0.001 floor at 3M
+  and held for the remaining 7M, which across 21 action dims holds the policy
+  std at equilibrium ~0.375 (`algo_std` 0.47 at 5.9M, 0.375 at 8.4M). Through
+  `_scale_action`'s residual mapping and this model's ctrlranges that std is a
+  1σ command noise of **24.4° at the hips and 18.8° at knee and ankle**, mean
+  **20.6°** across the major leg joints, resampled every control step at
+  100 Hz. A policy cannot learn to hold a pose it is being commanded to shake
+  by 20°; PPO optimises expected return *under* that noise, so it converged to
+  a 16.7 Hz limit cycle that survives its own tremor rather than to a still
+  stance.
+  The target is known reachable and known still: `action = 0` **is** the home
+  keyframe under `home-keyframe-residual/v1` and scores 3274.4 ± 7.6 with duty
+  0.0000 (measured locally with `stance_gate_report.py trex --stage 1
+  --zero-action`). So this is a convergence failure, not a reward-shaping one,
+  and the usual risk of zeroing entropy — premature convergence to a bad
+  optimum — is unusually low here.
+  Early exploration is deliberately unchanged: `ent_coef` still starts at
+  0.005, and the first 3M now decays more slowly than before. The 3M anchor
+  was sized for a 6M stage and never revisited when stage 1 became 10M.
 
 ### Fixed
 - **A stance-gated run that passed every gate still could not publish.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `_build_core_callbacks` takes `species` to construct it, and a test pins that
   `sb3_training.ipynb` passes it, because an optional argument the trainer
   forgets is exactly how the stance gate became dead code on the Colab path.
+- **`gate_progress.npz`, the gate criteria per evaluation.** The deterministic
+  panel-estimator numbers the stance gate actually tests — `duty_episodes`,
+  `unsupported_duty`, `unsupported_duty_ucb`, `bilateral_support_duty`,
+  `mean_reward` and `full_horizon_fraction`, against `timesteps` — were computed
+  every evaluation and recorded only to the SB3 logger. Diagnosing run
+  `20260804_143747` therefore had to substitute the *training-rollout* duty
+  from `diagnostics.npz`, which is contaminated by exploration noise; it
+  happened to agree to three decimals, but that was luck.
+  `StageGatePlateauCallback` now writes the file to the stage directory (beside
+  `diagnostics.npz`, not the scratch eval dir) after each evaluation, so the
+  gate's own view of a run is readable from Drive mid-run without TensorBoard.
+  A separate file rather than columns in `diagnostics.npz` because the two are
+  on different clocks — per evaluation versus per training rollout — and
+  merging them would force one series to be NaN-padded against the other's
+  timeline.
+- **`action_abs_mean` and `action_std` in `diagnostics.npz`.** Mean |action| is
+  the direct distance from the zero-action statue, which under
+  `home-keyframe-residual/v1` is exactly `action = 0`. Neither existing series
+  gives it: signs cancel in `action_mean`, so it sits near zero even for a
+  large-magnitude policy, and `action_abs_max` is dominated by whichever single
+  joint is most saturated. It separates the two ways an entropy collapse can
+  end — std falls and the mean settles *on* the statue, versus std falls and
+  the mean settles on some other committed pose — which are indistinguishable
+  in `algo_std` alone and mean opposite things for what to do next.
 ### Changed
 - **T-Rex stage 1 entropy now decays to zero, over 70% of the budget rather
   than 30%** (`ent_coef_end` 0.001 → 0.0, `ent_coef_decay_timesteps` 3M → 7M).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Reproducible Runs & Velociraptor Stage-1 Diagnosis (v0.3.6)
 
+### Added
+- **A watch on the do-nothing baseline.** Run `20260804_143747` trained T-Rex
+  stage 1 for its full 10,002,432 steps — 8h 13m — and finished at **2686.9
+  against the zero-action statue's 3271.8**: below the do-nothing policy on
+  every major reward term, for the entire run. Nothing reported it. Every
+  logged signal looked healthy (reward climbing, full-horizon 100%, evaluation
+  sd down to 5, the collapse backstop correctly silent), and the run was only
+  found to be in a worse-than-trivial local optimum by scoring `action = 0` by
+  hand afterwards (issue #486).
+  `curriculum.baseline_watch.BaselineProgressCallback` now reports every
+  evaluation against the run's own captured `zero_action_baseline.json` — one
+  float already written to the run directory before training starts, so the
+  comparison is free — and warns **once** if the policy has still never beaten
+  it past `baseline_warn_after_budget_fraction` of the budget (0.35 on trex
+  1a, i.e. 3.5M steps with ~5.5 hours still to save).
+  Deliberately **advisory**: it logs and warns, never stops. On stage 1 the
+  statue *is* the reward optimum, so a learning policy legitimately sits below
+  it for millions of steps; aborting on that would kill healthy runs for the
+  same reason tightening the collapse detector does. A run that beats the
+  baseline at any point is never warned about again — falling back under it is
+  what the collapse backstop is for.
+  `_build_core_callbacks` takes `species` to construct it, and a test pins that
+  `sb3_training.ipynb` passes it, because an optional argument the trainer
+  forgets is exactly how the stance gate became dead code on the Colab path.
+
 ### Fixed
 - **A stance-gated run that passed every gate still could not publish.**
   `result_bundle.evidence` refused any complete bundle whose stage declares

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -144,18 +144,48 @@ gamma = 0.98                            # Setting 4 sweep: 0.9797. Previous 0.99
 gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.005
-ent_coef_end = 0.001                    # Decay entropy over the stage (EntCoefDecayCallback). Velociraptor
-                                        # stages 1 & 2 both destabilized late under constant ent_coef
-                                        # (bimodal falls, action std growth); decay fixed its stage 2 and is
-                                        # enabled for its stage 1. See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
-ent_coef_decay_timesteps = 3000000      # Anchor the decay to ~half the 6M budget so ent_coef hits its 0.001 floor
-                                        # BEFORE the late std drift, instead of coasting high for the whole run. When
-                                        # unset, decay_timesteps defaults to the full stage budget
-                                        # (train_base._maybe_ent_coef_decay_callback), which is why run 20260723_204941
-                                        # never annealed: algo_std rose 1.01 -> 1.04 and the legs jittered at ~1.0
-                                        # RMS/joint for the entire run. Velociraptor stage 1 (annealed 1.01 -> 0.93,
-                                        # lowest jitter of any stage) and T-Rex stage 3 both anchor at 3M; stage 1 was
-                                        # the only balance stage missing it. See docs/investigations/TREX_STAGE1_LEG_JITTER.md.
+ent_coef_end = 0.0                      # Decay entropy to ZERO, not to a 0.001 floor. The floor is what kept run
+                                        # 20260804_143747 from ever standing still: ent_coef hit 0.001 at 3M and held
+                                        # there for the remaining 7M, and across 21 action dims that bonus holds the
+                                        # policy std at equilibrium ~0.375 indefinitely (`algo_std` 0.47 at 5.9M,
+                                        # 0.375 at 8.4M, still falling ~0.01/M -- it was never going to converge).
+                                        #
+                                        # In joint terms that std is enormous. Through `_scale_action`'s residual
+                                        # mapping and this model's ctrlranges, std 0.375 is a 1-sigma command noise of
+                                        # 24.4 deg at the hips and 18.8 deg at knee and ankle -- mean 20.6 deg across
+                                        # the major leg joints, resampled every control step at 100 Hz. A policy
+                                        # cannot learn to hold a pose it is being told to shake by 20 deg. PPO
+                                        # optimises expected return UNDER that noise, so the mean action it converges
+                                        # to is not the deterministic optimum but whatever survives its own tremor --
+                                        # in that run, a 16.7 Hz limit cycle with unsupported duty 0.1668 (issue #486).
+                                        #
+                                        # The target is known reachable and known still: `action = 0` IS the home
+                                        # keyframe under home-keyframe-residual/v1, and scores 3274.4 +/- 7.6 with
+                                        # duty 0.0000 (measured, stance_gate_report.py trex --stage 1 --zero-action).
+                                        # The trained policy scored 2686.9 -- 588 BELOW the do-nothing policy. This is
+                                        # a convergence failure, not a reward-shaping one, so the usual risk of
+                                        # zeroing entropy (premature convergence to a bad optimum) is unusually low:
+                                        # the good optimum is trivially reachable and the run's actual failure was
+                                        # never converging at all.
+                                        #
+                                        # 0.0 rather than a smaller floor because any floor sets a non-zero std
+                                        # equilibrium; std 0.05 (2.75 deg/joint, a plausible standing policy) needs
+                                        # the bonus to go away, not to get smaller.
+ent_coef_decay_timesteps = 7000000      # 70% of the 10M budget, not 30%. The old 3M anchor was chosen for a 6M
+                                        # stage (~half of it) and was never revisited when stage 1 went to 10M, so
+                                        # decay finished in the first third and the floor governed the rest. Keeping
+                                        # the decay live through 7M means entropy is still falling while the policy
+                                        # consolidates, instead of being pinned during the whole second half.
+                                        #
+                                        # Early exploration is deliberately unchanged: ent_coef still starts at 0.005
+                                        # and the first 3M now decays MORE slowly than before, so nothing about the
+                                        # early-training regime this stage depends on is tightened.
+                                        #
+                                        # Falsifiable prediction for the next run, to be checked at ~4M rather than
+                                        # at the end: `algo_std` should be well under 0.2 (it was 0.55 at 4.6M and
+                                        # 0.47 at 5.9M last run), and `unsupported_duty` should be below the 0.28 it
+                                        # showed at 4.34M. If either tracks the old curve, this hypothesis is wrong
+                                        # and the next suspect is the learning rate (3e-5 -> 1e-5 is very low).
 
 target_kl = 0.03                        # Cap destabilising late PPO updates (early-stop epochs on high approx-KL); mirrors the JAX target_kl guard.
 

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -297,6 +297,19 @@ collapse_drop_fraction = 0.5            # Only raw means >50% below the robust r
                                         # low-reward grind then a noisy breakthrough (run 20260721_004731: dip to ~1.2M,
                                         # turbulent transition at 2.2-2.3M, converged ~2.65M); the old stage-1 defaults
                                         # killed run 20260720_203454 at 1.1M off a variance-inflated 50k peak.
+baseline_warn_after_budget_fraction = 0.35  # Warn once past this share of the budget if the policy has still never
+                                         # beaten the zero-action statue. Advisory only -- it never stops a run.
+                                         # Run 20260804_143747 trained all 10,002,432 steps (8h 13m) and finished at
+                                         # 2686.9 against the statue's 3271.8: BELOW the do-nothing policy on every
+                                         # major reward term, for the entire run, and nothing said so (issue #486).
+                                         # Reward was climbing, full-horizon hit 100%, eval sd fell to 5, and the
+                                         # collapse backstop correctly never fired -- every logged signal looked
+                                         # healthy. 0.35 puts the warning at 3.5M steps, ~2.9h in on that run's
+                                         # hardware with ~5.5h still to save, and past the point where its duty had
+                                         # already flattened. Not lower: a learning policy legitimately climbs
+                                         # toward the statue from below for millions of steps (STAGE1_SPLIT_PLAN
+                                         # 2.3.1), so an early warning would be noise on a healthy run.
+
 collapse_peak_warmup_timesteps = 1000000 # Evaluations before this step cannot SET the peak. Not a tightening of
                                          # the detector (see collapse_settings_from_config on why tightening
                                          # aborts healthy runs) -- a separate axis, and the only one that works on

--- a/environments/shared/curriculum/__init__.py
+++ b/environments/shared/curriculum/__init__.py
@@ -51,6 +51,11 @@ from __future__ import annotations
 
 from . import sb3_compat
 from .advancement import CurriculumCallback, RewardRampCallback, StageWarmupCallback
+from .baseline_watch import (
+    BaselineProgressCallback,
+    build_baseline_progress_callback,
+    read_zero_action_baseline,
+)
 from .checkpoints import (
     DEFAULT_MAX_CHECKPOINTS,
     CheckpointRetentionCallback,
@@ -76,6 +81,7 @@ from .schedules import EntCoefDecayCallback, _ConstantSchedule
 
 __all__ = [
     "GATE_KINDS",
+    "BaselineProgressCallback",
     "GATE_SCHEMA_VERSION",
     "CurriculumCallback",
     "CurriculumManager",
@@ -91,8 +97,10 @@ __all__ = [
     "StageThreshold",
     "StageWarmupCallback",
     "_ConstantSchedule",
+    "build_baseline_progress_callback",
     "build_eval_collapse_early_stop_callback",
     "load_vecnorm_stats",
+    "read_zero_action_baseline",
     "prune_periodic_checkpoints",
     "sb3_compat",
     "thresholds_from_configs",

--- a/environments/shared/curriculum/baseline_watch.py
+++ b/environments/shared/curriculum/baseline_watch.py
@@ -1,0 +1,208 @@
+"""Report training progress against the do-nothing policy.
+
+Run ``20260804_143747`` trained T-Rex stage 1 for its full 10,002,432 steps,
+8h 13m, and finished **below the zero-action statue on every major reward
+term** -- 2686.9 against the statue's 3271.8, a 17.9% shortfall (issue #486).
+Nothing in the run said so.  Every signal that was logged looked healthy:
+reward climbing, 100% full-horizon, evaluation standard deviation down to 5,
+the collapse backstop correctly not firing.  The run only turned out to be in
+a worse-than-trivial local optimum once someone scored ``action = 0`` by hand
+afterwards.
+
+That comparison is nearly free.  ``zero_action_baseline.json`` is already
+written into the run directory before training starts, and the number needed
+is one float in it.  This module reads that float and reports it against each
+evaluation, so "the policy has not yet beaten doing nothing" is visible at
+100k steps instead of after the budget is spent.
+
+Deliberately **advisory only**.  It logs and warns; it never stops a run.
+Being under the baseline is normal for most of a stage -- the statue is the
+stage-1 reward optimum by construction (STAGE1_SPLIT_PLAN §2.3.1), so a
+learning policy climbs toward it from below and may legitimately sit under it
+for millions of steps.  Turning that into an abort would kill healthy runs for
+the same reason tightening the collapse detector does
+(:func:`~environments.shared.curriculum.early_stopping.collapse_settings_from_config`).
+The warning is about *elapsed budget with no crossing*, not about the gap
+itself.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from . import sb3_compat
+from .sb3_compat import BaseCallback
+
+logger = logging.getLogger(__name__)
+
+#: Fraction of the stage budget after which still being below the baseline is
+#: worth a warning.  0.35 is chosen so the warning lands with most of the
+#: budget still unspent: on the 10M stage that is 3.5M steps, ~2.9 hours in on
+#: run ``20260804_143747``'s hardware, with ~5.5 hours still to save.  It is
+#: also past the point where that run's duty had already fallen below 0.43 and
+#: its reward trend had flattened, so a policy still short of the statue there
+#: is not merely early.
+DEFAULT_WARN_AFTER_BUDGET_FRACTION = 0.35
+
+
+def read_zero_action_baseline(run_dir: "str | Path", species: str) -> float | None:
+    """The statue's mean reward for *species* from a run's captured baseline.
+
+    ``None`` when the file is absent, unreadable, or does not cover this
+    species -- the caller then skips the comparison rather than inventing a
+    reference.  A wrong baseline is worse than none: it would either mute a
+    real warning or cry wolf for a whole run.
+    """
+    path = Path(run_dir) / "zero_action_baseline.json"
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.warning("Zero-action baseline at %s could not be read; skipping the comparison.", path)
+        return None
+    entry = (payload.get("results") or {}).get(species)
+    if not isinstance(entry, dict):
+        return None
+    value: Any = entry.get("reward_mean")
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if np.isfinite(number) else None
+
+
+class BaselineProgressCallback(BaseCallback):  # type: ignore[misc]
+    """Log each evaluation against the zero-action baseline.
+
+    Args:
+        eval_callback: The ``EvalCallback`` whose ``evaluations_results`` to
+            read.  Same source as the collapse backstop, so no extra rollouts.
+        baseline_reward: The statue's mean reward for this species and stage.
+        total_timesteps: The stage's configured budget, used to decide when a
+            still-unbeaten baseline is worth warning about.
+        warn_after_budget_fraction: Fraction of the budget after which the
+            warning fires.
+        duty_ceiling: The stage's ``max_unsupported_duty`` when it declares
+            one, reported alongside so the gate's binding criterion is visible
+            in the same line.  ``None`` for stages with no stance gate.
+    """
+
+    #: Log-once latch, at class scope so an instance built without ``__init__``
+    #: (as the tests do, to exercise ``_on_step`` without stable-baselines3)
+    #: still has it.
+    _warned_below_baseline = False
+
+    def __init__(
+        self,
+        eval_callback: Any,
+        baseline_reward: float,
+        *,
+        total_timesteps: int,
+        warn_after_budget_fraction: float = DEFAULT_WARN_AFTER_BUDGET_FRACTION,
+        duty_ceiling: float | None = None,
+        verbose: int = 0,
+    ):
+        if not sb3_compat._SB3_AVAILABLE:
+            raise ImportError("stable-baselines3 is required for BaselineProgressCallback.")
+        super().__init__(verbose)
+        self.eval_callback = eval_callback
+        self.baseline_reward = float(baseline_reward)
+        self.total_timesteps = int(total_timesteps)
+        self.warn_after_budget_fraction = float(warn_after_budget_fraction)
+        self.duty_ceiling = None if duty_ceiling is None else float(duty_ceiling)
+        self._last_seen_n_evals = 0
+        self._warned_below_baseline = False
+        self._ever_beat_baseline = False
+
+    def _on_step(self) -> bool:
+        results = getattr(self.eval_callback, "evaluations_results", None)
+        if not results:
+            return True
+        n_evals = len(results)
+        if n_evals <= self._last_seen_n_evals:
+            return True
+        self._last_seen_n_evals = n_evals
+
+        latest = float(np.mean(results[-1]))
+        share = latest / self.baseline_reward if self.baseline_reward else float("nan")
+        if latest >= self.baseline_reward:
+            self._ever_beat_baseline = True
+
+        ceiling = "" if self.duty_ceiling is None else f", duty ceiling {self.duty_ceiling:.4f}"
+        logger.info(
+            "BaselineProgress: eval mean %.1f vs zero-action baseline %.1f (%.1f%% of baseline)%s",
+            latest,
+            self.baseline_reward,
+            100.0 * share,
+            ceiling,
+        )
+
+        # Once, and only once the budget spent makes "still climbing" an
+        # unconvincing explanation. Suppressed entirely for a run that has
+        # beaten the baseline at any point, because falling back under it
+        # afterwards is what the collapse backstop is for.
+        if (
+            not self._warned_below_baseline
+            and not self._ever_beat_baseline
+            and self.total_timesteps > 0
+            and self.num_timesteps >= self.warn_after_budget_fraction * self.total_timesteps
+        ):
+            self._warned_below_baseline = True
+            logger.warning(
+                "BaselineProgress: %d of %d steps (%.0f%% of budget) and the policy has never "
+                "beaten the zero-action baseline — latest eval %.1f vs %.1f (%.1f%%). On a stage "
+                "whose reward optimum IS the do-nothing policy this means the run is in a "
+                "worse-than-trivial local optimum, not merely early. Run 20260804_143747 spent "
+                "its whole 10M budget in exactly this state and failed its gate (issue #486).",
+                self.num_timesteps,
+                self.total_timesteps,
+                100.0 * self.num_timesteps / self.total_timesteps,
+                latest,
+                self.baseline_reward,
+                100.0 * share,
+            )
+        return True
+
+
+def build_baseline_progress_callback(
+    eval_callback: Any,
+    *,
+    run_dir: "str | Path | None",
+    species: str,
+    stage_config: dict[str, Any],
+    verbose: int = 0,
+) -> BaselineProgressCallback | None:
+    """Build the watcher, or ``None`` when there is no baseline to compare to.
+
+    Returning ``None`` rather than a no-op callback keeps the absence visible
+    in the callback list, and means a run without a captured baseline pays
+    nothing for a comparison it cannot make.
+    """
+    if run_dir is None:
+        return None
+    baseline = read_zero_action_baseline(run_dir, species)
+    if baseline is None:
+        logger.info(
+            "No zero-action baseline for %s in %s; skipping the below-baseline watch.",
+            species,
+            run_dir,
+        )
+        return None
+    curriculum = stage_config.get("curriculum_kwargs", {})
+    duty_ceiling = curriculum.get("max_unsupported_duty")
+    return BaselineProgressCallback(
+        eval_callback,
+        baseline,
+        total_timesteps=int(curriculum.get("timesteps", 0)),
+        warn_after_budget_fraction=float(
+            curriculum.get("baseline_warn_after_budget_fraction", DEFAULT_WARN_AFTER_BUDGET_FRACTION)
+        ),
+        duty_ceiling=None if duty_ceiling is None else float(duty_ceiling),
+        verbose=verbose,
+    )

--- a/environments/shared/curriculum/gate_schema.py
+++ b/environments/shared/curriculum/gate_schema.py
@@ -160,6 +160,7 @@ _DIAGNOSTIC_KEYS = frozenset(
         "diagnostics_plateau_min_relative_variation",
         "supplementary_episodes",
         "stance_report_episodes",
+        "baseline_warn_after_budget_fraction",
     }
 )
 

--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -198,6 +198,8 @@ class DiagnosticsCallback(_BaseCallback):
         # SAC critic_loss/ent_coef/…) captured from SB3's logger.
         self._history_algo_timesteps: list[int] = []
         self._history_algo: dict[str, list[float]] = {}
+        self._history_action_abs_mean: list[float] = []
+        self._history_action_std: list[float] = []
         # Throttle for diagnostics.npz rewrites (see _on_rollout_end).
         self.save_interval_seconds = save_interval_seconds
         self._last_save_time: float | None = None
@@ -284,8 +286,25 @@ class DiagnosticsCallback(_BaseCallback):
             self.logger.record("diagnostics/action_mean", _sanitize(float(_np.mean(acts))))
             self.logger.record("diagnostics/action_std", _sanitize(float(_np.std(acts))))
             self.logger.record("diagnostics/action_abs_max", _sanitize(float(_np.max(_np.abs(acts)))))
+            # Mean |action|, distinct from action_mean and action_abs_max and
+            # more informative than either for a residual interface. Under
+            # `home-keyframe-residual/v1` the zero-action statue is exactly
+            # `action = 0`, so this is the direct distance from it: signs
+            # cancel in action_mean (it sits near 0 even for a large-magnitude
+            # policy) and action_abs_max is dominated by whichever joint is
+            # most saturated. It separates the two ways an entropy collapse
+            # can end -- std falls and the mean settles ON the statue, versus
+            # std falls and the mean settles on some other committed pose --
+            # which look identical in algo_std alone and mean opposite things.
+            abs_mean = float(_np.mean(_np.abs(acts)))
+            self.logger.record("diagnostics/action_abs_mean", _sanitize(abs_mean))
             saturation = float(_np.mean(_np.abs(acts) >= self.action_saturation_threshold))
             self.logger.record("diagnostics/action_saturation", _sanitize(saturation))
+            # Persisted alongside the rollout series so post-hoc analysis sees
+            # it without TensorBoard. Aligned to _history_timesteps, which is
+            # appended in the same rollout-end pass.
+            self._history_action_abs_mean.append(abs_mean)
+            self._history_action_std.append(float(_np.std(acts)))
         self._step_actions = []
 
         # PPO post-update (clipped) gradient norm.  Scoped to PPO: SAC runs
@@ -393,6 +412,16 @@ class DiagnosticsCallback(_BaseCallback):
                 save_dict[key] = _np.array(arr)
         if len(self._history_heading_std) == len(self._history_timesteps):
             save_dict["heading_alignment_std"] = _np.array(self._history_heading_std)
+        for name, series in (
+            ("action_abs_mean", self._history_action_abs_mean),
+            ("action_std", self._history_action_std),
+        ):
+            # Length-guarded like every other optional series here: a rollout
+            # that collected no actions appends nothing, so the two clocks can
+            # legitimately diverge and a mismatched array would silently
+            # mis-align against `timesteps`.
+            if len(series) == len(self._history_timesteps):
+                save_dict[name] = _np.array(series)
         if self._history_term_timesteps:
             save_dict["term_timesteps"] = _np.array(self._history_term_timesteps)
             for reason, fracs in self._history_terminations.items():

--- a/environments/shared/eval_diagnostics.py
+++ b/environments/shared/eval_diagnostics.py
@@ -271,6 +271,7 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
     _gate_progress_dir: "Path | None" = None
     _gate_progress_timesteps: list[int] = []
     _gate_progress: dict[str, list[float]] = {}
+    _warned_gate_progress_unwritable = False
 
     def __init__(
         self,
@@ -308,6 +309,7 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         self._gate_progress_dir = None if gate_progress_dir is None else Path(gate_progress_dir)
         self._gate_progress_timesteps: list[int] = []
         self._gate_progress: dict[str, list[float]] = {}
+        self._warned_gate_progress_unwritable = False
 
     @staticmethod
     def _finite_mean(values: Any) -> float | None:
@@ -576,12 +578,26 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         try:
             from .file_io import atomic_savez
 
+            n = len(self._gate_progress_timesteps)
             payload = {"timesteps": np.array(self._gate_progress_timesteps)}
+            # Length-guarded against `timesteps`, like every optional series in
+            # `diagnostics.npz`. Today one call site supplies every key on every
+            # evaluation, so nothing can diverge -- but a future caller that
+            # supplies a key conditionally would otherwise write a short array
+            # that silently reads as the FIRST n evaluations rather than the
+            # ones it came from. Dropping it is recoverable; misaligning it is
+            # the kind of error this file exists to stop.
             for key, series in self._gate_progress.items():
-                payload[key] = np.array(series)
+                if len(series) == n:
+                    payload[key] = np.array(series)
             atomic_savez(Path(self._gate_progress_dir) / "gate_progress.npz", **payload)
         except Exception:  # noqa: BLE001 - a diagnostic must not sink a run
-            logger.warning("Could not write gate_progress.npz", exc_info=True)
+            # Once. An unwritable directory fails identically on all ~200
+            # evaluations of a 10M run, and 200 stack traces would bury the
+            # warnings this run is actually meant to surface.
+            if not self._warned_gate_progress_unwritable:
+                self._warned_gate_progress_unwritable = True
+                logger.warning("Could not write gate_progress.npz", exc_info=True)
 
     def _process_evaluation(self, index: int) -> None:
         panel = self._stance_panel(index)

--- a/environments/shared/eval_diagnostics.py
+++ b/environments/shared/eval_diagnostics.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -262,6 +263,15 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         ),
     }
 
+    #: Declared at class scope so an instance built without ``__init__``
+    #: still has them. The suite constructs this callback with
+    #: ``object.__new__`` to exercise the plateau logic without
+    #: stable-baselines3, and a new instance attribute only ``__init__`` set
+    #: would turn every one of those tests into an AttributeError.
+    _gate_progress_dir: "Path | None" = None
+    _gate_progress_timesteps: list[int] = []
+    _gate_progress: dict[str, list[float]] = {}
+
     def __init__(
         self,
         eval_callback: StageAwareEvalCallback,
@@ -271,6 +281,7 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         plateau_window: int = 5,
         min_relative_variation: float = 0.05,
         horizon: int = 1000,
+        gate_progress_dir: "str | Path | None" = None,
         verbose: int = 0,
     ) -> None:
         if not _SB3_AVAILABLE:
@@ -293,6 +304,10 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         self._histories: dict[str, list[float]] = {key: [] for key in self._METRIC_PRIORITY}
         self._plateau_active = False
         self._plateau_metric: str | None = None
+        # Per-evaluation gate criteria, persisted to `gate_progress.npz`.
+        self._gate_progress_dir = None if gate_progress_dir is None else Path(gate_progress_dir)
+        self._gate_progress_timesteps: list[int] = []
+        self._gate_progress: dict[str, list[float]] = {}
 
     @staticmethod
     def _finite_mean(values: Any) -> float | None:
@@ -506,6 +521,26 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
             return
         self.logger.record("diagnostics/eval_full_horizon_fraction", panel.full_horizon_fraction)
         self.logger.record("diagnostics/eval_duty_episodes", panel.n_duty_episodes)
+        bilateral = self._full_horizon_mean("evaluations_bilateral_duties", index)
+        # Recorded to TensorBoard AND accumulated for `gate_progress.npz`.
+        # These are the deterministic, panel-estimator gate criteria -- the
+        # same numbers the stance gate tests -- and until now they existed
+        # only in TensorBoard. Post-hoc analysis of run 20260804_143747 had to
+        # substitute the TRAINING-rollout duty from `diagnostics.npz`, which is
+        # contaminated by exploration noise; it happened to agree to three
+        # decimals there, but that was luck, not a property worth relying on.
+        self._record_gate_progress(
+            full_horizon_fraction=panel.full_horizon_fraction,
+            duty_episodes=panel.n_duty_episodes,
+            unsupported_duty=panel.mean_unsupported_duty if panel.n_duty_episodes else float("nan"),
+            unsupported_duty_ucb=(
+                panel.unsupported_duty_ucb
+                if panel.n_duty_episodes and math.isfinite(panel.unsupported_duty_ucb)
+                else float("nan")
+            ),
+            bilateral_support_duty=float("nan") if bilateral is None else bilateral,
+            mean_reward=panel.mean_reward,
+        )
         if not panel.n_duty_episodes:
             return
         self.logger.record("diagnostics/eval_unsupported_duty", panel.mean_unsupported_duty)
@@ -514,9 +549,39 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         # Not gated. Measured over the SAME full-horizon episodes as the duty
         # above so the two are comparable; averaging it over every episode is
         # what made the three stance shares stop summing to 1.
-        bilateral = self._full_horizon_mean("evaluations_bilateral_duties", index)
         if bilateral is not None:
             self.logger.record("diagnostics/eval_bilateral_support_duty", bilateral)
+
+    def _record_gate_progress(self, **values: float) -> None:
+        """Append one evaluation's gate criteria and rewrite ``gate_progress.npz``.
+
+        A separate file rather than columns in ``diagnostics.npz`` because the
+        two are on different clocks: diagnostics is per training rollout, this
+        is per evaluation. Merging them would force one series to be padded
+        with NaN against the other's timeline, which is exactly the alignment
+        trap ``_history_algo`` already has to work around.
+        """
+        # Bind instance-local containers before appending: the class-scope
+        # defaults above exist only so `object.__new__` instances have the
+        # attribute, and appending to them would share state across every
+        # instance in the process.
+        if "_gate_progress_timesteps" not in self.__dict__:
+            self._gate_progress_timesteps = []
+            self._gate_progress = {}
+        self._gate_progress_timesteps.append(int(self.num_timesteps))
+        for key, value in values.items():
+            self._gate_progress.setdefault(key, []).append(float(value))
+        if self._gate_progress_dir is None:
+            return
+        try:
+            from .file_io import atomic_savez
+
+            payload = {"timesteps": np.array(self._gate_progress_timesteps)}
+            for key, series in self._gate_progress.items():
+                payload[key] = np.array(series)
+            atomic_savez(Path(self._gate_progress_dir) / "gate_progress.npz", **payload)
+        except Exception:  # noqa: BLE001 - a diagnostic must not sink a run
+            logger.warning("Could not write gate_progress.npz", exc_info=True)
 
     def _process_evaluation(self, index: int) -> None:
         panel = self._stance_panel(index)
@@ -652,6 +717,7 @@ def build_stage_evaluation_callbacks(
     stage: int,
     stage_config: dict[str, Any],
     diagnostics_verbose: int = 0,
+    gate_progress_dir: "str | Path | None" = None,
     **eval_callback_kwargs: Any,
 ) -> tuple[StageAwareEvalCallback, StageGatePlateauCallback]:
     """Build the paired evaluation and stage-gate diagnostic callbacks."""
@@ -677,6 +743,7 @@ def build_stage_evaluation_callbacks(
         # From [env], not [curriculum]: the horizon defines what "full" means
         # for the full-horizon fraction, and it is an environment property.
         horizon=int(stage_config.get("env_kwargs", {}).get("max_episode_steps", 1000)),
+        gate_progress_dir=gate_progress_dir,
         verbose=diagnostics_verbose,
     )
     return eval_callback, plateau_callback

--- a/environments/shared/tests/test_curriculum_baseline_watch.py
+++ b/environments/shared/tests/test_curriculum_baseline_watch.py
@@ -1,0 +1,217 @@
+"""Tests for environments.shared.curriculum.baseline_watch.
+
+Regression for issue #486: run 20260804_143747 trained T-Rex stage 1 for its
+full 10,002,432 steps and finished at 2686.9 against the zero-action statue's
+3271.8 -- below the do-nothing policy on every major reward term, for the
+entire 8h 13m -- and nothing in the run reported it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from environments.shared.curriculum import baseline_watch
+from environments.shared.curriculum.baseline_watch import (
+    BaselineProgressCallback,
+    build_baseline_progress_callback,
+    read_zero_action_baseline,
+)
+
+#: The real numbers from run 20260804_143747 / its captured baseline.
+STATUE = 3271.770493548379
+POLICY = 2686.917084553575
+
+
+def _write_baseline(run_dir: Path, *, species: str = "trex", reward: float = STATUE) -> Path:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    path = run_dir / "zero_action_baseline.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "mesozoic.zero-action-baseline/v1",
+                "stage": 1,
+                "results": {species: {"reward_mean": reward, "episodes": 40}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestReadZeroActionBaseline:
+    def test_reads_the_species_reward(self, tmp_path):
+        _write_baseline(tmp_path)
+        assert read_zero_action_baseline(tmp_path, "trex") == pytest.approx(STATUE)
+
+    def test_missing_file_is_none_not_a_guess(self, tmp_path):
+        assert read_zero_action_baseline(tmp_path, "trex") is None
+
+    def test_other_species_is_none(self, tmp_path):
+        _write_baseline(tmp_path, species="velociraptor")
+        assert read_zero_action_baseline(tmp_path, "trex") is None
+
+    def test_corrupt_file_is_none_rather_than_raising(self, tmp_path):
+        (tmp_path / "zero_action_baseline.json").write_text("{not json", encoding="utf-8")
+        assert read_zero_action_baseline(tmp_path, "trex") is None
+
+    @pytest.mark.parametrize("value", [None, "abc", float("nan"), float("inf")])
+    def test_unusable_reward_is_none(self, tmp_path, value):
+        (tmp_path / "zero_action_baseline.json").write_text(
+            json.dumps({"results": {"trex": {"reward_mean": value}}}), encoding="utf-8"
+        )
+        assert read_zero_action_baseline(tmp_path, "trex") is None
+
+
+class TestBaselineProgressCallback:
+    """`object.__new__` throughout so `_on_step` runs without stable-baselines3."""
+
+    @staticmethod
+    def _callback(*, total=10_000_000, fraction=0.35, ceiling=0.02):
+        cb = object.__new__(BaselineProgressCallback)
+        cb.eval_callback = MagicMock()
+        cb.eval_callback.evaluations_results = []
+        cb.baseline_reward = STATUE
+        cb.total_timesteps = total
+        cb.warn_after_budget_fraction = fraction
+        cb.duty_ceiling = ceiling
+        cb._last_seen_n_evals = 0
+        cb._warned_below_baseline = False
+        cb._ever_beat_baseline = False
+        return cb
+
+    @staticmethod
+    def _feed(cb, reward, step):
+        cb.eval_callback.evaluations_results = cb.eval_callback.evaluations_results + [[reward]]
+        cb.num_timesteps = step
+        return cb._on_step()
+
+    def test_reports_each_evaluation_against_the_baseline(self, caplog):
+        cb = self._callback()
+        with caplog.at_level(logging.INFO, logger=baseline_watch.logger.name):
+            self._feed(cb, POLICY, 100_000)
+        assert any("zero-action baseline" in r.message for r in caplog.records)
+
+    def test_warns_once_past_the_budget_fraction_when_never_beaten(self, caplog):
+        """The signal run 20260804_143747 needed and did not have."""
+        cb = self._callback()
+        with caplog.at_level(logging.WARNING, logger=baseline_watch.logger.name):
+            self._feed(cb, POLICY, 1_000_000)  # 10% of budget: too early
+            early = [r for r in caplog.records if r.levelno >= logging.WARNING]
+            assert not early, "warned before the budget fraction"
+            self._feed(cb, POLICY, 4_000_000)  # 40%: past 0.35
+            self._feed(cb, POLICY, 6_000_000)
+            self._feed(cb, POLICY, 9_000_000)
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warnings) == 1, "must warn exactly once, not on every evaluation"
+        assert "never" in warnings[0].message and "worse-than-trivial" in warnings[0].message
+
+    def test_a_run_that_beats_the_baseline_is_never_warned_about(self, caplog):
+        """Falling back under it later is the collapse backstop's job, not this."""
+        cb = self._callback()
+        with caplog.at_level(logging.WARNING, logger=baseline_watch.logger.name):
+            self._feed(cb, STATUE + 100.0, 1_000_000)
+            self._feed(cb, POLICY, 5_000_000)
+            self._feed(cb, POLICY, 9_500_000)
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_it_never_stops_the_run(self):
+        """Advisory only: the statue is the stage-1 optimum, so a learning
+        policy legitimately sits below it for millions of steps."""
+        cb = self._callback()
+        for step in (1_000_000, 5_000_000, 9_900_000):
+            assert self._feed(cb, POLICY, step) is True
+
+    def test_repeated_step_without_a_new_evaluation_is_a_no_op(self, caplog):
+        cb = self._callback()
+        self._feed(cb, POLICY, 4_000_000)
+        caplog.clear()  # discard the setup evaluation's own records
+        with caplog.at_level(logging.INFO, logger=baseline_watch.logger.name):
+            cb.num_timesteps = 4_000_001
+            cb._on_step()
+        assert not caplog.records
+
+    def test_no_evaluations_yet_is_a_no_op(self):
+        cb = self._callback()
+        cb.num_timesteps = 0
+        assert cb._on_step() is True
+
+
+class TestBuilder:
+    def test_returns_none_without_a_baseline_file(self, tmp_path):
+        built = build_baseline_progress_callback(
+            MagicMock(), run_dir=tmp_path, species="trex", stage_config={"curriculum_kwargs": {}}
+        )
+        assert built is None
+
+    def test_returns_none_without_a_run_dir(self):
+        built = build_baseline_progress_callback(
+            MagicMock(), run_dir=None, species="trex", stage_config={"curriculum_kwargs": {}}
+        )
+        assert built is None
+
+    def test_forwards_the_stage_budget_ceiling_and_override(self, tmp_path, monkeypatch):
+        captured = {}
+
+        def _capture(eval_callback, baseline_reward, **kwargs):
+            captured["baseline"] = baseline_reward
+            captured.update(kwargs)
+            return "callback"
+
+        monkeypatch.setattr(baseline_watch, "BaselineProgressCallback", _capture)
+        _write_baseline(tmp_path)
+        built = build_baseline_progress_callback(
+            MagicMock(),
+            run_dir=tmp_path,
+            species="trex",
+            stage_config={
+                "curriculum_kwargs": {
+                    "timesteps": 10_000_000,
+                    "max_unsupported_duty": 0.02,
+                    "baseline_warn_after_budget_fraction": 0.5,
+                }
+            },
+        )
+        assert built == "callback"
+        assert captured["baseline"] == pytest.approx(STATUE)
+        assert captured["total_timesteps"] == 10_000_000
+        assert captured["duty_ceiling"] == 0.02
+        assert captured["warn_after_budget_fraction"] == 0.5
+
+
+def test_the_config_key_is_accepted_by_the_gate_schema():
+    """An unregistered [curriculum] key is fatal, which would make it unusable."""
+    from environments.shared.curriculum.gate_schema import validate_gate_config
+
+    validate_gate_config(
+        1,
+        {
+            "gate_schema_version": 1,
+            "gate_kind": "stance_quality/v1",
+            "min_full_horizon_fraction": 0.95,
+            "max_unsupported_duty": 0.02,
+            "max_unsupported_duty_ucb": 0.02,
+            "baseline_warn_after_budget_fraction": 0.5,
+        },
+    )
+
+
+def test_the_notebook_passes_species_so_the_watch_is_not_dead_code():
+    """`species` is optional, so omitting it silently disables the watch.
+
+    That is the failure mode this repository keeps rediscovering — a
+    mechanism wired into the library but never reached from the trainer.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    notebook = json.loads((repo_root / "notebooks" / "sb3_training.ipynb").read_text(encoding="utf-8"))
+    cells = ["".join(c.get("source", [])) for c in notebook["cells"] if c.get("cell_type") == "code"]
+    calls = [c for c in cells if "_build_core_callbacks(" in c]
+    assert len(calls) == 1, "expected exactly one _build_core_callbacks call"
+    assert "species=SPECIES," in calls[0], (
+        "sb3_training.ipynb must pass species= to _build_core_callbacks, or the "
+        "zero-action baseline watch is never constructed"
+    )

--- a/environments/shared/tests/test_curriculum_baseline_watch.py
+++ b/environments/shared/tests/test_curriculum_baseline_watch.py
@@ -215,3 +215,30 @@ def test_the_notebook_passes_species_so_the_watch_is_not_dead_code():
         "sb3_training.ipynb must pass species= to _build_core_callbacks, or the "
         "zero-action baseline watch is never constructed"
     )
+
+
+def test_every_trainer_call_site_passes_species():
+    """The notebook is not the only caller, and pinning only it missed two.
+
+    `train_stage` and `train_curriculum` both shipped omitting `species`,
+    which left the watch dead on both library entry points while the
+    notebook test above passed — the *same* dead-code failure that test was
+    written to prevent, one call site over. So this asserts over every call
+    site in `train_base.py` rather than a hand-listed one.
+    """
+    import ast
+
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "environments" / "shared" / "train_base.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "_build_core_callbacks"
+    ]
+    assert calls, "expected _build_core_callbacks to be called in train_base.py"
+    for call in calls:
+        assert any(kw.arg == "species" for kw in call.keywords), (
+            f"_build_core_callbacks call at train_base.py:{call.lineno} omits species=, "
+            "so the zero-action baseline watch is never constructed on that path"
+        )

--- a/environments/shared/tests/test_eval_diagnostics.py
+++ b/environments/shared/tests/test_eval_diagnostics.py
@@ -834,3 +834,66 @@ class TestDiagnosticAgreesWithTheGate:
         # 38 duty episodes is enough for both; 37 is enough for neither.
         assert self._both_verdicts(2) == (True, 1.0)
         assert self._both_verdicts(3) == (False, 0.0)
+
+
+class TestGateProgressIsPersisted:
+    """The deterministic gate criteria must survive outside TensorBoard.
+
+    They were computed every evaluation and recorded only to the SB3 logger,
+    so post-hoc analysis of run 20260804_143747 had to substitute the
+    TRAINING-rollout duty from `diagnostics.npz` — contaminated by exploration
+    noise. It happened to agree to three decimals there; that was luck, not a
+    property to rely on (issue #486).
+    """
+
+    @staticmethod
+    def _callback(tmp_path):
+        from environments.shared.eval_diagnostics import StageGatePlateauCallback
+
+        cb = object.__new__(StageGatePlateauCallback)
+        cb._gate_progress_dir = tmp_path
+        cb.num_timesteps = 0
+        return cb
+
+    def test_each_evaluation_appends_a_row_and_rewrites_the_file(self, tmp_path):
+        cb = self._callback(tmp_path)
+        for step, duty in ((50_000, 0.42), (100_000, 0.31), (150_000, 0.28)):
+            cb.num_timesteps = step
+            cb._record_gate_progress(
+                full_horizon_fraction=1.0,
+                duty_episodes=40,
+                unsupported_duty=duty,
+                unsupported_duty_ucb=duty + 0.001,
+                bilateral_support_duty=1.0 - duty,
+                mean_reward=2500.0,
+            )
+        data = np.load(tmp_path / "gate_progress.npz")
+        assert list(data["timesteps"]) == [50_000, 100_000, 150_000]
+        assert list(data["unsupported_duty"]) == pytest.approx([0.42, 0.31, 0.28])
+        assert list(data["unsupported_duty_ucb"]) == pytest.approx([0.421, 0.311, 0.281])
+        assert list(data["bilateral_support_duty"]) == pytest.approx([0.58, 0.69, 0.72])
+
+    def test_instances_do_not_share_the_class_level_defaults(self, tmp_path):
+        """The class attributes exist for `object.__new__`; appending to them
+        directly would leak one run's series into another's."""
+        a, b = self._callback(tmp_path / "a"), self._callback(tmp_path / "b")
+        (tmp_path / "a").mkdir()
+        (tmp_path / "b").mkdir()
+        a.num_timesteps = 1000
+        a._record_gate_progress(unsupported_duty=0.5)
+        b.num_timesteps = 2000
+        b._record_gate_progress(unsupported_duty=0.1)
+        assert a._gate_progress_timesteps == [1000]
+        assert b._gate_progress_timesteps == [2000]
+
+    def test_an_unwritable_directory_does_not_sink_the_run(self, tmp_path):
+        cb = self._callback(tmp_path / "does" / "not" / "exist")
+        cb.num_timesteps = 50_000
+        cb._record_gate_progress(unsupported_duty=0.42)  # must not raise
+        assert cb._gate_progress_timesteps == [50_000]
+
+    def test_no_directory_still_accumulates_in_memory(self, tmp_path):
+        cb = self._callback(None)
+        cb.num_timesteps = 50_000
+        cb._record_gate_progress(unsupported_duty=0.42)
+        assert cb._gate_progress["unsupported_duty"] == [0.42]

--- a/environments/shared/tests/test_eval_diagnostics.py
+++ b/environments/shared/tests/test_eval_diagnostics.py
@@ -886,11 +886,64 @@ class TestGateProgressIsPersisted:
         assert a._gate_progress_timesteps == [1000]
         assert b._gate_progress_timesteps == [2000]
 
+    @staticmethod
+    def _unwritable_dir(tmp_path):
+        """A target `atomic_copy` genuinely cannot create.
+
+        Not a merely absent directory: `atomic_copy` calls
+        `mkdir(parents=True)`, so a missing path is created rather than
+        failing, and asserting "does not raise" against one exercises the
+        success path under a name that claims otherwise. Rooting the target
+        under a regular *file* makes mkdir raise NotADirectoryError, and
+        unlike `chmod 000` it still fails when the suite runs as root.
+        """
+        blocker = tmp_path / "not-a-directory"
+        blocker.write_text("", encoding="utf-8")
+        return blocker / "gate"
+
+    def test_a_missing_directory_is_created_rather_than_dropped(self, tmp_path):
+        target = tmp_path / "does" / "not" / "exist"
+        cb = self._callback(target)
+        cb.num_timesteps = 50_000
+        cb._record_gate_progress(unsupported_duty=0.42)
+        assert list(np.load(target / "gate_progress.npz")["unsupported_duty"]) == pytest.approx([0.42])
+
     def test_an_unwritable_directory_does_not_sink_the_run(self, tmp_path):
-        cb = self._callback(tmp_path / "does" / "not" / "exist")
+        cb = self._callback(self._unwritable_dir(tmp_path))
         cb.num_timesteps = 50_000
         cb._record_gate_progress(unsupported_duty=0.42)  # must not raise
         assert cb._gate_progress_timesteps == [50_000]
+
+    def test_an_unwritable_directory_warns_once_not_per_evaluation(self, tmp_path, caplog):
+        """A 10M run evaluates ~200 times and would fail identically each time.
+
+        200 stack traces would bury the below-baseline warning this run is
+        actually meant to surface.
+        """
+        cb = self._callback(self._unwritable_dir(tmp_path))
+        with caplog.at_level(logging.WARNING, logger="environments.shared.eval_diagnostics"):
+            for step in range(1, 6):
+                cb.num_timesteps = step * 50_000
+                cb._record_gate_progress(unsupported_duty=0.42)
+        assert sum("gate_progress.npz" in r.message for r in caplog.records) == 1
+        assert len(cb._gate_progress_timesteps) == 5  # still accumulating in memory
+
+    def test_a_short_series_is_dropped_rather_than_written_misaligned(self, tmp_path):
+        """A key supplied on only some evaluations must not read as the first n.
+
+        Today one call site supplies every key every time, so this cannot
+        happen -- but a silently misaligned duty series is exactly the kind of
+        wrong number a kill/continue decision would be made on.
+        """
+        cb = self._callback(tmp_path)
+        cb.num_timesteps = 50_000
+        cb._record_gate_progress(unsupported_duty=0.42, duty_episodes=40)
+        cb.num_timesteps = 100_000
+        cb._record_gate_progress(unsupported_duty=0.31)  # duty_episodes absent
+        data = np.load(tmp_path / "gate_progress.npz")
+        assert list(data["timesteps"]) == [50_000, 100_000]
+        assert list(data["unsupported_duty"]) == pytest.approx([0.42, 0.31])
+        assert "duty_episodes" not in data
 
     def test_no_directory_still_accumulates_in_memory(self, tmp_path):
         cb = self._callback(None)

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -395,6 +395,7 @@ def _build_core_callbacks(
     use_wandb: bool = False,
     local_tb_dir: Path | None = None,
     gcs_tb_path: Path | None = None,
+    species: str | None = None,
 ) -> tuple[list, Any, Any]:
     """Build the standard callback set shared by train() and train_curriculum().
 
@@ -407,6 +408,7 @@ def _build_core_callbacks(
         PublishEvalArtifactsCallback,
         RobustBestModelCallback,
         SaveVecNormalizeCallback,
+        build_baseline_progress_callback,
         build_eval_collapse_early_stop_callback,
     )
     from .diagnostics import DiagnosticsCallback as _DiagCB
@@ -495,6 +497,29 @@ def _build_core_callbacks(
             verbose=verbose,
         )
     )
+
+    # Advisory only: reports each evaluation against the run's captured
+    # zero-action baseline. Run 20260804_143747 spent its whole 10M budget
+    # (8h 13m) below the statue on every major reward term and nothing said
+    # so -- reward was climbing, full-horizon was 100%, the backstop correctly
+    # never fired. The comparison costs one float already on disk. See
+    # `curriculum.baseline_watch` for why this warns rather than stops.
+    # `species` is optional so the existing positional callers keep working,
+    # but a caller that omits it silently loses the watch -- so the notebook
+    # passes it and a test pins that it still does.
+    baseline_cb = (
+        build_baseline_progress_callback(
+            eval_callback,
+            run_dir=Path(log_path).parent if log_path is not None else None,
+            species=species,
+            stage_config=stage_config,
+            verbose=verbose,
+        )
+        if species
+        else None
+    )
+    if baseline_cb is not None:
+        callbacks.append(baseline_cb)
 
     if use_wandb:
         callbacks.append(WandbCallback())

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -752,6 +752,7 @@ def train(
         use_wandb,
         local_tb_dir=local_tb_dir,
         gcs_tb_path=gcs_tb_path,
+        species=species,
     )
 
     ent_decay_cb = _maybe_ent_coef_decay_callback(config, algorithm, total_timesteps)
@@ -1235,6 +1236,7 @@ def train_curriculum(
             use_wandb,
             local_tb_dir=local_tb_dir,
             gcs_tb_path=gcs_tb_path,
+            species=species,
         )
 
         ent_decay_cb = _maybe_ent_coef_decay_callback(config, algorithm, total_timesteps)

--- a/environments/shared/train_base.py
+++ b/environments/shared/train_base.py
@@ -434,6 +434,10 @@ def _build_core_callbacks(
         stage=stage,
         stage_config=stage_config,
         diagnostics_verbose=verbose,
+        # The stage dir, not the local scratch eval dir: gate_progress.npz is
+        # the artifact a human (or a Drive reader) checks mid-run, so it has
+        # to land beside diagnostics.npz rather than in a temp directory.
+        gate_progress_dir=log_path,
         best_model_save_path=str(model_dir),
         log_path=local_eval_dir,
         eval_freq=eval_freq // n_envs,

--- a/notebooks/sb3_training.ipynb
+++ b/notebooks/sb3_training.ipynb
@@ -15,7 +15,7 @@
    "metadata": {
     "id": "6kes1b_8h7I1"
    },
-   "source": "# Dinosaur Training Notebook\n\nTrain one of the implemented species through balance, locomotion, and a species-specific simulator task with PPO or SAC.\n\nRun the full Stage 1 → Stage 2 → Stage 3 curriculum in order within one notebook session. Later stages consume model and result objects held in memory; files saved to Drive support analysis and archival, but this SB3 notebook does not reconstruct a cross-session curriculum continuation.\n\nChange `SPECIES` in the configuration cell below. Stage budgets, environment settings, and algorithm hyperparameters are loaded from `configs/<species>/stage*.toml`; those files and the generated species catalog are authoritative. Values differ by species and stage, so this notebook does not duplicate them.\n\nFor a smoke test, override the budget deliberately. For a full run, start with the configured values, measure memory and throughput on the target machine, and adjust parallel environments only from observed resource use. The repository does not publish a validated hardware-to-runtime or batch-size table."
+   "source": "# Dinosaur Training Notebook\n\nTrain one of the implemented species through balance, locomotion, and a species-specific simulator task with PPO or SAC.\n\nRun the full Stage 1 \u2192 Stage 2 \u2192 Stage 3 curriculum in order within one notebook session. Later stages consume model and result objects held in memory; files saved to Drive support analysis and archival, but this SB3 notebook does not reconstruct a cross-session curriculum continuation.\n\nChange `SPECIES` in the configuration cell below. Stage budgets, environment settings, and algorithm hyperparameters are loaded from `configs/<species>/stage*.toml`; those files and the generated species catalog are authoritative. Values differ by species and stage, so this notebook does not duplicate them.\n\nFor a smoke test, override the budget deliberately. For a full run, start with the configured values, measure memory and throughput on the target machine, and adjust parallel environments only from observed resource use. The repository does not publish a validated hardware-to-runtime or batch-size table."
   },
   {
    "cell_type": "markdown",
@@ -103,7 +103,7 @@
     ")\n",
     "from environments.shared.evaluation import evaluate\n",
     "\n",
-    "# Library imports — shared training infrastructure\n",
+    "# Library imports \u2014 shared training infrastructure\n",
     "from environments.shared.train_base import (\n",
     "    SpeciesConfig,\n",
     "    create_vec_env,\n",
@@ -349,7 +349,7 @@
     "\n",
     "Actions are residuals around each species' home keyframe (`home-keyframe-residual/v1`), so\n",
     "`action = 0` commands the nominal stance exactly. On a passively stable plant that is a real\n",
-    "policy, and on a balance stage it can be a strong one — strong enough that T-Rex runs\n",
+    "policy, and on a balance stage it can be a strong one \u2014 strong enough that T-Rex runs\n",
     "`20260723_204941` and `20260724_140441` both scored *below* it and advanced anyway, because\n",
     "the gate at the time was `min_avg_reward = 100.0`.\n",
     "\n",
@@ -361,7 +361,7 @@
     "| **reward standing** | conditioned on reaching the horizon. A gate between the two is cleared by a policy that has learned only \"do not fall\". |\n",
     "\n",
     "`configs/trex/stage1_balance.toml` asks for exactly this check: *\"this is a measured constant\n",
-    "and will go stale if the plant or the reward weights change — re-run the baseline script and\n",
+    "and will go stale if the plant or the reward weights change \u2014 re-run the baseline script and\n",
     "update it, or better, wire that script in as an automatic pre-stage check.\"* This cell is that\n",
     "check. Results are written to Drive so the calibration travels with the run.\n",
     "\n",
@@ -376,7 +376,7 @@
     "\n",
     "The JSON records the plant identity and the stage-1 env kwargs alongside the numbers, because\n",
     "those are what make the constant go stale. Widen `BASELINE_SPECIES` to all four (~4 min) to\n",
-    "find out whether a weak gate is species-specific or a shared-template problem — each species'\n",
+    "find out whether a weak gate is species-specific or a shared-template problem \u2014 each species'\n",
     "record still lands in its own directory.\n",
     "\n",
     "---\n",
@@ -390,11 +390,11 @@
     "\n",
     "# Debian's patched setuptools breaks legacy setup.py sdists; upgrade it first.\n",
     "pip install -q -U setuptools\n",
-    "pip install -q -e .          # core deps only — the baseline needs no torch/SB3\n",
+    "pip install -q -e .          # core deps only \u2014 the baseline needs no torch/SB3\n",
     "\n",
     "SPECIES=trex   # or velociraptor / brachiosaurus / dibothrosuchus\n",
     "OUT=/content/drive/MyDrive/mesozoic-labs/logs/$SPECIES/zero_action_baselines\n",
-    "[ -d /content/drive/MyDrive ] || echo \"WARNING: Drive not mounted — saving locally only\"\n",
+    "[ -d /content/drive/MyDrive ] || echo \"WARNING: Drive not mounted \u2014 saving locally only\"\n",
     "mkdir -p \"$OUT\"\n",
     "\n",
     "python environments/shared/scripts/zero_action_baseline.py \"$SPECIES\" \\\n",
@@ -403,7 +403,7 @@
     "\n",
     "Drive is only visible to the terminal once the notebook has mounted it (cell 2 of section 1).\n",
     "\n",
-    "Pass several species names to measure them in one go — the transcript then covers all of\n",
+    "Pass several species names to measure them in one go \u2014 the transcript then covers all of\n",
     "them, so `tee` it wherever makes sense rather than into one species' directory. Add\n",
     "`--sweep-noise` to sweep `reset_noise_scale` instead of measuring a single point; that is\n",
     "how the stage-1 reset noise gets calibrated."
@@ -453,14 +453,14 @@
     "    if _gate is None:\n",
     "        _verdict = \"NO GATE\"\n",
     "    elif _gate <= _result[\"reward_mean\"]:\n",
-    "        _verdict = \"FAILS — a statue clears this gate\"\n",
+    "        _verdict = \"FAILS \u2014 a statue clears this gate\"\n",
     "    elif _result[\"n_standing\"] == 0:\n",
     "        # The statue never reaches the horizon, so there is no standing floor to\n",
     "        # compare against.  That is its own problem: a plant that falls over under\n",
     "        # its own home controller is not ready for a balance stage.\n",
-    "        _verdict = \"CHECK PLANT — the statue never survives a full episode\"\n",
+    "        _verdict = \"CHECK PLANT \u2014 the statue never survives a full episode\"\n",
     "    elif _gate <= _result[\"reward_mean_standing\"]:\n",
-    "        _verdict = \"WEAK — binds only against a falling statue\"\n",
+    "        _verdict = \"WEAK \u2014 binds only against a falling statue\"\n",
     "    else:\n",
     "        _verdict = \"OK\"\n",
     "\n",
@@ -484,14 +484,14 @@
     "    f\"{'full-hz':>9}{'gate':>9}  verdict\"\n",
     ")\n",
     "_lines = [\n",
-    "    f\"zero-action baseline — stage {BASELINE_STAGE}, {BASELINE_EPISODES} episodes, seed {BASELINE_SEED}\",\n",
+    "    f\"zero-action baseline \u2014 stage {BASELINE_STAGE}, {BASELINE_EPISODES} episodes, seed {BASELINE_SEED}\",\n",
     "    \"\",\n",
     "    _header,\n",
     "    \"-\" * len(_header),\n",
     "]\n",
     "for _species, _r in results.items():\n",
-    "    _gate_text = \"—\" if _r[\"min_avg_reward\"] is None else f\"{_r['min_avg_reward']:.0f}\"\n",
-    "    _standing_text = \"—\" if _r[\"n_standing\"] == 0 else f\"{_r['reward_mean_standing']:.1f}\"\n",
+    "    _gate_text = \"\u2014\" if _r[\"min_avg_reward\"] is None else f\"{_r['min_avg_reward']:.0f}\"\n",
+    "    _standing_text = \"\u2014\" if _r[\"n_standing\"] == 0 else f\"{_r['reward_mean_standing']:.1f}\"\n",
     "    _lines.append(\n",
     "        f\"{_species:<16}{_r['reward_mean']:>10.1f}{_r['reward_mean_minus_std']:>10.1f}\"\n",
     "        f\"{_standing_text:>10}{_r['full_horizon_share']:>8.0%}\"\n",
@@ -547,7 +547,7 @@
     "        )\n",
     "        print(f\"Copied to run: {Path(_run_dir) / 'zero_action_baseline.json'}\")\n",
     "else:\n",
-    "    print(\"\\nLOG_BASE not defined — run the storage-configuration cell to save results.\")"
+    "    print(\"\\nLOG_BASE not defined \u2014 run the storage-configuration cell to save results.\")"
    ]
   },
   {
@@ -602,8 +602,8 @@
     "def disconnect_runtime(reason):\n",
     "    \"\"\"Flush Drive writes and release the Colab runtime.\n",
     "\n",
-    "    Called whenever training halts — curriculum gate failure or normal\n",
-    "    completion — so an unattended \"Run all\" never leaves a GPU runtime\n",
+    "    Called whenever training halts \u2014 curriculum gate failure or normal\n",
+    "    completion \u2014 so an unattended \"Run all\" never leaves a GPU runtime\n",
     "    idle. No-op outside Colab or when AUTO_DISCONNECT is False.\n",
     "    \"\"\"\n",
     "    print(f\"\\n{reason}\")\n",
@@ -716,7 +716,7 @@
     "    sb3 = _ensure_sb3()\n",
     "    AlgoClass = ALGO_CLASS[ALGORITHM.upper()]\n",
     "\n",
-    "    # Directories — each stage gets a subdirectory within the run directory\n",
+    "    # Directories \u2014 each stage gets a subdirectory within the run directory\n",
     "    if run_dir is None:\n",
     "        run_dir = repo_root / \"logs\"\n",
     "    stage_dir = Path(run_dir) / f\"stage{stage}\"\n",
@@ -800,7 +800,7 @@
     "    # Load VecNormalize stats from prior stage\n",
     "    if vecnorm_path:\n",
     "        if not load_vecnorm_stats(vecnorm_path, train_env, eval_env, current_plant=PLANT_IDENTITY):\n",
-    "            print(f\"WARNING: VecNormalize file not found: {vecnorm_path} — eval env will use defaults\")\n",
+    "            print(f\"WARNING: VecNormalize file not found: {vecnorm_path} \u2014 eval env will use defaults\")\n",
     "            eval_env.training = False\n",
     "            eval_env.norm_reward = False\n",
     "    else:\n",
@@ -842,6 +842,7 @@
     "        save_freq=500000,\n",
     "        verbose=VERBOSE,\n",
     "        stage_config=config,\n",
+    "        species=SPECIES,\n",
     "    )\n",
     "    best_vecnorm_path = save_vecnorm_cb.save_path\n",
     "\n",
@@ -878,7 +879,7 @@
     "        progress_bar=VERBOSE >= 1,\n",
     "    )\n",
     "\n",
-    "    # Actual steps trained — differs from the configured budget when a\n",
+    "    # Actual steps trained \u2014 differs from the configured budget when a\n",
     "    # callback (e.g. EvalCollapseEarlyStopCallback) ended training early.\n",
     "    actual_timesteps = int(model.num_timesteps)\n",
     "    if actual_timesteps < timesteps:\n",
@@ -1228,7 +1229,7 @@
    "source": [
     "## 5. Stage 1: Balance\n",
     "\n",
-    "The selected agent learns to stand upright without falling. No forward velocity reward —\n",
+    "The selected agent learns to stand upright without falling. No forward velocity reward \u2014\n",
     "just a strong alive bonus."
    ]
   },
@@ -1566,7 +1567,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "disconnect_runtime(\"Training finished — full curriculum complete.\")"
+    "disconnect_runtime(\"Training finished \u2014 full curriculum complete.\")"
    ]
   }
  ],


### PR DESCRIPTION
Three changes for issue #486, consolidated from #488. One fixes the suspected cause of the stage-1 failure; the other two make the *next* attempt cheap to judge.

Run `20260804_143747` trained T-Rex stage 1 for its full **10,002,432 steps — 8h 13m** — and finished at **2686.9** against the zero-action statue&#39;s **3271.8**. Below the do-nothing policy on every major reward term, for the entire run, with unsupported duty pinned at 0.1668 (8.3× the gate ceiling). Nothing reported it, and the cause was only found by scoring `action = 0` by hand afterwards.

---

# 1. Entropy decays to zero, over 70% of the budget rather than 30%

```diff
-ent_coef_end = 0.001
-ent_coef_decay_timesteps = 3000000
+ent_coef_end = 0.0
+ent_coef_decay_timesteps = 7000000
```

## The mechanism, measured

`ent_coef` reached its 0.001 floor at 3M and held there for the remaining 7M. Across 21 action dims that residual bonus holds policy std at equilibrium ~0.375:

| step | `algo_std` |
|---|---|
| 2.1M | 0.879 |
| 4.6M | 0.554 |
| 5.9M | 0.469 |
| 8.4M | **0.375** |

Still falling only ~0.01 per 1M at the end — it was never going to converge inside the budget.

**What that std means physically.** Converted through `_scale_action`&#39;s residual mapping and this model&#39;s actual ctrlranges:

| joint | 1σ command noise |
|---|---|
| hip pitch | **±24.4°** |
| knee | **±18.8°** |
| ankle | **±18.8°** |
| mean, major leg joints | **±20.6°** |

Resampled every control step, at 100 Hz, for the whole run.

**A policy cannot learn to hold a pose it is being commanded to shake by 20°.** PPO optimises expected return *under* its own action noise, so the mean action it converges to is not the deterministic optimum — it is whatever survives the tremor. In that run: a 16.7 Hz limit cycle, both feet leaving and landing together, `single_support_duty` exactly **0.0000**, duty locked to 133–134 airborne steps out of 800 across all 40 panel episodes (±1 step — a phase-locked cycle, not jitter).

## Why this is a convergence failure, not a reward problem

Measured locally, not quoted from a run:

```
$ python environments/shared/scripts/stance_gate_report.py trex --stage 1 --zero-action --episodes 8

reward                    3274.4 +/- 7.6
mean_unsupported_duty     0.0000   (&lt;= 0.0200)
  bilateral support       1.0000
```

Under `home-keyframe-residual/v1`, **`action = 0` *is* the home keyframe**. The gate&#39;s 0.02 ceiling is achievable under the *current* reward, by the most trivially reachable policy in the space, and the reward prefers it by 588 points on every major term.

That also makes the usual objection to zeroing entropy — premature convergence to a bad optimum — unusually weak. The good optimum is trivial to reach; the observed failure was never converging at all.

I also ruled out the plant: `timestep 0.002` × `frame_skip 5` = 100 Hz control, so the 6-step cycle is 16.7 Hz, while body-on-leg resonance is **~1.1–1.4 Hz** (16.7 Hz on this mass would need ~1.66 MN/m). The statue holds `bilateral 1.0000`, so it does not bounce passively. The oscillation is actively produced.

## The choices

- **0.0, not a smaller floor.** Any floor sets a non-zero std equilibrium. Reaching std ~0.05 (2.75°/joint) needs the bonus gone, not smaller.
- **7M, not 3M.** The 3M anchor was sized for a *6M* stage and never revisited when stage 1 became 10M, so decay finished in the first third and the floor governed the rest.
- **Early exploration deliberately unchanged.** Still starts at 0.005, and the first 3M now decays *more slowly* than before:

```
        0 steps: 0.005000
1,000,000 steps: 0.004286
3,000,000 steps: 0.002857   &lt;- old config was pinned at 0.001 from here on
5,000,000 steps: 0.001429
7,000,000 steps: 0.000000
```

## Falsifiable prediction — check at ~4M, not at the end

- **`algo_std` well under 0.2** — was 0.554 at 4.6M
- **`unsupported_duty` below 0.28** — was 0.282 at 4.34M

If either tracks the old curve, **this hypothesis is wrong**; kill the run rather than spending the remaining five hours. The next suspect is the learning rate (3e-5 → 1e-5 is very low for escaping a basin).

Both signals are readable from Drive mid-run without TensorBoard, and §3 is what makes the second one trustworthy: `algo_std` from `diagnostics.npz` every rollout, `unsupported_duty` from the new `gate_progress.npz` every evaluation.

---

# 2. Report every evaluation against the do-nothing policy

The deeper problem is that an 8-hour run gave no signal it was below the trivial policy. Every logged signal looked healthy: reward climbing 1583 → 2687, full-horizon **100% for 59 consecutive evaluations**, evaluation sd down to **5**, zero falls, the collapse backstop correctly silent.

`curriculum.baseline_watch.BaselineProgressCallback` reports each evaluation against the run&#39;s own captured baseline, and warns **once** if the policy has still never beaten it past a configured share of the budget. The comparison is free: `zero_action_baseline.json` is already written into every run directory before training starts, and `reward_mean` is the only field needed.

```
BaselineProgress: eval mean 2686.9 vs zero-action baseline 3271.8 (82.1% of baseline), duty ceiling 0.0200

BaselineProgress: 3500000 of 10000000 steps (35% of budget) and the policy has never beaten
the zero-action baseline — latest eval 2450.1 vs 3271.8 (74.9%). On a stage whose reward
optimum IS the do-nothing policy this means the run is in a worse-than-trivial local optimum,
not merely early. Run 20260804_143747 spent its whole 10M budget in exactly this state and
failed its gate (issue #486).
```

**Advisory only — it logs and warns, never stops.** On stage 1 the statue *is* the reward optimum (STAGE1_SPLIT_PLAN §2.3.1), so a learning policy legitimately climbs toward it from below for millions of steps; aborting on that would kill healthy runs for exactly the reason `collapse_settings_from_config` documents. The warning is about *elapsed budget with no crossing*, not the gap itself, and a run that beats the baseline at any point is never warned about again — falling back under it is the collapse backstop&#39;s job.

`baseline_warn_after_budget_fraction = 0.35` on trex 1a: 3.5M steps, ~2.9h in on that run&#39;s hardware with ~5.5h still to save, and past the point where its duty had already flattened below 0.43.

## Not repeating the dead-code mistake — and then nearly repeating it anyway

`_build_core_callbacks` gains an optional `species`, which means **a caller that omits it silently loses the watch** — precisely how the stance gate became dead code on the Colab path (#485 §1). So `sb3_training.ipynb` passes `species=SPECIES`, and a test pins that it still does.

That test passed while **both library entry points were broken**: `train_stage` and `train_curriculum` each called `_build_core_callbacks` without `species=`, so the watch was only ever constructed from the notebook — the same dead-code failure, one call site over, caught reviewing this branch. Pinning the caller I had just edited proved nothing about the two I hadn&#39;t. Both now pass it, and the replacement test walks the AST for **every** `_build_core_callbacks` call in `train_base.py`, so a third caller cannot repeat it.

`baseline_warn_after_budget_fraction` is registered in `gate_schema._DIAGNOSTIC_KEYS`, without which the fail-closed unknown-key check would make the TOML setting unreachable — the trap `max_checkpoints` and `stance_report_episodes` both hit.

---

# 3. The gate&#39;s own view of each evaluation, on disk

## `gate_progress.npz`

The deterministic panel-estimator numbers the stance gate actually tests — `full_horizon_fraction`, `duty_episodes`, `unsupported_duty`, `unsupported_duty_ucb`, `bilateral_support_duty`, `mean_reward`, against `timesteps` — were computed every evaluation and recorded **only to the SB3 logger**.

That is why diagnosing run `20260804_143747` had to substitute the *training-rollout* duty from `diagnostics.npz`, which is contaminated by exploration noise and is not the quantity the gate tests. It happened to agree to three decimals on that run. That was luck, and the 4M kill/continue decision above should not rest on it.

`StageGatePlateauCallback` now rewrites the file after each evaluation, into the **stage directory beside `diagnostics.npz`** rather than the scratch eval dir, so it syncs to Drive and can be read mid-run with three lines of numpy.

A separate file rather than columns in `diagnostics.npz` because the two are on different clocks — per evaluation versus per training rollout — and merging them would force one series to be NaN-padded against the other&#39;s timeline, which is the alignment trap `_history_algo` already works around.

## `action_abs_mean` in `diagnostics.npz`

Mean |action| is the direct distance from the zero-action statue, which under `home-keyframe-residual/v1` is exactly `action = 0`. Neither existing series gives it: signs cancel in `action_mean`, so it sits near zero even for a large-magnitude policy, and `action_abs_max` follows whichever single joint is most saturated.

It separates the two ways an entropy collapse can end — std falls and the mean settles **on** the statue, versus std falls and the mean settles on **some other committed pose** — which are indistinguishable in `algo_std` alone and mean opposite things for what to do next. `action_std` is persisted alongside it so the mean and the spread can be read from the same array.

Every series is length-guarded against its `timesteps`, and the npz write is try/excepted and warns **once**: an unwritable directory fails identically on all ~200 evaluations of a 10M run, and 200 stack traces would bury the below-baseline warning §2 exists to surface. A diagnostic must not sink an 8-hour run, and it must not drown it either.

---

## How the three fit together

They attack the same failure from opposite ends. §1 is the hypothesis for *why* the run failed. §2 and §3 are what make the next run cheap to judge whether or not that hypothesis is right — §2 says at 3.5M that the policy is still below trivial, and §3 makes the 4M numbers the decision rests on readable from the artifacts rather than reconstructed from a proxy.

## Testing

- 20 tests in `test_curriculum_baseline_watch.py`: baseline parsing (missing / corrupt / wrong species / non-finite all return `None` rather than inventing a reference), warn-once behaviour, never-warn-after-crossing, that it never stops a run, the notebook wiring, and the AST sweep over every `_build_core_callbacks` call site
- 6 tests in `TestGateProgressIsPersisted`: rows appended and the file rewritten per evaluation, instances not sharing the class-scope defaults, a missing directory created rather than dropped, an unwritable one neither sinking the run nor warning per evaluation, a short series dropped rather than written misaligned, and in-memory accumulation with no directory configured
- `_maybe_ent_coef_decay_callback` gates on `is None`, not truthiness, so `0.0` still builds the callback — checked, since a falsy-zero bug there would have silently disabled decay
- Full `environments/shared/tests` + `environments/trex/tests`: **1873 passed, 133 skipped**
- `ruff check` / `ruff format --check` clean; `mypy` clean on changed modules; `check_catalog()` up to date
- The statue baseline reproduced locally rather than taken from the run report

### One test in this PR was asserting nothing

`test_an_unwritable_directory_does_not_sink_the_run` pointed at a merely *absent* directory. `atomic_copy` calls `mkdir(parents=True)`, so the write succeeded and the test exercised the success path under a name claiming the opposite — found only because the new warn-once test asserted `== 1` and got `0`. The target is now rooted under a regular file so `mkdir` raises `NotADirectoryError`, which unlike `chmod 000` still fails when the suite runs as root, and the create-the-parents behaviour it had actually been testing is now its own named test.

## What this does not claim

That it will pass the gate. It is one hypothesis with one measured mechanism, and the 4M prediction is there so a failure is cheap and legible rather than another 8-hour ambiguity. If std collapses and duty *still* plateaus above 0.02, that is a genuinely informative negative — it would rule out exploration noise and point at the discounted objective under `gamma 0.98` rather than the episode return.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)