### PR TITLE
Revert leg_home_pose_weight to 0.5 — it governs 1.2% of the displacement it was raised to fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Because the statue commands `action = 0` at any weight its trajectory never
   changes and only the affected term rescales — which makes the new value
   exact and cheap to obtain, and makes forgetting it silent.
-  `stance_probe_filter_hz` is **kept**: the probe is what showed the tremor is
-  load-bearing, and it is the regression metric for #491.
+  `stance_probe_filter_hz` is **kept**, and widened from a single cutoff to a
+  **sweep** — `[5.0, 10.0, 20.0]` on trex 1a. A single cutoff answers a yes/no
+  that is already answered: the checkpoint that PASSED the gate falls at every
+  cutoff from 5 to 35 Hz against a 100 Hz control rate, so its PASS/FAIL
+  carries no information. What can move is how long the filtered policy
+  survives — measured 101 steps at 5 Hz, 199 at 10, 288 at 20, against a
+  1000-step horizon — and reading that against cutoff measures *how much*
+  high-frequency content the policy depends on rather than merely that it
+  depends on some (#491).
+  Balance correction on this plant is a ~1.1–1.4 Hz phenomenon and every cutoff
+  passes it essentially untouched (gain 0.963 at 1.4 Hz even at 5 Hz), while
+  the measured 22.7 Hz tremor is cut 13.3 dB at 5 Hz and 3.6 dB at 20 — so a
+  short episode means dependence on content well above what the task requires.
+  `stance_probe_filter_hz` now accepts a number or a list; unusable entries are
+  dropped with a warning rather than costing the cutoffs that are fine.
+  The sweep lands in `stance_gate_probe_filtered.{txt,json}` as one curve
+  sorted by cutoff, and is written even if a cutoff raises — a partial curve is
+  still a curve. It rolls **10 episodes per cutoff** rather than the gate's 40:
+  it certifies nothing, and the effect it measures is enormous (101 steps
+  against 1000), so it does not need the sample size the bound's power is
+  specified at. The whole sweep costs about what the old single 40-episode
+  probe did.
 
 ### Added
 - **The deterministic policy's action, measured instead of inferred.** Every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Reproducible Runs & Velociraptor Stage-1 Diagnosis (v0.3.6)
 
+### Changed
+- **Reverted T-Rex stage 1 `leg_home_pose_weight` to 0.5**, and the two statue-
+  derived constants with it (`min_avg_reward` 2550 → 1950,
+  `collapse_peak_floor_reference` 4250.4 → 3271.8). The 1.5 experiment **could
+  not have worked**, and the instrumentation added alongside it says why
+  (issue #491).
+  `leg_home_pose` governs eight joints — r/l `hip_pitch`, `hip_roll`, `knee`,
+  `ankle` — and measured per actuator, those eight carry **1.2% of the
+  policy's commanded pose offset**. The other 98.8% is in the tail, neck, head
+  and toes, which no term in this stage touches; 10–12 of 21 actuators sit
+  pinned at `|action| = 1.000`. The governed joints were **already** near home
+  (|DC| 0.035–0.263), so tripling their weight had nothing to pull on.
+  Measured, it didn't: commanded DC moved **0.766 → 0.738**, 3.7%, while the
+  run took roughly 2M extra steps to escape its early collapse. The joint
+  *list*, not the weight, is the problem.
+  What survives the revert is the discipline: both constants are documented as
+  derived from the statue and neither updates itself, so any reward-weight
+  change has to re-measure with `zero_action_baseline.py` and re-derive both.
+  Because the statue commands `action = 0` at any weight its trajectory never
+  changes and only the affected term rescales — which makes the new value
+  exact and cheap to obtain, and makes forgetting it silent.
+  `stance_probe_filter_hz` is **kept**: the probe is what showed the tremor is
+  load-bearing, and it is the regression metric for #491.
+
 ### Added
 - **The deterministic policy's action, measured instead of inferred.** Every
   action number on disk came from *training* rollouts, so all of it carried

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Apex Predator. **Specialty:** Head-contact attack task.
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
 |---|---|---:|---:|
-| 1 — Balance | Learn to stand and balance without falling | 10M | reward ≥ 2550; full-horizon episodes ≥ 95.0%; unsupported duty ≤ 0.02; unsupported duty 95% upper bound ≤ 0.02; ≥ 40 episodes/evaluation; 3 consecutive passes |
+| 1 — Balance | Learn to stand and balance without falling | 10M | reward ≥ 1950; full-horizon episodes ≥ 95.0%; unsupported duty ≤ 0.02; unsupported duty 95% upper bound ≤ 0.02; ≥ 40 episodes/evaluation; 3 consecutive passes |
 | 2 — Locomotion | Learn forward walking/running | 8M | reward ≥ 100; episode length ≥ 750; avg. velocity ≥ 2 m/s; ≥ 10 episodes/evaluation; 3 consecutive passes |
 | 3 — Bite | Sprint to prey and make contact with the head bite proxy | 8M | reward ≥ 100; task success ≥ 50.0%; ≥ 10 episodes/evaluation; 3 consecutive passes |
 

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -394,25 +394,33 @@ collapse_peak_floor_reference = 3271.8   # The zero-action statue's standing rew
                                          # statue commands action = 0 at any weight, so its trajectory never
                                          # changes and only the affected term rescales -- which makes the new
                                          # value exact and cheap to obtain, and makes forgetting it silent.
-stance_probe_filter_hz = 5.0             # After the gate report, re-score the SAME checkpoint with its actions
-                                         # low-passed at this cutoff and write stance_gate_probe_filtered.{txt,json}.
-                                         # Costs a second 40-episode panel (a few minutes); unset to skip.
+stance_probe_filter_hz = [5.0, 10.0, 20.0]  # After the gate report, re-score the SAME checkpoint with its actions
+                                         # low-passed at EACH of these cutoffs and write
+                                         # stance_gate_probe_filtered.{txt,json} as one curve. Unset to skip.
                                          #
-                                         # It settles the question this stage's remaining gap turns on. Run
-                                         # 20260805_011234 passed carrying a tremor of rms 0.277 at an effective
-                                         # 22.6 Hz, and whether that tremor is closed-loop stabilisation or a
-                                         # free-running buzz decides whether the fix belongs on the pose weight or
-                                         # on the action path (issue #489). Open-loop experiments on the statue
-                                         # bound what a tremor CAN do; only filtering the real policy answers it
-                                         # for that policy. If it still stands, the tremor was waste and
-                                         # leg_home_pose_weight is treating the wrong thing.
+                                         # A curve, not a point, because the yes/no is already answered and the
+                                         # answer is "no": the checkpoint that PASSED the gate falls at every
+                                         # cutoff from 5 to 35 Hz against a 100 Hz control rate, so a single
+                                         # cutoff's PASS/FAIL carries no information (issue #491). What can move
+                                         # is how long the filtered policy survives -- 96 steps at 5 Hz, 189 at
+                                         # 10, 289 at 20, against a 1000-step horizon -- and reading that against
+                                         # cutoff measures HOW MUCH high-frequency content the policy needs
+                                         # rather than merely that it needs some.
                                          #
-                                         # 5 Hz because balance corrections are a ~1-1.4 Hz phenomenon on this
-                                         # plant (body-on-leg resonance), so 5 Hz passes the control the policy
-                                         # plausibly needs while cutting a 22.6 Hz tremor hard.
+                                         # 5/10/20 spans the useful range. Balance correction on this plant is a
+                                         # ~1.1-1.4 Hz phenomenon and every cutoff here passes it essentially
+                                         # untouched (gain 0.963 at 1.4 Hz even at 5 Hz), while the measured
+                                         # 22.7 Hz tremor is cut 13.3 dB at 5 Hz and 3.6 dB at 20. So a short
+                                         # episode means dependence on content well above what the task needs.
                                          #
-                                         # The probe scores a MODIFIED policy: it gets its own filenames, never
-                                         # writes stance_panel_selected.csv, and its verdict is not a gate result.
+                                         # Each cutoff costs a panel, but the probe rolls 10 episodes rather than
+                                         # the gate's 40: it certifies nothing, and the effect is enormous
+                                         # (96 steps against 1000), so it does not need the sample size the
+                                         # bound's power is specified at. The sweep costs about what the old
+                                         # single 40-episode probe did.
+                                         #
+                                         # The probe scores a MODIFIED policy: its own filenames, never
+                                         # stance_panel_selected.csv, and its verdict is not a gate result.
 collapse_peak_floor_fraction = 0.45      # RELATIVE floor (PLANT_VALIDATION §14 item 3). An absolute floor has now
                                          # failed to arm TWICE for the same reason: 2200 against run 20260731_132102
                                          # (peak 1934.1, watched a -59% collapse), then 2450 against run

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -63,33 +63,17 @@ action_jerk_weight = 3.0                       # Frequency-aware smoothness: pen
                                                # ~8e4, so the term is nearly free for the behaviour we want and is
                                                # charged almost entirely to chatter.
 support_conditioned_alive_fraction = 0.5       # Keep recovery headroom while making one-foot survival less profitable
-leg_home_pose_weight = 1.5                     # Retain the authored p5 theropod leg stance. Raised 0.5 -> 1.5 because
-                                               # run 20260805_011234 PASSED the stance gate (duty 0.0000) while scoring
-                                               # 3004.3 against the statue's 3274.4, and the whole 270-point gap traces
-                                               # to ONE cause: it holds a displaced pose it must actively stabilise
-                                               # (issue #489).
-                                               #
-                                               # Inverting its action penalties gives a per-actuator DC offset of 0.800
-                                               # with an AC tremor of rms 0.277 at an effective 22.6 Hz. Measured, both
-                                               # halves of that are open-loop fatal: a static offset of just 0.10 rms
-                                               # falls in every direction tested (107-268 steps), and a 0.277 rms tremor
-                                               # collapses the statue at EVERY frequency from 2 to 40 Hz (38-80 steps),
-                                               # while action = 0 stands indefinitely. So the tremor is not waste, it is
-                                               # the closed-loop feedback holding up a pose the home keyframe holds for
-                                               # free -- which is why the fix is here and NOT on action_jerk_weight.
-                                               # Penalising the tremor attacks load-bearing feedback, and the cheapest
-                                               # response to a bigger jerk penalty is to fall over.
-                                               #
-                                               # 1.5 sizes the pose gap (85 -> 255 points) to dominate the tremor's
-                                               # 112-point cost by 2.3x, so the displaced operating point stops being
-                                               # competitive. If the policy returns to the home keyframe the feedback
-                                               # becomes unnecessary and the tremor cost goes with it -- 245 points, not
-                                               # the 112 a smoothness penalty could reach. 2.0 (3x) is the next step if
-                                               # 1.5 does not move it.
-                                               #
-                                               # NOTE: this rescales the reward. min_avg_reward and
-                                               # collapse_peak_floor_reference below are both derived from the statue
-                                               # and were re-measured for this weight; re-derive them again if it moves.
+leg_home_pose_weight = 0.5                     # Softly retain the authored p5 theropod leg stance.
+                                               # REVERTED from 1.5 (issue #491): the 1.5 experiment could not have
+                                               # worked, and measurement says why. This term governs 8 joints --
+                                               # r/l hip_pitch, hip_roll, knee, ankle -- and those 8 carry only
+                                               # 1.2% of the policy's commanded pose offset. 98.8% sits in the
+                                               # tail, neck, head and toes, which no term here touches, and 10-12
+                                               # of 21 actuators are pinned at |action| = 1.000. The governed
+                                               # joints were ALREADY near home (|DC| 0.035-0.263), so tripling the
+                                               # weight had nothing to pull on: measured DC moved 0.766 -> 0.738,
+                                               # 3.7%, while the run took ~2M extra steps to escape its early
+                                               # collapse. The list, not the weight, is the problem (#491).
 leg_home_pose_tolerance = 0.20                 # rad; broad enough for balancing corrections without joint locking
 head_clearance_weight = 0.35                   # Prevent the learned head-droop posture
 head_clearance_target = 0.90                   # m; settled home head tip is ~0.94 m
@@ -315,19 +299,19 @@ settle_steps = 200                       # [inferred], NOT measured. Duty is sco
 min_eval_episodes = 40                   # The panel size every figure above is specified at. n_eval_episodes must
                                          # match: at n=30 the bound's power and the 28%-rejection analysis no longer
                                          # describe this gate.
-min_avg_reward = 2550.0                 # Collapse RAIL, not the gate (PLANT_VALIDATION §9/§12): no reward threshold
+min_avg_reward = 1950.0                 # Collapse RAIL, not the gate (PLANT_VALIDATION §9/§12): no reward threshold
                                         # can separate a competent policy from a statue, because the statue is the
                                         # reward optimum. Sized to the one job a rail CAN do — rejecting a policy
                                         # that discarded most of the available return — at 0.60 x the statue's
                                         # standing reward at the 0.05 operating point.
                                         #
-                                        # RE-DERIVED for leg_home_pose_weight 1.5 (issue #489). The statue is now
-                                        # 4250.40 +/- 13.86 (40 episodes, noise 0.05, 100% full-horizon, measured
-                                        # with zero_action_baseline.py on this config), so 0.60 x 4250.4 = 2550.
-                                        # Was 1950 = 0.60 x 3271.8 under weight 0.5. The FRACTION is what carries
-                                        # across the rescale; the absolute number does not, and neither do the
-                                        # historical run values quoted below, which are all on the old scale --
-                                        # compare them as ratios to the statue, not as rewards.
+                                        # 0.60 x 3271.8, the statue at leg_home_pose_weight 0.5. Briefly 2550 while
+                                        # that weight was 1.5, which moved the statue to 4250.40 +/- 13.86;
+                                        # reverted with it (issue #491). The lesson survives the revert: this
+                                        # number and collapse_peak_floor_reference are both DERIVED from the
+                                        # statue and neither updates itself, so any reward-weight change has to
+                                        # re-measure with zero_action_baseline.py and re-derive both. The FRACTION
+                                        # is what carries across a rescale; the absolute number does not.
                                         #
                                         # Why 0.60 and not §12's 0.89: the measured collapse (run 20260731_132102,
                                         # full-horizon 93% -> 7%) bottomed at 888 = 0.27 x statue, so 0.60 clears
@@ -404,12 +388,12 @@ collapse_peak_warmup_timesteps = 1000000 # Evaluations before this step cannot S
                                          # post-150k rolling median in that run is 580.5, well under 1472.3. A
                                          # larger warm-up buys nothing and costs coverage: 1.0M leaves 88% of a 10M
                                          # budget protected, 2.5M only 72%.
-collapse_peak_floor_reference = 4250.4   # The zero-action statue's standing reward at noise 0.05, 40 episodes.
-                                         # RE-MEASURED for leg_home_pose_weight 1.5 (issue #489): 4250.40 +/- 13.86,
-                                         # was 3271.8 under weight 0.5. The statue commands action = 0 at any weight,
-                                         # so its trajectory is unchanged and only the leg_home_pose term rescales --
-                                         # 488.93 -> 1466.80, exactly 3x. The relative floor below is therefore
-                                         # unaffected in MEANING; only its absolute value moves, 1472 -> 1913.
+collapse_peak_floor_reference = 3271.8   # The zero-action statue's standing reward at noise 0.05, 40 episodes.
+                                         # Briefly 4250.4 while leg_home_pose_weight was 1.5; reverted with it
+                                         # (issue #491). Re-measure this whenever a reward weight changes: the
+                                         # statue commands action = 0 at any weight, so its trajectory never
+                                         # changes and only the affected term rescales -- which makes the new
+                                         # value exact and cheap to obtain, and makes forgetting it silent.
 stance_probe_filter_hz = 5.0             # After the gate report, re-score the SAME checkpoint with its actions
                                          # low-passed at this cutoff and write stance_gate_probe_filtered.{txt,json}.
                                          # Costs a second 40-episode panel (a few minutes); unset to skip.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -48,6 +48,40 @@ tolerance) remains the standing recommendation for the divergences above.
 
 ## Training / RL
 
+<!-- The three items below come from the 2026-08-05 stage-1 bounce
+     investigation; full evidence in
+     investigations/TREX_STAGE1_BOUNCE_2026_08.md. -->
+
+- **HIGH** — **T-Rex stage 1 passes or bounces depending on the run, and we
+  cannot yet say which is typical.** Three 10M runs, all seed 42: one passed
+  with duty 0.0000, two converged to a phase-locked vertical bounce at exact
+  integer subharmonics of the 100 Hz control rate (duty 1/6 = 16.7 Hz, and
+  1/5 = 20.0 Hz), both with single-support ≈ 0. **The bounce is not
+  reward-preferred** — scored under the same reward it is 450 points *worse*
+  than the policy that passed, and loses on every term. Every candidate reward
+  tweak (`foot_load_balance_airborne_penalty`, `support_conditioned_alive_fraction`,
+  `action_jerk_weight`) is already firing, already correct, and already losing,
+  so this is an optimisation failure rather than a shaping one and further
+  reward changes are not indicated. **The next experiment should be seed
+  replicates of the passing configuration**, which is the only thing that
+  distinguishes "solved" from "lucky".
+- **MEDIUM** — **half the actuators sit saturated and nothing opposes it.**
+  Ten to twelve of 21 actuators are pinned at `|action| ≥ 0.99` — tail, neck,
+  head, toes — in *both* passing and failing policies. `energy` charges
+  ~48/episode against an alive bonus paying ~1000, and `leg_home_pose` governs
+  only 8 joints carrying 1.2% of the commanded offset. A saturated actuator has
+  no headroom in one direction, so the recovery envelope on those axes is
+  one-sided. Not a stage-1 blocker (the passing policy saturates too) —
+  tracked as sim-to-real in #491.
+- **MEDIUM** — **a passing policy cannot stand if its actions are filtered, at
+  any cutoff.** Low-passing the checkpoint that passed the gate collapses it at
+  every cutoff from 5 to 35 Hz against a 100 Hz control rate (96 → 351 steps of
+  a 1000-step horizon). The high-frequency content is load-bearing closed-loop
+  stabilisation, so an action filter or rate limit **cannot be retrofitted** —
+  if one is wanted for sim-to-real it has to be present during training. The
+  probe conflates bandwidth-dependence with delay-sensitivity; a zero-phase
+  offline filter would separate them. Tracked in #491.
+
 <!-- The six items below come from the 2026-07-31 plant validation pass; full
      evidence in PLANT_VALIDATION_AND_STAGE1_OBJECTIVE.md. The reset and
      self-collision defects that pass also found are FIXED in PR #479 and so

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,7 @@ than rewrite.
 | [STAGE2_RECOMMENDATIONS.md](investigations/STAGE2_RECOMMENDATIONS.md) | 2026-07-11 | Replication review of run 20260711_165924, corrected fall-penalty math, ranked plan — validated 2026-07-12 by run 20260711_235303 (stages 1–3 cleared, stage-2 record); §5 has the outcome and cross-species lessons |
 | [VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md](investigations/VELOCIRAPTOR_STAGE1_BASIN_INVESTIGATION.md) | 2026-07-20 | Commit A physics probe and A-only PPO run 20260720_203454; natural-lean reward-conflict diagnosis, pending Commit B validation, and fresh-run decision rules |
 | [TREX_HOME_EQUILIBRIUM.md](investigations/TREX_HOME_EQUILIBRIUM.md) | 2026-07-23 | T-Rex neutral-stance basin repair, home-residual action mapping, and live plantar contact sensors |
+| [TREX_STAGE1_BOUNCE_2026_08.md](investigations/TREX_STAGE1_BOUNCE_2026_08.md) | 2026-08-05 | Three 10M stage-1 runs (one pass, two phase-locked bounces at 1/6 and 1/5 duty). Why raising `leg_home_pose_weight` could not work, why the bounce is 450 points *worse* than not bouncing and so is not a reward problem, the filter probe confirming the tremor is load-bearing, and why seed replicates outrank any further reward tweak |
 
 ## Code & repo reviews
 

--- a/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
+++ b/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
@@ -1,0 +1,268 @@
+# T-Rex Stage 1: the phase-locked bounce, and what three runs taught us
+
+**Date:** 2026-08-05
+**Runs:** `20260804_143747` (FAIL), `20260805_011234` (**PASS**), `20260805_132950` (FAIL)
+**Issues:** #486 (closed), #489, #491 · **PRs:** #487, #490, #492
+
+Point-in-time record. Not rewritten — corrections are appended.
+
+---
+
+## 1. Summary
+
+Three consecutive 10M-step stage-1 runs, all seed 42, same plant. One passed.
+The two that failed converged to a **phase-locked vertical bounce** at an exact
+integer subharmonic of the control rate, with both feet leaving and landing
+together.
+
+| run | `leg_home_pose_weight` | duty | single support | frequency | verdict |
+|---|---|---|---|---|---|
+| `20260804_143747` | 0.5 | **0.1668** = 1/6 | 0.0000 | 16.7 Hz | FAIL |
+| `20260805_011234` | 0.5 | **0.0000** | 0.0000 | — | **PASS** |
+| `20260805_132950` | 1.5 | **0.2001** = 1/5 | 0.0011 | 20.0 Hz | FAIL |
+
+The headline result is negative and worth stating plainly: **the change made in
+#490 did not work, and the instrumentation added in the same PR is what proved
+it.** That is the outcome the instrumentation was built for.
+
+---
+
+## 2. What was tried, and what happened
+
+**#487 — entropy decays to zero over 70% of the budget.** Diagnosed #486's
+16.7 Hz bounce as an optimisation failure driven by an `ent_coef` floor holding
+policy std at ~0.375 (≈20.6° of commanded joint noise). Fix: `ent_coef_end`
+0.001 → 0.0, decay 3M → 7M. **This worked** — run `20260805_011234` passed with
+duty 0.0000.
+
+**#489 — the residual gap.** The passing policy scored 3004.3 against the
+zero-action statue's 3274.4. Inverting the action penalties through their closed
+forms gave a per-actuator DC offset of ~0.800 and an AC tremor of ~0.277 rms at
+an effective 22.6 Hz, and argued the two were **one phenomenon**: the tremor is
+closed-loop feedback holding up a displaced pose.
+
+**#490 — raise `leg_home_pose_weight` 0.5 → 1.5,** on that hypothesis, plus
+per-actuator instrumentation to check it.
+
+**Run `20260805_132950` — FAIL.** Duty locked at exactly 1/5 for the entire
+second half of the run.
+
+---
+
+## 3. Why #490 could not have worked
+
+`leg_home_pose_joint_names` for trex is **eight joints**: r/l `hip_pitch`,
+`hip_roll`, `knee`, `ankle`. Measured per actuator (4.5M+, in-flight):
+
+| | DC | AC (tremor) |
+|---|---|---|
+| the 8 governed joints | 0.035 – 0.263 → **1.2% of DC power** | 0.681 rms |
+| the other 13 | up to ±0.996 → **98.8%** | 0.253 rms |
+
+The governed joints were **already at home**. The displacement lives in the
+tail, neck, head and toes, which no term in this stage touches.
+
+The final report is the cleanest possible confirmation. `reward_leg_home_pose`
+reached **1409.17 of the statue's 1466.80 — 96%**. *The term did exactly what it
+was asked to do.* `action_dc_rms` still finished at 0.724 against the passing
+policy's 0.766, and the stage failed anyway.
+
+**Lesson: the joint list, not the weight, was the lever.** A term's weight can
+only move what the term measures.
+
+---
+
+## 4. The bounce is not reward-preferred
+
+Restating both policies under the **same** reward (only `leg_home_pose`
+rescales between them):
+
+| | score |
+|---|---|
+| statue | 3271.8 |
+| passing policy (duty 0.0000) | 3004.3 |
+| **bouncing policy (duty 0.2001)** | **2554.3** |
+
+The bounce is **450 points worse**, and loses on every term but the one whose
+weight was raised:
+
+| term | passing | bouncing | Δ |
+|---|---|---|---|
+| `foot_load_balance` | −16.9 | −154.9 | **−137.9** |
+| `bilateral_support` | 594.2 | 477.8 | **−116.5** |
+| `alive` | 995.2 | 898.1 | **−97.1** |
+| `neck_posture` | 175.6 | 116.0 | −59.6 |
+| `smoothness` | −65.0 | −102.4 | −37.4 |
+| `action_jerk` | −41.4 | −68.0 | −26.6 |
+
+**This rules out the obvious reward tweaks.** Every candidate is already firing,
+already correct, and already losing:
+
+- `foot_load_balance_airborne_penalty` charges the bouncer 138 points more.
+- `support_conditioned_alive_fraction` costs it 97 points of the single largest
+  term in the reward.
+- `action_jerk_weight` charges it 64% more than the policy that passed.
+
+None deterred it. Raising any of them deepens a trap the optimiser is already
+stuck in without creating a route out.
+
+**Lesson: this is an optimisation failure, not a reward-shaping one** — the same
+category as #486, and the same mistake that would have been made twice if a new
+penalty had been proposed here.
+
+---
+
+## 5. The tremor is load-bearing (#489's other claim held)
+
+`stance_gate_report.py --filter-actions`, on the **passing** checkpoint, a
+first-order low-pass between policy and plant:
+
+| cutoff | mean episode length | outcome |
+|---|---|---|
+| none | 1000 | PASS, duty 0.0000 |
+| 35 Hz | 351 | falls, `tail_contact` |
+| 20 Hz | 289 | falls |
+| 10 Hz | 189 | falls |
+| 5 Hz | 96 | falls |
+
+Control runs at 100 Hz, so 35 Hz is most of the way to Nyquist. The failing
+policy behaves the same way (109 steps at 5 Hz, 40/40 `tail_contact`).
+
+**An action low-pass or rate limit cannot be retrofitted.** If one is wanted for
+sim-to-real it must be present during training.
+
+**Caveat:** a causal low-pass adds phase lag as well as attenuation, and a tight
+stabilising loop is delay-sensitive. This proves the policy cannot tolerate added
+latency; it does not cleanly separate "needs 22 Hz of bandwidth" from "needs zero
+delay". A zero-phase (`filtfilt`) offline pass would isolate that.
+
+### The coupling hypothesis was wrong
+
+#489 argued the tremor holds up the displaced pose. Per-actuator measurement
+says otherwise: the **displaced** joints barely move (tail/neck/head/toes, AC
+0.253) and the **shaking** is in the load-bearing legs (hips/knees/ankles, AC
+0.681). Different joints, different phenomena. The tremor being load-bearing and
+the pose being displaced are both true and **not the same fact**.
+
+---
+
+## 6. The control rate permits the bounce; it does not encourage it
+
+Both failures landed on exact integer subharmonics of the 100 Hz control rate —
+1/6 and 1/5. **That alone is not evidence of pathology:** in a deterministic
+discrete-time closed loop every limit cycle has an integer period by definition.
+
+What does survive is the *frequency*. Body-on-leg resonance here is ~1.1–1.4 Hz;
+16.7 Hz on this mass would need ~1.66 MN/m of stiffness, and the statue holds
+`bilateral 1.0000` — it does not bounce passively. **The oscillation is actively
+driven**, which requires command authority in the 20 Hz band.
+
+| | control | Nyquist | period-5 cycle | 20 Hz reachable? |
+|---|---|---|---|---|
+| **frame_skip 5 (current)** | **100 Hz** | 50 Hz | 20.0 Hz | yes |
+| frame_skip 10 | 50 Hz | 25 Hz | 10.0 Hz | yes |
+| frame_skip 16 | 31 Hz | 15.6 Hz | 6.2 Hz | **no** |
+
+The task needs almost none of that: 100 Hz gives **71 control steps per balance
+cycle** at 1.4 Hz, and even 25 Hz control would give 18.
+
+**But the passing run ran at the same 100 Hz and did not bounce.** The control
+rate is a background condition that makes the failure *reachable*, not the thing
+that separates pass from fail. Changing `frame_skip` bumps
+`policy_interface_revision` and invalidates every checkpoint and every measured
+constant in the config — too large a change to buy on this evidence.
+
+**Falsifiable test if it becomes worth it:** train at `frame_skip 10`. A bounce
+at period 5–6 control steps (8–10 Hz) means the cycle is locked to the control
+clock and lowering the rate removes the failure class. A bounce at ~20 Hz again
+means it is a plant/task property and the rate is irrelevant.
+
+---
+
+## 7. Actuator saturation (open — see #491)
+
+**Ten to twelve of 21 actuators sit pinned at `|action| ≥ 0.99`** — tail, neck,
+head, toes — in *both* the passing and failing policies. Nothing in the reward
+opposes this: `energy` penalises `mean(a²)` at weight 0.075 (~48/episode against
+an alive bonus paying ~1000), and `leg_home_pose` covers 1.2% of the offset.
+
+A saturated actuator has **no headroom in one direction**, so the recovery
+envelope on those axes is one-sided.
+
+This is a genuine gap, and it is the one reward idea whose mechanism is *not*
+already firing — but the **passing** policy saturates just as hard, so it is not
+what separates pass from fail. Treat it as sim-to-real (#491), not a stage-1
+blocker.
+
+---
+
+## 8. Method lessons
+
+**Measure before shaping.** The #489 inversion was *correct* — reproducing the
+inferred tremor on the statue matched the trained policy's per-step penalties to
+within 2%, and direct measurement later confirmed DC 0.766 / AC 0.359 / 22.7 Hz
+against the inferred 0.800 / 0.277 / 22.6 Hz. The **causal story built on top of
+it** was wrong. Being able to measure a quantity accurately is not the same as
+knowing what causes it.
+
+**Instrumentation earns its cost by refuting you.** #490 shipped a config change
+and the instrumentation to check it. The instrumentation refuted the change. Had
+only the config change shipped, the run would have looked like ordinary bad luck.
+
+**n = 1 is not a result.** Three runs, all seed 42: one pass, two bounce. Nothing
+here establishes whether passing is *reliable* or was *lucky*, and that question
+determines everything about what to do next. **Seed replicates are the highest-
+value next experiment** — higher than any reward tweak.
+
+**Derived constants go stale silently.** `min_avg_reward` and
+`collapse_peak_floor_reference` are both derived from the zero-action statue,
+and the statue moves whenever a reward weight moves. Because the statue commands
+`action = 0` at any weight, its trajectory never changes and only the affected
+term rescales — which makes the new value exact and cheap to obtain, and makes
+forgetting it silent. Any reward-weight change must re-measure with
+`zero_action_baseline.py` and re-derive both.
+
+**A probe must not be able to masquerade as a verdict.** The `--filter-actions`
+report scores a *modified* policy. It gets its own filenames, prints its warning
+above the verdict, and never writes `stance_panel_selected.csv` — the
+per-episode evidence a bundle is certified from. All three are enforced
+structurally rather than by caller discipline.
+
+---
+
+## 9. Recommendations
+
+1. **Merge #492** (revert `leg_home_pose_weight` to 0.5 and the two
+   statue-derived constants with it) and re-run unchanged. That is the
+   configuration that produced duty 0.0000.
+2. **Then run it again at a different seed.** One pass and two failures at a
+   single seed cannot tell you whether the stage is solved or lucky. If two seeds
+   pass, #490 was the whole problem. If one bounces, the escape is a coin flip
+   and the work is making it reliable — which no reward term addresses.
+3. **Do not add or reweight reward terms** on this evidence (§4).
+4. **Do not raise `action_jerk_weight`** — the high-frequency content is
+   load-bearing in both policies (§5).
+5. **Leave saturation and near-Nyquist dependence in #491** as sim-to-real work.
+6. **`frame_skip` is a later experiment,** not a fix (§6).
+
+---
+
+## 10. Instrumentation added along the way
+
+All merged and running on every SB3 run, with no opt-in:
+
+- `gate_progress.npz` — the deterministic gate criteria per evaluation, plus
+  `action_dc_rms` / `action_ac_rms` / `action_delta` / `action_jerk` /
+  `action_freq_hz`, the per-actuator `action_dc_per_actuator` and
+  `action_ac_rms_per_actuator` matrices, and every reward term as `term_*`.
+- `action_jerk` in `diagnostics.npz` — the environment always emitted it and
+  `INFO_KEYS` always dropped it.
+- `stance_gate_report.py --filter-actions HZ` and the automatic probe, with
+  per-actuator DC/AC printed under real joint names.
+- `curriculum.baseline_watch` — reports every evaluation against the run's own
+  zero-action baseline, advisory only.
+
+The frequency estimate is `jerk/delta = (2 sin πfΔt)²`, which is blind to any
+constant offset — the DC/AC split is the point, because a pooled standard
+deviation over actuators and time cannot separate "sitting in the wrong place"
+from "shaking", and those have different causes and different fixes.

--- a/environments/shared/reporting/stage_artifacts.py
+++ b/environments/shared/reporting/stage_artifacts.py
@@ -18,6 +18,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+#: Episodes per cutoff in the action-filter probe sweep. Far below the gate's
+#: ``min_eval_episodes`` on purpose: the probe certifies nothing, and the
+#: effect it measures is enormous -- 96 steps against a 1000-step horizon on
+#: T-Rex stage 1 (issue #491) -- so it does not need the sample size the
+#: gate's bound has its power specified at. Keeping it small is what makes a
+#: multi-cutoff sweep cost about what the old single 40-episode probe did.
+_PROBE_EPISODES = 10
+
 
 def build_stage_results_from_eval_data(
     stage_dir: "str | Path",
@@ -262,6 +270,31 @@ def _write_stance_gate_report(
     return None
 
 
+def _probe_cutoffs(raw: Any) -> list[float]:
+    """Normalise ``stance_probe_filter_hz`` to a sorted list of cutoffs.
+
+    Accepts a single number or a list, because the useful reading is a curve
+    rather than a point. A single cutoff answers a yes/no that is already
+    known to be "no" on this plant -- the checkpoint that PASSED the gate
+    falls at every cutoff from 5 to 35 Hz against a 100 Hz control rate
+    (issue #491) -- so its PASS/FAIL carries no information. The scalar that
+    can actually move is how long the filtered policy survives, and reading
+    that against cutoff shows *how much* high-frequency content the policy
+    depends on rather than merely that it depends on some.
+    """
+    values = raw if isinstance(raw, (list, tuple)) else [raw]
+    cutoffs: list[float] = []
+    for value in values:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            logger.warning("stance_probe_filter_hz entry is not a number: %r; ignoring it", value)
+            continue
+        if number > 0:
+            cutoffs.append(number)
+    return sorted(set(cutoffs))
+
+
 def _write_filtered_action_probe(
     *,
     species: str,
@@ -272,62 +305,73 @@ def _write_filtered_action_probe(
     vecnorm_path: str | None,
     episodes: int,
 ) -> None:
-    """Re-score the selected checkpoint with its actions low-passed.
+    """Re-score the selected checkpoint with its actions low-passed, over a sweep.
 
-    Answers, automatically and for every run, whether the policy's
-    high-frequency action content is load-bearing or waste: if it still stands
-    with the tremor filtered out the tremor was waste and the fix belongs on
-    the action path, and if it falls the tremor is closed-loop stabilisation
-    and the fix belongs on the pose (issue #489). Deriving that by hand meant
-    inverting per-episode reward totals and running open-loop experiments on
-    the statue, which bound what a tremor *can* do but never answer it for the
-    actual policy.
+    Measures how much of its own high-frequency command content the policy
+    needs in order to stand. A first-order low-pass between policy and plant
+    attenuates the tremor while leaving balance correction -- a ~1.1-1.4 Hz
+    phenomenon on this plant -- essentially untouched, so survival under the
+    filter is a direct read on whether the tremor is load-bearing.
 
-    Off unless ``stance_probe_filter_hz`` is set, because it costs a second
-    panel -- a few minutes per stage, and per sweep trial.
+    That question is settled for today's policies and the answer is "yes"
+    (issue #491), which is why this logs a CURVE. Reported per cutoff, the
+    survival length is a regression metric: 96 steps at 5 Hz is the current
+    T-Rex stage-1 baseline, and a policy reaching the horizon there would be
+    one that could survive a real actuator's bandwidth limit.
+
+    Off unless ``stance_probe_filter_hz`` is set. Each cutoff costs a panel,
+    so the probe deliberately rolls far fewer episodes than the gate report:
+    it certifies nothing, and the effect it measures is enormous (96 steps
+    against 1000), so it does not need the sample size the bound's power is
+    specified at.
 
     Writes ``stance_gate_probe_filtered.{txt,json}`` and deliberately NOT
     ``stance_panel_selected.csv``; the probe scored a modified policy and must
     never supply the evidence a bundle is certified from.
     """
-    cutoff = stage_config.get("curriculum_kwargs", {}).get("stance_probe_filter_hz")
-    if cutoff is None:
+    cutoffs = _probe_cutoffs(stage_config.get("curriculum_kwargs", {}).get("stance_probe_filter_hz"))
+    if not cutoffs:
         return
-    try:
-        cutoff = float(cutoff)
-    except (TypeError, ValueError):
-        logger.warning("stance_probe_filter_hz is not a number: %r; skipping the probe", cutoff)
-        return
-    if cutoff <= 0:
-        logger.info("Filtered action probe skipped for stage %d: stance_probe_filter_hz = %g", stage, cutoff)
-        return
+    probe_episodes = max(1, min(episodes, _PROBE_EPISODES))
+    entries: list[dict[str, Any]] = []
     try:
         from environments.shared.scripts.stance_gate_report import (
             build_stance_gate_report,
-            write_stance_gate_report,
+            write_action_filter_sweep,
         )
 
-        probe = build_stance_gate_report(
-            species,
-            stage,
-            stage_config=stage_config,
-            model_path=model_path,
-            vecnorm_path=vecnorm_path,
-            episodes=episodes,
-            filter_actions_hz=cutoff,
-        )
-        written = write_stance_gate_report(stage_dir, probe)
-        logger.info(
-            "Filtered action probe (%.4g Hz): reward %.1f, full-horizon %.4f, duty %.4f -> %s. "
-            "This scored a MODIFIED policy and is not a gate verdict.",
-            cutoff,
-            probe["metrics"]["reward_mean"],
-            probe["metrics"]["full_horizon_fraction"],
-            probe["metrics"]["mean_unsupported_duty"],
-            written["stance_gate_report_txt"],
-        )
+        for cutoff in cutoffs:
+            probe = build_stance_gate_report(
+                species,
+                stage,
+                stage_config=stage_config,
+                model_path=model_path,
+                vecnorm_path=vecnorm_path,
+                episodes=probe_episodes,
+                filter_actions_hz=cutoff,
+            )
+            entries.append(probe)
+            logger.info(
+                "Filtered action probe %.4g Hz: episode length %.1f, full-horizon %.4f, reward %.1f. "
+                "MODIFIED policy -- not a gate verdict.",
+                cutoff,
+                probe["metrics"]["episode_length_mean"],
+                probe["metrics"]["full_horizon_fraction"],
+                probe["metrics"]["reward_mean"],
+            )
     except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
         logger.warning("Filtered action probe failed for stage %d", stage, exc_info=True)
+    # Written even if a later cutoff raised: a partial curve is still a curve,
+    # and discarding the cutoffs that succeeded would lose the measurement to
+    # a failure in one of them.
+    if entries:
+        try:
+            from environments.shared.scripts.stance_gate_report import write_action_filter_sweep
+
+            written = write_action_filter_sweep(stage_dir, entries, probe_episodes=probe_episodes)
+            logger.info("Filtered action probe sweep -> %s", written["action_filter_sweep_txt"])
+        except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
+            logger.warning("Could not write the filtered action probe sweep", exc_info=True)
 
 
 def _apply_stage_gate(

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -807,6 +807,92 @@ def write_stance_gate_report(stage_dir: "str | Path", report: dict[str, Any]) ->
     return written
 
 
+def write_action_filter_sweep(
+    stage_dir: "str | Path", reports: list[dict[str, Any]], *, probe_episodes: int
+) -> dict[str, Path]:
+    """Write the action-filter probe sweep as one curve, not N verdicts.
+
+    Each entry scored a MODIFIED policy, so none of them is a gate result and
+    the artifact says so before it says anything else. What is worth reading is
+    the trend: how long the filtered policy survives against cutoff. On T-Rex
+    stage 1 today that is 96 steps at 5 Hz rising to 351 at 35 Hz, against a
+    1000-step horizon -- the policy needs essentially its full command
+    bandwidth to stand (issue #491), and a future policy that reaches the
+    horizon at a low cutoff is one that could survive a real actuator.
+
+    Deliberately does not write ``stance_panel_selected.csv``: that file is the
+    per-episode evidence a stance-gated bundle is certified from, and none of
+    these panels scored the policy that would be certified.
+    """
+    directory = Path(stage_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    rows = sorted(
+        (
+            {
+                "filter_actions_hz": report["filter_actions_hz"],
+                "episode_length_mean": report["metrics"]["episode_length_mean"],
+                "full_horizon_fraction": report["metrics"]["full_horizon_fraction"],
+                "reward_mean": report["metrics"]["reward_mean"],
+                "mean_unsupported_duty": report["metrics"]["mean_unsupported_duty"],
+                "terminations": report["terminations"],
+            }
+            for report in reports
+        ),
+        key=lambda row: row["filter_actions_hz"],
+    )
+    horizon = reports[0]["horizon"]
+    # Each entry's `policy` carries its own cutoff suffix, so the first one
+    # would label the whole sweep "low-passed at 5 Hz" -- wrong for every other
+    # row. Strip it; the per-cutoff values are the table's first column.
+    policy = str(reports[0]["policy"]).split(" — actions low-passed at ")[0]
+    payload = {
+        "schema": "mesozoic.action-filter-sweep/v1",
+        "species": reports[0]["species"],
+        "stage": reports[0]["stage"],
+        "policy": policy,
+        "horizon": horizon,
+        "episodes_per_cutoff": probe_episodes,
+        "note": (
+            "Each row scored a MODIFIED policy (actions low-passed before reaching the "
+            "plant). No row is a gate verdict. The metric to read is episode_length_mean "
+            "against filter_actions_hz."
+        ),
+        "sweep": rows,
+        "reports": reports,
+    }
+    lines = [
+        "PROBE: actions low-passed before reaching the plant, at several cutoffs.",
+        "Every row scores a MODIFIED policy. None of them is a gate verdict.",
+        "",
+        f"policy              {policy}",
+        f"stage               {reports[0]['species']} stage {reports[0]['stage']}",
+        f"panel               {probe_episodes} episodes per cutoff, horizon {horizon}",
+        "",
+        f"  {'cutoff':>9}{'ep length':>12}{'full-horiz':>12}{'reward':>10}   terminations",
+    ]
+    for row in rows:
+        lines.append(
+            f"  {row['filter_actions_hz']:>7.4g} Hz{row['episode_length_mean']:>12.1f}"
+            f"{row['full_horizon_fraction']:>12.4f}{row['reward_mean']:>10.1f}   {row['terminations']}"
+        )
+    lines += [
+        "",
+        "Read the trend, not the rows: episode_length_mean against cutoff measures how",
+        "much of its own high-frequency command content the policy needs in order to",
+        "stand. Balance correction on this plant is ~1.1-1.4 Hz, which every cutoff here",
+        "passes essentially untouched, so a short episode means the policy depends on",
+        "content well above the frequency band the task itself requires.",
+    ]
+    text_path = directory / "stance_gate_probe_filtered.txt"
+    json_path = directory / "stance_gate_probe_filtered.json"
+    text_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    json_path.write_text(
+        json.dumps(_json_safe(payload), indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return {"action_filter_sweep_txt": text_path, "action_filter_sweep_json": json_path}
+
+
 #: Column order of ``stance_panel_selected.csv``.  ``unsupported_duty`` is
 #: empty for an episode whose duty could not be measured (one shorter than the
 #: settling window); the auditor treats empty as unmeasured rather than zero,

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -172,10 +172,10 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
     # everyone else the 100.0 placeholder) were all cleared by their own
     # species' statue and certified nothing.
     stage_one_min_avg_reward = {
-        # 0.60 x the statue's standing reward, which moved with
-        # leg_home_pose_weight 0.5 -> 1.5: statue 3271.8 -> 4250.4 (issue #489).
-        # The FRACTION is the invariant here, not the absolute reward.
-        "trex": 2550.0,
+        # 0.60 x the statue's standing reward at leg_home_pose_weight 0.5.
+        # Was briefly 2550 while that weight was 1.5 (statue 4250.4), reverted
+        # with it in issue #491. The FRACTION is the invariant, not the reward.
+        "trex": 1950.0,
         "velociraptor": 1050.0,
         "brachiosaurus": 1040.0,
         "dibothrosuchus": 1560.0,

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -1124,6 +1124,99 @@ class TestTheProbeIsWiredIntoTrainingArtifacts:
         )
         assert not called
 
+    def test_a_scalar_cutoff_still_works(self):
+        from environments.shared.reporting.stage_artifacts import _probe_cutoffs
+
+        assert _probe_cutoffs(5.0) == [5.0]
+
+    def test_a_list_becomes_a_sorted_deduplicated_sweep(self):
+        from environments.shared.reporting.stage_artifacts import _probe_cutoffs
+
+        assert _probe_cutoffs([20, 5.0, 10, 5.0]) == [5.0, 10.0, 20.0]
+
+    def test_unusable_entries_are_dropped_not_fatal(self):
+        """One bad entry must not cost the cutoffs that are fine."""
+        from environments.shared.reporting.stage_artifacts import _probe_cutoffs
+
+        assert _probe_cutoffs([5.0, "nonsense", -3.0, 0.0, 10.0]) == [5.0, 10.0]
+
+    def test_the_sweep_writes_one_curve_and_no_panel_evidence(self, tmp_path):
+        from environments.shared.scripts.stance_gate_report import write_action_filter_sweep
+
+        reports = []
+        for hz, length in ((20.0, 289.2), (5.0, 96.2), (10.0, 189.1)):
+            r = _minimal_stance_report()
+            r["filter_actions_hz"] = hz
+            r["metrics"] = dict(r["metrics"], episode_length_mean=length, full_horizon_fraction=0.0)
+            r["terminations"] = {"tail_contact": 10}
+            reports.append(r)
+        written = write_action_filter_sweep(tmp_path, reports, probe_episodes=10)
+        assert set(written) == {"action_filter_sweep_txt", "action_filter_sweep_json"}
+        text = (tmp_path / "stance_gate_probe_filtered.txt").read_text()
+        # Sorted by cutoff so the curve reads in order, whatever order they ran.
+        assert text.index("5 Hz") < text.index("10 Hz") < text.index("20 Hz")
+        assert "MODIFIED policy" in text
+        assert not (tmp_path / "stance_panel_selected.csv").exists()
+        assert not (tmp_path / "stance_gate_report.txt").exists()
+        import json
+
+        payload = json.loads((tmp_path / "stance_gate_probe_filtered.json").read_text())
+        assert [row["filter_actions_hz"] for row in payload["sweep"]] == [5.0, 10.0, 20.0]
+        assert payload["episodes_per_cutoff"] == 10
+
+    def test_a_partial_sweep_is_still_written(self, tmp_path, monkeypatch):
+        """A failure at one cutoff must not discard the ones that succeeded."""
+        from environments.shared.reporting import stage_artifacts
+
+        calls = {"n": 0}
+
+        def _flaky(species, stage, **kwargs):
+            calls["n"] += 1
+            if kwargs["filter_actions_hz"] == 10.0:
+                raise RuntimeError("this cutoff exploded")
+            r = _minimal_stance_report()
+            r["filter_actions_hz"] = kwargs["filter_actions_hz"]
+            return r
+
+        monkeypatch.setattr(stance_gate_report, "build_stance_gate_report", _flaky)
+        stage_artifacts._write_filtered_action_probe(
+            species="trex",
+            stage=1,
+            stage_config={"curriculum_kwargs": {"stance_probe_filter_hz": [5.0, 10.0, 20.0]}},
+            stage_dir=tmp_path,
+            model_path="m.zip",
+            vecnorm_path="v.pkl",
+            episodes=40,
+        )
+        import json
+
+        payload = json.loads((tmp_path / "stance_gate_probe_filtered.json").read_text())
+        assert [row["filter_actions_hz"] for row in payload["sweep"]] == [5.0]
+
+    def test_the_probe_rolls_fewer_episodes_than_the_gate(self, tmp_path, monkeypatch):
+        """Each cutoff costs a panel; the probe certifies nothing."""
+        from environments.shared.reporting import stage_artifacts
+
+        seen = {}
+
+        def _capture(species, stage, **kwargs):
+            seen["episodes"] = kwargs["episodes"]
+            r = _minimal_stance_report()
+            r["filter_actions_hz"] = kwargs["filter_actions_hz"]
+            return r
+
+        monkeypatch.setattr(stance_gate_report, "build_stance_gate_report", _capture)
+        stage_artifacts._write_filtered_action_probe(
+            species="trex",
+            stage=1,
+            stage_config={"curriculum_kwargs": {"stance_probe_filter_hz": [5.0]}},
+            stage_dir=tmp_path,
+            model_path="m.zip",
+            vecnorm_path="v.pkl",
+            episodes=40,
+        )
+        assert seen["episodes"] == 10
+
     def test_it_passes_the_configured_cutoff_through(self, tmp_path, monkeypatch):
         from environments.shared.reporting import stage_artifacts
 
@@ -1147,6 +1240,7 @@ class TestTheProbeIsWiredIntoTrainingArtifacts:
         )
         assert seen["filter_actions_hz"] == 5.0
         assert (tmp_path / "stance_gate_probe_filtered.txt").exists()
+        assert not (tmp_path / "stance_panel_selected.csv").exists()
 
     def test_a_failing_probe_does_not_sink_the_run(self, tmp_path, monkeypatch, caplog):
         from environments.shared.reporting import stage_artifacts
@@ -1174,7 +1268,7 @@ class TestTheProbeIsWiredIntoTrainingArtifacts:
         from environments.shared.curriculum.gate_schema import validate_gate_config
 
         curriculum = load_stage_config("trex", 1)["curriculum_kwargs"]
-        assert curriculum["stance_probe_filter_hz"] == 5.0
+        assert curriculum["stance_probe_filter_hz"] == [5.0, 10.0, 20.0]
         validate_gate_config(1, curriculum)
 
 

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -417,7 +417,7 @@
           "config_path": "configs/trex/stage1_balance.toml",
           "timesteps": 10000000,
           "advancement_gate": {
-            "min_avg_reward": 2550.0,
+            "min_avg_reward": 1950.0,
             "min_avg_episode_length": null,
             "min_avg_forward_velocity": null,
             "min_success_rate": null,


### PR DESCRIPTION
Reverts the config change from #490, logs the action-filter probe as a sweep, and records the whole investigation in [`docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md`](docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md).

Run `20260805_132950` has now finished. **`GATE: FAIL`** — and the instrumentation #490 added is what refuted #490's own hypothesis, which is the outcome it was built for.

## The final result

```
reward                    3493.7 +/- 22.0
episode length            1000.0
full_horizon_fraction     1.0000   (>= 0.9500)   PASS
mean_unsupported_duty     0.2001   (<= 0.0200)   FAIL
unsupported_duty_ucb      0.2002   (<= 0.0200)   FAIL
  bilateral support       0.7988   (statue 0.998)
  single support          0.0011   (statue 0.002)
terminations           {'truncated': 40}
```

Duty locked at **exactly 1/5** — 160 airborne steps of the 800-step measured window, 20.0 Hz — held across 100 consecutive evaluations from 5M onward, through `ent_coef` reaching zero at 7M. `single_support 0.0011` means both feet leave and land together: a vertical bounce, the same failure as run `20260804`'s 1/6 at 16.7 Hz.

## Why the change could not have worked

`leg_home_pose_joint_names` is **eight joints** — r/l `hip_pitch`, `hip_roll`, `knee`, `ankle`. Measured per actuator:

| | DC | AC (tremor) |
|---|---|---|
| the 8 governed joints | 0.035 – 0.263 → **1.2% of DC power** | 0.681 rms |
| the other 13 | up to ±0.996 → **98.8%** | 0.253 rms |

The governed joints were already at home. The displacement lives in the tail, neck, head and toes, which no term in this stage touches.

**The final report is the cleanest possible confirmation.** `reward_leg_home_pose` reached **1409.17 of the statue's 1466.80 — 96%**. The term did exactly what it was asked to do. `action_dc_rms` still finished at 0.724 against the passing policy's 0.766, and the stage failed anyway.

The joint *list*, not the weight, was the lever.

## And why no other reward tweak is indicated

Restating both policies under the **same** reward (only `leg_home_pose` rescales):

| | score |
|---|---|
| statue | 3271.8 |
| passing policy (duty 0.0000) | 3004.3 |
| **bouncing policy (duty 0.2001)** | **2554.3** |

The bounce is **450 points worse**, and loses on every term but the one whose weight was raised:

| term | passing | bouncing | Δ |
|---|---|---|---|
| `foot_load_balance` | −16.9 | −154.9 | **−137.9** |
| `bilateral_support` | 594.2 | 477.8 | **−116.5** |
| `alive` | 995.2 | 898.1 | **−97.1** |
| `smoothness` | −65.0 | −102.4 | −37.4 |
| `action_jerk` | −41.4 | −68.0 | −26.6 |

Every obvious candidate is **already firing, already correct, and already losing**. `foot_load_balance_airborne_penalty` charges the bouncer 138 points more; `support_conditioned_alive_fraction` costs it 97 points of the single largest term; `action_jerk_weight` charges 64% more than the policy that passed. None deterred it.

**This is an optimisation failure, not a reward-shaping one.** Raising any of those weights deepens a trap the optimiser is already stuck in without creating a route out.

## The change

```diff
-leg_home_pose_weight = 1.5
+leg_home_pose_weight = 0.5
-min_avg_reward = 2550.0
+min_avg_reward = 1950.0
-collapse_peak_floor_reference = 4250.4
+collapse_peak_floor_reference = 3271.8
-stance_probe_filter_hz = 5.0
+stance_probe_filter_hz = [5.0, 10.0, 20.0]
```

The two constants revert because both are derived from the statue and the statue moves with the weight. **The discipline survives the revert**, and the comments now say so rather than narrating a rescale that no longer applies: neither updates itself, so any reward-weight change must re-measure with `zero_action_baseline.py` and re-derive both.

### The probe becomes a sweep

A single cutoff answers a yes/no that is already answered — the checkpoint that **passed** falls at every cutoff from 5 to 35 Hz against a 100 Hz control rate — so its PASS/FAIL carries no information and the automatic probe would report a catastrophic failure on every run forever.

What can move is **how long the filtered policy survives**. Verified end to end against the real passing checkpoint pulled from Drive:

```
     cutoff   ep length  full-horiz    reward   terminations
        5 Hz       101.2      0.0000     144.1   {'tail_contact': 10}
       10 Hz       199.2      0.0000     384.0   {'tail_contact': 10}
       20 Hz       288.1      0.0000     588.1   {'tail_contact': 10}
```

That's the baseline for #491. Balance correction here is ~1.1–1.4 Hz and every cutoff passes it essentially untouched (gain 0.963 at 1.4 Hz even at 5 Hz), so a short episode means dependence on content well above what the task requires.

Cost is unchanged: 10 episodes per cutoff rather than the gate's 40, because the probe certifies nothing and the effect it measures is enormous. A failing cutoff doesn't discard the ones that worked, and a bare number is still accepted.

## The document

[`TREX_STAGE1_BOUNCE_2026_08.md`](docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md) records the full arc across #486 → #487 → #489 → #490 → #491, including the parts where I was wrong:

- The **coupling hypothesis in #489 was wrong.** The displaced joints (tail/neck/head/toes, AC 0.253) and the shaking joints (hips/knees/ankles, AC 0.681) are different joints. The tremor being load-bearing and the pose being displaced are both true and *not the same fact*.
- The **inversion itself was right** — accurate to 2% on reproduction, and confirmed by direct measurement (0.766 / 0.359 / 22.7 Hz against the inferred 0.800 / 0.277 / 22.6 Hz). Measuring a quantity accurately is not the same as knowing what causes it.
- The **integer-lock framing was overstated.** In a deterministic discrete-time loop every limit cycle has an integer period; that alone is not evidence of pathology. What survives is that 20 Hz is not a plant property (resonance is ~1.1–1.4 Hz), so the oscillation is actively driven — and the control rate *permits* it rather than encouraging it. The passing run ran at the same 100 Hz.

Three items folded into `KNOWN_ISSUES.md`: the pass/bounce nondeterminism, the saturated actuators, and the filter intolerance.

## Testing

- `environments/shared/tests` + `environments/trex/tests`: **1966 passed, 77 skipped**, exit 0
- New: sweep normalisation (scalar, list, dedup, bad entries dropped), one-curve output sorted by cutoff, partial sweep still written, reduced episode count, and that the probe never writes `stance_panel_selected.csv`
- `test_catalog_exports_effective_early_advancement_gates` returned to 1950 with the derivation in a comment; catalog regenerated
- `ruff check` / `ruff format --check` clean

## What happens next

**This does not fix the stage** — it restores the configuration that last passed. Duty on that configuration was 0.0000; on this one it is 0.2001.

The recommendation in the document, and the thing I'd push hardest: **run the reverted config at two seeds.** There is one pass and two failures, all at seed 42. Nothing so far distinguishes "solved" from "lucky", and that question determines everything about what to do next — more than any reward change would.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)