### PR TITLE
Fix the pose, not the tremor: T-Rex stage 1 leg_home_pose_weight 0.5 → 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Reproducible Runs & Velociraptor Stage-1 Diagnosis (v0.3.6)
 
+### Added
+- **The deterministic policy's action, measured instead of inferred.** Every
+  action number on disk came from *training* rollouts, so all of it carried
+  exploration noise; diagnosing issue #489 meant recovering the commanded pose
+  and the tremor about it by inverting per-episode reward totals under a
+  narrowband assumption. `StageAwareEvalCallback` now measures them directly
+  during evaluation and `gate_progress.npz` carries them:
+  `action_dc_rms` (the static distance from the home keyframe, which under
+  `home-keyframe-residual/v1` is exactly `action = 0`), `action_ac_rms` (the
+  tremor about it), `action_delta`, `action_jerk`, and `action_freq_hz`.
+  The DC/AC split is the point: a pooled standard deviation over actuators and
+  time — which is what `diagnostics.action_std` computes — cannot separate
+  "sitting in the wrong place" from "shaking", and those have different causes
+  and different fixes. Measured over the post-settle window, the same one the
+  duty uses, so the reset transient does not inflate the AC term.
+- **`action_dc_per_actuator` / `action_ac_rms_per_actuator`**, the same two
+  quantities as `(n_evals, n_actuators)` matrices. Which actuators carry the
+  offset decides whether a leg-pose weight can reach it at all: `leg_home_pose`
+  covers only the leg joints, so a displacement living in the tail or neck is
+  invisible to it and unfixable by it. Logged per actuator rather than
+  per group because grouping is an analysis decision, and resolving joint names
+  through the VecEnv wrappers is exactly the kind of best-effort lookup that
+  silently returns nothing.
+- **`term_*` in `gate_progress.npz`** — every reward term, per evaluation.
+  Only `mean_reward` was kept, so comparing two runs meant comparing their
+  final checkpoints and nothing in between, with no way to ask *when* a policy
+  adopted the pose it ended up with.
+- **`action_jerk` in `diagnostics.npz`.** The environment has always emitted it
+  (it is what `reward_action_jerk` charges) and `INFO_KEYS` has always dropped
+  it, so the signal was computed every step and discarded. With both
+  differences recorded the effective frequency is free:
+  `jerk/delta = (2 sin πfΔt)²`, which unlike either alone is blind to a
+  constant offset.
+- **`stance_gate_report.py --filter-actions HZ`**, a probe for whether a
+  policy's high-frequency action content is load-bearing or waste. It
+  low-passes the action between the policy and the plant and scores *that*:
+  if the policy still stands, the tremor was waste and the fix belongs on the
+  action path; if it falls, the tremor is closed-loop stabilisation and the fix
+  belongs elsewhere (#489). Open-loop experiments on the statue bound what a
+  tremor *can* do; only filtering the real policy answers it for that policy.
+  A filtered rollout scores a **modified** policy, so the report records
+  `filter_actions_hz` and the text form prints the warning *above* the verdict
+  — a PASS obtained this way must never be mistakable for a gate result.
+
 ### Changed
 - **T-Rex stage 1 `leg_home_pose_weight` 0.5 → 1.5, and the two constants
   derived from the statue re-measured with it.** Run `20260805_011234` **passed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Reproducible Runs & Velociraptor Stage-1 Diagnosis (v0.3.6)
 
+### Changed
+- **T-Rex stage 1 `leg_home_pose_weight` 0.5 → 1.5, and the two constants
+  derived from the statue re-measured with it.** Run `20260805_011234` **passed**
+  `stance_quality/v1` — unsupported duty 0.0000 against a 0.0200 ceiling, 40/40
+  episodes at the horizon, bilateral support 1.0000, confirming the entropy
+  diagnosis in #487 — but scored **3004.3 against the zero-action statue's
+  3274.4** and never crossed it in 200 evaluations (issue #489).
+  The whole 270-point gap has one cause. Inverting the action penalties through
+  their closed forms gives a per-actuator DC offset of **0.800** with an AC
+  tremor of **rms 0.277 at an effective 22.6 Hz** (from `J/D = (2 sin πfΔt)²`,
+  which is DC-blind); reproducing that tremor on the statue matches the trained
+  policy's per-step penalties to within 2%. Both halves are open-loop fatal:
+  a static offset of just **0.10 rms falls in every direction tested**
+  (107–268 steps), and a 0.277 rms tremor collapses the statue at **every**
+  frequency from 2 to 40 Hz (38–80 steps), while `action = 0` stands
+  indefinitely. So the policy is holding a displaced pose upright with
+  closed-loop feedback that the home keyframe does not need — the tremor is the
+  cost of the pose, not a separate defect.
+  That is why the fix is not on `action_jerk_weight`, whose penalty sits at
+  1.4% of its normaliser and looks like the obvious lever. Penalising the
+  tremor attacks load-bearing feedback, and the cheapest response to a bigger
+  jerk penalty is to fall over. Raising the pose weight instead makes the
+  displaced operating point uncompetitive — the pose gap goes 85 → 255 points,
+  dominating the tremor's 112-point cost by 2.3× — and if the policy returns to
+  the home keyframe the feedback becomes unnecessary and its cost goes too:
+  **245 points, not the 112 a smoothness penalty could reach.**
+  `min_avg_reward` 1950 → **2550** and `collapse_peak_floor_reference` 3271.8 →
+  **4250.4**. Both are documented as derived from the statue (0.60× and 1.00×),
+  and neither updates itself — leaving them would arm the collapse backstop
+  against the wrong scale, the exact staleness the config's own comments warn
+  about. The new baseline is measured, not scaled: 4250.40 ± 13.86 over 40
+  episodes at noise 0.05, 100% full-horizon, from `zero_action_baseline.py`.
+  The ratios are unchanged (rail 0.60×, floor 0.45× → 1913), which is what
+  carries across a rescale; the absolute numbers do not, and neither do the
+  historical run figures quoted in the config, now flagged as old-scale.
+
 ### Added
 - **A watch on the do-nothing baseline.** Run `20260804_143747` trained T-Rex
   stage 1 for its full 10,002,432 steps — 8h 13m — and finished at **2686.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `reward_terms/eval_*`. A diagnostic that exists only in a file nobody
   opens mid-run is how the stance gate criteria stayed invisible for the whole
   of run `20260804_143747`.
+- **`stance_gate_report.py` now reports the commanded action per actuator** —
+  DC, AC rms, and the effective frequency, over the post-settle window, with
+  real joint names (`r_hip_pitch`, `r_knee`, …). This script holds the
+  environment directly rather than through VecEnv wrappers, so the
+  actuator→joint mapping is exact rather than a best-effort lookup.
+  It means **one five-minute run against an existing checkpoint** tests both
+  premises of the `leg_home_pose_weight` change: whether the tremor is
+  load-bearing (`--filter-actions`) and whether the static offset is even in
+  the leg joints, which is the other way that change can fail by construction.
+  Neither previously needed a training run to answer — they needed instrumentation
+  that did not exist.
 
 ### Changed
 - **T-Rex stage 1 `leg_home_pose_weight` 0.5 → 1.5, and the two constants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A filtered rollout scores a **modified** policy, so the report records
   `filter_actions_hz` and the text form prints the warning *above* the verdict
   — a PASS obtained this way must never be mistakable for a gate result.
+  **Wired into the training path**, not left as a manual script: with
+  `stance_probe_filter_hz` set in `[curriculum]` (5.0 on trex 1a) the artifact
+  writer re-scores the selected checkpoint after the gate report and emits
+  `stance_gate_probe_filtered.{txt,json}`, so every run answers the question
+  without anyone remembering to. Unset elsewhere, because it costs a second
+  40-episode panel per stage and per sweep trial.
+  The probe can corrupt the record two ways, and both are made structurally
+  impossible rather than left to the caller: it gets its own filenames derived
+  from the report itself, and it never writes `stance_panel_selected.csv` —
+  that file is the per-episode evidence `result_bundle.evidence` certifies a
+  stance-gated stage from, and a filtered panel there would certify a policy
+  that was never run. `stance_probe_filter_hz` is registered in
+  `gate_schema._DIAGNOSTIC_KEYS`, without which the fail-closed unknown-key
+  check would make the setting unreachable.
+- Every new evaluation series is recorded to the **SB3 logger as well as the
+  npz**, so TensorBoard and W&B carry them live: `diagnostics/eval_action_*`
+  and `reward_terms/eval_*`. A diagnostic that exists only in a file nobody
+  opens mid-run is how the stance gate criteria stayed invisible for the whole
+  of run `20260804_143747`.
 
 ### Changed
 - **T-Rex stage 1 `leg_home_pose_weight` 0.5 → 1.5, and the two constants

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Apex Predator. **Specialty:** Head-contact attack task.
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
 |---|---|---:|---:|
-| 1 — Balance | Learn to stand and balance without falling | 10M | reward ≥ 1950; full-horizon episodes ≥ 95.0%; unsupported duty ≤ 0.02; unsupported duty 95% upper bound ≤ 0.02; ≥ 40 episodes/evaluation; 3 consecutive passes |
+| 1 — Balance | Learn to stand and balance without falling | 10M | reward ≥ 2550; full-horizon episodes ≥ 95.0%; unsupported duty ≤ 0.02; unsupported duty 95% upper bound ≤ 0.02; ≥ 40 episodes/evaluation; 3 consecutive passes |
 | 2 — Locomotion | Learn forward walking/running | 8M | reward ≥ 100; episode length ≥ 750; avg. velocity ≥ 2 m/s; ≥ 10 episodes/evaluation; 3 consecutive passes |
 | 3 — Bite | Sprint to prey and make contact with the head bite proxy | 8M | reward ≥ 100; task success ≥ 50.0%; ≥ 10 episodes/evaluation; 3 consecutive passes |
 

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -63,7 +63,33 @@ action_jerk_weight = 3.0                       # Frequency-aware smoothness: pen
                                                # ~8e4, so the term is nearly free for the behaviour we want and is
                                                # charged almost entirely to chatter.
 support_conditioned_alive_fraction = 0.5       # Keep recovery headroom while making one-foot survival less profitable
-leg_home_pose_weight = 0.5                     # Softly retain the authored p5 theropod leg stance
+leg_home_pose_weight = 1.5                     # Retain the authored p5 theropod leg stance. Raised 0.5 -> 1.5 because
+                                               # run 20260805_011234 PASSED the stance gate (duty 0.0000) while scoring
+                                               # 3004.3 against the statue's 3274.4, and the whole 270-point gap traces
+                                               # to ONE cause: it holds a displaced pose it must actively stabilise
+                                               # (issue #489).
+                                               #
+                                               # Inverting its action penalties gives a per-actuator DC offset of 0.800
+                                               # with an AC tremor of rms 0.277 at an effective 22.6 Hz. Measured, both
+                                               # halves of that are open-loop fatal: a static offset of just 0.10 rms
+                                               # falls in every direction tested (107-268 steps), and a 0.277 rms tremor
+                                               # collapses the statue at EVERY frequency from 2 to 40 Hz (38-80 steps),
+                                               # while action = 0 stands indefinitely. So the tremor is not waste, it is
+                                               # the closed-loop feedback holding up a pose the home keyframe holds for
+                                               # free -- which is why the fix is here and NOT on action_jerk_weight.
+                                               # Penalising the tremor attacks load-bearing feedback, and the cheapest
+                                               # response to a bigger jerk penalty is to fall over.
+                                               #
+                                               # 1.5 sizes the pose gap (85 -> 255 points) to dominate the tremor's
+                                               # 112-point cost by 2.3x, so the displaced operating point stops being
+                                               # competitive. If the policy returns to the home keyframe the feedback
+                                               # becomes unnecessary and the tremor cost goes with it -- 245 points, not
+                                               # the 112 a smoothness penalty could reach. 2.0 (3x) is the next step if
+                                               # 1.5 does not move it.
+                                               #
+                                               # NOTE: this rescales the reward. min_avg_reward and
+                                               # collapse_peak_floor_reference below are both derived from the statue
+                                               # and were re-measured for this weight; re-derive them again if it moves.
 leg_home_pose_tolerance = 0.20                 # rad; broad enough for balancing corrections without joint locking
 head_clearance_weight = 0.35                   # Prevent the learned head-droop posture
 head_clearance_target = 0.90                   # m; settled home head tip is ~0.94 m
@@ -240,7 +266,11 @@ timesteps = 10000000
 # The 1a gate: physical stance quality, not return.
 #
 # Adopted 2026-08-01, replacing reward_and_length/v1. That gate was passable by
-# doing nothing: the statue scores 3271.8 (clearing min_avg_reward = 1950) at
+# doing nothing. Every reward figure in this block is on the leg_home_pose_weight
+# 0.5 scale in force at adoption; weight is now 1.5, which moves the statue to
+# 4250.4 and the rail to 2550 (issue #489). Kept as written because it is the
+# record of WHY the gate changed -- read the numbers as ratios to the statue.
+# The statue scored 3271.8 (clearing min_avg_reward = 1950) at
 # 1000.0 steps (clearing min_avg_episode_length = 950), which this run's own
 # zero_action_baseline.json reported as "FAILS — a statue clears this gate".
 # Worse, it also passed the policy we actually needed to reject — run
@@ -285,13 +315,19 @@ settle_steps = 200                       # [inferred], NOT measured. Duty is sco
 min_eval_episodes = 40                   # The panel size every figure above is specified at. n_eval_episodes must
                                          # match: at n=30 the bound's power and the 28%-rejection analysis no longer
                                          # describe this gate.
-min_avg_reward = 1950.0                 # Collapse RAIL, not the gate (PLANT_VALIDATION §9/§12): no reward threshold
+min_avg_reward = 2550.0                 # Collapse RAIL, not the gate (PLANT_VALIDATION §9/§12): no reward threshold
                                         # can separate a competent policy from a statue, because the statue is the
-                                        # reward optimum (3271.8 = 97.7% of the 3.35/step ceiling with zero actuation
-                                        # cost; the 97.0% quoted elsewhere is the pre-repair 3250.27 measurement).
-                                        # Sized to the one job a rail CAN do — rejecting a policy that discarded
-                                        # most of the available return — at 0.60 x the statue's standing reward at
-                                        # the 0.05 operating point (3271.8 +/- 12.0, 40 episodes).
+                                        # reward optimum. Sized to the one job a rail CAN do — rejecting a policy
+                                        # that discarded most of the available return — at 0.60 x the statue's
+                                        # standing reward at the 0.05 operating point.
+                                        #
+                                        # RE-DERIVED for leg_home_pose_weight 1.5 (issue #489). The statue is now
+                                        # 4250.40 +/- 13.86 (40 episodes, noise 0.05, 100% full-horizon, measured
+                                        # with zero_action_baseline.py on this config), so 0.60 x 4250.4 = 2550.
+                                        # Was 1950 = 0.60 x 3271.8 under weight 0.5. The FRACTION is what carries
+                                        # across the rescale; the absolute number does not, and neither do the
+                                        # historical run values quoted below, which are all on the old scale --
+                                        # compare them as ratios to the statue, not as rewards.
                                         #
                                         # Why 0.60 and not §12's 0.89: the measured collapse (run 20260731_132102,
                                         # full-horizon 93% -> 7%) bottomed at 888 = 0.27 x statue, so 0.60 clears
@@ -368,7 +404,12 @@ collapse_peak_warmup_timesteps = 1000000 # Evaluations before this step cannot S
                                          # post-150k rolling median in that run is 580.5, well under 1472.3. A
                                          # larger warm-up buys nothing and costs coverage: 1.0M leaves 88% of a 10M
                                          # budget protected, 2.5M only 72%.
-collapse_peak_floor_reference = 3271.8   # The zero-action statue's standing reward at noise 0.05, 40 episodes.
+collapse_peak_floor_reference = 4250.4   # The zero-action statue's standing reward at noise 0.05, 40 episodes.
+                                         # RE-MEASURED for leg_home_pose_weight 1.5 (issue #489): 4250.40 +/- 13.86,
+                                         # was 3271.8 under weight 0.5. The statue commands action = 0 at any weight,
+                                         # so its trajectory is unchanged and only the leg_home_pose term rescales --
+                                         # 488.93 -> 1466.80, exactly 3x. The relative floor below is therefore
+                                         # unaffected in MEANING; only its absolute value moves, 1472 -> 1913.
 collapse_peak_floor_fraction = 0.45      # RELATIVE floor (PLANT_VALIDATION §14 item 3). An absolute floor has now
                                          # failed to arm TWICE for the same reason: 2200 against run 20260731_132102
                                          # (peak 1934.1, watched a -59% collapse), then 2450 against run

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -410,6 +410,25 @@ collapse_peak_floor_reference = 4250.4   # The zero-action statue's standing rew
                                          # so its trajectory is unchanged and only the leg_home_pose term rescales --
                                          # 488.93 -> 1466.80, exactly 3x. The relative floor below is therefore
                                          # unaffected in MEANING; only its absolute value moves, 1472 -> 1913.
+stance_probe_filter_hz = 5.0             # After the gate report, re-score the SAME checkpoint with its actions
+                                         # low-passed at this cutoff and write stance_gate_probe_filtered.{txt,json}.
+                                         # Costs a second 40-episode panel (a few minutes); unset to skip.
+                                         #
+                                         # It settles the question this stage's remaining gap turns on. Run
+                                         # 20260805_011234 passed carrying a tremor of rms 0.277 at an effective
+                                         # 22.6 Hz, and whether that tremor is closed-loop stabilisation or a
+                                         # free-running buzz decides whether the fix belongs on the pose weight or
+                                         # on the action path (issue #489). Open-loop experiments on the statue
+                                         # bound what a tremor CAN do; only filtering the real policy answers it
+                                         # for that policy. If it still stands, the tremor was waste and
+                                         # leg_home_pose_weight is treating the wrong thing.
+                                         #
+                                         # 5 Hz because balance corrections are a ~1-1.4 Hz phenomenon on this
+                                         # plant (body-on-leg resonance), so 5 Hz passes the control the policy
+                                         # plausibly needs while cutting a 22.6 Hz tremor hard.
+                                         #
+                                         # The probe scores a MODIFIED policy: it gets its own filenames, never
+                                         # writes stance_panel_selected.csv, and its verdict is not a gate result.
 collapse_peak_floor_fraction = 0.45      # RELATIVE floor (PLANT_VALIDATION §14 item 3). An absolute floor has now
                                          # failed to arm TWICE for the same reason: 2200 against run 20260731_132102
                                          # (peak 1934.1, watched a -59% collapse), then 2450 against run

--- a/environments/shared/curriculum/gate_schema.py
+++ b/environments/shared/curriculum/gate_schema.py
@@ -161,6 +161,7 @@ _DIAGNOSTIC_KEYS = frozenset(
         "supplementary_episodes",
         "stance_report_episodes",
         "baseline_warn_after_budget_fraction",
+        "stance_probe_filter_hz",
     }
 )
 

--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -134,6 +134,15 @@ class DiagnosticsCallback(_BaseCallback):
         "tail_instability",
         "contact_asymmetry",
         "action_delta",
+        # The SECOND difference, alongside the first. The environment has
+        # always emitted it (it is what `reward_action_jerk` charges) and this
+        # list has always dropped it, so the signal was computed every step and
+        # discarded. Their ratio is a frequency: for a narrowband action
+        # signal, `jerk/delta = (2 sin(pi f dt))^2`, and unlike either alone it
+        # is blind to any constant offset. Recovering the 22.6 Hz tremor in
+        # issue #489 needed exactly this and had to invert it out of the
+        # per-episode reward terms instead.
+        "action_jerk",
         "heading_alignment",
         "lateral_vel",
         "forward_z",

--- a/environments/shared/eval_diagnostics.py
+++ b/environments/shared/eval_diagnostics.py
@@ -142,6 +142,12 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         self._action_delta_sum = 0.0
         self._action_jerk_sum = 0.0
         self._action_count = 0
+        # Counted separately from the samples: a difference needs two and a
+        # second difference three, and episode boundaries reset the history.
+        # Dividing all three by the sample count biases their ratio, and that
+        # ratio is what becomes a frequency.
+        self._action_delta_count = 0
+        self._action_jerk_count = 0
         self._prev_action: dict[int, Any] = {}
         self._prev_prev_action: dict[int, Any] = {}
         # Reward terms accumulate over the WHOLE episode: they are episode
@@ -165,6 +171,8 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         self._action_delta_sum = 0.0
         self._action_jerk_sum = 0.0
         self._action_count = 0
+        self._action_delta_count = 0
+        self._action_jerk_count = 0
         self._prev_action.clear()
         self._prev_prev_action.clear()
         self._reward_term_sums.clear()
@@ -200,8 +208,10 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
                 # so the numbers invert straight back through those formulas.
                 if prev is not None and prev.shape == action.shape:
                     self._action_delta_sum += float(np.sum((action - prev) ** 2))
+                    self._action_delta_count += 1
                     if prev_prev is not None and prev_prev.shape == action.shape:
                         self._action_jerk_sum += float(np.sum((action - 2.0 * prev + prev_prev) ** 2))
+                        self._action_jerk_count += 1
             self._prev_prev_action[env_index] = prev
             self._prev_action[env_index] = action
         except Exception:  # noqa: BLE001 - a diagnostic must not sink a run
@@ -283,9 +293,14 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
             var = np.maximum(self._action_sq_sum / count - mean * mean, 0.0)
             self.evaluations_action_dc.append([float(v) for v in mean])
             self.evaluations_action_ac_rms.append([float(v) for v in np.sqrt(var)])
-            # Per step, so they invert directly through the reward formulas.
-            self.evaluations_action_delta.append(self._action_delta_sum / count)
-            self.evaluations_action_jerk.append(self._action_jerk_sum / count)
+            # Per differencing opportunity, so they invert directly through
+            # the reward formulas without an edge-effect bias.
+            self.evaluations_action_delta.append(
+                self._action_delta_sum / self._action_delta_count if self._action_delta_count else float("nan")
+            )
+            self.evaluations_action_jerk.append(
+                self._action_jerk_sum / self._action_jerk_count if self._action_jerk_count else float("nan")
+            )
         else:
             self.evaluations_action_dc.append([])
             self.evaluations_action_ac_rms.append([])

--- a/environments/shared/eval_diagnostics.py
+++ b/environments/shared/eval_diagnostics.py
@@ -102,6 +102,29 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         # single support, and how much is unmeasured. Recording it every
         # evaluation is what turns that into evidence instead of a guess.
         self.evaluations_bilateral_duties: list[list[float]] = []
+        # Action statistics for the DETERMINISTIC policy, which is what the
+        # gate scores. `diagnostics.npz` records actions from training
+        # rollouts, so every number in it carries exploration noise; the
+        # quantities that matter here -- how far the commanded pose sits from
+        # the home keyframe, and how much the policy shakes about it -- are
+        # properties of the mean action and are unrecoverable from a noisy
+        # sample. Issue #489 had to invert them out of per-episode reward
+        # totals under a narrowband assumption. These measure them.
+        #
+        # Per actuator, not per group: grouping is an analysis decision, and
+        # resolving joint names through the VecEnv wrappers is exactly the kind
+        # of best-effort lookup that silently returns nothing. Recording the
+        # full vector keeps the grouping offline and impossible to get wrong
+        # here.
+        self.evaluations_action_dc: list[list[float]] = []
+        self.evaluations_action_ac_rms: list[list[float]] = []
+        self.evaluations_action_delta: list[float] = []
+        self.evaluations_action_jerk: list[float] = []
+        # Per-episode reward decomposition. Only `mean_reward` was kept, so
+        # comparing two runs meant comparing their final checkpoints and
+        # nothing in between -- there was no way to ask WHEN a policy adopted
+        # the pose it ended up with.
+        self.evaluations_reward_terms: list[dict[str, float]] = []
         self._episode_forward_sums: dict[int, float] = {}
         self._episode_forward_counts: dict[int, int] = {}
         self._current_eval_forward_velocities: list[float] = []
@@ -111,6 +134,21 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         self._episode_measured: dict[int, int] = {}
         self._current_eval_unsupported_duties: list[float] = []
         self._current_eval_bilateral_duties: list[float] = []
+        # Action accumulators, over the post-settle window so the reset
+        # transient does not inflate the AC term -- the same window the duty
+        # uses, and for the same reason.
+        self._action_sum: Any = None
+        self._action_sq_sum: Any = None
+        self._action_delta_sum = 0.0
+        self._action_jerk_sum = 0.0
+        self._action_count = 0
+        self._prev_action: dict[int, Any] = {}
+        self._prev_prev_action: dict[int, Any] = {}
+        # Reward terms accumulate over the WHOLE episode: they are episode
+        # returns, and truncating them to the post-settle window would make
+        # them incomparable with `stance_gate_report.py`'s breakdown.
+        self._reward_term_sums: dict[str, float] = {}
+        self._reward_term_episodes = 0
 
     def _reset_forward_velocity_capture(self) -> None:
         self._episode_forward_sums.clear()
@@ -122,12 +160,67 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         self._episode_measured.clear()
         self._current_eval_unsupported_duties = []
         self._current_eval_bilateral_duties = []
+        self._action_sum = None
+        self._action_sq_sum = None
+        self._action_delta_sum = 0.0
+        self._action_jerk_sum = 0.0
+        self._action_count = 0
+        self._prev_action.clear()
+        self._prev_prev_action.clear()
+        self._reward_term_sums.clear()
+        self._reward_term_episodes = 0
+
+    def _capture_action(self, locals_: dict[str, Any], env_index: int, after_settle: bool) -> None:
+        """Accumulate deterministic-policy action statistics for one step.
+
+        Wrapped defensively because ``actions`` is a local of SB3's
+        ``evaluate_policy``, not part of any documented callback contract: a
+        version that renames it must cost this diagnostic, not the run.
+        """
+        try:
+            actions = locals_.get("actions")
+            if actions is None:
+                return
+            action = np.asarray(actions)
+            action = action[env_index] if action.ndim > 1 else action
+            action = np.asarray(action, dtype=np.float64).ravel()
+            if not action.size:
+                return
+            prev = self._prev_action.get(env_index)
+            prev_prev = self._prev_prev_action.get(env_index)
+            if after_settle:
+                if self._action_sum is None or self._action_sum.shape != action.shape:
+                    self._action_sum = np.zeros_like(action)
+                    self._action_sq_sum = np.zeros_like(action)
+                self._action_sum += action
+                self._action_sq_sum += action * action
+                self._action_count += 1
+                # Both differences are summed over actuators, matching the
+                # `Sum` in `reward_action_smoothness` / `reward_action_jerk`
+                # so the numbers invert straight back through those formulas.
+                if prev is not None and prev.shape == action.shape:
+                    self._action_delta_sum += float(np.sum((action - prev) ** 2))
+                    if prev_prev is not None and prev_prev.shape == action.shape:
+                        self._action_jerk_sum += float(np.sum((action - 2.0 * prev + prev_prev) ** 2))
+            self._prev_prev_action[env_index] = prev
+            self._prev_action[env_index] = action
+        except Exception:  # noqa: BLE001 - a diagnostic must not sink a run
+            return
 
     def _log_success_callback(self, locals_: dict[str, Any], globals_: dict[str, Any]) -> None:
         """Capture evaluation velocity and duty, conditionally delegate success."""
 
         info = locals_["info"]
         env_index = int(locals_.get("i", 0))
+        for key, value in info.items():
+            if not key.startswith("reward_"):
+                continue
+            try:
+                number = float(value)
+            except (TypeError, ValueError):
+                continue
+            if math.isfinite(number):
+                self._reward_term_sums[key] = self._reward_term_sums.get(key, 0.0) + number
         forward_vel = info.get("forward_vel")
         if forward_vel is not None:
             value = float(forward_vel)
@@ -140,6 +233,7 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         # it -- and settling is the capability stage 1a exists to certify.
         step_index = self._episode_steps.get(env_index, 0)
         self._episode_steps[env_index] = step_index + 1
+        self._capture_action(locals_, env_index, after_settle=step_index >= self.settle_steps)
         if step_index >= self.settle_steps:
             stance = derive_stance_info(info)
             if stance:
@@ -165,9 +259,42 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
             # panel builder drops those rather than scoring them as zero.
             self._current_eval_unsupported_duties.append(unsupported / measured if measured else float("nan"))
             self._current_eval_bilateral_duties.append(bilateral / measured if measured else float("nan"))
+            self._reward_term_episodes += 1
+            self._prev_action.pop(env_index, None)
+            self._prev_prev_action.pop(env_index, None)
 
         if self.success_applicable:
             super()._log_success_callback(locals_, globals_)
+
+    def _publish_action_statistics(self) -> None:
+        """Reduce one evaluation's accumulators into the published series.
+
+        The DC/AC split is the whole point. ``mean(a)`` per actuator is the
+        static pose the policy commands -- the distance from the home keyframe,
+        which under ``home-keyframe-residual/v1`` is exactly ``action = 0``.
+        ``sqrt(mean(a^2) - mean(a)^2)`` is what it does *around* that pose. The
+        two answer different questions and a pooled standard deviation over
+        actuators and time (which is what ``diagnostics.action_std`` computes)
+        cannot separate them.
+        """
+        count = self._action_count
+        if count and self._action_sum is not None:
+            mean = self._action_sum / count
+            var = np.maximum(self._action_sq_sum / count - mean * mean, 0.0)
+            self.evaluations_action_dc.append([float(v) for v in mean])
+            self.evaluations_action_ac_rms.append([float(v) for v in np.sqrt(var)])
+            # Per step, so they invert directly through the reward formulas.
+            self.evaluations_action_delta.append(self._action_delta_sum / count)
+            self.evaluations_action_jerk.append(self._action_jerk_sum / count)
+        else:
+            self.evaluations_action_dc.append([])
+            self.evaluations_action_ac_rms.append([])
+            self.evaluations_action_delta.append(float("nan"))
+            self.evaluations_action_jerk.append(float("nan"))
+        episodes = self._reward_term_episodes
+        self.evaluations_reward_terms.append(
+            {key: value / episodes for key, value in self._reward_term_sums.items()} if episodes else {}
+        )
 
     def _on_step(self) -> bool:
         evaluation_due = self.eval_freq > 0 and self.n_calls % self.eval_freq == 0
@@ -180,6 +307,7 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
             self.evaluations_forward_velocities.append(list(self._current_eval_forward_velocities))
             self.evaluations_unsupported_duties.append(list(self._current_eval_unsupported_duties))
             self.evaluations_bilateral_duties.append(list(self._current_eval_bilateral_duties))
+            self._publish_action_statistics()
             if not self.success_applicable and self.verbose >= 1:
                 print(f"Success rate: N/A (not an active Stage {self.stage} gate)")
 
@@ -283,6 +411,7 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         min_relative_variation: float = 0.05,
         horizon: int = 1000,
         gate_progress_dir: "str | Path | None" = None,
+        control_dt: float = 0.01,
         verbose: int = 0,
     ) -> None:
         if not _SB3_AVAILABLE:
