### PR TITLE
Decay trex stage-1 entropy to zero: the policy was being told to shake its legs by 20° for the whole run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Reproducible Runs & Velociraptor Stage-1 Diagnosis (v0.3.6)
 
+### Changed
+- **T-Rex stage 1 entropy now decays to zero, over 70% of the budget rather
+  than 30%** (`ent_coef_end` 0.001 → 0.0, `ent_coef_decay_timesteps` 3M → 7M).
+  Run `20260804_143747` trained the full 10M and finished at 2686.9 against
+  the zero-action statue's 3271.8 — **588 below the do-nothing policy** — with
+  unsupported duty pinned at 0.1668, 8.3× the gate ceiling (issue #486).
+  The cause is measured, not guessed: `ent_coef` reached its 0.001 floor at 3M
+  and held for the remaining 7M, which across 21 action dims holds the policy
+  std at equilibrium ~0.375 (`algo_std` 0.47 at 5.9M, 0.375 at 8.4M). Through
+  `_scale_action`'s residual mapping and this model's ctrlranges that std is a
+  1σ command noise of **24.4° at the hips and 18.8° at knee and ankle**, mean
+  **20.6°** across the major leg joints, resampled every control step at
+  100 Hz. A policy cannot learn to hold a pose it is being commanded to shake
+  by 20°; PPO optimises expected return *under* that noise, so it converged to
+  a 16.7 Hz limit cycle that survives its own tremor rather than to a still
+  stance.
+  The target is known reachable and known still: `action = 0` **is** the home
+  keyframe under `home-keyframe-residual/v1` and scores 3274.4 ± 7.6 with duty
+  0.0000 (measured locally with `stance_gate_report.py trex --stage 1
+  --zero-action`). So this is a convergence failure, not a reward-shaping one,
+  and the usual risk of zeroing entropy — premature convergence to a bad
+  optimum — is unusually low here.
+  Early exploration is deliberately unchanged: `ent_coef` still starts at
+  0.005, and the first 3M now decays more slowly than before. The 3M anchor
+  was sized for a 6M stage and never revisited when stage 1 became 10M.
+
 ### Fixed
 - **A stance-gated run that passed every gate still could not publish.**
   `result_bundle.evidence` refused any complete bundle whose stage declares

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -144,18 +144,48 @@ gamma = 0.98                            # Setting 4 sweep: 0.9797. Previous 0.99
 gae_lambda = 0.95
 clip_range = 0.2
 ent_coef = 0.005
-ent_coef_end = 0.001                    # Decay entropy over the stage (EntCoefDecayCallback). Velociraptor
-                                        # stages 1 & 2 both destabilized late under constant ent_coef
-                                        # (bimodal falls, action std growth); decay fixed its stage 2 and is
-                                        # enabled for its stage 1. See docs/investigations/STAGE2_RECOMMENDATIONS.md §5.
-ent_coef_decay_timesteps = 3000000      # Anchor the decay to ~half the 6M budget so ent_coef hits its 0.001 floor
-                                        # BEFORE the late std drift, instead of coasting high for the whole run. When
-                                        # unset, decay_timesteps defaults to the full stage budget
-                                        # (train_base._maybe_ent_coef_decay_callback), which is why run 20260723_204941
-                                        # never annealed: algo_std rose 1.01 -> 1.04 and the legs jittered at ~1.0
-                                        # RMS/joint for the entire run. Velociraptor stage 1 (annealed 1.01 -> 0.93,
-                                        # lowest jitter of any stage) and T-Rex stage 3 both anchor at 3M; stage 1 was
-                                        # the only balance stage missing it. See docs/investigations/TREX_STAGE1_LEG_JITTER.md.
+ent_coef_end = 0.0                      # Decay entropy to ZERO, not to a 0.001 floor. The floor is what kept run
+                                        # 20260804_143747 from ever standing still: ent_coef hit 0.001 at 3M and held
+                                        # there for the remaining 7M, and across 21 action dims that bonus holds the
+                                        # policy std at equilibrium ~0.375 indefinitely (`algo_std` 0.47 at 5.9M,
+                                        # 0.375 at 8.4M, still falling ~0.01/M -- it was never going to converge).
+                                        #
+                                        # In joint terms that std is enormous. Through `_scale_action`'s residual
+                                        # mapping and this model's ctrlranges, std 0.375 is a 1-sigma command noise of
+                                        # 24.4 deg at the hips and 18.8 deg at knee and ankle -- mean 20.6 deg across
+                                        # the major leg joints, resampled every control step at 100 Hz. A policy
+                                        # cannot learn to hold a pose it is being told to shake by 20 deg. PPO
+                                        # optimises expected return UNDER that noise, so the mean action it converges
+                                        # to is not the deterministic optimum but whatever survives its own tremor --
+                                        # in that run, a 16.7 Hz limit cycle with unsupported duty 0.1668 (issue #486).
+                                        #
+                                        # The target is known reachable and known still: `action = 0` IS the home
+                                        # keyframe under home-keyframe-residual/v1, and scores 3274.4 +/- 7.6 with
+                                        # duty 0.0000 (measured, stance_gate_report.py trex --stage 1 --zero-action).
+                                        # The trained policy scored 2686.9 -- 588 BELOW the do-nothing policy. This is
+                                        # a convergence failure, not a reward-shaping one, so the usual risk of
+                                        # zeroing entropy (premature convergence to a bad optimum) is unusually low:
+                                        # the good optimum is trivially reachable and the run's actual failure was
+                                        # never converging at all.
+                                        #
+                                        # 0.0 rather than a smaller floor because any floor sets a non-zero std
+                                        # equilibrium; std 0.05 (2.75 deg/joint, a plausible standing policy) needs
+                                        # the bonus to go away, not to get smaller.
+ent_coef_decay_timesteps = 7000000      # 70% of the 10M budget, not 30%. The old 3M anchor was chosen for a 6M
+                                        # stage (~half of it) and was never revisited when stage 1 went to 10M, so
+                                        # decay finished in the first third and the floor governed the rest. Keeping
+                                        # the decay live through 7M means entropy is still falling while the policy
+                                        # consolidates, instead of being pinned during the whole second half.
+                                        #
+                                        # Early exploration is deliberately unchanged: ent_coef still starts at 0.005
+                                        # and the first 3M now decays MORE slowly than before, so nothing about the
+                                        # early-training regime this stage depends on is tightened.
+                                        #
+                                        # Falsifiable prediction for the next run, to be checked at ~4M rather than
+                                        # at the end: `algo_std` should be well under 0.2 (it was 0.55 at 4.6M and
+                                        # 0.47 at 5.9M last run), and `unsupported_duty` should be below the 0.28 it
+                                        # showed at 4.34M. If either tracks the old curve, this hypothesis is wrong
+                                        # and the next suspect is the learning rate (3e-5 -> 1e-5 is very low).
 
 target_kl = 0.03                        # Cap destabilising late PPO updates (early-stop epochs on high approx-KL); mirrors the JAX target_kl guard.
 


### PR DESCRIPTION
Two-line config change for issue #486, with a measured mechanism and a falsifiable prediction attached.

```diff
-ent_coef_end = 0.001
-ent_coef_decay_timesteps = 3000000
+ent_coef_end = 0.0
+ent_coef_decay_timesteps = 7000000
```

## The mechanism

Run `20260804_143747` trained the full 10,002,432 steps and finished at **2686.9** against the zero-action statue's **3271.8** — 588 *below* the do-nothing policy — with unsupported duty pinned at 0.1668, 8.3× the ceiling.

`ent_coef` reached its 0.001 floor at 3M and held there for the remaining 7M. Across 21 action dims that residual bonus holds the policy std at equilibrium ~0.375:

| step | `algo_std` |
|---|---|
| 2.1M | 0.879 |
| 4.6M | 0.554 |
| 5.9M | 0.469 |
| 8.4M | **0.375** |

Still falling ~0.01 per 1M at the end — it was never going to converge inside the budget.

**What that std means physically.** Converted through `_scale_action`'s residual mapping and this model's actual ctrlranges:

| joint | 1σ command noise |
|---|---|
| hip pitch | **±24.4°** |
| knee | **±18.8°** |
| ankle | **±18.8°** |
| mean, major leg joints | **±20.6°** |

Resampled every control step, at 100 Hz, for the entire run.

**A policy cannot learn to hold a pose it is being commanded to shake by 20°.** PPO optimises expected return *under* its own action noise, so the mean action it converges to is not the deterministic optimum — it is whatever survives the tremor. In that run: a 16.7 Hz limit cycle, both feet leaving and landing together, `single_support_duty` exactly **0.0000**.

## Why this is a convergence failure, not a reward problem

Measured locally, not quoted from a run:

```
$ python environments/shared/scripts/stance_gate_report.py trex --stage 1 --zero-action --episodes 8

reward                    3274.4 +/- 7.6
mean_unsupported_duty     0.0000   (<= 0.0200)
  bilateral support       1.0000
```

Under `home-keyframe-residual/v1`, **`action = 0` *is* the home keyframe**. The gate's 0.02 ceiling is achievable under the *current* reward, by the most trivially reachable policy in the space, and the reward prefers it by 588 points on every major term.

That also makes the usual objection to zeroing entropy — premature convergence to a bad optimum — unusually weak here. The good optimum is trivial to reach, and the observed failure was never converging at all.

## The choices

**0.0, not a smaller floor.** Any floor sets a non-zero std equilibrium. Reaching std ~0.05 (2.75°/joint, a plausible standing policy) needs the bonus to go away, not to get smaller.

**7M, not 3M.** The 3M anchor was chosen for a *6M* stage (~half of it) and was never revisited when stage 1 became 10M — so decay finished in the first third and the floor governed the rest. Keeping decay live through 7M means entropy is still falling while the policy consolidates.

**Early exploration is deliberately unchanged.** `ent_coef` still starts at 0.005 and the first 3M now decays *more slowly* than before, so nothing about the early regime this stage depends on is tightened:

```
        0 steps: 0.005000
1,000,000 steps: 0.004286
3,000,000 steps: 0.002857   <- old config was pinned at 0.001 from here on
5,000,000 steps: 0.001429
7,000,000 steps: 0.000000
```

## Falsifiable prediction — check at ~4M, not at the end

If the hypothesis is right, by roughly 4M steps:

- **`algo_std` well under 0.2** — it was 0.554 at 4.6M last run
- **`unsupported_duty` below 0.28** — it was 0.282 at 4.34M last run

If either tracks the old curve, **this hypothesis is wrong** and the next suspect is the learning rate (3e-5 → 1e-5 is very low for escaping a basin). Kill the run at that point rather than spending the remaining five hours.

Both are visible live: `algo_std` and `unsupported_duty` are already logged into `diagnostics.npz` every rollout.

## Interaction with #487

Independent — this branch is cut from `main` and touches only `configs/trex/stage1_balance.toml` and the CHANGELOG. But they compose well: with #487 merged, a run that is still below the statue at 3.5M says so in the log, which is the same "kill it early" signal from a different angle. Either order works.

## Testing

Config-only, no code paths changed.

- `_maybe_ent_coef_decay_callback` gates on `is None`, not truthiness, so `0.0` still builds the callback — checked, since a falsy-zero bug there would have silently disabled decay entirely
- Full `environments/shared/tests` plus `environments/trex/tests`: **exit 0**
- `ruff check` clean; `check_catalog()` reports up to date (no regeneration needed)
- Resolved schedule verified end to end from `load_stage_config`

## What this does not claim

That it will pass the gate. It is one hypothesis with one measured mechanism, and the prediction above is there so a failure is cheap and legible rather than another 8-hour ambiguity. If std collapses and duty *still* plateaus above 0.02, that is a genuinely informative negative — it would rule out exploration noise and point at the objective PPO actually optimises (discounted return under `gamma 0.98`) rather than the episode return.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnEFdfBDkHAnVnxExdrzaG)_