@@ -305,6 +434,9 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         self._histories: dict[str, list[float]] = {key: [] for key in self._METRIC_PRIORITY}
         self._plateau_active = False
         self._plateau_metric: str | None = None
+        # Seconds per control step: `timestep * frame_skip`, needed to turn the
+        # jerk/delta ratio into a frequency rather than a bare ratio.
+        self.control_dt = float(control_dt) if control_dt and control_dt > 0 else 0.01
         # Per-evaluation gate criteria, persisted to `gate_progress.npz`.
         self._gate_progress_dir = None if gate_progress_dir is None else Path(gate_progress_dir)
         self._gate_progress_timesteps: list[int] = []
@@ -542,6 +674,8 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
             ),
             bilateral_support_duty=float("nan") if bilateral is None else bilateral,
             mean_reward=panel.mean_reward,
+            **self._action_statistics(index),
+            **self._reward_term_scalars(index),
         )
         if not panel.n_duty_episodes:
             return
@@ -553,6 +687,50 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         # what made the three stance shares stop summing to 1.
         if bilateral is not None:
             self.logger.record("diagnostics/eval_bilateral_support_duty", bilateral)
+
+    def _eval_series(self, name: str, index: int) -> Any:
+        series = getattr(self.eval_callback, name, None)
+        if not series or index >= len(series):
+            return None
+        return series[index]
+
+    def _action_statistics(self, index: int) -> dict[str, float]:
+        """Scalar summaries of the deterministic policy's action.
+
+        ``action_dc_rms`` is the distance from the home keyframe and
+        ``action_ac_rms`` is the tremor about it; keeping them apart is the
+        point, because they have different causes and different fixes
+        (issue #489). The per-actuator vectors go to `gate_progress.npz`
+        separately -- these scalars exist so the series is readable without
+        reducing a matrix.
+        """
+        out: dict[str, float] = {}
+        dc = self._eval_series("evaluations_action_dc", index)
+        ac = self._eval_series("evaluations_action_ac_rms", index)
+        out["action_dc_rms"] = float(np.sqrt(np.mean(np.square(dc)))) if dc else float("nan")
+        out["action_ac_rms"] = float(np.sqrt(np.mean(np.square(ac)))) if ac else float("nan")
+        for key, name in (("action_delta", "evaluations_action_delta"), ("action_jerk", "evaluations_action_jerk")):
+            series = getattr(self.eval_callback, name, None)
+            value = series[index] if series and index < len(series) else float("nan")
+            out[key] = float(value)
+        # The frequency the two differences imply, for a narrowband action
+        # signal: jerk/delta = (2 sin(pi f dt))^2, blind to any DC offset. A
+        # value at the white-noise limit means the ratio is saturated and the
+        # signal is broadband, not that it sits at that frequency.
+        delta, jerk = out["action_delta"], out["action_jerk"]
+        if math.isfinite(delta) and math.isfinite(jerk) and delta > 0.0:
+            gain = math.sqrt(jerk / delta)
+            out["action_freq_hz"] = math.asin(min(1.0, gain / 2.0)) / (math.pi * self.control_dt)
+        else:
+            out["action_freq_hz"] = float("nan")
+        return out
+
+    def _reward_term_scalars(self, index: int) -> dict[str, float]:
+        """Per-episode mean of each reward term, flattened into the npz."""
+        terms = self._eval_series("evaluations_reward_terms", index)
+        if not terms:
+            return {}
+        return {f"term_{key[len('reward_') :]}": float(value) for key, value in terms.items()}
 
     def _record_gate_progress(self, **values: float) -> None:
         """Append one evaluation's gate criteria and rewrite ``gate_progress.npz``.
@@ -580,6 +758,29 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
 
             n = len(self._gate_progress_timesteps)
             payload = {"timesteps": np.array(self._gate_progress_timesteps)}
+            # Per-actuator DC and AC as (n_evals, n_actuators) matrices. Which
+            # actuators carry the offset decides whether a leg-pose weight can
+            # reach it at all -- `leg_home_pose` covers only the leg joints, so
+            # a displacement living in the tail or neck is invisible to it and
+            # unfixable by it (issue #489). Scalar summaries alone cannot answer
+            # that, and the grouping is left to analysis rather than guessed at
+            # here.
+            # `getattr` on self, not `self.eval_callback` directly: these
+            # matrices are an enhancement, and an AttributeError here would be
+            # caught by the outer handler and take the ENTIRE file down with
+            # it -- losing the gate criteria to a failure in a side channel.
+            source = getattr(self, "eval_callback", None)
+            for key, name in (
+                ("action_dc_per_actuator", "evaluations_action_dc"),
+                ("action_ac_rms_per_actuator", "evaluations_action_ac_rms"),
+            ):
+                series = getattr(source, name, None) or []
+                rows = [row for row in series[:n] if row]
+                # Ragged rows would need padding, which invents values. A run
+                # whose actuator count changed mid-flight is not a thing that
+                # happens; a run with some empty evaluations is.
+                if len(rows) == n and len({len(row) for row in rows}) == 1:
+                    payload[key] = np.array(rows, dtype=float)
             # Length-guarded against `timesteps`, like every optional series in
             # `diagnostics.npz`. Today one call site supplies every key on every
             # evaluation, so nothing can diverge -- but a future caller that
@@ -760,6 +961,14 @@ def build_stage_evaluation_callbacks(
         # for the full-horizon fraction, and it is an environment property.
         horizon=int(stage_config.get("env_kwargs", {}).get("max_episode_steps", 1000)),
         gate_progress_dir=gate_progress_dir,
+        # Also from [env]: one control step is `timestep * frame_skip`, and
+        # without it the jerk/delta ratio is a bare number rather than a
+        # frequency. Defaults match the MuJoCo/repo defaults so a config that
+        # declares neither still reports a sane 100 Hz rather than nothing.
+        control_dt=(
+            float(stage_config.get("env_kwargs", {}).get("timestep", 0.002))
+            * int(stage_config.get("env_kwargs", {}).get("frame_skip", 5))
+        ),
         verbose=diagnostics_verbose,
     )
     return eval_callback, plateau_callback

--- a/environments/shared/eval_diagnostics.py
+++ b/environments/shared/eval_diagnostics.py
@@ -663,6 +663,16 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
         # substitute the TRAINING-rollout duty from `diagnostics.npz`, which is
         # contaminated by exploration noise; it happened to agree to three
         # decimals there, but that was luck, not a property worth relying on.
+        # Also to the SB3 logger, so TensorBoard and W&B carry them live
+        # rather than only the npz. A diagnostic that exists solely in a file
+        # nobody opens mid-run is how the stance gate criteria stayed invisible
+        # for the whole of run 20260804_143747.
+        action_stats = self._action_statistics(index)
+        for key, value in action_stats.items():
+            if math.isfinite(value):
+                self.logger.record(f"diagnostics/eval_{key}", value)
+        for key, value in self._reward_term_scalars(index).items():
+            self.logger.record(f"reward_terms/eval_{key[len('term_') :]}", value)
         self._record_gate_progress(
             full_horizon_fraction=panel.full_horizon_fraction,
             duty_episodes=panel.n_duty_episodes,
@@ -674,7 +684,7 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
             ),
             bilateral_support_duty=float("nan") if bilateral is None else bilateral,
             mean_reward=panel.mean_reward,
-            **self._action_statistics(index),
+            **action_stats,
             **self._reward_term_scalars(index),
         )
         if not panel.n_duty_episodes:

--- a/environments/shared/reporting/stage_artifacts.py
+++ b/environments/shared/reporting/stage_artifacts.py
@@ -247,10 +247,87 @@ def _write_stance_gate_report(
             report["metrics"]["bilateral_support_duty"],
             written["stance_gate_report_txt"],
         )
+        _write_filtered_action_probe(
+            species=species,
+            stage=stage,
+            stage_config=stage_config,
+            stage_dir=stage_dir,
+            model_path=f"{selected_path}.zip",
+            vecnorm_path=selected_vecnorm,
+            episodes=report_episodes,
+        )
         return report
     except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
         logger.warning("Stance gate report failed for stage %d", stage, exc_info=True)
     return None
+
+
+def _write_filtered_action_probe(
+    *,
+    species: str,
+    stage: int,
+    stage_config: dict[str, Any],
+    stage_dir: Path,
+    model_path: str,
+    vecnorm_path: str | None,
+    episodes: int,
+) -> None:
+    """Re-score the selected checkpoint with its actions low-passed.
+
+    Answers, automatically and for every run, whether the policy's
+    high-frequency action content is load-bearing or waste: if it still stands
+    with the tremor filtered out the tremor was waste and the fix belongs on
+    the action path, and if it falls the tremor is closed-loop stabilisation
+    and the fix belongs on the pose (issue #489). Deriving that by hand meant
+    inverting per-episode reward totals and running open-loop experiments on
+    the statue, which bound what a tremor *can* do but never answer it for the
+    actual policy.
+
+    Off unless ``stance_probe_filter_hz`` is set, because it costs a second
+    panel -- a few minutes per stage, and per sweep trial.
+
+    Writes ``stance_gate_probe_filtered.{txt,json}`` and deliberately NOT
+    ``stance_panel_selected.csv``; the probe scored a modified policy and must
+    never supply the evidence a bundle is certified from.
+    """
+    cutoff = stage_config.get("curriculum_kwargs", {}).get("stance_probe_filter_hz")
+    if cutoff is None:
+        return
+    try:
+        cutoff = float(cutoff)
+    except (TypeError, ValueError):
+        logger.warning("stance_probe_filter_hz is not a number: %r; skipping the probe", cutoff)
+        return
+    if cutoff <= 0:
+        logger.info("Filtered action probe skipped for stage %d: stance_probe_filter_hz = %g", stage, cutoff)
+        return
+    try:
+        from environments.shared.scripts.stance_gate_report import (
+            build_stance_gate_report,
+            write_stance_gate_report,
+        )
+
+        probe = build_stance_gate_report(
+            species,
+            stage,
+            stage_config=stage_config,
+            model_path=model_path,
+            vecnorm_path=vecnorm_path,
+            episodes=episodes,
+            filter_actions_hz=cutoff,
+        )
+        written = write_stance_gate_report(stage_dir, probe)
+        logger.info(
+            "Filtered action probe (%.4g Hz): reward %.1f, full-horizon %.4f, duty %.4f -> %s. "
+            "This scored a MODIFIED policy and is not a gate verdict.",
+            cutoff,
+            probe["metrics"]["reward_mean"],
+            probe["metrics"]["full_horizon_fraction"],
+            probe["metrics"]["mean_unsupported_duty"],
+            written["stance_gate_report_txt"],
+        )
+    except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
+        logger.warning("Filtered action probe failed for stage %d", stage, exc_info=True)
 
 
 def _apply_stage_gate(

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -635,8 +635,17 @@ def write_stance_gate_report(stage_dir: "str | Path", report: dict[str, Any]) ->
     """
     directory = Path(stage_dir)
     directory.mkdir(parents=True, exist_ok=True)
-    text_path = directory / "stance_gate_report.txt"
-    json_path = directory / "stance_gate_report.json"
+    # A filtered rollout scored a MODIFIED policy, so it gets its own filenames
+    # and never the certification ones. Derived here rather than passed in so a
+    # caller cannot land a probe on top of the real verdict by forgetting an
+    # argument -- and `stance_panel_selected.csv` is skipped entirely below,
+    # because that file is the per-episode evidence `result_bundle.evidence`
+    # certifies a stance-gated stage from. Writing a filtered panel there would
+    # certify a policy that was never run.
+    probe = report.get("filter_actions_hz") is not None
+    stem = "stance_gate_probe_filtered" if probe else "stance_gate_report"
+    text_path = directory / f"{stem}.txt"
+    json_path = directory / f"{stem}.json"
     text_path.write_text(render_stance_gate_report(report) + "\n", encoding="utf-8")
     # allow_nan=False turns any non-finite value _json_safe missed into a
     # ValueError here rather than an unparseable artifact on Drive.
@@ -645,6 +654,8 @@ def write_stance_gate_report(stage_dir: "str | Path", report: dict[str, Any]) ->
         encoding="utf-8",
     )
     written = {"stance_gate_report_txt": text_path, "stance_gate_report_json": json_path}
+    if probe:
+        return written
     panel_path = write_stance_panel_evidence(directory, report)
     if panel_path is not None:
         written["stance_panel_csv"] = panel_path

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -287,6 +287,11 @@ def _roll_episodes(
     """
     for index in range(episodes):
         obs, _ = env.reset(seed=seed + index)
+        # A stateful predict (the low-pass probe) must not carry one episode's
+        # tail into the next; plain policies have no reset and are untouched.
+        reset_predict = getattr(predict, "reset", None)
+        if callable(reset_predict):
+            reset_predict()
         total = 0.0
         steps = 0
         unsupported = 0
@@ -345,6 +350,47 @@ def thresholds_from_curriculum(curriculum: dict[str, Any]) -> StanceGateThreshol
     )
 
 
+def _low_pass_predict(predict: Any, cutoff_hz: float, control_dt: float) -> Any:
+    """Wrap *predict* so its action is low-passed before reaching the plant.
+
+    A probe, not a feature: it answers whether a policy's high-frequency
+    action content is load-bearing or waste. Run ``20260805_011234`` passed
+    the stance gate carrying a tremor of rms 0.277 at an effective 22.6 Hz,
+    and whether that tremor is closed-loop stabilisation or a free-running
+    buzz decides whether the fix belongs on the pose or on the action path
+    (issue #489). Open-loop experiments on the statue bound what a tremor
+    *can* do; only filtering the real policy answers it for that policy.
+
+    First-order IIR, ``y += alpha * (x - y)`` with
+    ``alpha = dt / (RC + dt)`` and ``RC = 1 / (2*pi*fc)`` -- the discrete
+    equivalent of an RC filter, chosen because it is the one a plant-side
+    implementation would most plausibly use. Filtering happens between the
+    policy and the environment, so the policy still sees unfiltered
+    observations and is genuinely being asked to stand without its own
+    high-frequency component.
+
+    The state is per-call-sequence and reset by the caller between episodes
+    via :func:`reset`, so one episode's tail cannot leak into the next.
+    """
+    rc = 1.0 / (2.0 * math.pi * cutoff_hz)
+    alpha = control_dt / (rc + control_dt)
+    state: dict[str, Any] = {"y": None}
+
+    def filtered(obs: np.ndarray) -> np.ndarray:
+        action = np.asarray(predict(obs), dtype=np.float64)
+        previous = state["y"]
+        # Seeded with the first action rather than zeros: starting from zero
+        # would inject a step transient that is an artefact of the probe, not
+        # a property of the policy.
+        state["y"] = (
+            action if previous is None or previous.shape != action.shape else previous + alpha * (action - previous)
+        )
+        return np.asarray(state["y"], dtype=np.float32)
+
+    filtered.reset = lambda: state.update(y=None)  # type: ignore[attr-defined]
+    return filtered
+
+
 def build_stance_gate_report(
     species: str,
     stage: int,
@@ -356,6 +402,7 @@ def build_stance_gate_report(
     episodes: int | None = None,
     seed: int = 3042,
     allow_legacy_plant: bool = False,
+    filter_actions_hz: float | None = None,
 ) -> dict[str, Any]:
     """Roll a policy and return its gate verdict as a serializable dict.
 
@@ -376,9 +423,12 @@ def build_stance_gate_report(
     """
     if episodes is not None and episodes < 1:
         raise ValueError(f"episodes must be at least 1 if given, got {episodes}")
+    if filter_actions_hz is not None and filter_actions_hz <= 0:
+        raise ValueError(f"filter_actions_hz must be positive if given, got {filter_actions_hz}")
     curriculum = stage_config["curriculum_kwargs"]
     env_kwargs = dict(stage_config["env_kwargs"])
     horizon = int(env_kwargs.get("max_episode_steps", 1000))
+    control_dt = float(env_kwargs.get("timestep", 0.002)) * int(env_kwargs.get("frame_skip", 5))
     thresholds = thresholds_from_curriculum(curriculum)
     panel_episodes = thresholds.min_eval_episodes if episodes is None else episodes
 
@@ -407,6 +457,10 @@ def build_stance_gate_report(
             allow_legacy_plant=allow_legacy_plant,
         )
         description = f"{Path(model_path).name} — {note}"
+
+    if filter_actions_hz is not None:
+        predict = _low_pass_predict(predict, filter_actions_hz, control_dt)
+        description += f" — actions low-passed at {filter_actions_hz:g} Hz"
 
     result = run_panel(
         species,
@@ -460,6 +514,12 @@ def build_stance_gate_report(
         # field is deliberately narrow rather than a blanket "plant_validated"
         # that would claim something false in the zero-action case.
         "checkpoint_plant_validated": None if zero_action else not allow_legacy_plant,
+        # `None` for an ordinary run. Recorded because a filtered rollout is
+        # NOT a verdict about the policy: it is a probe of a modified one, and
+        # a PASS produced this way must never be mistakable for a real PASS in
+        # a stored report. `render_stance_gate_report` prints it for the same
+        # reason.
+        "filter_actions_hz": filter_actions_hz,
         "terminations": result["terminations"],
         "reward_components": result["components"],
         # The per-episode measurements the panel was reduced from. This is
@@ -483,6 +543,15 @@ def render_stance_gate_report(report: dict[str, Any]) -> str:
             "below are reported but are not what this stage advances on."
         )
         lines.append("")
+    # Before the verdict, not after: a filtered rollout scores a MODIFIED
+    # policy, so its PASS/FAIL is not a statement about the checkpoint and a
+    # reader must not reach the verdict line without knowing that.
+    if report.get("filter_actions_hz") is not None:
+        lines += [
+            f"PROBE: actions low-passed at {report['filter_actions_hz']:g} Hz before reaching the plant.",
+            "This scores a MODIFIED policy. The verdict below is not a gate result for this checkpoint.",
+            "",
+        ]
     measured = report["horizon"] - report["settle_steps"]
     lines += [
         f"policy              {report['policy']}",
@@ -655,10 +724,21 @@ def main() -> int:
     parser.add_argument("--seed", type=int, default=3042, help="First evaluation seed (default: publication seed)")
     parser.add_argument("--config", help="Explicit stage TOML path")
     parser.add_argument("--out-dir", help="Also write stance_gate_report.{txt,json} to this directory")
+    parser.add_argument(
+        "--filter-actions",
+        type=float,
+        metavar="HZ",
+        help="Low-pass the policy's actions at HZ before they reach the plant, and score THAT. "
+        "A probe for whether a policy's high-frequency action content is load-bearing: if it "
+        "still stands, the tremor was waste and belongs on the action path; if it falls, the "
+        "tremor is closed-loop stabilisation and the fix belongs elsewhere (issue #489).",
+    )
     args = parser.parse_args()
 
     if not args.zero_action and not args.model:
         parser.error("pass --model, or --zero-action for the do-nothing reference")
+    if args.filter_actions is not None and args.filter_actions <= 0:
+        parser.error(f"--filter-actions must be positive, got {args.filter_actions}")
     # `--episodes 0` used to fall through `episodes or min_eval_episodes` to the
     # stage default AND skip the under-powered-panel warning below, so it
     # silently produced a full-size panel while reading as an override.
@@ -677,6 +757,7 @@ def main() -> int:
             episodes=args.episodes,
             seed=args.seed,
             allow_legacy_plant=args.allow_legacy_plant,
+            filter_actions_hz=args.filter_actions,
         )
     except StanceGateReportError as exc:
         # The CLI boundary is where a diagnosable failure becomes an exit

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -163,6 +163,7 @@ def run_panel(
     horizon: int,
     env_kwargs: dict[str, Any],
     plant_identity: Any = None,
+    control_dt: float = 0.01,
 ) -> dict[str, Any]:
     """Roll ``episodes`` deterministic episodes and reduce them for the gate.
 
@@ -194,8 +195,15 @@ def run_panel(
     # keeps paying the airborne penalty is being funded by some other term;
     # which one is not guessable from the aggregate score.
     components: dict[str, float] = {}
+    # Per-actuator action statistics. Which actuators carry a static offset
+    # decides whether a leg-pose weight can reach it at all: `leg_home_pose`
+    # covers only the leg joints, so a displacement living in the tail or neck
+    # is invisible to it and unfixable by it (issue #489).
+    action_stats = _new_action_stats()
+    joint_names: list[str] = []
 
     try:
+        joint_names = _actuator_joint_names(env)
         _roll_episodes(
             env,
             predict=predict,
@@ -209,6 +217,7 @@ def run_panel(
             single_duties=single_duties,
             terminations=terminations,
             components=components,
+            action_stats=action_stats,
         )
     finally:
         env.close()
@@ -243,6 +252,7 @@ def run_panel(
         "components": {key: value / episodes for key, value in components.items()},
         "bilateral_duty": _full_horizon_mean(bilateral_duties),
         "single_duty": _full_horizon_mean(single_duties),
+        "action": _reduce_action_stats(action_stats, joint_names, control_dt),
         # The measurements the panel was reduced from. Kept rather than
         # discarded so the report can serialize the evidence, not only its
         # summary: an aggregate cannot be re-checked, and duty is the one
@@ -265,6 +275,111 @@ def run_panel(
     }
 
 
+def _new_action_stats() -> dict[str, Any]:
+    return {
+        "sum": None,
+        "sq_sum": None,
+        "count": 0,
+        "delta": 0.0,
+        "jerk": 0.0,
+        # Counted separately: a difference needs two samples and a second
+        # difference three, and episode boundaries reset the history, so
+        # dividing all three by the sample count biases the ratio -- and the
+        # ratio is what becomes a frequency.
+        "delta_count": 0,
+        "jerk_count": 0,
+        "prev": None,
+        "prev_prev": None,
+    }
+
+
+def _accumulate_action(stats: dict[str, Any], action: np.ndarray) -> None:
+    """Accumulate one post-settle action into the per-actuator statistics."""
+    if stats["sum"] is None or stats["sum"].shape != action.shape:
+        stats["sum"] = np.zeros_like(action)
+        stats["sq_sum"] = np.zeros_like(action)
+    stats["sum"] += action
+    stats["sq_sum"] += action * action
+    stats["count"] += 1
+    prev, prev_prev = stats["prev"], stats["prev_prev"]
+    if prev is not None and prev.shape == action.shape:
+        # Summed over actuators, matching the `Sum` in the reward terms so
+        # these invert straight back through `reward_action_smoothness` and
+        # `reward_action_jerk`.
+        stats["delta"] += float(np.sum((action - prev) ** 2))
+        stats["delta_count"] += 1
+        if prev_prev is not None and prev_prev.shape == action.shape:
+            stats["jerk"] += float(np.sum((action - 2.0 * prev + prev_prev) ** 2))
+            stats["jerk_count"] += 1
+    stats["prev_prev"] = prev
+    stats["prev"] = action
+
+
+def _actuator_joint_names(env: Any) -> list[str]:
+    """Names of the joint each actuator drives, or ``[]`` if unavailable.
+
+    Unlike the training callback -- which reaches the environment only through
+    VecEnv wrappers and so cannot resolve these without a best-effort lookup
+    that silently returns nothing -- this script holds the env directly, so the
+    mapping is exact and the per-actuator report can be read by joint rather
+    than by index.
+    """
+    try:
+        import mujoco
+
+        model = env.unwrapped.model
+        names = []
+        for index in range(model.nu):
+            joint_id = int(model.actuator_trnid[index, 0])
+            name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
+            names.append(name or f"actuator_{index}")
+        return names
+    except Exception:  # noqa: BLE001 - names are a convenience, not the measurement
+        return []
+
+
+def _reduce_action_stats(stats: dict[str, Any], names: list[str], control_dt: float) -> dict[str, Any]:
+    """Reduce the accumulators into the report's ``action`` block.
+
+    The DC/AC split is the point. ``mean(a)`` per actuator is the static pose
+    the policy commands -- under ``home-keyframe-residual/v1`` the distance
+    from the home keyframe, since ``action = 0`` *is* that keyframe -- and the
+    spread about it is what the policy does on top. They have different causes
+    and different fixes, and a single pooled number cannot tell them apart
+    (issue #489).
+    """
+    count = stats["count"]
+    if not count or stats["sum"] is None:
+        return {}
+    mean = stats["sum"] / count
+    var = np.maximum(stats["sq_sum"] / count - mean * mean, 0.0)
+    ac = np.sqrt(var)
+    delta = stats["delta"] / stats["delta_count"] if stats["delta_count"] else 0.0
+    jerk = stats["jerk"] / stats["jerk_count"] if stats["jerk_count"] else 0.0
+    # For a narrowband action signal `jerk/delta = (2 sin(pi f dt))^2`, blind
+    # to any constant offset. At the white-noise limit the ratio saturates,
+    # which means broadband rather than a tone at that frequency.
+    freq = float("nan")
+    if delta > 0.0:
+        freq = math.asin(min(1.0, math.sqrt(jerk / delta) / 2.0)) / (math.pi * control_dt)
+    return {
+        "dc_rms": float(np.sqrt(np.mean(mean * mean))),
+        "ac_rms": float(np.sqrt(np.mean(var))),
+        "delta_per_step": float(delta),
+        "jerk_per_step": float(jerk),
+        "effective_freq_hz": freq,
+        "per_actuator": [
+            {
+                "index": index,
+                "joint": names[index] if index < len(names) else f"actuator_{index}",
+                "dc": float(mean[index]),
+                "ac_rms": float(ac[index]),
+            }
+            for index in range(mean.size)
+        ],
+    }
+
+
 def _roll_episodes(
     env: Any,
     *,
@@ -279,6 +394,7 @@ def _roll_episodes(
     single_duties: list[float],
     terminations: dict[str, int],
     components: dict[str, float],
+    action_stats: dict[str, Any],
 ) -> None:
     """Roll the panel, appending per-episode measurements to the given lists.
 
@@ -299,7 +415,12 @@ def _roll_episodes(
         single = 0
         measured = 0
         while True:
-            obs, reward, terminated, truncated, info = env.step(predict(obs))
+            action = np.asarray(predict(obs), dtype=np.float64).ravel()
+            # Post-settle only, the same window the duty uses, so the reset
+            # transient does not read as tremor.
+            if steps >= settle_steps:
+                _accumulate_action(action_stats, action)
+            obs, reward, terminated, truncated, info = env.step(action)
             total += float(reward)
             for key, value in info.items():
                 if key.startswith("reward_") and key != "reward_total":
@@ -319,6 +440,9 @@ def _roll_episodes(
                 reason = info.get("termination_reason", "terminated" if terminated else "truncated")
                 terminations[reason] = terminations.get(reason, 0) + 1
                 break
+        # An episode boundary is not an action difference.
+        action_stats["prev"] = None
+        action_stats["prev_prev"] = None
         lengths.append(float(steps))
         rewards.append(total)
         # All three shares stay positionally aligned with `lengths`, so the
@@ -471,6 +595,7 @@ def build_stance_gate_report(
         horizon=horizon,
         env_kwargs=env_kwargs,
         plant_identity=plant_identity,
+        control_dt=control_dt,
     )
     panel = result["panel"]
     passed, failures = evaluate_stance_gate(panel, thresholds)
@@ -520,6 +645,9 @@ def build_stance_gate_report(
         # a stored report. `render_stance_gate_report` prints it for the same
         # reason.
         "filter_actions_hz": filter_actions_hz,
+        # Where the commanded pose sits and what the policy does around it,
+        # per actuator. `{}` when no post-settle step was measured.
+        "action": result.get("action", {}),
         "terminations": result["terminations"],
         "reward_components": result["components"],
         # The per-episode measurements the panel was reduced from. This is
@@ -579,6 +707,23 @@ def render_stance_gate_report(report: dict[str, Any]) -> str:
         for key in sorted(components, key=lambda k: -abs(components[k])):
             if abs(components[key]) > 0.05:
                 lines.append(f"  {key:28s} {components[key]:10.2f}")
+    action = report.get("action") or {}
+    if action:
+        lines += [
+            "",
+            "commanded action, post-settle "
+            f"(DC {action['dc_rms']:.3f} rms, AC {action['ac_rms']:.3f} rms, "
+            f"~{action['effective_freq_hz']:.1f} Hz):",
+            "  DC is the distance from the home keyframe (action = 0 IS that pose);",
+            "  AC is what the policy does around it. Different causes, different fixes.",
+        ]
+        per_actuator = action.get("per_actuator") or []
+        # Largest offset first: the question this answers is WHICH joints are
+        # displaced, because a leg-pose weight can only reach the leg ones.
+        for entry in sorted(per_actuator, key=lambda e: -abs(e["dc"]))[:12]:
+            lines.append(f"  {entry['joint']:28s} DC {entry['dc']:+7.3f}   AC {entry['ac_rms']:6.3f}")
+        if len(per_actuator) > 12:
+            lines.append(f"  ... {len(per_actuator) - 12} more (full list in the JSON)")
     lines += ["", f"GATE: {'PASS' if report['passed'] else 'FAIL'}"]
     lines += [f"  - {failure}" for failure in report["failures"]]
     return "\n".join(lines)

--- a/environments/shared/tests/test_diagnostics.py
+++ b/environments/shared/tests/test_diagnostics.py
@@ -536,3 +536,27 @@ class TestSaveThrottle:
         cb._on_training_end()  # final flush writes the full history
         data = np.load(str(tmp_path / "diagnostics.npz"))
         assert len(data["timesteps"]) == 2
+
+
+class TestActionJerkIsNotDiscarded:
+    """The environment emitted `action_jerk` every step and nothing kept it.
+
+    `INFO_KEYS` carried `action_delta` but not its second difference, so the
+    signal `reward_action_jerk` charges was computed and thrown away. Their
+    ratio is a frequency — `jerk/delta = (2 sin(pi f dt))^2`, blind to any
+    constant offset — and recovering the 22.6 Hz tremor in issue #489 had to
+    invert it back out of per-episode reward totals instead of reading it.
+    """
+
+    def test_both_action_differences_are_tracked(self):
+        from environments.shared.diagnostics import DiagnosticsCallback
+
+        assert "action_delta" in DiagnosticsCallback.INFO_KEYS
+        assert "action_jerk" in DiagnosticsCallback.INFO_KEYS
+
+    def test_the_trex_env_actually_emits_it(self):
+        """A tracked key the environment never sets is a silently empty column."""
+        from pathlib import Path
+
+        source = (Path(__file__).resolve().parents[3] / "environments/trex/envs/trex_env.py").read_text()
+        assert 'info["action_jerk"]' in source

--- a/environments/shared/tests/test_eval_diagnostics.py
+++ b/environments/shared/tests/test_eval_diagnostics.py
@@ -69,6 +69,8 @@ def _bare_stage_aware_callback(
     callback._action_delta_sum = 0.0
     callback._action_jerk_sum = 0.0
     callback._action_count = 0
+    callback._action_delta_count = 0
+    callback._action_jerk_count = 0
     callback._prev_action = {}
     callback._prev_prev_action = {}
     callback._reward_term_sums = {}
@@ -1007,9 +1009,10 @@ class TestDeterministicActionStatistics:
         # first, and the second difference is -/+4.
         self._feed(callback, [[1.0], [-1.0]] * 8, done_at=15)
         callback._publish_action_statistics()
-        # 15 of 16 steps have a previous action; 14 have two.
-        assert callback.evaluations_action_delta[0] == pytest.approx(15 * 4.0 / 16)
-        assert callback.evaluations_action_jerk[0] == pytest.approx(14 * 16.0 / 16)
+        # Averaged over differencing opportunities, not samples: 15 pairs and
+        # 14 triples, so the alternation reads as its exact amplitude.
+        assert callback.evaluations_action_delta[0] == pytest.approx(4.0)
+        assert callback.evaluations_action_jerk[0] == pytest.approx(16.0)
 
     def test_the_settling_window_is_excluded(self):
         """Same window as the duty: the reset transient is not the tremor."""
@@ -1038,8 +1041,10 @@ class TestDeterministicActionStatistics:
         self._feed(callback, [[-1.0]], done_at=0)
         callback._publish_action_statistics()
         # Two episodes of one step each: no within-episode pair exists, so the
-        # boundary jump of 2.0 must not be charged.
-        assert callback.evaluations_action_delta[0] == pytest.approx(0.0)
+        # boundary jump of 2.0 must not be charged. NaN rather than 0.0,
+        # because nothing was measured -- 0.0 would read as "perfectly smooth".
+        assert math.isnan(callback.evaluations_action_delta[0])
+        assert callback._action_delta_count == 0
 
     def test_reward_terms_are_averaged_per_episode(self):
         callback = _bare_stage_aware_callback(success_applicable=False)

--- a/environments/shared/tests/test_eval_diagnostics.py
+++ b/environments/shared/tests/test_eval_diagnostics.py
@@ -1,6 +1,7 @@
 """Tests for stage-aware SB3 evaluation diagnostics."""
 
 import logging
+import math
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock, patch
@@ -58,6 +59,20 @@ def _bare_stage_aware_callback(
     callback._episode_measured = {}
     callback._current_eval_unsupported_duties = []
     callback._current_eval_bilateral_duties = []
+    callback.evaluations_action_dc = []
+    callback.evaluations_action_ac_rms = []
+    callback.evaluations_action_delta = []
+    callback.evaluations_action_jerk = []
+    callback.evaluations_reward_terms = []
+    callback._action_sum = None
+    callback._action_sq_sum = None
+    callback._action_delta_sum = 0.0
+    callback._action_jerk_sum = 0.0
+    callback._action_count = 0
+    callback._prev_action = {}
+    callback._prev_prev_action = {}
+    callback._reward_term_sums = {}
+    callback._reward_term_episodes = 0
     return callback
 
 
@@ -950,3 +965,127 @@ class TestGateProgressIsPersisted:
         cb.num_timesteps = 50_000
         cb._record_gate_progress(unsupported_duty=0.42)
         assert cb._gate_progress["unsupported_duty"] == [0.42]
+
+
+class TestDeterministicActionStatistics:
+    """The gate scores the deterministic policy; only training rollouts were logged.
+
+    Issue #489 had to recover the commanded pose and the tremor about it by
+    inverting per-episode reward totals under a narrowband assumption, because
+    every action number on disk came from exploration-noisy training rollouts.
+    """
+
+    @staticmethod
+    def _feed(callback, actions, *, env_index=0, done_at=None, info=None):
+        for step, action in enumerate(actions):
+            callback._log_success_callback(
+                {
+                    "i": env_index,
+                    "done": done_at is not None and step == done_at,
+                    "info": dict(info or {}),
+                    "actions": np.array([action]),
+                },
+                {},
+            )
+
+    def test_dc_and_ac_are_separated(self):
+        """A steady offset with a tremor on top must not read as one number."""
+        callback = _bare_stage_aware_callback(success_applicable=False)
+        # Two actuators: the first holds 0.5 and shakes +/-0.1, the second
+        # holds 0.0 and is still. A pooled std cannot express that.
+        self._feed(callback, [[0.6, 0.0], [0.4, 0.0]] * 10, done_at=19)
+        callback._publish_action_statistics()
+        dc = callback.evaluations_action_dc[0]
+        ac = callback.evaluations_action_ac_rms[0]
+        assert dc == pytest.approx([0.5, 0.0])
+        assert ac == pytest.approx([0.1, 0.0])
+
+    def test_differences_invert_through_the_reward_formulas(self):
+        """Sums are over actuators, so they feed straight back into the terms."""
+        callback = _bare_stage_aware_callback(success_applicable=False)
+        # Alternating +/-1 on one actuator: |delta| = 2 every step after the
+        # first, and the second difference is -/+4.
+        self._feed(callback, [[1.0], [-1.0]] * 8, done_at=15)
+        callback._publish_action_statistics()
+        # 15 of 16 steps have a previous action; 14 have two.
+        assert callback.evaluations_action_delta[0] == pytest.approx(15 * 4.0 / 16)
+        assert callback.evaluations_action_jerk[0] == pytest.approx(14 * 16.0 / 16)
+
+    def test_the_settling_window_is_excluded(self):
+        """Same window as the duty: the reset transient is not the tremor."""
+        callback = _bare_stage_aware_callback(success_applicable=False, settle_steps=4)
+        self._feed(callback, [[9.0]] * 4 + [[1.0]] * 4, done_at=7)
+        callback._publish_action_statistics()
+        assert callback.evaluations_action_dc[0] == pytest.approx([1.0])
+
+    def test_an_evaluation_with_no_actions_records_nan_not_zero(self):
+        callback = _bare_stage_aware_callback(success_applicable=False)
+        callback._publish_action_statistics()
+        assert callback.evaluations_action_dc[0] == []
+        assert math.isnan(callback.evaluations_action_delta[0])
+
+    def test_a_missing_actions_local_does_not_raise(self):
+        """`actions` is a local of SB3's evaluate_policy, not a contract."""
+        callback = _bare_stage_aware_callback(success_applicable=False)
+        callback._log_success_callback({"i": 0, "done": True, "info": {}}, {})
+        callback._publish_action_statistics()
+        assert callback.evaluations_action_dc[0] == []
+
+    def test_episodes_do_not_leak_their_last_action_into_the_next(self):
+        """The difference across an episode boundary is not a real difference."""
+        callback = _bare_stage_aware_callback(success_applicable=False)
+        self._feed(callback, [[1.0]], done_at=0)
+        self._feed(callback, [[-1.0]], done_at=0)
+        callback._publish_action_statistics()
+        # Two episodes of one step each: no within-episode pair exists, so the
+        # boundary jump of 2.0 must not be charged.
+        assert callback.evaluations_action_delta[0] == pytest.approx(0.0)
+
+    def test_reward_terms_are_averaged_per_episode(self):
+        callback = _bare_stage_aware_callback(success_applicable=False)
+        self._feed(callback, [[0.0]] * 4, done_at=3, info={"reward_energy": -1.0})
+        callback._publish_action_statistics()
+        assert callback.evaluations_reward_terms[0] == {"reward_energy": pytest.approx(-4.0)}
+
+
+class TestGateProgressCarriesTheNewSeries:
+    @staticmethod
+    def _plateau(eval_callback, tmp_path):
+        cb = object.__new__(StageGatePlateauCallback)
+        cb._gate_progress_dir = tmp_path
+        cb.num_timesteps = 50_000
+        cb.eval_callback = eval_callback
+        cb.control_dt = 0.01
+        return cb
+
+    def test_action_statistics_and_terms_reach_the_file(self, tmp_path):
+        ev = _bare_stage_aware_callback(success_applicable=False)
+        ev.evaluations_action_dc = [[0.8, 0.8]]
+        ev.evaluations_action_ac_rms = [[0.2, 0.2]]
+        ev.evaluations_action_delta = [1.0]
+        ev.evaluations_action_jerk = [1.699]
+        ev.evaluations_reward_terms = [{"reward_energy": -53.68}]
+        cb = self._plateau(ev, tmp_path)
+        cb._record_gate_progress(**cb._action_statistics(0), **cb._reward_term_scalars(0))
+        data = np.load(tmp_path / "gate_progress.npz")
+        assert data["action_dc_rms"][0] == pytest.approx(0.8)
+        assert data["action_ac_rms"][0] == pytest.approx(0.2)
+        assert data["term_energy"][0] == pytest.approx(-53.68)
+        # jerk/delta = 1.699 -> 2 sin(pi f dt) = 1.3034 -> ~22.6 Hz, the
+        # tremor issue #489 had to derive by inverting reward totals.
+        assert data["action_freq_hz"][0] == pytest.approx(22.6, abs=0.2)
+        assert data["action_dc_per_actuator"].shape == (1, 2)
+
+    def test_a_constant_action_reports_zero_frequency_not_nan(self, tmp_path):
+        ev = _bare_stage_aware_callback(success_applicable=False)
+        ev.evaluations_action_dc = [[0.5]]
+        ev.evaluations_action_ac_rms = [[0.0]]
+        ev.evaluations_action_delta = [0.0]
+        ev.evaluations_action_jerk = [0.0]
+        ev.evaluations_reward_terms = [{}]
+        cb = self._plateau(ev, tmp_path)
+        stats = cb._action_statistics(0)
+        # delta == 0 leaves the ratio undefined; NaN is the honest answer and
+        # 0 Hz would read as a measured slow drift.
+        assert math.isnan(stats["action_freq_hz"])
+        assert stats["action_dc_rms"] == pytest.approx(0.5)

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -172,7 +172,10 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
     # everyone else the 100.0 placeholder) were all cleared by their own
     # species' statue and certified nothing.
     stage_one_min_avg_reward = {
-        "trex": 1950.0,
+        # 0.60 x the statue's standing reward, which moved with
+        # leg_home_pose_weight 0.5 -> 1.5: statue 3271.8 -> 4250.4 (issue #489).
+        # The FRACTION is the invariant here, not the absolute reward.
+        "trex": 2550.0,
         "velociraptor": 1050.0,
         "brachiosaurus": 1040.0,
         "dibothrosuchus": 1560.0,

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -16,6 +16,7 @@ import csv
 import pickle
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from environments.shared.scripts import stance_gate_report
@@ -949,3 +950,99 @@ class TestStancePanelEvidenceFile:
         written = write_stance_gate_report(tmp_path, report)
         assert "stance_panel_csv" not in written
         assert not (tmp_path / "stance_panel_selected.csv").exists()
+
+
+def _minimal_stance_report() -> dict:
+    """A report dict complete enough for the renderer."""
+    return {
+        "schema": "mesozoic.stance-gate-report/v1",
+        "species": "trex",
+        "stage": 1,
+        "gate_kind": "stance_quality/v1",
+        "policy": "robust_best_model.zip",
+        "episodes": 40,
+        "seed": 3042,
+        "settle_steps": 200,
+        "horizon": 1000,
+        "passed": True,
+        "failures": [],
+        "thresholds": {
+            "min_full_horizon_fraction": 0.95,
+            "max_unsupported_duty": 0.02,
+            "max_unsupported_duty_ucb": 0.02,
+            "min_avg_reward": 2550.0,
+            "min_eval_episodes": 40,
+        },
+        "metrics": {
+            "reward_mean": 3004.3,
+            "reward_std": 17.1,
+            "episode_length_mean": 1000.0,
+            "full_horizon_fraction": 1.0,
+            "mean_unsupported_duty": 0.0,
+            "unsupported_duty_ucb": 0.0,
+            "n_duty_episodes": 40,
+            "bilateral_support_duty": 1.0,
+            "single_support_duty": 0.0,
+        },
+        "terminations": {"truncated": 40},
+        "reward_components": {"reward_alive": 995.2},
+    }
+
+
+class TestActionFilterProbe:
+    """`--filter-actions` scores a MODIFIED policy, and must say so.
+
+    It exists to answer whether a policy's high-frequency action content is
+    load-bearing or waste (issue #489): if a filtered policy still stands, the
+    tremor was waste and the fix belongs on the action path; if it falls, the
+    tremor is closed-loop stabilisation and the fix belongs elsewhere.
+    """
+
+    @staticmethod
+    def _filtered(cutoff_hz, control_dt=0.01, actions=None):
+        from environments.shared.scripts.stance_gate_report import _low_pass_predict
+
+        seq = iter(actions or [])
+        base = lambda _obs: np.asarray(next(seq), dtype=np.float64)  # noqa: E731
+        return _low_pass_predict(base, cutoff_hz, control_dt)
+
+    def test_a_constant_action_passes_through_unchanged(self):
+        """A low-pass must be a no-op on DC, or it would move the pose itself."""
+        predict = self._filtered(5.0, actions=[[0.5]] * 20)
+        out = [float(predict(None)[0]) for _ in range(20)]
+        assert out[0] == pytest.approx(0.5)
+        assert out[-1] == pytest.approx(0.5)
+
+    def test_it_attenuates_a_fast_alternation(self):
+        predict = self._filtered(5.0, actions=[[1.0], [-1.0]] * 30)
+        out = [float(predict(None)[0]) for _ in range(60)]
+        # Seeded with the first action, so settle before measuring.
+        tail = out[20:]
+        assert max(abs(v) for v in tail) < 0.4, "22.6 Hz-class content should be cut hard at 5 Hz"
+
+    def test_it_seeds_on_the_first_action_rather_than_zero(self):
+        """Starting from zero injects a step transient that is a probe artefact."""
+        predict = self._filtered(5.0, actions=[[0.9]])
+        assert float(predict(None)[0]) == pytest.approx(0.9)
+
+    def test_reset_prevents_one_episode_leaking_into_the_next(self):
+        predict = self._filtered(5.0, actions=[[1.0], [-1.0]])
+        assert float(predict(None)[0]) == pytest.approx(1.0)
+        predict.reset()
+        assert float(predict(None)[0]) == pytest.approx(-1.0)
+
+    def test_the_report_records_the_probe_so_a_pass_cannot_be_mistaken(self):
+        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+
+        report = _minimal_stance_report()
+        report["filter_actions_hz"] = 5.0
+        text = render_stance_gate_report(report)
+        assert "PROBE" in text
+        assert "not a gate result" in text
+        # The warning must precede the verdict a reader would otherwise act on.
+        assert text.index("PROBE") < text.index("GATE:")
+
+    def test_an_unfiltered_report_says_nothing_about_the_probe(self):
+        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+
+        assert "PROBE" not in render_stance_gate_report(_minimal_stance_report())

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -1046,3 +1046,132 @@ class TestActionFilterProbe:
         from environments.shared.scripts.stance_gate_report import render_stance_gate_report
 
         assert "PROBE" not in render_stance_gate_report(_minimal_stance_report())
+
+
+class TestTheProbeCannotBeMistakenForTheVerdict:
+    """A filtered rollout scored a policy that was never actually run.
+
+    Two ways it could corrupt the record: overwriting the real report, or
+    supplying `stance_panel_selected.csv`, which is the per-episode evidence
+    `result_bundle.evidence` certifies a stance-gated stage from. Both are
+    made structurally impossible rather than left to the caller.
+    """
+
+    def test_a_probe_writes_its_own_filenames(self, tmp_path):
+        report = _minimal_stance_report()
+        report["filter_actions_hz"] = 5.0
+        written = write_stance_gate_report(tmp_path, report)
+        assert (tmp_path / "stance_gate_probe_filtered.txt").exists()
+        assert (tmp_path / "stance_gate_probe_filtered.json").exists()
+        assert not (tmp_path / "stance_gate_report.txt").exists()
+        assert "stance_panel_csv" not in written
+
+    def test_a_probe_never_writes_the_certification_evidence(self, tmp_path):
+        real = _minimal_stance_report()
+        real["episode_evidence"] = [
+            {
+                "episode": 0,
+                "seed": 3042,
+                "length": 1000,
+                "reward": 3004.3,
+                "reached_horizon": True,
+                "unsupported_duty": 0.0,
+                "bilateral_support_duty": 1.0,
+                "single_support_duty": 0.0,
+            }
+        ]
+        write_stance_gate_report(tmp_path, real)
+        before = (tmp_path / "stance_panel_selected.csv").read_text()
+
+        probe = dict(real)
+        probe["filter_actions_hz"] = 5.0
+        probe["metrics"] = dict(real["metrics"], reward_mean=-99.0)
+        write_stance_gate_report(tmp_path, probe)
+
+        # The real panel must be untouched: a filtered panel here would
+        # certify a policy that was never run.
+        assert (tmp_path / "stance_panel_selected.csv").read_text() == before
+
+    def test_the_real_report_is_unaffected(self, tmp_path):
+        written = write_stance_gate_report(tmp_path, _minimal_stance_report())
+        assert (tmp_path / "stance_gate_report.txt").exists()
+        assert not (tmp_path / "stance_gate_probe_filtered.txt").exists()
+        # No episode_evidence in this fixture, so no panel CSV either; the
+        # evidence path is covered by the test above.
+        assert "stance_panel_csv" not in written
+
+
+class TestTheProbeIsWiredIntoTrainingArtifacts:
+    def test_it_is_skipped_when_unconfigured(self, tmp_path, monkeypatch):
+        from environments.shared.reporting import stage_artifacts
+
+        called = False
+
+        def _boom(*a, **k):
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(stance_gate_report, "build_stance_gate_report", _boom)
+        stage_artifacts._write_filtered_action_probe(
+            species="trex",
+            stage=1,
+            stage_config={"curriculum_kwargs": {}},
+            stage_dir=tmp_path,
+            model_path="m.zip",
+            vecnorm_path="v.pkl",
+            episodes=40,
+        )
+        assert not called
+
+    def test_it_passes_the_configured_cutoff_through(self, tmp_path, monkeypatch):
+        from environments.shared.reporting import stage_artifacts
+
+        seen = {}
+
+        def _capture(species, stage, **kwargs):
+            seen.update(kwargs)
+            report = _minimal_stance_report()
+            report["filter_actions_hz"] = kwargs["filter_actions_hz"]
+            return report
+
+        monkeypatch.setattr(stance_gate_report, "build_stance_gate_report", _capture)
+        stage_artifacts._write_filtered_action_probe(
+            species="trex",
+            stage=1,
+            stage_config={"curriculum_kwargs": {"stance_probe_filter_hz": 5.0}},
+            stage_dir=tmp_path,
+            model_path="m.zip",
+            vecnorm_path="v.pkl",
+            episodes=40,
+        )
+        assert seen["filter_actions_hz"] == 5.0
+        assert (tmp_path / "stance_gate_probe_filtered.txt").exists()
+
+    def test_a_failing_probe_does_not_sink_the_run(self, tmp_path, monkeypatch, caplog):
+        from environments.shared.reporting import stage_artifacts
+
+        monkeypatch.setattr(
+            stance_gate_report,
+            "build_stance_gate_report",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("probe exploded")),
+        )
+        with caplog.at_level("WARNING"):
+            stage_artifacts._write_filtered_action_probe(
+                species="trex",
+                stage=1,
+                stage_config={"curriculum_kwargs": {"stance_probe_filter_hz": 5.0}},
+                stage_dir=tmp_path,
+                model_path="m.zip",
+                vecnorm_path="v.pkl",
+                episodes=40,
+            )
+        assert "Filtered action probe failed" in caplog.text
+
+    def test_the_config_key_is_accepted_by_the_gate_schema(self):
+        """An unregistered key is unreachable under the fail-closed check."""
+        from environments.shared.config import load_stage_config
+        from environments.shared.curriculum.gate_schema import validate_gate_config
+
+        curriculum = load_stage_config("trex", 1)["curriculum_kwargs"]
+        assert curriculum["stance_probe_filter_hz"] == 5.0
+        validate_gate_config(1, curriculum)

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -13,6 +13,7 @@ loudly rather than degrade.
 from __future__ import annotations
 
 import csv
+import math
 import pickle
 from pathlib import Path
 
@@ -1175,3 +1176,92 @@ class TestTheProbeIsWiredIntoTrainingArtifacts:
         curriculum = load_stage_config("trex", 1)["curriculum_kwargs"]
         assert curriculum["stance_probe_filter_hz"] == 5.0
         validate_gate_config(1, curriculum)
+
+
+class TestPerActuatorActionReporting:
+    """Which actuators carry the offset decides whether a pose weight reaches it.
+
+    `leg_home_pose` covers only the leg joints, so a displacement living in the
+    tail or neck is invisible to it and unfixable by it (issue #489). The
+    scalar summaries cannot answer that; this is what makes one five-minute
+    run on an existing checkpoint test it.
+    """
+
+    @staticmethod
+    def _stats(sequence):
+        from environments.shared.scripts.stance_gate_report import (
+            _accumulate_action,
+            _new_action_stats,
+        )
+
+        stats = _new_action_stats()
+        for action in sequence:
+            _accumulate_action(stats, np.asarray(action, dtype=np.float64))
+        return stats
+
+    def test_dc_and_ac_are_reported_per_actuator(self):
+        from environments.shared.scripts.stance_gate_report import _reduce_action_stats
+
+        # Actuator 0 holds 0.5 and shakes +/-0.1; actuator 1 is still at 0.
+        stats = self._stats([[0.6, 0.0], [0.4, 0.0]] * 10)
+        out = _reduce_action_stats(stats, ["r_hip_pitch", "tail_1"], 0.01)
+        by_joint = {entry["joint"]: entry for entry in out["per_actuator"]}
+        assert by_joint["r_hip_pitch"]["dc"] == pytest.approx(0.5)
+        assert by_joint["r_hip_pitch"]["ac_rms"] == pytest.approx(0.1)
+        assert by_joint["tail_1"]["dc"] == pytest.approx(0.0)
+        assert by_joint["tail_1"]["ac_rms"] == pytest.approx(0.0)
+
+    def test_the_effective_frequency_matches_the_inversion(self):
+        from environments.shared.scripts.stance_gate_report import _reduce_action_stats
+
+        # Alternating every step is the Nyquist rate: 50 Hz at dt = 0.01.
+        stats = self._stats([[1.0], [-1.0]] * 20)
+        out = _reduce_action_stats(stats, ["j"], 0.01)
+        assert out["effective_freq_hz"] == pytest.approx(50.0, abs=0.5)
+
+    def test_a_constant_action_has_no_frequency(self):
+        from environments.shared.scripts.stance_gate_report import _reduce_action_stats
+
+        out = _reduce_action_stats(self._stats([[0.5]] * 10), ["j"], 0.01)
+        # No first difference leaves the ratio undefined. NaN is honest;
+        # 0 Hz would read as a measured slow drift.
+        assert math.isnan(out["effective_freq_hz"])
+        assert out["dc_rms"] == pytest.approx(0.5)
+
+    def test_no_measured_steps_yields_an_empty_block(self):
+        from environments.shared.scripts.stance_gate_report import (
+            _new_action_stats,
+            _reduce_action_stats,
+        )
+
+        assert _reduce_action_stats(_new_action_stats(), [], 0.01) == {}
+
+    def test_unnamed_actuators_fall_back_to_an_index(self):
+        from environments.shared.scripts.stance_gate_report import _reduce_action_stats
+
+        out = _reduce_action_stats(self._stats([[0.1, 0.2]] * 4), [], 0.01)
+        assert [entry["joint"] for entry in out["per_actuator"]] == ["actuator_0", "actuator_1"]
+
+    def test_the_text_form_lists_the_largest_offsets_first(self):
+        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+
+        report = _minimal_stance_report()
+        report["action"] = {
+            "dc_rms": 0.8,
+            "ac_rms": 0.277,
+            "delta_per_step": 2.73,
+            "jerk_per_step": 4.64,
+            "effective_freq_hz": 22.6,
+            "per_actuator": [
+                {"index": 0, "joint": "tail_1", "dc": 0.9, "ac_rms": 0.1},
+                {"index": 1, "joint": "r_knee", "dc": -0.2, "ac_rms": 0.3},
+            ],
+        }
+        text = render_stance_gate_report(report)
+        assert "22.6 Hz" in text
+        assert text.index("tail_1") < text.index("r_knee")
+
+    def test_a_report_without_the_block_still_renders(self):
+        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+
+        assert "commanded action" not in render_stance_gate_report(_minimal_stance_report())

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -417,7 +417,7 @@
           "config_path": "configs/trex/stage1_balance.toml",
           "timesteps": 10000000,
           "advancement_gate": {
-            "min_avg_reward": 1950.0,
+            "min_avg_reward": 2550.0,
             "min_avg_episode_length": null,
             "min_avg_forward_velocity": null,
             "min_success_rate": null,


### PR DESCRIPTION
Closes the gap left by #487. For issue #489.

Run `20260805_011234` **passed** `stance_quality/v1` — unsupported duty **0.0000** against a 0.0200 ceiling, 40/40 episodes at the horizon, bilateral support 1.0000, zero falls. The entropy diagnosis was right.

But it scored **3004.3 against the zero-action statue's 3274.4**, and never crossed it in 200 evaluations. This PR is that 270-point gap: **a config change that attacks its cause, and the instrumentation to tell whether that worked.**

---

# 1. The gap has one cause, not two

The three action terms invert to physical quantities through their closed forms (`n_actuators = 21`, 1000 steps, 100 Hz):

| | 20260805 (PASS) | 20260804 (FAIL) |
|---|---|---|
| `Σ(Δa)²` | 2.73 — **3.2%** of its `n×4` normaliser | 2.77 |
| `Σ(a−2a′+a″)²` | 4.64 — **1.4%** of its `n×16` normaliser | 4.73 |
| effective frequency | **22.6 Hz** | 22.7 Hz |
| per-actuator DC offset | **0.800** | 0.782 |
| per-actuator AC rms | **0.277** | 0.278 |

Frequency comes from `J/D = (2 sin πfΔt)²`, which is DC-blind. **The entropy fix changed neither the amplitude nor the frequency** — it removed the foot-lift and nothing else.

Verified by reproduction: injecting a 0.277-rms, 22.6 Hz tremor onto the statue matches the trained policy's per-step penalties to within 2% (smoothness −0.0642 vs −0.0650, jerk −0.0402 vs −0.0414, energy −0.0057 vs −0.0058).

That splits the gap:

| component | cost/episode | share |
|---|---|---|
| static pose displacement (`leg_home_pose` 84.98 + energy DC 47.92) | **132.9** | 49% |
| tremor (`smoothness` 65.00 + `action_jerk` 41.41 + energy AC 5.75) | **112.2** | 42% |
| everything else | 24.9 | 9% |

## Why the obvious lever is the wrong one

`action_jerk` sits at **1.4% of its normaliser**. The natural conclusion is that it is badly under-weighted and should be raised, or that the actions should be low-pass filtered. Two experiments say otherwise.

**Open-loop, the statue cannot absorb this tremor** — tolerance is ~0.05–0.07 rms:

```
 freq  amp rms    reward   ep len  full-horizon
  -      0.000    3275.6   1000.0     1.00
 22.6    0.050    3051.6   1000.0     1.00
 22.6    0.100     194.2    157.0     0.00
 22.6    0.277     -27.6     60.2     0.00
  2.0    0.277     -35.5     38.0     0.00
 40.0    0.277     -30.0     60.8     0.00
```

Amplitude destabilises, not frequency. The policy carries 0.277 rms and stands 1000 steps with zero falls — so its high-frequency content is **state-correlated feedback, not noise**.

**And a displaced static pose is passively unstable.** Zero action is a narrow island:

```
offset rms  dir    reward   ep len  full-horizon
      0.00   -    3275.6   1000.0     1.00
      0.10   0     197.8    107.2     0.00
      0.10   1     239.3    122.2     0.00
      0.10   2     594.0    268.0     0.00
      0.80   0     -93.1     23.2     0.00
```

The policy holds a **0.800 rms** displacement — open-loop that collapses in ~25 steps — upright for 10 seconds.

**So the tremor is the cost of the pose.** Penalising it attacks load-bearing feedback, and the optimiser's cheapest response to a bigger jerk penalty is to fall over, not to find the passive solution.

## The change

```diff
-leg_home_pose_weight = 0.5
+leg_home_pose_weight = 1.5
```

| weight | statue | pose gap | vs tremor cost 112 |
|---|---|---|---|
| 0.5 (current) | 3272.4 | 85 | tremor dominates |
| **1.5** | **4250.3** | **255** | pose dominates 2.3:1 |
| 2.0 | 4739.2 | 340 | 3:1 |

If the policy returns to the home keyframe the feedback becomes unnecessary and its cost goes too — **245 points, not the 112 a smoothness penalty could reach**. One lever, both halves. 2.0 is the next step if 1.5 does not move it.

## Two constants would have gone stale

Both are documented in the config as derived from the statue, and neither updates itself:

```diff
-min_avg_reward = 1950.0                  # 0.60 x statue 3271.8
+min_avg_reward = 2550.0                  # 0.60 x statue 4250.4
-collapse_peak_floor_reference = 3271.8
+collapse_peak_floor_reference = 4250.4
```

Leaving them would arm the collapse backstop against the wrong scale — exactly the staleness the config's own comments warn about (*"this is a measured constant and will go stale if the plant or the reward weights change"*).

The new baseline is **measured, not scaled**: `zero_action_baseline.py trex --episodes 40` gives **4250.40 ± 13.86**, 100% full-horizon, at noise 0.05 — the same protocol the old 3271.8 came from. Ratios preserved exactly (rail 0.60×, floor 0.45× → 1913).

---

# 2. Instrumentation, so the next run does not need this analysis

Everything above was recovered by **inverting per-episode reward totals under a narrowband assumption**, because every action number on disk came from *training* rollouts and carried exploration noise. Five additions make it a direct read.

### `gate_progress.npz` gains the deterministic policy's action

`action_dc_rms`, `action_ac_rms`, `action_delta`, `action_jerk`, `action_freq_hz`, over the post-settle window (the same one the duty uses, so the reset transient does not inflate the AC term).

The DC/AC split is the point. `action_dc_rms` is the static distance from the home keyframe — which under `home-keyframe-residual/v1` is exactly `action = 0` — and `action_ac_rms` is what the policy does *around* it. A pooled standard deviation over actuators and time, which is what `diagnostics.action_std` computes, cannot separate "sitting in the wrong place" from "shaking", and those have different causes and different fixes.

### `action_dc_per_actuator` / `action_ac_rms_per_actuator` — the falsification test for this PR

The same two quantities as `(n_evals, n_actuators)` matrices.

**`leg_home_pose` covers only the leg joints.** If the 0.800 offset lives in the tail or neck, raising its weight cannot reach it and §1 fails by construction. I cannot currently tell, and this makes it visible at 2M rather than after another 8 hours.

Per actuator rather than per group deliberately: grouping is an analysis decision, and resolving joint names through the VecEnv wrappers is exactly the kind of best-effort lookup that silently returns nothing.

### `term_*` — every reward term, per evaluation

Only `mean_reward` was kept, so comparing two runs meant comparing their final checkpoints and nothing in between. This answers *when* the policy adopted the pose it ended up with — during the 150k–1.15M collapse, or later. Adopted-during-collapse is a local-optimum story that §1 should fix; drifted-in-late means §1 is treating a symptom.

### `action_jerk` in `diagnostics.npz`

The environment has always emitted it (`trex_env.py` sets `info["action_jerk"]`, it is what `reward_action_jerk` charges) and `INFO_KEYS` has always dropped it — computed every step, discarded. With both differences recorded the effective frequency is free.

### `stance_gate_report.py --filter-actions HZ` — settles the tremor question

The open-loop experiments in §1 bound what a tremor *can* do to a statue. They do not prove the trained policy's tremor is load-bearing; that is an inference. This low-passes the action between policy and plant and scores **that**:

```
python environments/shared/scripts/stance_gate_report.py trex --stage 1 \
    --model .../robust_best_model.zip --vecnorm .../robust_best_model_vecnorm.pkl \
    --filter-actions 5
```

Still stands → the tremor was waste, **my reasoning in #489 is wrong**, and an action filter in the plant is the right fix. Falls → the feedback is confirmed load-bearing and §1 is right. Runs on the checkpoint already on Drive; no training needed.

A filtered rollout scores a **modified** policy, so the report records `filter_actions_hz` and the text form prints the warning *above* the verdict, with a test asserting that ordering. A PASS obtained this way must never be mistakable for a gate result.

---

## Testing

- `environments/shared/tests` + `environments/trex/tests`: **1890 passed, 133 skipped**, exit 0
- New: `TestDeterministicActionStatistics` (DC/AC separation, differences inverting back through the reward formulas, settle-window exclusion, no-actions and missing-`actions`-local cases, no cross-episode leakage), `TestGateProgressCarriesTheNewSeries`, `TestActionFilterProbe`, `TestActionJerkIsNotDiscarded`
- `test_catalog_exports_effective_early_advancement_gates` updated for the new rail, with the derivation in a comment so the next rescale is not a mystery
- `python -m environments.shared.species_catalog` regenerated; `README.md` and `website/src/data/species.generated.json` follow
- `ruff check` / `ruff format --check` clean; `mypy` clean on changed modules
- Statue linearity confirmed directly: `leg_home_pose` 488.93 → 1466.80 → 1955.73 at weights 0.5 / 1.5 / 2.0, exactly 3× and 4×, since `action = 0` gives the same trajectory at any weight
- The filter probe verified as a no-op on a constant action — it must not move the pose itself, only what happens around it

### A bug the existing tests caught

The per-actuator matrix code first read `self.eval_callback` directly inside the npz write path. On an instance without that attribute the `AttributeError` was swallowed by the outer handler and took the **entire** `gate_progress.npz` write with it — losing the gate criteria to a failure in a side channel. It now reads through `getattr` on `self` and skips only the matrices. `TestGateProgressIsPersisted` from #487 is what surfaced it.

## What this does not claim

That the policy will return to the home keyframe. It is one hypothesis with a measured mechanism, and the falsifiable version is cheap: **`leg_home_pose` should rise well above its 404.19/500-equivalent, and `smoothness` + `action_jerk` should fall from −106.4**. If the pose moves and the tremor does not, the two are not as coupled as the open-loop experiments suggest, and the next suspect is the plant having no action-rate limit at all — `_scale_action` maps straight to `ctrl` with no filter.

One risk worth naming: raising this weight strengthens the do-nothing attractor. Correct for a balance stage whose optimum *is* the statue, but a policy trained never to leave the home pose has more to unlearn at stage 2.

Note the baseline in `zero_action_baseline.json` will now come out near 4250 rather than 3272 — the new run's rewards are not comparable to the old numbers.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)