### PR TITLE
Stance probes + seed-43 result: the bounce is a coin flip, the toe splay reproduces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,15 +80,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **All four stance probes now run automatically on every SB3 run.** The
   notebook calls `generate_stage_artifacts` and nothing else, so a probe
   reachable only from the CLI produces nothing on a real run — and a diagnostic
-  nobody runs is a diagnostic that does not exist. `_write_stance_gate_report`
-  now dispatches to all four, each gated by its own `[curriculum]` key:
+  nobody runs is a diagnostic that does not exist. `_run_stance_probes`
+  dispatches to all four, each gated by its own `[curriculum]` key:
   `stance_probe_filter_hz`, `stance_probe_hold_constant`,
   `stance_probe_release_ablation`, `stance_probe_impulse_speeds`. All four are
   on for trex stage 1; every other stage and species is unaffected.
-  Pinned by an AST check over the real call site rather than a mock, so a fifth
-  probe added beside them cannot quietly go unwired the way these two nearly
-  did. Each is individually non-fatal: a probe that raises loses itself and
-  nothing else, because the gate report is what certifies the stage.
+  The probes run **dead last** in `generate_stage_artifacts` — after the gate
+  verdict is recorded, the summary written, and the graphs and replays saved —
+  because they are the most expensive artifact step and nothing downstream
+  reads them: a runtime lost mid-probe costs the probes alone, and a
+  probe-wiring failure has nothing left to sink. (They briefly ran inside the
+  gate report's own `try`, where a caller-side exception would have been
+  caught by the report's handler and recorded a FAIL for a stage whose
+  on-disk report says PASS — the founding defect of `_apply_stage_gate`, one
+  layer up.) Pinned by behaviour tests through the real call sites — kwarg
+  drift fails them, not just a deleted call — plus a source-order check that
+  the verdict precedes the probes, so a fifth probe added beside them cannot
+  quietly go unwired the way these two nearly did. Each is individually
+  non-fatal at both levels: the helpers guard their own rollouts, and the
+  runner guards each call site.
   Cost, per stage, at the trex settings: 3 filter panels at 10 episodes, 5 hold
   panels at 10, 13 ablation panels at 8, and 14 impulse panels at 8 — the
   impulse sweep doubled because the statue control is rolled over the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   probe did.
 
 ### Added
+- **A constant-hold probe, which separates "needs bandwidth" from "needs
+  feedback".** `stance_gate_report.py --hold-constant` replaces the policy's
+  commanded action with the constant it commands *on average* — its own
+  post-settle per-actuator DC — partway through each episode, and scores that.
+  Runs automatically after the gate report when a stage sets
+  `stance_probe_hold_constant`, writing
+  `stance_gate_probe_constant.{txt,json}`.
+  The existing low-pass probe could not answer this. A filtered policy still
+  responds to what it sees, just slowly, so a fall under the filter shows the
+  policy needs *bandwidth* without showing whether it needs *feedback* at all —
+  and the two have opposite fixes. Cutting the loop outright decides it.
+  Five variants bracketed by two controls: the unmodified policy (expressed as
+  a handoff at the horizon, so it still carries the probe marker and can never
+  land on the certification filenames) and the zero hold, which is the statue.
+  Between them the measured pose is held from settle, hard and ramped, and from
+  reset. The ramped variant exists to answer the obvious objection to a hard
+  switch — that a step transient rather than the loss of feedback knocked the
+  animal over — with a measurement instead of an argument.
+  Measured on the passing `20260805_011234` checkpoint: **both controls reach
+  the 1000-step horizon** (policy 3006.9, statue 3271.0) and **every held
+  variant collapses** — 348.9 steps from settle, 330.2 ramped, 133.3 from
+  reset, all at full-horizon 0.0000. The pose that policy holds requires
+  continuous feedback, so the tremor is stabilisation rather than waste and
+  raising `smoothness`/`action_jerk` is contraindicated. Full analysis in the
+  2026-08-06 addendum to `TREX_STAGE1_BOUNCE_2026_08.md`.
+  Probe branding is now a registry (`_PROBE_MARKERS`) rather than a chain of
+  `is not None` tests. The filter probe's guard was a single such test, and a
+  second probe added beside it would have silently inherited the certification
+  filenames and the `stance_panel_selected.csv` evidence a bundle is certified
+  from.
 - **The deterministic policy's action, measured instead of inferred.** Every
   action number on disk came from *training* rollouts, so all of it carried
   exploration noise; diagnosing issue #489 meant recovering the commanded pose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   continuous feedback, so the tremor is stabilisation rather than waste and
   raising `smoothness`/`action_jerk` is contraindicated. Full analysis in the
   2026-08-06 addendum to `TREX_STAGE1_BOUNCE_2026_08.md`.
+- **An impulse recovery probe**, `--impulse-probe`, which answers the one
+  question no training artifact can: does a stage-1 policy actually *correct*,
+  or has it only learned to stand still? Stage 1 declares no in-episode
+  disturbance — the sole perturbation is joint-angle noise at reset — so the
+  gate, the reward and all three earlier probes are silent on it by
+  construction. This applies a step change to the root's linear velocity
+  mid-episode (a shove, fully specified by `delta_v`) and sweeps magnitude in
+  **both lateral directions**, with the **zero-action statue as the control**:
+  it commands a constant and cannot respond, so its survival is the plant's
+  passive robustness and only the policy's margin over it is active control.
+  Measured on the passing checkpoint: **recovery envelope 0.50 m/s one way,
+  0.00 the other.** It takes a 0.5 m/s shove to the horizon 8/8 pushed one
+  direction and falls 0/8 pushed the other (424 steps against the statue's
+  337); at 1.0 m/s and above it is within noise of the statue on both sides.
+  Narrow *and* asymmetric — which is what a pose with differently-splayed toes
+  predicts. So stage 1's gap is a **metric** gap: the capability partly exists
+  and the task cannot see it, which makes the envelope a ready-made acceptance
+  metric for `STAGE1_SPLIT_PLAN`'s 1b.
+  The read-out is keyed off that envelope rather than a mean step margin. The
+  first version averaged the margin across rows and reported +135, of which 82%
+  came from one row — a number equally produced by a policy that recovers
+  everywhere. That is the **third** pooled statistic in this investigation to
+  hide the structure it summarised, after `action_std` over actuators-and-time
+  and the saturation count over differing `ctrlrange`s. The pooled margin is
+  still printed, second, with its caveat attached.
 - **Per-actuator pose reported in degrees, and the table ordered by them.**
   `|action| = 1` is not one physical event: `_scale_action` maps `[-1, 1]` onto
   each actuator's own `ctrlrange`, and on the T-Rex those differ by 6× — a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ankles' +5.5° `key_ctrl - key_qpos` is an intentional gravity preload, now
   reported separately instead of being mislabeled as policy displacement or a
   reason to re-centre the control range.
+  The same correction is now swept through the prose that taught the old
+  identity: docstrings in `eval_diagnostics.py` and the hold/ablation helpers,
+  the rendered ablation header, the CLI help, and the KNOWN_ISSUES saturation
+  entry all say "home control" where they said "home keyframe" for what
+  `action = 0` commands — the keyframe's *pose* keeps its name. The
+  constant-hold docstring also now states its one deliberate approximation:
+  the held command is `f(mean(action))`, not `mean(f(action))`, which differs
+  only on zero-crossing actuators with asymmetric spans (neck/head pitch on
+  this plant, bias ~0.01°).
 - **A release ablation on top of it**, `--hold-release-ablation`, which asks
   *which* joints make a held pose unholdable. Each actuator group gets two
   variants: `release_G` holds everything except G (is G **necessary** — does

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   continuous feedback, so the tremor is stabilisation rather than waste and
   raising `smoothness`/`action_jerk` is contraindicated. Full analysis in the
   2026-08-06 addendum to `TREX_STAGE1_BOUNCE_2026_08.md`.
+- **All four stance probes now run automatically on every SB3 run.** The
+  notebook calls `generate_stage_artifacts` and nothing else, so a probe
+  reachable only from the CLI produces nothing on a real run — and a diagnostic
+  nobody runs is a diagnostic that does not exist. `_write_stance_gate_report`
+  now dispatches to all four, each gated by its own `[curriculum]` key:
+  `stance_probe_filter_hz`, `stance_probe_hold_constant`,
+  `stance_probe_release_ablation`, `stance_probe_impulse_speeds`. All four are
+  on for trex stage 1; every other stage and species is unaffected.
+  Pinned by an AST check over the real call site rather than a mock, so a fifth
+  probe added beside them cannot quietly go unwired the way these two nearly
+  did. Each is individually non-fatal: a probe that raises loses itself and
+  nothing else, because the gate report is what certifies the stage.
+  Cost, per stage, at the trex settings: 3 filter panels at 10 episodes, 5 hold
+  panels at 10, 13 ablation panels at 8, and 14 impulse panels at 8 — the
+  impulse sweep doubled because the statue control is rolled over the same
+  magnitudes and is not optional.
 - **An impulse recovery probe**, `--impulse-probe`, which answers the one
   question no training artifact can: does a stage-1 policy actually *correct*,
   or has it only learned to stand still? Stage 1 declares no in-episode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   continuous feedback, so the tremor is stabilisation rather than waste and
   raising `smoothness`/`action_jerk` is contraindicated. Full analysis in the
   2026-08-06 addendum to `TREX_STAGE1_BOUNCE_2026_08.md`.
+- **A release ablation on top of it**, `--hold-release-ablation`, which asks
+  *which* joints make a held pose unholdable. Each actuator group gets two
+  variants: `release_G` holds everything except G (is G **necessary** — does
+  removing it rescue the pose?) and `only_G` holds G alone (is G
+  **sufficient** — does it break the statue by itself?). One side alone
+  misleads, and a group can look implicated purely because it is conspicuous.
+  Measured on the passing checkpoint: **holding only the six toe joints
+  reproduces the entire failure** (125.5 steps against the full pose's 128.6,
+  `tail_contact` 8 of 8 in both), while **holding only the four tail joints at
+  ±1.000 stands the full horizon** at reward 3254.0 — within 0.6% of the statue
+  — and head/neck likewise at 3286.1. No group is necessary (releasing all
+  twelve saturated actuators still falls at 224.6), so the pose is
+  over-determined, which the artifact now says in as many words.
+  **This refutes the saturation hypothesis** recorded the same day: saturation
+  is conspicuous, not causal, and the largest saturated group is provably inert.
+  Every ablated variant is commanded **from reset**, which is load-bearing and
+  was wrong in the first run: handing off at `settle_steps` snapped joints from
+  ±1.000 to 0 mid-episode, the transient dominated, all thirteen variants landed
+  within 311–349 steps of each other, and the `hold_zero` row — the statue,
+  known to stand 1000 — fell at 323. The control caught it; without it the flat
+  table would have read as "no group matters", which is a conclusion and a wrong
+  one. `TestReleaseAblationVariants` now pins the from-reset requirement.
   Probe branding is now a registry (`_PROBE_MARKERS`) rather than a chain of
   `is not None` tests. The filter probe's guard was a single such test, and a
   second probe added beside it would have silently inherited the certification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still printed, second, with its caveat attached.
 - **Per-actuator pose reported in degrees, and the table ordered by them.**
   `|action| = 1` is not one physical event: `_scale_action` maps `[-1, 1]` onto
-  each actuator's own `ctrlrange`, and on the T-Rex those differ by 6× — a
+  each actuator's own control span, and on the T-Rex those differ by 6× — a
   saturated tail joint is **8–12°** of deflection while a saturated toe is
   **37.5°**. Sorted by normalised `|dc|`, the per-actuator table put twelve
   joints at exactly `±1.000` at the top with no way to tell them apart, and the
@@ -129,18 +129,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This is the same error the DC/AC split was introduced to fix, one level down:
   a pooled *normalised* offset cannot separate moving 8° from moving 37.5° any
   more than a pooled standard deviation can separate "sitting in the wrong
-  place" from "shaking". The report now carries `dc_deg`, `ac_rms_deg`,
-  `range_deg` and `zero_offset_deg` per actuator plus `dc_rms_deg` overall, and
-  **orders the table by degrees** — which puts the five saturated toes on top at
-  ±37.5° and drops `tail_1_yaw` (±8°) out of the printed twelve. The normalised
-  `dc` is kept alongside, because that is what inverts through the action
-  penalties; the degrees are what say whether a joint moved.
-  It also surfaces that **`action = 0` is not exactly the home keyframe**: it is
-  the `ctrlrange` midpoint, and for four of 21 actuators the two differ — both
-  ankles by +5.5°, `head_pitch`/`neck_pitch` by +5.0°. Small enough that nothing
-  measured is invalidated, but `home-keyframe-residual/v1` is named for that
-  identity and both statue-derived constants lean on it, so the report now
-  prints the offset rather than leaving it to be rediscovered.
+  place" from "shaking". Report schema v2 now records applied `ctrl_mean` and
+  `ctrl_ac_rms` in native units, preserves the separate `action_zero_ctrl` and
+  `home_ctrl` anchors, and marks which actuators are direct angular position
+  controls. Only those receive `dc_deg`, `ac_rms_deg`, `range_deg`,
+  `zero_offset_deg`, `home_qpos`, and `home_preload_deg`; geared motors are not
+  mislabeled as radians. It adds `dc_rms_deg` across the compatible controls
+  and **orders the table by degrees** — which puts the five
+  saturated toes on top at ±37.5° and drops `tail_1_yaw` (±8°) out of the
+  printed twelve. The normalised `dc` is kept alongside, because that is what
+  inverts through the action penalties; the degree fields are reduced from the
+  controls actually applied during rollout.
+  This distinction matters for `home-keyframe-residual/v1`: T-Rex maps the two
+  halves piecewise around `key_ctrl[home]`, so neither the mean nor RMS physical
+  target can be reconstructed from normalised moments with one full-range
+  scale. Action zero maps exactly to the home control for all 21 actuators. The
+  ankles' +5.5° `key_ctrl - key_qpos` is an intentional gravity preload, now
+  reported separately instead of being mislabeled as policy displacement or a
+  reason to re-centre the control range.
 - **A release ablation on top of it**, `--hold-release-ablation`, which asks
   *which* joints make a held pose unholdable. Each actuator group gets two
   variants: `release_G` holds everything except G (is G **necessary** — does

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   continuous feedback, so the tremor is stabilisation rather than waste and
   raising `smoothness`/`action_jerk` is contraindicated. Full analysis in the
   2026-08-06 addendum to `TREX_STAGE1_BOUNCE_2026_08.md`.
+- **Per-actuator pose reported in degrees, and the table ordered by them.**
+  `|action| = 1` is not one physical event: `_scale_action` maps `[-1, 1]` onto
+  each actuator's own `ctrlrange`, and on the T-Rex those differ by 6× — a
+  saturated tail joint is **8–12°** of deflection while a saturated toe is
+  **37.5°**. Sorted by normalised `|dc|`, the per-actuator table put twelve
+  joints at exactly `±1.000` at the top with no way to tell them apart, and the
+  most conspicuous of them (the tail) was the one later measured to be
+  mechanically inert.
+  This is the same error the DC/AC split was introduced to fix, one level down:
+  a pooled *normalised* offset cannot separate moving 8° from moving 37.5° any
+  more than a pooled standard deviation can separate "sitting in the wrong
+  place" from "shaking". The report now carries `dc_deg`, `ac_rms_deg`,
+  `range_deg` and `zero_offset_deg` per actuator plus `dc_rms_deg` overall, and
+  **orders the table by degrees** — which puts the five saturated toes on top at
+  ±37.5° and drops `tail_1_yaw` (±8°) out of the printed twelve. The normalised
+  `dc` is kept alongside, because that is what inverts through the action
+  penalties; the degrees are what say whether a joint moved.
+  It also surfaces that **`action = 0` is not exactly the home keyframe**: it is
+  the `ctrlrange` midpoint, and for four of 21 actuators the two differ — both
+  ankles by +5.5°, `head_pitch`/`neck_pitch` by +5.0°. Small enough that nothing
+  measured is invalidated, but `home-keyframe-residual/v1` is named for that
+  identity and both statue-derived constants lean on it, so the report now
+  prints the offset rather than leaving it to be rediscovered.
 - **A release ablation on top of it**, `--hold-release-ablation`, which asks
   *which* joints make a held pose unholdable. Each actuator group gets two
   variants: `release_G` holds everything except G (is G **necessary** — does

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -450,6 +450,42 @@ stance_probe_hold_constant = true        # After the gate report, re-score the S
                                          # DC -- and rolls 10 episodes per variant for the same reason the filter
                                          # sweep does. Scores a MODIFIED policy: own filenames, never
                                          # stance_panel_selected.csv, verdict is not a gate result.
+stance_probe_release_ablation = true     # Ablate the held pose one actuator group at a time and write
+                                         # stance_gate_probe_release.{txt,json}. Answers WHICH joints make the
+                                         # pose unholdable, where the hold probe only answers whether it is.
+                                         #
+                                         # Each group is tested twice: released (is it NECESSARY -- does removing
+                                         # it rescue the pose?) and held alone (is it SUFFICIENT -- does it break
+                                         # the statue by itself?). One side alone lets a conspicuous group
+                                         # masquerade as a cause, which is not hypothetical here: the tail is the
+                                         # most extreme entry in the DC table and holding it alone stands the full
+                                         # horizon at 3254.0, while holding only the six toes reproduces the whole
+                                         # failure (125.5 steps against the full pose's 128.6).
+                                         #
+                                         # 13 panels at 8 episodes -- the most expensive of the four probes, which
+                                         # is why it is per-stage opt-in rather than on by default.
+stance_probe_impulse_speeds = [0.5, 1.0, 2.0]  # Shove the animal mid-episode at each of these speeds (m/s of root
+                                         # velocity), in BOTH lateral directions, and write
+                                         # stance_gate_probe_impulse.{txt,json}. Unset to skip.
+                                         #
+                                         # The only measurement in the pipeline that tracks BALANCE rather than
+                                         # NOT FALLING OVER. This stage declares no in-episode disturbance, so
+                                         # every other criterion here -- duty, full-horizon share, the reward rail
+                                         # -- is satisfied by a zero-action statue, and nothing else can tell a
+                                         # policy that learned to RECOVER from one that learned to stand still.
+                                         #
+                                         # The statue is rolled over the same sweep as the control, which doubles
+                                         # the cost and is not optional: it commands a constant and cannot respond,
+                                         # so its survival is the plant's PASSIVE robustness and only the policy's
+                                         # margin above it is control. Reporting the policy alone would credit the
+                                         # plant's own stability to the policy.
+                                         #
+                                         # Both directions because policies here are asymmetric. Measured on
+                                         # 20260805_011234: full recovery at 0.50 m/s one way, 0/8 the other, and
+                                         # within noise of the statue at 1.0 m/s and above. Recovery envelope on
+                                         # the WEAKER side is the number to track; 0.00 m/s is the baseline.
+                                         #
+                                         # 14 panels at 8 episodes (7 sweep rows x policy + statue).
 collapse_peak_floor_fraction = 0.45    # RELATIVE floor (PLANT_VALIDATION §14 item 3). An absolute floor has now
                                          # failed to arm TWICE for the same reason: 2200 against run 20260731_132102
                                          # (peak 1934.1, watched a -59% collapse), then 2450 against run

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -421,7 +421,36 @@ stance_probe_filter_hz = [5.0, 10.0, 20.0]  # After the gate report, re-score th
                                          #
                                          # The probe scores a MODIFIED policy: its own filenames, never
                                          # stance_panel_selected.csv, and its verdict is not a gate result.
-collapse_peak_floor_fraction = 0.45      # RELATIVE floor (PLANT_VALIDATION §14 item 3). An absolute floor has now
+stance_probe_hold_constant = true        # After the gate report, re-score the SAME checkpoint with its commanded
+                                         # action FROZEN to the constant it averages, and write
+                                         # stance_gate_probe_constant.{txt,json}. Unset to skip.
+                                         #
+                                         # The question the filter probe cannot answer. A low-passed policy still
+                                         # responds to what it sees, just slowly, so a fall under the filter proves
+                                         # the policy needs BANDWIDTH without saying whether it needs FEEDBACK.
+                                         # Freezing the action cuts the loop outright, and the two readings have
+                                         # opposite fixes: a pose that stands under a constant means the tremor is
+                                         # waste the action penalties failed to suppress (an optimisation problem),
+                                         # while a pose that falls means the tremor is the only thing holding the
+                                         # animal up and penalising it harder would be actively wrong.
+                                         #
+                                         # Five variants bracketed by two controls -- the unmodified policy, which
+                                         # must reach the horizon, and the zero hold, which is the statue and
+                                         # already stands 40 of 40. Between them the measured pose is held from
+                                         # settle (hard and ramped) and from reset. The ramped variant exists to
+                                         # answer the objection that a step transient rather than the loss of
+                                         # feedback knocked the animal over, with a measurement instead of an
+                                         # argument.
+                                         #
+                                         # Measured on the 20260805_011234 checkpoint: policy 1000 steps, statue
+                                         # 1000, and every held variant falls. The pose this policy holds requires
+                                         # continuous feedback.
+                                         #
+                                         # Costs no measurement panel -- it reuses the gate report's per-actuator
+                                         # DC -- and rolls 10 episodes per variant for the same reason the filter
+                                         # sweep does. Scores a MODIFIED policy: own filenames, never
+                                         # stance_panel_selected.csv, verdict is not a gate result.
+collapse_peak_floor_fraction = 0.45    # RELATIVE floor (PLANT_VALIDATION §14 item 3). An absolute floor has now
                                          # failed to arm TWICE for the same reason: 2200 against run 20260731_132102
                                          # (peak 1934.1, watched a -59% collapse), then 2450 against run
                                          # 20260801_021545 (best eval 2347.67 -- still under it, watched

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -124,16 +124,6 @@ tolerance) remains the standing recommendation for the divergences above.
   from home against a 75° range, and adjacent toes on the same foot are driven
   to opposite ends — the foot is splayed into a twist, asymmetrically between
   the two feet. The mechanism survives.
-- **LOW** — **`action = 0` is not exactly the home keyframe for 4 of 21
-  actuators.** It is the `ctrlrange` midpoint, which equals home only where the
-  range was authored centred on it: both ankles sit **+5.5°** off and
-  `head_pitch`/`neck_pitch` **+5.0°** off. Everything else is exact. Small
-  enough that the statue still reaches the horizon 40 of 40, so nothing measured
-  is invalidated — but "`action = 0` **is** the home keyframe" is the phrasing
-  `home-keyframe-residual/v1` is named for, and both statue-derived constants
-  and every DC interpretation rest on it. The stance report now prints the
-  offset. Fix by re-centring those four `ctrlrange`s, which bumps
-  `policy_interface_revision`.
 - **MEDIUM** — **stage 1 contains no in-episode disturbance, so it cannot ask
   for postural correction.** The only perturbation is joint-angle noise at
   reset (`reset_noise_scale 0.05`); nothing applies an external force during an

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -142,6 +142,16 @@ tolerance) remains the standing recommendation for the divergences above.
   optimum. Active balance recovery is **absent from the task**, not
   underweighted in the reward, and no reweighting substitutes for adding it —
   that is what `STAGE1_SPLIT_PLAN.md`'s 1a stance / 1b recovery split is for.
+  **Measured (2026-08-06):** `--impulse-probe` shows the passing policy *does*
+  correct, but only just — it fully recovers a **0.50 m/s** lateral shove in one
+  direction (8/8 to the horizon, against a statue that never recovers from
+  anything) and **fails the same shove in the other direction** (0/8, 424 steps
+  against the statue's 337). At **1.0 m/s and above it is within noise of the
+  statue on both sides.** Recovery envelope: **0.50 m/s one way, 0.00 the
+  other** — narrow *and* asymmetric, which is what the differently-splayed toes
+  predict. So the stage-1 gap is a **metric** gap: the capability partly exists
+  and the task cannot see it. The envelope on the weaker side is a ready-made
+  acceptance metric for 1b, and 0.00 m/s is the number to beat.
 
 <!-- The six items below come from the 2026-07-31 plant validation pass; full
      evidence in PLANT_VALIDATION_AND_STAGE1_OBJECTIVE.md. The reset and

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -81,6 +81,32 @@ tolerance) remains the standing recommendation for the divergences above.
   if one is wanted for sim-to-real it has to be present during training. The
   probe conflates bandwidth-dependence with delay-sensitivity; a zero-phase
   offline filter would separate them. Tracked in #491.
+- **HIGH** — **the passing policy stands in a pose it cannot hold without
+  continuous feedback.** Freezing its commanded action to the constant it
+  averages collapses it from every handoff point — 348.9 steps of a 1000-step
+  horizon from settle, 330.2 when ramped in over 50 steps, 133.3 from reset —
+  while both controls reach the horizon (unmodified policy 1000, zero-action
+  statue 1000 at reward 3271.0). The ramped variant falling too rules out a
+  handoff transient. The statue holds the *home* pose on a constant forever;
+  the policy stands 0.765 rms away from home with 12 of 21 actuators pinned at
+  ±1.000, and **that** pose needs active stabilisation. So the tremor is the
+  price of where the policy chose to stand, not a property of the task, and
+  **raising `smoothness`/`action_jerk` is contraindicated** — they would
+  suppress the only thing holding the animal up. The open question is why the
+  policy leaves a pose that is free to hold for one costing 267 reward points
+  plus continuous stabilisation; the candidate answer is that no stage-1 term
+  constrains 13 of the 21 actuators (`leg_home_pose` covers 8 carrying 1.2% of
+  the offset). Measured by `stance_gate_report.py --hold-constant`; see the
+  2026-08-06 addendum in the bounce investigation. Untested next step: release
+  only the saturated joints back to home and re-measure.
+- **MEDIUM** — **stage 1 contains no in-episode disturbance, so it cannot ask
+  for postural correction.** The only perturbation is joint-angle noise at
+  reset (`reset_noise_scale 0.05`); nothing applies an external force during an
+  episode. A policy that learns active correction therefore earns nothing over
+  one that stands still, which is why the zero-action statue is the objective's
+  optimum. Active balance recovery is **absent from the task**, not
+  underweighted in the reward, and no reweighting substitutes for adding it —
+  that is what `STAGE1_SPLIT_PLAN.md`'s 1a stance / 1b recovery split is for.
 
 <!-- The six items below come from the 2026-07-31 plant validation pass; full
      evidence in PLANT_VALIDATION_AND_STAGE1_OBJECTIVE.md. The reset and

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -67,7 +67,14 @@ tolerance) remains the standing recommendation for the divergences above.
   distinguishes "solved" from "lucky".
 - **MEDIUM** — **half the actuators sit saturated and nothing opposes it.**
   Ten to twelve of 21 actuators are pinned at `|action| ≥ 0.99` — tail, neck,
-  head, toes — in *both* passing and failing policies. `energy` charges
+  head, toes — in *both* passing and failing policies.
+  **Read this count with care (2026-08-06):** `|action| = 1` is not one physical
+  event. Actions map linearly onto each actuator's own `ctrlrange`, and those
+  differ by 6× — a saturated tail joint is **8–12°** of deflection while a
+  saturated toe is **37.5°**. The saturation count pools them, and the ablation
+  showed the tail is mechanically inert while the toes carry the whole effect.
+  The stance report now orders per-actuator DC by **degrees**; use that, not the
+  saturation count, to decide which joints moved. `energy` charges
   ~48/episode against an alive bonus paying ~1000, and `leg_home_pose` governs
   only 8 joints carrying 1.2% of the commanded offset. A saturated actuator has
   no headroom in one direction, so the recovery envelope on those axes is
@@ -113,8 +120,20 @@ tolerance) remains the standing recommendation for the divergences above.
   their stops, which changes the support polygon — a plant effect, not a
   reward-shaping one. **Not yet a reason to add a toe reward term**: sufficiency
   says the toe pose breaks a *statue*, not that constraining it would make the
-  policy stand. Unmeasured prerequisite: whether `±1.000` on a toe is a large
-  joint angle at all — read `ctrlrange` out of `trex.xml` first.
+  policy stand. **Prerequisite now measured:** `±1.000` on a toe is **±37.5°**
+  from home against a 75° range, and adjacent toes on the same foot are driven
+  to opposite ends — the foot is splayed into a twist, asymmetrically between
+  the two feet. The mechanism survives.
+- **LOW** — **`action = 0` is not exactly the home keyframe for 4 of 21
+  actuators.** It is the `ctrlrange` midpoint, which equals home only where the
+  range was authored centred on it: both ankles sit **+5.5°** off and
+  `head_pitch`/`neck_pitch` **+5.0°** off. Everything else is exact. Small
+  enough that the statue still reaches the horizon 40 of 40, so nothing measured
+  is invalidated — but "`action = 0` **is** the home keyframe" is the phrasing
+  `home-keyframe-residual/v1` is named for, and both statue-derived constants
+  and every DC interpretation rest on it. The stance report now prints the
+  offset. Fix by re-centring those four `ctrlrange`s, which bumps
+  `policy_interface_revision`.
 - **MEDIUM** — **stage 1 contains no in-episode disturbance, so it cannot ask
   for postural correction.** The only perturbation is joint-angle noise at
   reset (`reset_noise_scale 0.05`); nothing applies an external force during an

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -97,8 +97,24 @@ tolerance) remains the standing recommendation for the divergences above.
   plus continuous stabilisation; the candidate answer is that no stage-1 term
   constrains 13 of the 21 actuators (`leg_home_pose` covers 8 carrying 1.2% of
   the offset). Measured by `stance_gate_report.py --hold-constant`; see the
-  2026-08-06 addendum in the bounce investigation. Untested next step: release
-  only the saturated joints back to home and re-measure.
+  2026-08-06 addendum in the bounce investigation.
+- **HIGH** — **the toes alone account for the unholdable pose; the tail is a
+  bystander.** Ablating the held pose one actuator group at a time
+  (`--hold-release-ablation`, necessity *and* sufficiency per group): holding
+  only the **six toe joints** at their commanded DC with everything else at
+  home reproduces the whole failure — **125.5 steps against the full pose's
+  128.6, `tail_contact` 8 of 8 in both**. Holding only the **four tail joints**
+  at `±1.000` stands the full horizon at reward **3254.0**, within 0.6% of the
+  statue; head and neck likewise at **3286.1**. No group is *necessary* —
+  releasing all twelve saturated actuators still falls (224.6 steps) — so the
+  pose is over-determined and several subsets break it independently. **This
+  refutes the saturation hypothesis** recorded above it: saturation is
+  conspicuous, not causal. Toes are the ground contact and five of six sit at
+  their stops, which changes the support polygon — a plant effect, not a
+  reward-shaping one. **Not yet a reason to add a toe reward term**: sufficiency
+  says the toe pose breaks a *statue*, not that constraining it would make the
+  policy stand. Unmeasured prerequisite: whether `±1.000` on a toe is a large
+  joint angle at all — read `ctrlrange` out of `trex.xml` first.
 - **MEDIUM** — **stage 1 contains no in-episode disturbance, so it cannot ask
   for postural correction.** The only perturbation is joint-angle noise at
   reset (`reset_noise_scale 0.05`); nothing applies an external force during an

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -69,8 +69,9 @@ tolerance) remains the standing recommendation for the divergences above.
   Ten to twelve of 21 actuators are pinned at `|action| ≥ 0.99` — tail, neck,
   head, toes — in *both* passing and failing policies.
   **Read this count with care (2026-08-06):** `|action| = 1` is not one physical
-  event. Actions map linearly onto each actuator's own `ctrlrange`, and those
-  differ by 6× — a saturated tail joint is **8–12°** of deflection while a
+  event. Actions map piecewise-affine around each actuator's home control onto
+  its own `ctrlrange`, and those ranges differ by 6× — a saturated tail joint is
+  **8–12°** of deflection while a
   saturated toe is **37.5°**. The saturation count pools them, and the ablation
   showed the tail is mechanically inert while the toes carry the whole effect.
   The stance report now orders per-actuator DC by **degrees**; use that, not the

--- a/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
+++ b/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
@@ -554,3 +554,85 @@ statue still stands 40 of 40, so nothing measured here is invalidated. But
 named for, and both statue-derived constants and every DC interpretation in
 this document rest on it. It is inexact for those four, and the report now says
 so rather than leaving it to be rediscovered.
+
+---
+
+## Addendum 4, 2026-08-06 — does it actually correct? Barely, and only one way
+
+Appended. This answers the question the whole investigation was really about.
+
+### Why it needed a new probe
+
+Stage 1 has **no in-episode disturbance** — the only perturbation anywhere is
+joint-angle noise at reset. So nothing in any training artifact can distinguish
+a policy that learned to *recover* from one that learned to *stand still*: the
+task never asks. The gate, the reward, the statue baseline and all three
+earlier probes are silent on it by construction.
+
+`stance_gate_report.py --impulse-probe` asks directly. A step change in the
+root's linear velocity at step 200 — a shove to the torso, fully specified by
+`delta_v` — swept over magnitude and **both lateral directions**, with the
+zero-action statue as the control. The statue commands a constant and therefore
+cannot respond to anything, so whatever it survives is the plant's *passive*
+robustness; only the policy's margin above that is active control.
+
+### Result, passing checkpoint, 8 episodes per row
+
+| impulse | direction | policy len | policy fh | statue len | statue fh | margin |
+|---|---|---|---|---|---|---|
+| none | control | 1000.0 | 1.0000 | 1000.0 | 1.0000 | +0 |
+| 0.50 m/s | lateral +y | 423.9 | 0.0000 | 337.1 | 0.0000 | +87 |
+| **0.50 m/s** | **lateral −y** | **1000.0** | **1.0000** | 337.5 | 0.0000 | **+662** |
+| 1.00 m/s | lateral +y | 264.2 | 0.0000 | 272.5 | 0.0000 | −8 |
+| 1.00 m/s | lateral −y | 329.8 | 0.0000 | 272.4 | 0.0000 | +57 |
+| 2.00 m/s | lateral +y | 244.5 | 0.0000 | 240.8 | 0.0000 | +4 |
+| 2.00 m/s | lateral −y | 249.0 | 0.0000 | 240.2 | 0.0000 | +9 |
+
+**Recovery envelope: 0.50 m/s one way, nothing the other.** The statue never
+recovers from anything, so the single full-horizon row is unambiguous — the
+policy does something under load that a constant command cannot.
+
+So the answer is **yes, it corrects — barely, and only in one direction.**
+
+- At **0.5 m/s** it fully recovers pushed one way (8/8 episodes to the horizon)
+  and completely fails pushed the other (0/8, and only 87 steps better than a
+  statue).
+- At **1.0 m/s and above** it is within noise of the statue on both sides. The
+  envelope is not merely asymmetric, it is *narrow*.
+
+The asymmetry is worth taking seriously given §Addendum 2: this policy's toes
+are splayed **differently on the two feet**, so a left-right asymmetric recovery
+envelope is what that pose predicts. A single-direction sweep would have
+measured whichever side it happens to be good at and reported that as the
+capability.
+
+### Correction: a pooled margin nearly buried this
+
+The probe's first read-out averaged the step margin over all disturbed rows and
+reported **+135**, concluding "active correction exists" — true, but 82% of that
+average is the one +662 row, and the same number is produced by a policy that
+recovers everywhere at +135. It pooled a full recovery with a total failure and
+described neither.
+
+**This is the third time in this investigation a pooled statistic hid the
+structure it was summarising** — after `action_std` over actuators and time
+(§10), and the saturation count over actuators of different `ctrlrange`
+(Addendum 3). The read-out is now keyed off the **recovery envelope per
+direction**, with the pooled margin printed second and labelled with its own
+caveat. The rule that keeps being relearned: *report the quantity the decision
+depends on, not the average of it.*
+
+### What this means
+
+**Stage 1's gap is a metric gap, not a reward one.** Something in the policy
+does correct; the stage simply has no disturbance with which to see it, so it
+can neither reward the capability nor certify it. No reweighting of the current
+terms changes that — there is nothing for a term to pay for in an episode where
+nothing goes wrong.
+
+That makes `STAGE1_SPLIT_PLAN.md`'s **1b recovery** stage the indicated work,
+and this probe is a ready-made acceptance metric for it: the recovery envelope
+in m/s, on the weaker side, is a single number that goes up when the policy
+gets better at the thing the stage is named for.
+
+**A baseline now exists to beat: 0.50 m/s one way, 0.00 the other.**

--- a/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
+++ b/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
@@ -484,3 +484,73 @@ without the statue control the flat table would have read as "no group matters",
 which is a conclusion and a wrong one. The control cost 8 episodes and saved a
 false negative. `TestReleaseAblationVariants` now pins the from-reset
 requirement.
+
+---
+
+## Addendum 3, 2026-08-06 — why the ablation was needed at all
+
+Appended. This answers the prerequisite Addendum 2 flagged as unmeasured, and
+the answer means the ablation should not have been necessary to find its result.
+
+### `|action| = 1` is not one physical event
+
+`_scale_action` maps `[-1, 1]` linearly onto each actuator's own `ctrlrange`.
+Those ranges differ by a factor of six across the T-Rex:
+
+| group | `action = +1` | `action = −1` | deflection from home | ablation verdict |
+|---|---|---|---|---|
+| **toes** | **+50°** | **−25°** | **±37.5°** | **sufficient** |
+| hip_roll | +25° | −25° | ±25° | inconclusive (0.875) |
+| head / neck | +20…40° | −20…30° | ~±25° | bystander |
+| **tail** | **+12° pitch, +8° yaw** | **−12° / −8°** | **±8–12°** | **bystander** |
+
+The ablation's result falls straight out of that column. The tail is inert
+because saturating a tail joint moves it **eight to twelve degrees**. The toes
+carry the effect because saturating a toe moves it **37.5°**, and adjacent toes
+on the same foot are driven to opposite ends — on the right foot d2 and d4 at
++50° while d3 sits at −25°, a **75° spread across one foot**. The foot is
+splayed into a twist, asymmetrically between the two feet.
+
+So the answer to Addendum 2's open question is **yes, very large** — and the
+"toes are the ground contact" mechanism survives.
+
+### The metric was the problem
+
+"Ten to twelve of 21 actuators pinned at `|action| ≥ 0.99`" — quoted in §7, in
+KNOWN_ISSUES and throughout this investigation — pools an 8° tail deflection
+with a 37.5° toe deflection and counts them as the same event. Sorted by `|dc|`,
+the per-actuator table put twelve joints at exactly `±1.000` at the top with no
+way to tell them apart, and the most conspicuous of them was the inert one.
+
+**This is the same error the DC/AC split was introduced to fix, one level
+down.** §10 says a pooled standard deviation "cannot separate sitting in the
+wrong place from shaking". A pooled *normalised* offset cannot separate moving
+8° from moving 37.5°, and the fix is the same shape: report the physical
+quantity next to the normalised one.
+
+`stance_gate_report.py` now emits `dc_deg`, `ac_rms_deg`, `range_deg` and
+`zero_offset_deg` per actuator, and **orders the table by degrees**. On the
+passing checkpoint that puts the five saturated toes at the top at ±37.5° and
+drops `tail_1_yaw` (±8°) out of the printed twelve entirely — the ablation's
+conclusion, readable directly off the report.
+
+**Lesson: a normalised summary is only as good as the assumption that its units
+mean the same thing everywhere.** Twice now that assumption has been false, and
+both times it hid the answer rather than merely blurring it.
+
+### And `action = 0` is not exactly the home keyframe
+
+`action = 0` is the `ctrlrange` **midpoint**, which equals home only where the
+range was authored centred on it. For four of 21 actuators it is not:
+
+| actuator | `action = 0` minus home |
+|---|---|
+| `r_ankle`, `l_ankle` | **+5.5°** |
+| `head_pitch`, `neck_pitch` | **+5.0°** |
+
+Everything else is exact to floating point. The magnitude is small and the
+statue still stands 40 of 40, so nothing measured here is invalidated. But
+"`action = 0` **is** the home keyframe" is the phrasing the residual mapping is
+named for, and both statue-derived constants and every DC interpretation in
+this document rest on it. It is inexact for those four, and the report now says
+so rather than leaving it to be rediscovered.

--- a/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
+++ b/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
@@ -266,3 +266,99 @@ The frequency estimate is `jerk/delta = (2 sin πfΔt)²`, which is blind to any
 constant offset — the DC/AC split is the point, because a pooled standard
 deviation over actuators and time cannot separate "sitting in the wrong place"
 from "shaking", and those have different causes and different fixes.
+
+---
+
+## Addendum, 2026-08-06 — the tremor is feedback, not bandwidth
+
+Appended, not rewritten. This settles the question §5 left open.
+
+### What §5 could not answer
+
+The low-pass probe proved the tremor is load-bearing, but a low-passed policy
+**still responds to what it sees** — just slowly. So a fall under the filter
+shows the policy needs *bandwidth*; it cannot show whether it needs *feedback*
+at all. Two readings survived, with opposite fixes:
+
+- the pose the policy holds needs continuous active stabilisation, or
+- the pose is holdable by a constant, and the tremor is waste the action
+  penalties failed to suppress.
+
+### The experiment
+
+Replace the commanded action with the constant the policy commands **on
+average** — its own post-settle per-actuator DC — and keep everything else
+identical. Feedback is cut outright rather than attenuated. Two controls
+bracket the measurement.
+
+`stance_gate_report.py --hold-constant`, on the **passing** checkpoint
+(`20260805_011234`), 10 episodes per variant:
+
+| variant | handoff | ramp | ep length | full-horizon | reward | terminations |
+|---|---|---|---|---|---|---|
+| policy (control) | never | — | **1000.0** | 1.0000 | 3006.9 | truncated 10 |
+| `hold_after_settle` | 200 | 0 | 348.9 | 0.0000 | 908.8 | tail_contact 9, fallen 1 |
+| `hold_after_settle_ramped` | 200 | 50 | 330.2 | 0.0000 | 795.0 | fallen 8, tail_contact 2 |
+| `hold_from_reset` | 0 | 50 | 133.3 | 0.0000 | 284.8 | tail_contact 10 |
+| `hold_zero` (statue control) | 0 | 0 | **1000.0** | 1.0000 | 3271.0 | truncated 10 |
+
+Both controls behave exactly as required — the unmodified policy reaches the
+horizon, and the statue reproduces its known 3271.8 within panel noise — so the
+harness is measuring the pose and not itself.
+
+### Result
+
+**The pose the policy holds requires continuous feedback.** Every held variant
+collapses, and the ramped variant collapses too, which removes the obvious
+objection: it is not a step transient at the handoff. Ramping in over 50 steps
+made it *slightly worse* and shifted the termination reason from `tail_contact`
+to `fallen`, which is what a slow topple looks like rather than a jolt.
+
+### Why this matters more than it first appears
+
+The statue stands at the home keyframe for the full horizon on a constant
+command. The policy stands 0.765 rms **away** from home — 12 of 21 actuators
+pinned at exactly ±1.000 with AC 0.000 — and *that* pose cannot be held by a
+constant. So the tremor is not a property of the task. It is the cost of
+standing where the policy chose to stand.
+
+That reframes the whole question. It is not "why does the policy shake?" but
+**"why did it walk off a pose that is free to hold, onto one that costs 267
+reward points *and* requires continuous stabilisation?"** The answer is not in
+the action penalties, and raising them is now positively contraindicated —
+§4 already showed they are firing and losing, and this shows the thing they
+would suppress is the only thing holding the animal up.
+
+The candidate answer is that **nothing in stage 1 constrains where 13 of the 21
+actuators sit.** `leg_home_pose` covers 8 joints carrying 1.2% of the offset
+(§3). The tail, neck, head and toes are unconstrained, they saturate, and the
+sagittal chain — hip pitch, knee, ankle, the joints with headroom left — pays
+for it at 22.6 Hz.
+
+### It does not, by itself, argue for a reward change
+
+Two things must not be read into this:
+
+1. **It says nothing about the bounce.** The bounce is still 450 points worse
+   under the same reward (§4), still an optimisation failure, and still not
+   addressable by reweighting.
+2. **It does not show the reward is wrong, only that it is silent.** A term
+   constraining the unconstrained joints is a *hypothesis*, and the last time a
+   pose term was reweighted on a plausible mechanism (#490) it did exactly what
+   it was asked to do and the stage failed anyway. Measure the mechanism before
+   shaping for it.
+
+The measurement that would test it is cheap and does not need a training run:
+hold the constant pose but **release only the saturated joints back to home**,
+and see whether the rest becomes holdable. If it does, the saturated pose is
+what creates the stabilisation load.
+
+### And a separate point about the task
+
+Stage 1 has **no in-episode disturbance** — the only perturbation is joint-angle
+noise at reset (`reset_noise_scale 0.05`); there is no external force anywhere
+in the environment. So a policy that learns active postural correction earns
+nothing over one that stands still, and "actively stand and correct posture"
+is not underweighted in this reward, it is absent from the task. That is the
+gap `STAGE1_SPLIT_PLAN.md` proposes 1a/1b for, and no reweighting substitutes
+for it.

--- a/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
+++ b/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
@@ -494,8 +494,9 @@ the answer means the ablation should not have been necessary to find its result.
 
 ### `|action| = 1` is not one physical event
 
-`_scale_action` maps `[-1, 1]` linearly onto each actuator's own `ctrlrange`.
-Those ranges differ by a factor of six across the T-Rex:
+`_scale_action` maps `[-1, 1]` piecewise-affine around the home keyframe's
+control target, retaining each actuator's `ctrlrange` as its two endpoints.
+Those physical spans differ by a factor of six across the T-Rex:
 
 | group | `action = +1` | `action = −1` | deflection from home | ablation verdict |
 |---|---|---|---|---|
@@ -528,32 +529,35 @@ wrong place from shaking". A pooled *normalised* offset cannot separate moving
 8° from moving 37.5°, and the fix is the same shape: report the physical
 quantity next to the normalised one.
 
-`stance_gate_report.py` now emits `dc_deg`, `ac_rms_deg`, `range_deg` and
-`zero_offset_deg` per actuator, and **orders the table by degrees**. On the
-passing checkpoint that puts the five saturated toes at the top at ±37.5° and
-drops `tail_1_yaw` (±8°) out of the printed twelve entirely — the ablation's
-conclusion, readable directly off the report.
+`stance_gate_report.py` now emits `dc_deg`, `ac_rms_deg`, `range_deg`,
+`zero_offset_deg`, and `home_preload_deg` per actuator, and **orders the table
+by degrees**. The degree moments come from the physical controls actually
+applied during rollout, not from rescaling the normalised mean and variance.
+The shared reporter emits them only for verified angular position servos, so a
+geared motor control cannot be mislabeled or ranked as a joint angle.
+On the passing checkpoint that puts the five saturated toes at the top at
+±37.5° and drops `tail_1_yaw` (±8°) out of the printed twelve entirely — the
+ablation's conclusion, readable directly off the report.
 
 **Lesson: a normalised summary is only as good as the assumption that its units
 mean the same thing everywhere.** Twice now that assumption has been false, and
 both times it hid the answer rather than merely blurring it.
 
-### And `action = 0` is not exactly the home keyframe
+### Action origin, home control, and home pose are different quantities
 
-`action = 0` is the `ctrlrange` **midpoint**, which equals home only where the
-range was authored centred on it. For four of 21 actuators it is not:
+The first version of the degree report duplicated the base environment's
+midpoint formula and compared that target with `key_qpos`. T-Rex does neither:
+its override maps the negative and positive halves independently around
+`key_ctrl[home]`, so **`action = 0` maps exactly to the named home control for
+all 21 actuators**.
 
-| actuator | `action = 0` minus home |
-|---|---|
-| `r_ankle`, `l_ankle` | **+5.5°** |
-| `head_pitch`, `neck_pitch` | **+5.0°** |
-
-Everything else is exact to floating point. The magnitude is small and the
-statue still stands 40 of 40, so nothing measured here is invalidated. But
-"`action = 0` **is** the home keyframe" is the phrasing the residual mapping is
-named for, and both statue-derived constants and every DC interpretation in
-this document rest on it. It is inexact for those four, and the report now says
-so rather than leaving it to be rediscovered.
+The two ankle home controls are 5.5° above their home joint poses. That is the
+intentional gravity preload documented beside the XML actuator ranges, not an
+action-mapping defect; head and neck have no such offset. Report schema v2 now
+keeps `action_zero_ctrl`, `home_ctrl`, and `home_qpos` separate, records applied
+control moments per sample, and reports the ankle difference neutrally as
+`home_preload_deg`. There is no basis here for re-centring any control range or
+bumping the policy interface.
 
 ---
 
@@ -667,9 +671,11 @@ the probe work changes that.
 | `--hold-release-ablation` | which joints? | **toes**, sufficient alone; tail and head/neck inert |
 | `--impulse-probe` | does it actually correct? | **barely** — 0.50 m/s one way, 0.00 the other |
 
-Plus two measurement defects found on the way: `|action| = 1` means 8° on a tail
-joint and 37.5° on a toe (Addendum 3), and `action = 0` is not exactly home for
-four actuators.
+Plus one measurement defect found on the way: `|action| = 1` means 8° on a tail
+joint and 37.5° on a toe (Addendum 3). The follow-up action-mapping audit also
+fixed the reporter itself: T-Rex action zero already mapped exactly to the
+named home control, while the ankle's control-vs-pose difference is intentional
+preload.
 
 ### The changes that target the bounce and the tremor
 
@@ -724,17 +730,16 @@ the plant work below if it is done at all.
 
 ### The plant work
 
-**4. One `policy_interface_revision` bump carrying two fixes**, prepared now and
-merged after the in-flight lineage finishes:
+**4. Couple the toe digits in the next plant revision**, prepared now and
+merged after the in-flight lineage finishes.
 
-- **Couple the toe digits.** Three independent actuators per foot let the policy
-  command adjacent digits **75° apart**, which no theropod foot can do — the
-  digital flexors and transverse ligaments couple them. And because the model
-  lumps each digit into one rigid hinge instead of a four-phalanx chain,
-  commanding digit III to its limit lifts the primary weight-bearing toe
-  **~11.6 cm** off the floor rather than curling it.
-- **Re-centre the four off-home `ctrlrange`s** so `action = 0` is the home
-  keyframe the residual mapping is named for.
+Three independent actuators per foot let the policy command adjacent digits
+**75° apart**, which no theropod foot can do — the digital flexors and
+transverse ligaments couple them. And because the model lumps each digit into
+one rigid hinge instead of a four-phalanx chain, commanding digit III to its
+limit lifts the primary weight-bearing toe **~11.6 cm** off the floor rather
+than curling it. The action-mapping audit found no second plant change to batch
+with this: action zero already is the named home control.
 
 Stated honestly: **this does not fix the current policy's pose** — returning the
 toes to home still falls at 198.5 steps, because the pose is over-determined.
@@ -902,11 +907,13 @@ Bernoulli nobody can estimate from. Every experiment worth running now
 arm**, and running those on a plant already known to be wrong wastes precisely
 the runs that matter most.
 
-1. **Land the plant revision** — passive toes, plus re-centring the four
-   off-home `ctrlrange`s (both ankles +5.5°, `head_pitch`/`neck_pitch` +5.0°).
-   One `policy_interface_revision` bump. Re-measure the statue with
-   `zero_action_baseline.py` and re-derive `min_avg_reward` and
-   `collapse_peak_floor_reference`.
+1. **Land the plant revision** — passive toes. This changes both physics and
+   the action dimension, so bump the relevant plant/interface revisions.
+   Re-measure the statue with `zero_action_baseline.py` and re-derive
+   `min_avg_reward` and `collapse_peak_floor_reference`. Do not alter the four
+   ranges previously called "off-home": the action-mapping audit showed action
+   zero already reaches every named home control, and the ankle difference is
+   intentional preload.
 2. **Action filter in the training loop, multi-seed.** Still the candidate fix
    for the bounce; the plant work does not address it. Curriculum the cutoff
    down from ~30 Hz.

--- a/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
+++ b/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
@@ -636,3 +636,138 @@ in m/s, on the weaker side, is a single number that goes up when the policy
 gets better at the thing the stage is named for.
 
 **A baseline now exists to beat: 0.50 m/s one way, 0.00 the other.**
+
+---
+
+## Addendum 5, 2026-08-06 — revised recommendations
+
+Appended. **Supersedes §9**, which was written before the four probes existed
+and before the plant audit.
+
+### First, an honest correction
+
+§9 and the recommendations that followed it steered toward *measurement* and
+*task design*, and quietly stopped targeting **the bounce itself**. That was a
+drift, not a decision. The reasoning behind it — §4 showed the bounce is 450
+points worse under the reward, so it is an optimisation failure and not a
+shaping one — is a statement about *what will not fix it*, and it got treated
+as a statement that it did not need fixing.
+
+It does. A policy that stands by dithering at 22.6 Hz, in a pose it cannot hold
+without continuous feedback, with 12 actuators pinned at their limits, **will
+not transfer to hardware.** Standing is the sim-to-real foundation, and none of
+the probe work changes that.
+
+### What the four probes established
+
+| probe | question | answer |
+|---|---|---|
+| `--filter-actions` | is the high-frequency content load-bearing? | yes, at every cutoff 5–35 Hz |
+| `--hold-constant` | does the pose need *feedback*, or only bandwidth? | **feedback** — every held variant falls |
+| `--hold-release-ablation` | which joints? | **toes**, sufficient alone; tail and head/neck inert |
+| `--impulse-probe` | does it actually correct? | **barely** — 0.50 m/s one way, 0.00 the other |
+
+Plus two measurement defects found on the way: `|action| = 1` means 8° on a tail
+joint and 37.5° on a toe (Addendum 3), and `action = 0` is not exactly home for
+four actuators.
+
+### The changes that target the bounce and the tremor
+
+**1. Train with an action low-pass or rate limit in the loop.** The strongest
+single recommendation, and the one §9 missed.
+
+The bounce sits at **16.7–20 Hz** and the tremor at **22.6 Hz**. Balance
+correction on this plant is **~1.1–1.4 Hz**. If the policy physically cannot
+command above, say, 8 Hz, then neither the bounce nor the tremor is available
+to it — while the band the task actually needs is untouched, with better than a
+5× margin.
+
+§5 already proved this cannot be retrofitted: the passing checkpoint collapses
+under a filter at every cutoff from 5 to 35 Hz. The conclusion drawn there was
+"so a filter is not an option". The correct conclusion is **"so it has to be
+present during training"**, which is a different sentence and the one that
+matters. It is also the single most sim-to-real-relevant change available: a
+policy requiring 22.6 Hz of command bandwidth and full actuator authority will
+not survive contact with a real actuator.
+
+*Risk:* it makes the task harder, and the policy may fail to learn at all.
+*Mitigation:* curriculum the cutoff — start generous (~30 Hz, which the current
+policy already half-survives at 351 steps) and lower it across training. That
+also produces a usable regression metric on the way down.
+
+**2. Drive the policy's exploration noise down faster.** Measured on the passing
+run: policy std starts at **1.00** and only reaches **0.42** at 10M — *with*
+`ent_coef` already decayed to zero at 7M.
+
+That matters because **PPO maximises the return of the noisy policy, not the
+deterministic one the gate scores.** At std 0.42 "hold the home pose" means
+"hold it ±18° of knee angle, resampled every 10 ms", which is a different
+policy with a different return. The deterministic optimum (the statue, 3271.8)
+and the stochastic optimum are not the same point, and the network *starts* at
+the statue — SB3 initialises the action head near zero — and walks away from it
+because under std 1.0 the sampled version falls over.
+
+The fingerprint: **correlation between policy std and the number of saturated
+actuators is −0.967.** Saturation appears exactly as noise decays, because only
+then can an extreme pose be *held* rather than smeared.
+
+#487 moved this lever once (`ent_coef_end` 0.001 → 0.0, decay 3M → 7M) and
+turned a bouncer into a passer. Going further is indicated: a direct schedule on
+`log_std`, or a lower initial std, so the two objectives converge before the
+policy has committed to a basin.
+
+**3. `frame_skip 10`.** §6's falsifiable test, unchanged and still valid: a
+bounce at 8–10 Hz means the cycle is locked to the control clock and halving the
+rate removes the failure class; a bounce at ~20 Hz again means it is a plant
+property. Expensive — it bumps `policy_interface_revision` — so batch it with
+the plant work below if it is done at all.
+
+### The plant work
+
+**4. One `policy_interface_revision` bump carrying two fixes**, prepared now and
+merged after the in-flight lineage finishes:
+
+- **Couple the toe digits.** Three independent actuators per foot let the policy
+  command adjacent digits **75° apart**, which no theropod foot can do — the
+  digital flexors and transverse ligaments couple them. And because the model
+  lumps each digit into one rigid hinge instead of a four-phalanx chain,
+  commanding digit III to its limit lifts the primary weight-bearing toe
+  **~11.6 cm** off the floor rather than curling it.
+- **Re-centre the four off-home `ctrlrange`s** so `action = 0` is the home
+  keyframe the residual mapping is named for.
+
+Stated honestly: **this does not fix the current policy's pose** — returning the
+toes to home still falls at 198.5 steps, because the pose is over-determined.
+What it does is remove a way of standing badly that the anatomy does not permit
+and that policies demonstrably find. That constrains every *future* policy,
+which is worth having before spending more 10M runs.
+
+### The task work
+
+**5. Promote the impulse to a training-time disturbance.** `_apply_root_impulse`
+is already the primitive and the environment has no other perturbation path.
+Behind a config key it becomes what `STAGE1_SPLIT_PLAN`'s **1b recovery** needs,
+and it is what makes "actively stand and correct" a trainable objective rather
+than an aspiration.
+
+**6. Adopt the recovery envelope as the acceptance metric.** The weaker
+direction is the capability. Current baseline: **0.50 m/s one way, 0.00 the
+other.** Every existing stage-1 criterion is satisfied by a statue; this one is
+not.
+
+### Still ruled out
+
+**Do not reweight the reward.** Three independent reasons now: the bounce
+already loses on every term (§4), the tremor is load-bearing so penalising it
+removes what holds the animal up (Addendum 1), and the toes are sufficient but
+not necessary so a toe term is not shown to help (Addendum 2).
+
+**Do not chase the statue.** It outscoring the trained policy is a defect in the
+reward, not a target. A statue recovers from nothing — measured, 0.00 m/s in
+both directions — which is strictly worse at what the stage is for.
+
+### Ordering
+
+1 and 2 are additive, cheap, and target the bouncing directly — **do them
+first.** 5 and 6 are additive and serve the stated goal. 4 invalidates every
+checkpoint, so it waits for a clean break. 3 only if 1 and 2 fail.

--- a/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
+++ b/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
@@ -771,3 +771,152 @@ both directions — which is strictly worse at what the stage is for.
 1 and 2 are additive, cheap, and target the bouncing directly — **do them
 first.** 5 and 6 are additive and serve the stated goal. 4 invalidates every
 checkpoint, so it waits for a clean break. 3 only if 1 and 2 fail.
+
+---
+
+## Addendum 6, 2026-08-06 — seed 43 bounces; the toe splay reproduces
+
+Appended. **Supersedes the ordering in Addendum 5.**
+
+### Seed 43 locked at exactly 1/5
+
+Run `20260806_133233`, seed 43, identical config to the passing seed-42 run,
+**0 of 158 evaluations matching seed 42 bitwise** — genuinely independent.
+
+| step | duty | bilateral | single support | full-horiz | reward |
+|---|---|---|---|---|---|
+| 7.55M | 0.2000 | 0.8000 | 0.0000 | 1.000 | 2369.9 |
+| 7.70M | 0.2000 | 0.8000 | 0.0000 | 1.000 | 2403.4 |
+| 7.85M | 0.2000 | 0.8000 | 0.0000 | 1.000 | 2421.9 |
+| 7.90M | 0.2000 | 0.8000 | −0.0000 | 0.925 | 2317.8 |
+
+Over the last 10 evaluations: duty mean **0.2000**, std **0.00000**. Over the
+last 20: **20 of 20** within 0.0015 of exactly 1/5, single support **0.0002**
+against the rule's 0.005 ceiling, bilateral pinned at 0.8000 = 4/5.
+
+The early-abort criterion from Addendum 5 fired at full strength, not
+marginally. This is `20260805_132950`'s signature reproduced exactly.
+
+### The stage-1 record, at the current configuration
+
+| run | weight | seed | result |
+|---|---|---|---|
+| `20260804_143747` | 0.5 | 42 | FAIL — 1/6, pre-#487 |
+| `20260805_011234` | 0.5 | 42 | **PASS** |
+| `20260805_132950` | 1.5 | 42 | FAIL — 1/5 |
+| `20260805_221141` | 0.5 | 42 | **PASS** (bitwise replay of `011234`) |
+| `20260806_133233` | 0.5 | **43** | **FAIL — 1/5** |
+
+At the current configuration, across independent seeds: **one pass, one
+bounce.** §8's question — "is passing reliable or lucky?" — has its answer, and
+it is **a coin flip**. #487 helped; it did not make stage 1 reliable.
+
+### The toe splay reproduces — and it is the only thing that does
+
+Comparing final per-actuator pose between the two independent seeds:
+
+| joint | seed 42 | seed 43 | 42° | 43° | |
+|---|---|---|---|---|---|
+| `r_toe_d2` | +1.000 | −0.998 | +37.5 | −37.4 | both pinned |
+| `r_toe_d3` | −1.000 | +0.999 | −37.5 | +37.5 | both pinned |
+| `r_toe_d4` | +1.000 | +0.999 | +37.5 | +37.5 | **both, same sign** |
+| `l_toe_d2` | −0.193 | −0.999 | −7.2 | −37.5 | 43 only |
+| `l_toe_d3` | +1.000 | +0.998 | +37.5 | +37.4 | **both, same sign** |
+| `l_toe_d4` | −1.000 | −0.994 | −37.5 | −37.3 | **both, same sign** |
+| `tail_1_pitch` | +1.000 | −0.608 | +12.0 | −7.3 | 42 only |
+| `tail_2_pitch` | +1.000 | +0.135 | +12.0 | +1.6 | 42 only |
+| `r_hip_roll` | +1.000 | −0.540 | +25.0 | −13.5 | 42 only |
+| `l_hip_roll` | −1.000 | +0.591 | −25.0 | +14.8 | 42 only |
+| `neck_yaw` | −0.177 | +0.996 | −3.5 | +19.9 | 43 only |
+
+Toe |DC| mean: **0.865** (seed 42) → **0.998** (seed 43). Spread across one
+foot: **75.0°** and **74.9°**, on *both* feet, in *both* seeds.
+
+Everything else disagrees. The tail — all four joints pinned in seed 42 — is
+largely unpinned in seed 43, with `tail_1_yaw` at the *opposite* limit. Hip
+rolls flip sign. Neck yaw is unsaturated in one and pinned in the other.
+
+**The toes are the one thing two independent seeds agree on.** That moves the
+splay from "one policy's quirk" to "this plant reliably invites it" — the
+condition set in Addendum 5 for reordering the plan.
+
+Note it does **not** separate pass from fail: the passing policy splays too. It
+is a plant-correctness finding, not the bounce's cause.
+
+### The toes do no work, in either stage
+
+Stage 2, the seed-42 policy running at **3.33 m/s**:
+
+| | AC (movement) | \|DC\| | pinned |
+|---|---|---|---|
+| **toes** | **0.129** | 0.907 | 4 of 6 |
+| legs (hip / knee / ankle) | **0.670** | 0.114 | 0 of 6 |
+
+Five times less movement than the leg chain, four of six at their stops. In
+stage 1 every saturated toe has AC **exactly 0.000**. **Toe actuation is
+authority no policy in this project has ever used productively, and every
+policy abuses.**
+
+The `leg_joint` class already gives each toe `stiffness = 40`, and the toes
+carry `damping = 15` with `springref = 12.5`, so an unactuated toe already has
+a passive spring returning it to home and compliance under load.
+
+### Recommended plant change: passive toes
+
+Three ways to couple the digits:
+
+| | `action_dim` | verdict |
+|---|---|---|
+| **remove the six toe actuators** | 21 → **15** | **recommended** |
+| fixed tendon + one actuator per foot | 21 → 17 | fallback if toe-off is ever shown to matter |
+| joint equality constraints, keep 3 actuators | 21 | rejected |
+
+**Equality constraints are the worst option:** the action space keeps three
+redundant toe entries per foot that can be commanded to disagree while the
+solver fights them, MuJoCo joint equalities are soft and get violated under
+load — exactly when it matters — and it encodes a lie about the mechanism.
+
+**Passive is recommended over the tendon** because this failure was *caused by
+control authority the policy does not need*. Six independent toe actuators,
+unused across three stages and five runs, exploited by every policy that has
+touched them. A tendon repeats that in miniature: smaller unneeded authority,
+plus new unanchored modelling decisions (tendon coefficients, actuator gear and
+`ctrlrange`). The tendon can be added later, with evidence, for the same
+revision cost. Authority cannot be un-added once a policy leans on it.
+
+Passive also collapses two open questions to zero: the toe `ctrlrange` audit
+stops mattering, and the 75° opposition becomes *unreachable* rather than
+discouraged.
+
+**When to revisit:** if `action_ac_rms_per_actuator` on the toes ever rises
+toward the leg chain's level in a locomotion run, the toes are doing work and
+deserve a command. Today it is 0.129 against 0.670.
+
+### Revised ordering — plant first
+
+Addendum 5 put the plant work last, on the grounds that seed 42 and 43 were
+free controls that a revision bump would destroy. **That argument is dead.**
+With the bounce at one-in-two, `n = 2` is not a rate — it is two samples of a
+Bernoulli nobody can estimate from. Every experiment worth running now
+("does an action filter reduce the bounce rate?") needs **several seeds per
+arm**, and running those on a plant already known to be wrong wastes precisely
+the runs that matter most.
+
+1. **Land the plant revision** — passive toes, plus re-centring the four
+   off-home `ctrlrange`s (both ankles +5.5°, `head_pitch`/`neck_pitch` +5.0°).
+   One `policy_interface_revision` bump. Re-measure the statue with
+   `zero_action_baseline.py` and re-derive `min_avg_reward` and
+   `collapse_peak_floor_reference`.
+2. **Action filter in the training loop, multi-seed.** Still the candidate fix
+   for the bounce; the plant work does not address it. Curriculum the cutoff
+   down from ~30 Hz.
+3. **SAC as the discriminator, multi-seed** — bounces too → task/plant
+   property; doesn't → PPO's exploration schedule is the culprit.
+4. **Impulse as a training-time disturbance**, and the recovery envelope as
+   1b's acceptance metric. Baseline to beat: **0.00 m/s** on the weaker side.
+
+Cost, stated plainly: the seed-42 stage-1→2 chain becomes historical. With the
+bounce at one-in-two that chain was **luck rather than a reproducible
+foundation**, so it was a weaker asset than it looked before seed 43 landed.
+
+**Unchanged:** do not reweight the reward, and do not chase the statue.

--- a/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
+++ b/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
@@ -353,6 +353,12 @@ hold the constant pose but **release only the saturated joints back to home**,
 and see whether the rest becomes holdable. If it does, the saturated pose is
 what creates the stabilisation load.
 
+> **Run, same day — and the answer is no.** See §Addendum 2 below. Releasing
+> all twelve saturated actuators does *not* rescue the pose, and the tail, the
+> single most conspicuous thing in the DC table, turns out to be a bystander.
+> The candidate answer above is **refuted**; the conspicuousness of saturation
+> is exactly why it needed testing rather than adopting.
+
 ### And a separate point about the task
 
 Stage 1 has **no in-episode disturbance** — the only perturbation is joint-angle
@@ -362,3 +368,119 @@ nothing over one that stands still, and "actively stand and correct posture"
 is not underweighted in this reward, it is absent from the task. That is the
 gap `STAGE1_SPLIT_PLAN.md` proposes 1a/1b for, and no reweighting substitutes
 for it.
+
+---
+
+## Addendum 2, 2026-08-06 — which joints make the pose unholdable
+
+Appended, not rewritten. This **refutes** the candidate answer in Addendum 1.
+
+### The experiment
+
+Addendum 1 established that the policy's pose cannot be held by a constant, and
+proposed that the twelve saturated actuators were why. Testing that needs two
+questions per group, not one, because either alone misleads:
+
+- `release_G` — hold everything **except** G. Is G **necessary**? Does removing
+  it rescue a pose that otherwise falls?
+- `only_G` — hold **only** G. Is G **sufficient**? Does it alone break the
+  statue, which is known to stand?
+
+All variants are commanded **from reset**, so the endpoints are the two known
+measurements: releasing everything is the statue (stands 1000), releasing
+nothing is Addendum 1's `hold_from_reset` (falls at ~133).
+
+`stance_gate_report.py --hold-release-ablation`, passing checkpoint, 8 episodes:
+
+| variant | released | ep length | full-horizon | reward | terminations |
+|---|---|---|---|---|---|
+| policy (control) | — | **1000.0** | 1.0000 | 3010.1 | truncated 8 |
+| `hold_all` | 0 | 128.6 | 0.0000 | 268.8 | tail_contact 8 |
+| `release_saturated` | 12 | 224.6 | 0.0000 | 460.1 | fallen 5, tail_contact 3 |
+| `only_saturated` | 9 | 140.5 | 0.0000 | 330.6 | tail_contact 8 |
+| `release_tail` | 4 | 116.6 | 0.0000 | 250.1 | tail_contact 8 |
+| **`only_tail`** | 17 | **1000.0** | **1.0000** | **3254.0** | truncated 8 |
+| `release_toes` | 6 | 198.5 | 0.0000 | 397.3 | fallen 6, tail_contact 2 |
+| **`only_toes`** | 15 | **125.5** | 0.0000 | 289.2 | tail_contact 8 |
+| `release_head_neck` | 3 | 123.2 | 0.0000 | 256.4 | tail_contact 8 |
+| **`only_head_neck`** | 18 | **1000.0** | **1.0000** | **3286.1** | truncated 8 |
+| `release_hip_rolls` | 2 | 129.4 | 0.0000 | 270.4 | tail_contact 8 |
+| `only_hip_rolls` | 19 | 989.8 | 0.8750 | 3190.5 | truncated 7, fallen 1 |
+| `hold_zero` (statue control) | 21 | **1000.0** | 1.0000 | 3274.4 | truncated 8 |
+
+Controls behave, and `hold_all` at 128.6 reproduces Addendum 1's 133.3 — the
+same experiment reached twice by different routes.
+
+### Result
+
+**The toes are sufficient on their own.** Holding the six toe joints at their
+commanded DC with every other actuator returned to home reproduces the full
+failure almost exactly — **125.5 steps against `hold_all`'s 128.6, with
+`tail_contact` 8 of 8 in both.** Six of 21 actuators account for essentially the
+whole effect.
+
+**The tail is a bystander.** All four tail joints held at `+1.000`, everything
+else at home, stands the **full horizon at reward 3254.0** — within 0.6% of the
+statue's 3274.4. Head and neck likewise: 1000 steps, **3286.1**, which is
+*above* the statue. The two groups whose DC looks most alarming do nothing.
+
+**No group is necessary.** `release_saturated` improves matters (128.6 → 224.6)
+but still falls; so does `release_toes` (198.5). The pose is **over-determined**
+— more than one subset breaks it independently, so removing any single group
+leaves another still able to. "Which joint is the cause" is the wrong question.
+"Where is the effect concentrated" has an answer, and it is the toes.
+
+### What this refutes
+
+Addendum 1 proposed that **saturation** creates the stabilisation load, on the
+reasoning that twelve actuators pinned at `±1.000` with no headroom must be
+doing something. Measured: releasing all twelve does not rescue the pose, and
+the largest saturated group — the tail — is provably inert. `only_saturated`
+falls (140.5), but it contains five of the six toes, so its sufficiency is
+plausibly the toes' and nothing else's.
+
+Saturation is *conspicuous*, not *causal*. It was worth testing precisely
+because it looked obvious, and the same instinct that made #490 attractive
+would have made a tail- or saturation-targeted reward term attractive here.
+
+### Why the toes are a plausible mechanism
+
+They are the ground contact. Five of six sit at `±1.000` — driven to their
+stops — which changes the foot's contact geometry and therefore the support
+polygon the whole body balances on. Unlike the tail, whose effect on a standing
+animal is a static moment the position servos absorb, a toe at its limit
+changes *where and how the animal touches the floor*. That is a mechanical
+effect on the plant, not a reward-shaping one, and it is the strongest evidence
+so far for the "something is off with the mechanics" reading.
+
+The termination reason agrees: `only_toes` and `hold_all` both end in
+`tail_contact` 8 of 8, while the partial rescues (`release_saturated`,
+`release_toes`) shift toward `fallen` — a different failure, reached later.
+
+### What this does NOT establish
+
+- **Not a reason to add a toe reward term.** Sufficiency says the toe pose
+  breaks a *statue*; it does not say the trained policy would stand if the toes
+  were constrained, because the rest of the pose falls on its own too
+  (`release_toes` = 198.5).
+- **Nothing about the bounce.** §4 is untouched: still 450 points worse, still
+  an optimisation failure.
+- **Nothing about `ctrlrange`.** Whether `±1.000` on a toe is a large joint
+  angle or a small one has not been measured. Read the actual ranges out of
+  `trex.xml` before concluding the toes are over-driven rather than merely
+  commanded to their limits.
+
+### Method note: the control caught a broken experiment
+
+The first run of this ablation handed off at `settle_steps` rather than from
+reset, so each variant snapped a subset of joints from `±1.000` to `0` in one
+step midway through the episode. The transient dominated: all thirteen variants
+landed within **311–349 steps** of each other, indistinguishable from
+`hold_all`. The tell was the `hold_zero` row — supposedly the statue — falling
+at **323 steps** when it is known to stand for 1000.
+
+Both endpoints on the same side of the answer means the path has no signal, and
+without the statue control the flat table would have read as "no group matters",
+which is a conclusion and a wrong one. The control cost 8 episodes and saved a
+false negative. `TestReleaseAblationVariants` now pins the from-reset
+requirement.

--- a/environments/shared/curriculum/gate_schema.py
+++ b/environments/shared/curriculum/gate_schema.py
@@ -163,6 +163,8 @@ _DIAGNOSTIC_KEYS = frozenset(
         "baseline_warn_after_budget_fraction",
         "stance_probe_filter_hz",
         "stance_probe_hold_constant",
+        "stance_probe_release_ablation",
+        "stance_probe_impulse_speeds",
     }
 )
 

--- a/environments/shared/curriculum/gate_schema.py
+++ b/environments/shared/curriculum/gate_schema.py
@@ -162,6 +162,7 @@ _DIAGNOSTIC_KEYS = frozenset(
         "stance_report_episodes",
         "baseline_warn_after_budget_fraction",
         "stance_probe_filter_hz",
+        "stance_probe_hold_constant",
     }
 )
 

--- a/environments/shared/eval_diagnostics.py
+++ b/environments/shared/eval_diagnostics.py
@@ -105,8 +105,8 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         # Action statistics for the DETERMINISTIC policy, which is what the
         # gate scores. `diagnostics.npz` records actions from training
         # rollouts, so every number in it carries exploration noise; the
-        # quantities that matter here -- how far the commanded pose sits from
-        # the home keyframe, and how much the policy shakes about it -- are
+        # quantities that matter here -- how far the commanded target sits from
+        # the home control (action = 0), and how much the policy shakes about it -- are
         # properties of the mean action and are unrecoverable from a noisy
         # sample. Issue #489 had to invert them out of per-episode reward
         # totals under a narrowband assumption. These measure them.
@@ -280,8 +280,10 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         """Reduce one evaluation's accumulators into the published series.
 
         The DC/AC split is the whole point. ``mean(a)`` per actuator is the
-        static pose the policy commands -- the distance from the home keyframe,
-        which under ``home-keyframe-residual/v1`` is exactly ``action = 0``.
+        static target the policy commands -- the distance from the home
+        control, which under ``home-keyframe-residual/v1`` is exactly
+        ``action = 0`` (the home keyframe's control targets, not necessarily
+        its joint pose: the trex ankles carry an authored preload).
         ``sqrt(mean(a^2) - mean(a)^2)`` is what it does *around* that pose. The
         two answer different questions and a pooled standard deviation over
         actuators and time (which is what ``diagnostics.action_std`` computes)
@@ -722,7 +724,7 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
     def _action_statistics(self, index: int) -> dict[str, float]:
         """Scalar summaries of the deterministic policy's action.
 
-        ``action_dc_rms`` is the distance from the home keyframe and
+        ``action_dc_rms`` is the distance from the home control (``action = 0``) and
         ``action_ac_rms`` is the tremor about it; keeping them apart is the
         point, because they have different causes and different fixes
         (issue #489). The per-actuator vectors go to `gate_progress.npz`

--- a/environments/shared/reporting/gates.py
+++ b/environments/shared/reporting/gates.py
@@ -236,7 +236,7 @@ def evaluate_stage_gate(
             checkpoint's metrics (``best_model_*``, falling back to
             ``best_eval_*`` and then the live-eval means).
         stage: Stage identifier, used only in failure messages.
-        stance_report: The ``mesozoic.stance-gate-report/v1`` dict produced for
+        stance_report: The ``mesozoic.stance-gate-report/v2`` dict produced for
             this stage, required by ``stance_quality/v1`` and ignored by every
             other kind.
 

--- a/environments/shared/reporting/stage_artifacts.py
+++ b/environments/shared/reporting/stage_artifacts.py
@@ -262,47 +262,117 @@ def _write_stance_gate_report(
             report["metrics"]["bilateral_support_duty"],
             written["stance_gate_report_txt"],
         )
-        _write_filtered_action_probe(
-            species=species,
-            stage=stage,
-            stage_config=stage_config,
-            stage_dir=stage_dir,
-            model_path=f"{selected_path}.zip",
-            vecnorm_path=selected_vecnorm,
-            episodes=report_episodes,
-        )
-        _write_constant_hold_probe(
-            species=species,
-            stage=stage,
-            stage_config=stage_config,
-            stage_dir=stage_dir,
-            model_path=f"{selected_path}.zip",
-            vecnorm_path=selected_vecnorm,
-            episodes=report_episodes,
-            measured=report,
-        )
-        _write_constant_hold_ablation(
-            species=species,
-            stage=stage,
-            stage_config=stage_config,
-            stage_dir=stage_dir,
-            model_path=f"{selected_path}.zip",
-            vecnorm_path=selected_vecnorm,
-            measured=report,
-        )
-        _write_impulse_probe(
-            species=species,
-            stage=stage,
-            stage_config=stage_config,
-            stage_dir=stage_dir,
-            model_path=f"{selected_path}.zip",
-            vecnorm_path=selected_vecnorm,
-            settle_steps=int(report["settle_steps"]),
-        )
         return report
     except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
         logger.warning("Stance gate report failed for stage %d", stage, exc_info=True)
     return None
+
+
+def _run_stance_probes(
+    *,
+    species: str,
+    stage: int,
+    stage_config: dict[str, Any],
+    stage_dir: Path,
+    model_dir: Path,
+    report: dict[str, Any] | None,
+) -> None:
+    """Run the stance probe battery against the selected checkpoint.
+
+    Pure diagnostics, so they run LAST in :func:`generate_stage_artifacts` --
+    after the gate verdict is recorded and the summary, graphs and replays are
+    written. They used to run inside :func:`_write_stance_gate_report`'s
+    ``try``, between "report written" and "verdict recorded", which put ~300
+    probe episodes of exposure in front of everything a finished run cannot
+    afford to lose -- and meant a probe-wiring exception (one the helpers'
+    internal handlers cannot see, e.g. a signature drift at a call site) was
+    caught by the report's handler and turned an already-written PASS into a
+    recorded FAIL.
+
+    *report* is the certification report the probes annotate; ``None`` (no
+    panel was measured) means there is nothing to probe. Each probe call
+    carries its own handler so a failure costs that probe alone -- including
+    caller-side failures, which is what makes the CHANGELOG's "individually
+    non-fatal" claim true at this level too.
+    """
+    if report is None:
+        return
+
+    curriculum = stage_config.get("curriculum_kwargs", {})
+    declared_episodes = int(curriculum.get("min_eval_episodes", 40))
+    report_episodes = curriculum.get("stance_report_episodes")
+    report_episodes = declared_episodes if report_episodes is None else int(report_episodes)
+
+    # The same selector the report itself used; re-resolved here so the probes
+    # keep describing the one policy every other artifact describes.
+    from environments.shared.train_base import _select_handoff_checkpoint
+
+    handoff = _select_handoff_checkpoint(model_dir)
+    if handoff is None:
+        logger.warning(
+            "Stance probes skipped for stage %d: no checkpoint in %s has its matched _vecnorm.pkl",
+            stage,
+            model_dir,
+        )
+        return
+    _selected_name, selected_path, selected_vecnorm = handoff
+
+    probe_calls = (
+        (
+            "filtered action",
+            lambda: _write_filtered_action_probe(
+                species=species,
+                stage=stage,
+                stage_config=stage_config,
+                stage_dir=stage_dir,
+                model_path=f"{selected_path}.zip",
+                vecnorm_path=selected_vecnorm,
+                episodes=report_episodes,
+            ),
+        ),
+        (
+            "constant hold",
+            lambda: _write_constant_hold_probe(
+                species=species,
+                stage=stage,
+                stage_config=stage_config,
+                stage_dir=stage_dir,
+                model_path=f"{selected_path}.zip",
+                vecnorm_path=selected_vecnorm,
+                episodes=report_episodes,
+                measured=report,
+            ),
+        ),
+        (
+            "release ablation",
+            lambda: _write_constant_hold_ablation(
+                species=species,
+                stage=stage,
+                stage_config=stage_config,
+                stage_dir=stage_dir,
+                model_path=f"{selected_path}.zip",
+                vecnorm_path=selected_vecnorm,
+                measured=report,
+            ),
+        ),
+        (
+            "impulse",
+            lambda: _write_impulse_probe(
+                species=species,
+                stage=stage,
+                stage_config=stage_config,
+                stage_dir=stage_dir,
+                model_path=f"{selected_path}.zip",
+                vecnorm_path=selected_vecnorm,
+                settle_steps=int(report["settle_steps"]),
+            ),
+        ),
+    )
+    for label, run_probe in probe_calls:
+        try:
+            run_probe()
+        except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
+            logger.warning("Stance probe (%s) failed for stage %d", label, stage, exc_info=True)
 
 
 def _probe_cutoffs(raw: Any) -> list[float]:
@@ -826,21 +896,35 @@ def generate_stage_artifacts(
             except Exception:
                 logger.warning("Graph generation failed.", exc_info=True)
 
-        if not record_videos:
-            return stage_results
+        if record_videos:
+            stage_results = _record_stage_replays(
+                species_cfg=species_cfg,
+                stage_config=stage_config,
+                stage=stage,
+                algorithm=algorithm,
+                stage_dir=stage_dir,
+                replays_out=replays_out,
+                model_dir=model_dir,
+                seed=seed,
+                stage_results=stage_results,
+                allow_legacy_plant=allow_legacy_plant,
+            )
 
-        return _record_stage_replays(
-            species_cfg=species_cfg,
-            stage_config=stage_config,
-            stage=stage,
-            algorithm=algorithm,
-            stage_dir=stage_dir,
-            replays_out=replays_out,
-            model_dir=model_dir,
-            seed=seed,
-            stage_results=stage_results,
-            allow_legacy_plant=allow_legacy_plant,
-        )
+    # Probes run dead last, outside the staging context: they are the most
+    # expensive artifact step (~300 episodes at the trex stage-1 settings) and
+    # nothing downstream reads them, so a runtime lost mid-probe costs the
+    # probes alone -- never the recorded verdict, summary, graphs or replays
+    # above. Ordering is pinned by the wiring tests.
+    _run_stance_probes(
+        species=species,
+        stage=stage,
+        stage_config=stage_config,
+        stage_dir=stage_dir,
+        model_dir=model_dir,
+        report=stance_report,
+    )
+
+    return stage_results
 
 
 def _record_stage_replays(

--- a/environments/shared/reporting/stage_artifacts.py
+++ b/environments/shared/reporting/stage_artifacts.py
@@ -525,9 +525,7 @@ def _write_constant_hold_ablation(
         )
 
         hold = constant_hold_actions(measured)
-        for variant in constant_hold_release_variants(
-            hold, measured, horizon=int(measured["horizon"])
-        ):
+        for variant in constant_hold_release_variants(hold, measured, horizon=int(measured["horizon"])):
             probe = build_stance_gate_report(
                 species,
                 stage,
@@ -539,8 +537,7 @@ def _write_constant_hold_ablation(
             )
             entries.append(probe)
             logger.info(
-                "Release ablation %s: episode length %.1f, full-horizon %.4f. "
-                "MODIFIED policy -- not a gate verdict.",
+                "Release ablation %s: episode length %.1f, full-horizon %.4f. MODIFIED policy -- not a gate verdict.",
                 variant.label,
                 probe["metrics"]["episode_length_mean"],
                 probe["metrics"]["full_horizon_fraction"],
@@ -551,9 +548,7 @@ def _write_constant_hold_ablation(
         try:
             from environments.shared.scripts.stance_gate_report import write_constant_hold_ablation
 
-            written = write_constant_hold_ablation(
-                stage_dir, entries, probe_episodes=_ABLATION_EPISODES
-            )
+            written = write_constant_hold_ablation(stage_dir, entries, probe_episodes=_ABLATION_EPISODES)
             logger.info("Release ablation -> %s", written["constant_hold_ablation_txt"])
         except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
             logger.warning("Could not write the release ablation", exc_info=True)
@@ -629,17 +624,14 @@ def _write_impulse_probe(
 
         policy_sweep = _sweep(zero_action=False)
         statue_sweep = _sweep(zero_action=True)
-        written = write_impulse_probe(
-            stage_dir, policy_sweep, statue_sweep, probe_episodes=_IMPULSE_EPISODES
-        )
+        written = write_impulse_probe(stage_dir, policy_sweep, statue_sweep, probe_episodes=_IMPULSE_EPISODES)
         envelopes = {
             row["impulse"]["axis_label"]: row["metrics"]["full_horizon_fraction"]
             for row in policy_sweep
             if row["impulse"]["speed"] > 0
         }
         logger.info(
-            "Impulse recovery probe -> %s (policy full-horizon by direction: %s). "
-            "MODIFIED task -- not a gate verdict.",
+            "Impulse recovery probe -> %s (policy full-horizon by direction: %s). MODIFIED task -- not a gate verdict.",
             written["impulse_probe_txt"],
             envelopes,
         )

--- a/environments/shared/reporting/stage_artifacts.py
+++ b/environments/shared/reporting/stage_artifacts.py
@@ -26,6 +26,13 @@ logger = logging.getLogger(__name__)
 #: multi-cutoff sweep cost about what the old single 40-episode probe did.
 _PROBE_EPISODES = 10
 
+#: Episodes per row in the two sweep probes. Smaller than ``_PROBE_EPISODES``
+#: because both roll far more rows -- 13 for the ablation, 14 for the impulse
+#: sweep once the statue control doubles it -- and both measure effects that are
+#: a fall or a full horizon rather than a shift in a mean.
+_ABLATION_EPISODES = 8
+_IMPULSE_EPISODES = 8
+
 
 def build_stage_results_from_eval_data(
     stage_dir: "str | Path",
@@ -274,6 +281,24 @@ def _write_stance_gate_report(
             episodes=report_episodes,
             measured=report,
         )
+        _write_constant_hold_ablation(
+            species=species,
+            stage=stage,
+            stage_config=stage_config,
+            stage_dir=stage_dir,
+            model_path=f"{selected_path}.zip",
+            vecnorm_path=selected_vecnorm,
+            measured=report,
+        )
+        _write_impulse_probe(
+            species=species,
+            stage=stage,
+            stage_config=stage_config,
+            stage_dir=stage_dir,
+            model_path=f"{selected_path}.zip",
+            vecnorm_path=selected_vecnorm,
+            settle_steps=int(report["settle_steps"]),
+        )
         return report
     except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
         logger.warning("Stance gate report failed for stage %d", stage, exc_info=True)
@@ -463,6 +488,163 @@ def _write_constant_hold_probe(
             logger.info("Constant-hold probe -> %s", written["constant_hold_probe_txt"])
         except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
             logger.warning("Could not write the constant-hold probe", exc_info=True)
+
+
+def _write_constant_hold_ablation(
+    *,
+    species: str,
+    stage: int,
+    stage_config: dict[str, Any],
+    stage_dir: Path,
+    model_path: str,
+    vecnorm_path: str | None,
+    measured: dict[str, Any],
+) -> None:
+    """Ablate the held pose one actuator group at a time, into the run dir.
+
+    Answers *which* joints make the pose unholdable, where the constant-hold
+    probe only answers *whether* it is. Each group is tested twice -- released
+    (is it necessary?) and held alone (is it sufficient?) -- because either
+    side alone lets a conspicuous group masquerade as a cause. On the T-Rex
+    that is not hypothetical: the tail is the most extreme thing in the DC
+    table and is provably inert, while the toes carry the whole effect.
+
+    Off unless ``stance_probe_release_ablation`` is set. Costs 2 panels per
+    actuator group plus 3 fixed rows -- 13 on the T-Rex -- so it is the most
+    expensive of the three probes and is opt-in per stage.
+    """
+    curriculum = stage_config.get("curriculum_kwargs", {})
+    if not curriculum.get("stance_probe_release_ablation"):
+        return
+    entries: list[dict[str, Any]] = []
+    try:
+        from environments.shared.scripts.stance_gate_report import (
+            build_stance_gate_report,
+            constant_hold_actions,
+            constant_hold_release_variants,
+        )
+
+        hold = constant_hold_actions(measured)
+        for variant in constant_hold_release_variants(
+            hold, measured, horizon=int(measured["horizon"])
+        ):
+            probe = build_stance_gate_report(
+                species,
+                stage,
+                stage_config=stage_config,
+                model_path=model_path,
+                vecnorm_path=vecnorm_path,
+                episodes=_ABLATION_EPISODES,
+                hold_constant=variant,
+            )
+            entries.append(probe)
+            logger.info(
+                "Release ablation %s: episode length %.1f, full-horizon %.4f. "
+                "MODIFIED policy -- not a gate verdict.",
+                variant.label,
+                probe["metrics"]["episode_length_mean"],
+                probe["metrics"]["full_horizon_fraction"],
+            )
+    except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
+        logger.warning("Release ablation failed for stage %d", stage, exc_info=True)
+    if entries:
+        try:
+            from environments.shared.scripts.stance_gate_report import write_constant_hold_ablation
+
+            written = write_constant_hold_ablation(
+                stage_dir, entries, probe_episodes=_ABLATION_EPISODES
+            )
+            logger.info("Release ablation -> %s", written["constant_hold_ablation_txt"])
+        except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
+            logger.warning("Could not write the release ablation", exc_info=True)
+
+
+def _write_impulse_probe(
+    *,
+    species: str,
+    stage: int,
+    stage_config: dict[str, Any],
+    stage_dir: Path,
+    model_path: str,
+    vecnorm_path: str | None,
+    settle_steps: int,
+) -> None:
+    """Shove the animal mid-episode and record whether it recovers.
+
+    The only measurement in the pipeline that tracks *balance* rather than
+    *not falling over*. Stage 1 declares no in-episode disturbance, so every
+    other criterion -- duty, full-horizon share, reward -- is satisfied by a
+    statue, and nothing else can tell a policy that learned to recover from one
+    that learned to stand still.
+
+    Rolls the zero-action statue over the same sweep as the control. That is
+    not optional: the statue cannot respond to anything, so its survival is the
+    plant's *passive* robustness and only the policy's margin above it is
+    attributable to control. Reporting the policy's numbers alone would credit
+    the plant's own stability to the policy.
+
+    Off unless ``stance_probe_impulse_speeds`` is set. Costs 2 panels per
+    (speed, direction) plus the two zero controls -- 14 on the default sweep --
+    because the statue side doubles it.
+    """
+    curriculum = stage_config.get("curriculum_kwargs", {})
+    raw = curriculum.get("stance_probe_impulse_speeds")
+    if not raw:
+        return
+    values = raw if isinstance(raw, (list, tuple)) else [raw]
+    speeds: list[float] = []
+    for value in values:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            logger.warning("stance_probe_impulse_speeds entry is not a number: %r; ignoring it", value)
+            continue
+        if number > 0:
+            speeds.append(number)
+    if not speeds:
+        return
+    try:
+        from environments.shared.scripts.stance_gate_report import (
+            build_stance_gate_report,
+            impulse_variants,
+            write_impulse_probe,
+        )
+
+        variants = impulse_variants(speeds, step=settle_steps)
+
+        def _sweep(zero_action: bool) -> list[dict[str, Any]]:
+            return [
+                build_stance_gate_report(
+                    species,
+                    stage,
+                    stage_config=stage_config,
+                    model_path=None if zero_action else model_path,
+                    vecnorm_path=None if zero_action else vecnorm_path,
+                    zero_action=zero_action,
+                    episodes=_IMPULSE_EPISODES,
+                    impulse=variant,
+                )
+                for variant in variants
+            ]
+
+        policy_sweep = _sweep(zero_action=False)
+        statue_sweep = _sweep(zero_action=True)
+        written = write_impulse_probe(
+            stage_dir, policy_sweep, statue_sweep, probe_episodes=_IMPULSE_EPISODES
+        )
+        envelopes = {
+            row["impulse"]["axis_label"]: row["metrics"]["full_horizon_fraction"]
+            for row in policy_sweep
+            if row["impulse"]["speed"] > 0
+        }
+        logger.info(
+            "Impulse recovery probe -> %s (policy full-horizon by direction: %s). "
+            "MODIFIED task -- not a gate verdict.",
+            written["impulse_probe_txt"],
+            envelopes,
+        )
+    except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
+        logger.warning("Impulse recovery probe failed for stage %d", stage, exc_info=True)
 
 
 def _apply_stage_gate(

--- a/environments/shared/reporting/stage_artifacts.py
+++ b/environments/shared/reporting/stage_artifacts.py
@@ -264,6 +264,16 @@ def _write_stance_gate_report(
             vecnorm_path=selected_vecnorm,
             episodes=report_episodes,
         )
+        _write_constant_hold_probe(
+            species=species,
+            stage=stage,
+            stage_config=stage_config,
+            stage_dir=stage_dir,
+            model_path=f"{selected_path}.zip",
+            vecnorm_path=selected_vecnorm,
+            episodes=report_episodes,
+            measured=report,
+        )
         return report
     except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
         logger.warning("Stance gate report failed for stage %d", stage, exc_info=True)
@@ -372,6 +382,87 @@ def _write_filtered_action_probe(
             logger.info("Filtered action probe sweep -> %s", written["action_filter_sweep_txt"])
         except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
             logger.warning("Could not write the filtered action probe sweep", exc_info=True)
+
+
+def _write_constant_hold_probe(
+    *,
+    species: str,
+    stage: int,
+    stage_config: dict[str, Any],
+    stage_dir: Path,
+    model_path: str,
+    vecnorm_path: str | None,
+    episodes: int,
+    measured: dict[str, Any],
+) -> None:
+    """Re-score the checkpoint with its action frozen to the constant it averages.
+
+    The question the filtered probe leaves open. Low-passing a policy still
+    lets it respond, just slowly, so a fall under the filter proves the policy
+    needs *bandwidth* without saying whether it needs *feedback*. Cutting the
+    feedback outright and commanding the policy's own post-settle mean
+    separates the two, and the two have opposite fixes: a pose that stands
+    under a constant means the tremor is waste the action penalties failed to
+    suppress, while a pose that falls means the tremor is the only thing
+    holding the animal up and penalising it harder would be actively wrong.
+
+    Off unless ``stance_probe_hold_constant`` is set. Reuses the gate report's
+    already-measured per-actuator DC rather than rolling a measurement panel of
+    its own, so the whole probe costs the variant panels and nothing else.
+
+    Writes ``stance_gate_probe_constant.{txt,json}`` and deliberately NOT
+    ``stance_panel_selected.csv``.
+    """
+    curriculum = stage_config.get("curriculum_kwargs", {})
+    if not curriculum.get("stance_probe_hold_constant"):
+        return
+    probe_episodes = max(1, min(episodes, _PROBE_EPISODES))
+    entries: list[dict[str, Any]] = []
+    try:
+        from environments.shared.scripts.stance_gate_report import (
+            build_stance_gate_report,
+            constant_hold_actions,
+            constant_hold_variants,
+        )
+
+        hold = constant_hold_actions(measured)
+        variants = constant_hold_variants(
+            hold,
+            settle_steps=int(measured["settle_steps"]),
+            horizon=int(measured["horizon"]),
+        )
+        for variant in variants:
+            probe = build_stance_gate_report(
+                species,
+                stage,
+                stage_config=stage_config,
+                model_path=model_path,
+                vecnorm_path=vecnorm_path,
+                episodes=probe_episodes,
+                hold_constant=variant,
+            )
+            entries.append(probe)
+            logger.info(
+                "Constant-hold probe %s: episode length %.1f, full-horizon %.4f, reward %.1f. "
+                "MODIFIED policy -- not a gate verdict.",
+                variant.label,
+                probe["metrics"]["episode_length_mean"],
+                probe["metrics"]["full_horizon_fraction"],
+                probe["metrics"]["reward_mean"],
+            )
+    except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
+        logger.warning("Constant-hold probe failed for stage %d", stage, exc_info=True)
+    # Written even if a later variant raised, for the same reason the filter
+    # sweep is: the variants that succeeded are still a measurement, and the
+    # controls are what make the others readable.
+    if entries:
+        try:
+            from environments.shared.scripts.stance_gate_report import write_constant_hold_probe
+
+            written = write_constant_hold_probe(stage_dir, entries, probe_episodes=probe_episodes)
+            logger.info("Constant-hold probe -> %s", written["constant_hold_probe_txt"])
+        except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
+            logger.warning("Could not write the constant-hold probe", exc_info=True)
 
 
 def _apply_stage_gate(

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -208,9 +208,11 @@ def run_panel(
     # is invisible to it and unfixable by it (issue #489).
     action_stats = _new_action_stats()
     joint_names: list[str] = []
+    pose_mapping: list[dict[str, float]] = []
 
     try:
         joint_names = _actuator_joint_names(env)
+        pose_mapping = _actuator_pose_mapping(env)
         _roll_episodes(
             env,
             predict=predict,
@@ -259,7 +261,7 @@ def run_panel(
         "components": {key: value / episodes for key, value in components.items()},
         "bilateral_duty": _full_horizon_mean(bilateral_duties),
         "single_duty": _full_horizon_mean(single_duties),
-        "action": _reduce_action_stats(action_stats, joint_names, control_dt),
+        "action": _reduce_action_stats(action_stats, joint_names, control_dt, pose_mapping),
         # The measurements the panel was reduced from. Kept rather than
         # discarded so the report can serialize the evidence, not only its
         # summary: an aggregate cannot be re-checked, and duty is the one
@@ -345,7 +347,62 @@ def _actuator_joint_names(env: Any) -> list[str]:
         return []
 
 
-def _reduce_action_stats(stats: dict[str, Any], names: list[str], control_dt: float) -> dict[str, Any]:
+def _actuator_pose_mapping(env: Any) -> list[dict[str, float]]:
+    """Per actuator, what a commanded action means as a joint angle.
+
+    Returns ``ctrl_min``/``ctrl_max`` (radians) and the ``home`` angle from the
+    keyframe the environment actually resets to, or ``[]`` when the model
+    cannot be reached.
+
+    This exists because ``|action| = 1`` is **not one physical event**.
+    ``_scale_action`` maps ``[-1, 1]`` linearly onto each actuator's own
+    ``ctrlrange``, and on the T-Rex those ranges differ by a factor of six: a
+    saturated tail joint is 8-12 degrees of deflection while a saturated toe is
+    50. Counting both as "saturated" pools them into one number, which is the
+    same mistake the DC/AC split was introduced to fix one level up -- a
+    normalized-unit summary hiding a physical distinction. Measured, it hid the
+    answer: the tail looked like the most extreme thing in the DC table and is
+    provably inert, while the toes carry the whole effect.
+    """
+    try:
+        # No `mujoco` import needed, unlike the joint-name lookup: everything
+        # below is attribute access on a model the environment already holds.
+        model = env.unwrapped.model
+        keyframe = int(getattr(env.unwrapped, "_reset_keyframe_id", 0))
+        if not 0 <= keyframe < model.nkey:
+            keyframe = 0
+        home_qpos = model.key_qpos[keyframe] if model.nkey else None
+        mapping = []
+        for index in range(model.nu):
+            joint_id = int(model.actuator_trnid[index, 0])
+            address = int(model.jnt_qposadr[joint_id])
+            low, high = (float(value) for value in model.actuator_ctrlrange[index])
+            mapping.append(
+                {
+                    "ctrl_min": low,
+                    "ctrl_max": high,
+                    # Falls back to the ctrlrange midpoint -- i.e. `action = 0`
+                    # -- when the model has no keyframe, which makes the
+                    # reported deflection zero rather than wrong.
+                    "home": float(home_qpos[address]) if home_qpos is not None else 0.5 * (low + high),
+                }
+            )
+        return mapping
+    except Exception:  # noqa: BLE001 - the angles are a convenience, not the measurement
+        return []
+
+
+def _commanded_angle(entry: dict[str, float], action: float) -> float:
+    """The joint angle an action commands, mirroring ``BaseDinoEnv._scale_action``."""
+    return entry["ctrl_min"] + (action + 1.0) * 0.5 * (entry["ctrl_max"] - entry["ctrl_min"])
+
+
+def _reduce_action_stats(
+    stats: dict[str, Any],
+    names: list[str],
+    control_dt: float,
+    pose_mapping: "list[dict[str, float]] | None" = None,
+) -> dict[str, Any]:
     """Reduce the accumulators into the report's ``action`` block.
 
     The DC/AC split is the point. ``mean(a)`` per actuator is the static pose
@@ -369,22 +426,45 @@ def _reduce_action_stats(stats: dict[str, Any], names: list[str], control_dt: fl
     freq = float("nan")
     if delta > 0.0:
         freq = math.asin(min(1.0, math.sqrt(jerk / delta) / 2.0)) / (math.pi * control_dt)
-    return {
+    mapping = pose_mapping or []
+    per_actuator = []
+    for index in range(mean.size):
+        entry: dict[str, Any] = {
+            "index": index,
+            "joint": names[index] if index < len(names) else f"actuator_{index}",
+            "dc": float(mean[index]),
+            "ac_rms": float(ac[index]),
+        }
+        if index < len(mapping):
+            scale = mapping[index]
+            span = scale["ctrl_max"] - scale["ctrl_min"]
+            entry["dc_deg"] = math.degrees(_commanded_angle(scale, float(mean[index])) - scale["home"])
+            # A unit of action is HALF the range, so that is what the tremor
+            # scales by.
+            entry["ac_rms_deg"] = math.degrees(float(ac[index]) * 0.5 * span)
+            entry["range_deg"] = math.degrees(span)
+            # Where `action = 0` sits relative to home. Non-zero means
+            # "action = 0 IS the home keyframe" -- which the residual mapping's
+            # name asserts and several derived constants lean on -- is inexact
+            # for this actuator.
+            entry["zero_offset_deg"] = math.degrees(_commanded_angle(scale, 0.0) - scale["home"])
+        per_actuator.append(entry)
+    reduced = {
         "dc_rms": float(np.sqrt(np.mean(mean * mean))),
         "ac_rms": float(np.sqrt(np.mean(var))),
         "delta_per_step": float(delta),
         "jerk_per_step": float(jerk),
         "effective_freq_hz": freq,
-        "per_actuator": [
-            {
-                "index": index,
-                "joint": names[index] if index < len(names) else f"actuator_{index}",
-                "dc": float(mean[index]),
-                "ac_rms": float(ac[index]),
-            }
-            for index in range(mean.size)
-        ],
+        "per_actuator": per_actuator,
     }
+    degrees = [entry["dc_deg"] for entry in per_actuator if "dc_deg" in entry]
+    if degrees:
+        # Reported alongside `dc_rms` rather than replacing it: the normalized
+        # figure is what inverts through the action penalties, and the degrees
+        # are what says whether a saturated actuator moved anything.
+        reduced["dc_rms_deg"] = float(np.sqrt(np.mean(np.square(degrees))))
+        reduced["max_abs_dc_deg"] = float(np.max(np.abs(degrees)))
+    return reduced
 
 
 def _roll_episodes(
@@ -898,21 +978,56 @@ def render_stance_gate_report(report: dict[str, Any]) -> str:
                 lines.append(f"  {key:28s} {components[key]:10.2f}")
     action = report.get("action") or {}
     if action:
+        summary = (
+            f"DC {action['dc_rms']:.3f} rms, AC {action['ac_rms']:.3f} rms, "
+            f"~{action['effective_freq_hz']:.1f} Hz"
+        )
+        if "dc_rms_deg" in action:
+            summary += f"; {action['dc_rms_deg']:.1f}deg rms of joint deflection"
         lines += [
             "",
-            "commanded action, post-settle "
-            f"(DC {action['dc_rms']:.3f} rms, AC {action['ac_rms']:.3f} rms, "
-            f"~{action['effective_freq_hz']:.1f} Hz):",
-            "  DC is the distance from the home keyframe (action = 0 IS that pose);",
-            "  AC is what the policy does around it. Different causes, different fixes.",
+            f"commanded action, post-settle ({summary}):",
+            "  DC is the distance from the home keyframe; AC is what the policy does",
+            "  around it. Different causes, different fixes.",
         ]
         per_actuator = action.get("per_actuator") or []
-        # Largest offset first: the question this answers is WHICH joints are
-        # displaced, because a leg-pose weight can only reach the leg ones.
-        for entry in sorted(per_actuator, key=lambda e: -abs(e["dc"]))[:12]:
-            lines.append(f"  {entry['joint']:28s} DC {entry['dc']:+7.3f}   AC {entry['ac_rms']:6.3f}")
+        has_degrees = any("dc_deg" in entry for entry in per_actuator)
+        if has_degrees:
+            lines += [
+                "  Ordered by DEGREES, not by normalised action: |action| = 1 maps onto each",
+                "  actuator's own ctrlrange, so a saturated joint can be 8deg or 50deg of",
+                "  deflection. Ranking by the normalised value pools those and hides which",
+                "  joints actually moved.",
+            ]
+        # Largest physical offset first when it can be computed. That ordering
+        # is the point: sorted by |dc| this table put twelve joints at exactly
+        # +/-1.000 at the top, of which the most extreme-looking (the tail, at
+        # 12deg of travel) was later measured to be mechanically inert.
+        key = (lambda e: -abs(e.get("dc_deg", 0.0))) if has_degrees else (lambda e: -abs(e["dc"]))
+        for entry in sorted(per_actuator, key=key)[:12]:
+            line = f"  {entry['joint']:22s} DC {entry['dc']:+7.3f}   AC {entry['ac_rms']:6.3f}"
+            if "dc_deg" in entry:
+                line += (
+                    f"   {entry['dc_deg']:+7.1f}deg   +/-{entry['ac_rms_deg']:5.1f}deg"
+                    f"   of {entry['range_deg']:5.1f}deg"
+                )
+            lines.append(line)
         if len(per_actuator) > 12:
             lines.append(f"  ... {len(per_actuator) - 12} more (full list in the JSON)")
+        # `action = 0` is the ctrlrange MIDPOINT, which equals the home keyframe
+        # only where the range was authored centred on it. Where it is not, the
+        # residual mapping's own name is inexact for that actuator and anything
+        # derived from "the statue commands home" carries the same small error.
+        offset = [
+            entry for entry in per_actuator if abs(entry.get("zero_offset_deg", 0.0)) > 0.05
+        ]
+        if offset:
+            worst = max(offset, key=lambda e: abs(e["zero_offset_deg"]))
+            lines.append(
+                f"  NOTE: action = 0 is not exactly home for {len(offset)} of {len(per_actuator)} "
+                f"actuators (worst {worst['joint']} {worst['zero_offset_deg']:+.1f}deg); "
+                "ctrlrange is centred elsewhere."
+            )
     lines += ["", f"GATE: {'PASS' if report['passed'] else 'FAIL'}"]
     lines += [f"  - {failure}" for failure in report["failures"]]
     return "\n".join(lines)

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -209,7 +209,7 @@ def run_panel(
     # is invisible to it and unfixable by it (issue #489).
     action_stats = _new_action_stats()
     joint_names: list[str] = []
-    pose_mapping: list[dict[str, float]] = []
+    pose_mapping: list[dict[str, Any]] = []
 
     try:
         joint_names = _actuator_joint_names(env)
@@ -291,6 +291,14 @@ def _new_action_stats() -> dict[str, Any]:
         "sum": None,
         "sq_sum": None,
         "count": 0,
+        # Physical controls actually applied by the environment.  These stay
+        # separate from normalized actions because the species mapping can be
+        # piecewise about its home control; in that case E[f(a)] != f(E[a])
+        # and a normalized variance cannot be converted with one range-wide
+        # scale factor.
+        "ctrl_sum": None,
+        "ctrl_sq_sum": None,
+        "ctrl_count": 0,
         "delta": 0.0,
         "jerk": 0.0,
         # Counted separately: a difference needs two samples and a second
@@ -304,8 +312,12 @@ def _new_action_stats() -> dict[str, Any]:
     }
 
 
-def _accumulate_action(stats: dict[str, Any], action: np.ndarray) -> None:
-    """Accumulate one post-settle action into the per-actuator statistics."""
+def _accumulate_action(
+    stats: dict[str, Any],
+    action: np.ndarray,
+    applied_ctrl: "np.ndarray | None" = None,
+) -> None:
+    """Accumulate one post-settle action and its applied physical control."""
     if stats["sum"] is None or stats["sum"].shape != action.shape:
         stats["sum"] = np.zeros_like(action)
         stats["sq_sum"] = np.zeros_like(action)
@@ -324,6 +336,17 @@ def _accumulate_action(stats: dict[str, Any], action: np.ndarray) -> None:
             stats["jerk_count"] += 1
     stats["prev_prev"] = prev
     stats["prev"] = action
+
+    if applied_ctrl is not None:
+        ctrl = np.asarray(applied_ctrl, dtype=np.float64).ravel()
+        if ctrl.shape == action.shape:
+            if stats["ctrl_sum"] is None or stats["ctrl_sum"].shape != ctrl.shape:
+                stats["ctrl_sum"] = np.zeros_like(ctrl)
+                stats["ctrl_sq_sum"] = np.zeros_like(ctrl)
+                stats["ctrl_count"] = 0
+            stats["ctrl_sum"] += ctrl
+            stats["ctrl_sq_sum"] += ctrl * ctrl
+            stats["ctrl_count"] += 1
 
 
 def _actuator_joint_names(env: Any) -> list[str]:
@@ -349,31 +372,81 @@ def _actuator_joint_names(env: Any) -> list[str]:
         return []
 
 
-def _actuator_pose_mapping(env: Any) -> list[dict[str, float]]:
-    """Per actuator, what a commanded action means as a joint angle.
+def _is_angular_position_control(model: Any, index: int, joint_id: int) -> bool:
+    """Whether actuator control values are directly interpretable as radians.
 
-    Returns ``ctrl_min``/``ctrl_max`` (radians) and the ``home`` angle from the
-    keyframe the environment actually resets to, or ``[]`` when the model
-    cannot be reached.
+    A joint transmission alone is not enough: Velociraptor's claw actuators
+    are geared motors, where ``ctrl=1`` is a dimensionless motor command rather
+    than a one-radian target.  Restrict degree fields to the canonical direct,
+    unit-gear hinge position servo compiled by MuJoCo's ``<position>`` shortcut.
+    Anything else keeps normalized and native-control statistics only.
+    """
+    import mujoco
+
+    gain = float(model.actuator_gainprm[index, 0])
+    bias = np.asarray(model.actuator_biasprm[index], dtype=np.float64)
+    gear = np.asarray(model.actuator_gear[index], dtype=np.float64)
+    return bool(
+        int(model.actuator_trntype[index]) == int(mujoco.mjtTrn.mjTRN_JOINT)
+        and int(model.jnt_type[joint_id]) == int(mujoco.mjtJoint.mjJNT_HINGE)
+        and int(model.actuator_gaintype[index]) == int(mujoco.mjtGain.mjGAIN_FIXED)
+        and int(model.actuator_biastype[index]) == int(mujoco.mjtBias.mjBIAS_AFFINE)
+        and np.isfinite(gain)
+        and gain > 0.0
+        and np.isclose(bias[0], 0.0)
+        and np.isclose(bias[1], -gain)
+        and np.isclose(gear[0], 1.0)
+        and np.allclose(gear[1:], 0.0)
+    )
+
+
+def _actuator_pose_mapping(env: Any) -> list[dict[str, Any]]:
+    """Per actuator, separate action origin, home control, and home pose.
+
+    Returns the physical control at normalized actions -1, 0, and +1, the
+    named home keyframe's control target, and the joint pose in that keyframe.
+    These are deliberately distinct: T-Rex maps residuals piecewise around
+    ``key_ctrl['home']``, while its ankles use an intentional control preload
+    relative to ``key_qpos['home']``.
 
     This exists because ``|action| = 1`` is **not one physical event**.
-    ``_scale_action`` maps ``[-1, 1]`` linearly onto each actuator's own
-    ``ctrlrange``, and on the T-Rex those ranges differ by a factor of six: a
-    saturated tail joint is 8-12 degrees of deflection while a saturated toe is
-    50. Counting both as "saturated" pools them into one number, which is the
-    same mistake the DC/AC split was introduced to fix one level up -- a
-    normalized-unit summary hiding a physical distinction. Measured, it hid the
-    answer: the tail looked like the most extreme thing in the DC table and is
-    provably inert, while the toes carry the whole effect.
+    ``_scale_action`` maps ``[-1, 1]`` onto each actuator's own physical
+    control targets, and on the T-Rex those spans differ by a factor of six: a
+    saturated tail target is 8-12 degrees from its origin while a saturated toe
+    target is 37.5 degrees away. Counting both as "saturated" pools them into
+    one number, which is the same mistake the DC/AC split was introduced to fix
+    one level up -- a normalized-unit summary hiding a physical distinction.
+    Measured, it hid the answer: the tail looked like the most extreme thing in
+    the DC table and is provably inert, while the toes carry the whole effect.
     """
     try:
-        # No `mujoco` import needed, unlike the joint-name lookup: everything
-        # below is attribute access on a model the environment already holds.
-        model = env.unwrapped.model
-        keyframe = int(getattr(env.unwrapped, "_reset_keyframe_id", 0))
+        # Probe the environment's own mapping instead of duplicating a shared
+        # midpoint formula.  T-Rex overrides that formula with a piecewise
+        # home-control residual mapping, and future action interfaces may do
+        # the same.
+        unwrapped = env.unwrapped
+        model = unwrapped.model
+        action_shape = tuple(unwrapped.action_space.shape)
+        negative_ctrl = np.asarray(
+            unwrapped._scale_action(-np.ones(action_shape, dtype=np.float64)),
+            dtype=np.float64,
+        ).ravel()
+        action_zero_ctrl = np.asarray(
+            unwrapped._scale_action(np.zeros(action_shape, dtype=np.float64)),
+            dtype=np.float64,
+        ).ravel()
+        positive_ctrl = np.asarray(
+            unwrapped._scale_action(np.ones(action_shape, dtype=np.float64)),
+            dtype=np.float64,
+        ).ravel()
+        if any(values.shape != (model.nu,) for values in (negative_ctrl, action_zero_ctrl, positive_ctrl)):
+            return []
+
+        keyframe = int(getattr(unwrapped, "_reset_keyframe_id", 0))
         if not 0 <= keyframe < model.nkey:
             keyframe = 0
         home_qpos = model.key_qpos[keyframe] if model.nkey else None
+        home_ctrl = model.key_ctrl[keyframe] if model.nkey else action_zero_ctrl
         mapping = []
         for index in range(model.nu):
             joint_id = int(model.actuator_trnid[index, 0])
@@ -383,10 +456,17 @@ def _actuator_pose_mapping(env: Any) -> list[dict[str, float]]:
                 {
                     "ctrl_min": low,
                     "ctrl_max": high,
-                    # Falls back to the ctrlrange midpoint -- i.e. `action = 0`
-                    # -- when the model has no keyframe, which makes the
-                    # reported deflection zero rather than wrong.
-                    "home": float(home_qpos[address]) if home_qpos is not None else 0.5 * (low + high),
+                    "action_negative_ctrl": float(negative_ctrl[index]),
+                    "action_zero_ctrl": float(action_zero_ctrl[index]),
+                    "action_positive_ctrl": float(positive_ctrl[index]),
+                    "angular_position_ctrl": _is_angular_position_control(model, index, joint_id),
+                    # With no keyframe, use action zero for both anchors so the
+                    # optional offsets read as unavailable/zero rather than
+                    # inventing a nominal posture.
+                    "home_ctrl": float(home_ctrl[index]),
+                    "home_qpos": (
+                        float(home_qpos[address]) if home_qpos is not None else float(action_zero_ctrl[index])
+                    ),
                 }
             )
         return mapping
@@ -394,25 +474,39 @@ def _actuator_pose_mapping(env: Any) -> list[dict[str, float]]:
         return []
 
 
-def _commanded_angle(entry: dict[str, float], action: float) -> float:
-    """The joint angle an action commands, mirroring ``BaseDinoEnv._scale_action``."""
-    return entry["ctrl_min"] + (action + 1.0) * 0.5 * (entry["ctrl_max"] - entry["ctrl_min"])
+def _commanded_angle(entry: dict[str, Any], action: float) -> float:
+    """The control target for an action, using the probed piecewise mapping.
+
+    Real reports use the applied-control moments recorded during rollout.  The
+    helper remains useful for endpoint display, fixtures, and legacy reports,
+    but must still mirror ``home-keyframe-residual/v1`` on both sides of zero.
+    """
+    clipped = float(np.clip(action, -1.0, 1.0))
+    zero = float(
+        entry.get(
+            "action_zero_ctrl",
+            entry.get("home_ctrl", entry.get("home", 0.5 * (entry["ctrl_min"] + entry["ctrl_max"]))),
+        )
+    )
+    negative = float(entry.get("action_negative_ctrl", entry["ctrl_min"]))
+    positive = float(entry.get("action_positive_ctrl", entry["ctrl_max"]))
+    return zero + clipped * (zero - negative if clipped < 0.0 else positive - zero)
 
 
 def _reduce_action_stats(
     stats: dict[str, Any],
     names: list[str],
     control_dt: float,
-    pose_mapping: "list[dict[str, float]] | None" = None,
+    pose_mapping: "list[dict[str, Any]] | None" = None,
 ) -> dict[str, Any]:
     """Reduce the accumulators into the report's ``action`` block.
 
-    The DC/AC split is the point. ``mean(a)`` per actuator is the static pose
-    the policy commands -- under ``home-keyframe-residual/v1`` the distance
-    from the home keyframe, since ``action = 0`` *is* that keyframe -- and the
-    spread about it is what the policy does on top. They have different causes
-    and different fixes, and a single pooled number cannot tell them apart
-    (issue #489).
+    The DC/AC split is the point. ``mean(a)`` per actuator is the policy's
+    static normalized residual and the spread about it is what the policy does
+    on top. Applied-control moments are reduced independently, because the
+    residual-to-control mapping can have different slopes on either side of
+    zero. Static offset and variation have different causes and fixes, and a
+    single pooled number cannot tell them apart (issue #489).
     """
     count = stats["count"]
     if not count or stats["sum"] is None:
@@ -429,6 +523,19 @@ def _reduce_action_stats(
     if delta > 0.0:
         freq = math.asin(min(1.0, math.sqrt(jerk / delta) / 2.0)) / (math.pi * control_dt)
     mapping = pose_mapping or []
+    ctrl_count = int(stats.get("ctrl_count", 0))
+    ctrl_mean: "np.ndarray | None" = None
+    ctrl_ac: "np.ndarray | None" = None
+    if (
+        ctrl_count == count
+        and stats.get("ctrl_sum") is not None
+        and stats.get("ctrl_sq_sum") is not None
+        and stats["ctrl_sum"].shape == mean.shape
+        and stats["ctrl_sq_sum"].shape == mean.shape
+    ):
+        ctrl_mean = stats["ctrl_sum"] / ctrl_count
+        ctrl_var = np.maximum(stats["ctrl_sq_sum"] / ctrl_count - ctrl_mean * ctrl_mean, 0.0)
+        ctrl_ac = np.sqrt(ctrl_var)
     per_actuator = []
     for index in range(mean.size):
         entry: dict[str, Any] = {
@@ -439,17 +546,41 @@ def _reduce_action_stats(
         }
         if index < len(mapping):
             scale = mapping[index]
-            span = scale["ctrl_max"] - scale["ctrl_min"]
-            entry["dc_deg"] = math.degrees(_commanded_angle(scale, float(mean[index])) - scale["home"])
-            # A unit of action is HALF the range, so that is what the tremor
-            # scales by.
-            entry["ac_rms_deg"] = math.degrees(float(ac[index]) * 0.5 * span)
-            entry["range_deg"] = math.degrees(span)
-            # Where `action = 0` sits relative to home. Non-zero means
-            # "action = 0 IS the home keyframe" -- which the residual mapping's
-            # name asserts and several derived constants lean on -- is inexact
-            # for this actuator.
-            entry["zero_offset_deg"] = math.degrees(_commanded_angle(scale, 0.0) - scale["home"])
+            action_zero_ctrl = float(
+                scale.get(
+                    "action_zero_ctrl",
+                    scale.get("home_ctrl", scale.get("home", 0.5 * (scale["ctrl_min"] + scale["ctrl_max"]))),
+                )
+            )
+            home_ctrl = float(scale.get("home_ctrl", action_zero_ctrl))
+            home_qpos = float(scale.get("home_qpos", scale.get("home", home_ctrl)))
+            angular_position_ctrl = bool(scale.get("angular_position_ctrl", True))
+            # Preserve control anchors in native units so the report is
+            # auditable without reloading the exact plant model.  Control and
+            # qpos units are comparable only for the verified position-servo
+            # case below.
+            entry["angular_position_ctrl"] = angular_position_ctrl
+            entry["action_zero_ctrl"] = action_zero_ctrl
+            entry["home_ctrl"] = home_ctrl
+            # Applied-control moments are authoritative.  Mapping the action
+            # mean and variance after reduction is not equivalent when the
+            # negative and positive residual slopes differ, so omit physical
+            # DC/AC rather than fabricate them when controls were unavailable.
+            if ctrl_mean is not None and ctrl_ac is not None:
+                entry["ctrl_mean"] = float(ctrl_mean[index])
+                entry["ctrl_ac_rms"] = float(ctrl_ac[index])
+            if angular_position_ctrl:
+                entry["home_qpos"] = home_qpos
+                entry["range_deg"] = math.degrees(scale["ctrl_max"] - scale["ctrl_min"])
+                if ctrl_mean is not None and ctrl_ac is not None:
+                    entry["dc_deg"] = math.degrees(float(ctrl_mean[index]) - action_zero_ctrl)
+                    entry["ac_rms_deg"] = math.degrees(float(ctrl_ac[index]))
+                # A mapping-contract check, not a posture offset.  Under
+                # home-keyframe-residual/v1 this must be zero even when the
+                # home actuator target intentionally preloads a joint against
+                # gravity.
+                entry["zero_offset_deg"] = math.degrees(action_zero_ctrl - home_ctrl)
+                entry["home_preload_deg"] = math.degrees(home_ctrl - home_qpos)
         per_actuator.append(entry)
     reduced = {
         "dc_rms": float(np.sqrt(np.mean(mean * mean))),
@@ -463,7 +594,7 @@ def _reduce_action_stats(
     if degrees:
         # Reported alongside `dc_rms` rather than replacing it: the normalized
         # figure is what inverts through the action penalties, and the degrees
-        # are what says whether a saturated actuator moved anything.
+        # say how far the physical control targets moved.
         reduced["dc_rms_deg"] = float(np.sqrt(np.mean(np.square(degrees))))
         reduced["max_abs_dc_deg"] = float(np.max(np.abs(degrees)))
     return reduced
@@ -513,15 +644,24 @@ def _roll_episodes(
             action = np.asarray(predict(obs), dtype=np.float64).ravel()
             # Post-settle only, the same window the duty uses, so the reset
             # transient does not read as tremor.
-            if steps >= settle_steps:
-                _accumulate_action(action_stats, action)
+            measure_step = steps >= settle_steps
             obs, reward, terminated, truncated, info = env.step(action)
+            if measure_step:
+                # ``data.ctrl`` is the target the environment actually
+                # applied.  Reading it after ``step`` avoids a second call to
+                # a potentially species-specific mapping and also remains
+                # correct if plant-side action dynamics are added later.
+                try:
+                    applied_ctrl = np.asarray(env.unwrapped.data.ctrl, dtype=np.float64).copy()
+                except Exception:  # noqa: BLE001 - normalized stats remain useful without it
+                    applied_ctrl = None
+                _accumulate_action(action_stats, action, applied_ctrl)
             total += float(reward)
             for key, value in info.items():
                 if key.startswith("reward_") and key != "reward_total":
                     components[key] = components.get(key, 0.0) + float(value)
             stance = derive_stance_info(info)
-            if stance and steps >= settle_steps:
+            if stance and measure_step:
                 measured += 1
                 unsupported += int(stance["unsupported_duty"])
                 # The gate bounds unsupported duty only. Reporting the full
@@ -548,7 +688,7 @@ def _roll_episodes(
 
 
 #: Bumped when the JSON report's field meanings change.
-REPORT_SCHEMA = "mesozoic.stance-gate-report/v1"
+REPORT_SCHEMA = "mesozoic.stance-gate-report/v2"
 
 
 def thresholds_from_curriculum(curriculum: dict[str, Any]) -> StanceGateThresholds:
@@ -868,8 +1008,7 @@ def build_stance_gate_report(
             # broadcasts a mismatched length silently, which would score a
             # policy nobody asked for and report it as this one.
             raise ValueError(
-                f"hold_constant carries {len(hold_constant.actions)} actions but "
-                f"{species} has action_dim {expected}"
+                f"hold_constant carries {len(hold_constant.actions)} actions but {species} has action_dim {expected}"
             )
         predict = _hold_constant_predict(predict, hold_constant)
         description += (
@@ -1062,26 +1201,24 @@ def render_stance_gate_report(report: dict[str, Any]) -> str:
                 lines.append(f"  {key:28s} {components[key]:10.2f}")
     action = report.get("action") or {}
     if action:
-        summary = (
-            f"DC {action['dc_rms']:.3f} rms, AC {action['ac_rms']:.3f} rms, "
-            f"~{action['effective_freq_hz']:.1f} Hz"
-        )
+        summary = f"DC {action['dc_rms']:.3f} rms, AC {action['ac_rms']:.3f} rms, ~{action['effective_freq_hz']:.1f} Hz"
         if "dc_rms_deg" in action:
-            summary += f"; {action['dc_rms_deg']:.1f}deg rms of joint deflection"
+            summary += f"; {action['dc_rms_deg']:.1f}deg rms across angular position controls"
         lines += [
             "",
             f"commanded action, post-settle ({summary}):",
-            "  DC is the distance from the home keyframe; AC is what the policy does",
-            "  around it. Different causes, different fixes.",
+            "  Normalised DC is the mean policy action; degree DC is the applied control",
+            "  target relative to action zero. AC is variation around each mean.",
         ]
         per_actuator = action.get("per_actuator") or []
         has_degrees = any("dc_deg" in entry for entry in per_actuator)
         if has_degrees:
             lines += [
                 "  Ordered by DEGREES, not by normalised action: |action| = 1 maps onto each",
-                "  actuator's own ctrlrange, so a saturated joint can be 8deg or 50deg of",
-                "  deflection. Ranking by the normalised value pools those and hides which",
-                "  joints actually moved.",
+                "  actuator's own control span, so saturation can move a target 8deg or 37.5deg",
+                "  from its nominal target. Ranking by the normalised value pools those and",
+                "  hides which targets moved. Degree fields are emitted for verified angular",
+                "  position controls only; motors retain native control units in the JSON.",
             ]
         # Largest physical offset first when it can be computed. That ordering
         # is the point: sorted by |dc| this table put twelve joints at exactly
@@ -1098,19 +1235,25 @@ def render_stance_gate_report(report: dict[str, Any]) -> str:
             lines.append(line)
         if len(per_actuator) > 12:
             lines.append(f"  ... {len(per_actuator) - 12} more (full list in the JSON)")
-        # `action = 0` is the ctrlrange MIDPOINT, which equals the home keyframe
-        # only where the range was authored centred on it. Where it is not, the
-        # residual mapping's own name is inexact for that actuator and anything
-        # derived from "the statue commands home" carries the same small error.
-        offset = [
-            entry for entry in per_actuator if abs(entry.get("zero_offset_deg", 0.0)) > 0.05
-        ]
+        # Contract check: under the home-keyframe residual mapping action zero
+        # must be the named home CONTROL.  Keep that distinct from a deliberate
+        # control-vs-qpos preload, which is a plant property rather than policy
+        # displacement or an action-mapping error.
+        offset = [entry for entry in per_actuator if abs(entry.get("zero_offset_deg", 0.0)) > 0.05]
         if offset:
             worst = max(offset, key=lambda e: abs(e["zero_offset_deg"]))
             lines.append(
-                f"  NOTE: action = 0 is not exactly home for {len(offset)} of {len(per_actuator)} "
-                f"actuators (worst {worst['joint']} {worst['zero_offset_deg']:+.1f}deg); "
-                "ctrlrange is centred elsewhere."
+                f"  NOTE: action = 0 differs from the named home control for {len(offset)} of "
+                f"{len(per_actuator)} actuators (worst {worst['joint']} "
+                f"{worst['zero_offset_deg']:+.1f}deg); inspect the action-mapping contract."
+            )
+        preload = [entry for entry in per_actuator if abs(entry.get("home_preload_deg", 0.0)) > 0.05]
+        if preload:
+            worst = max(preload, key=lambda e: abs(e["home_preload_deg"]))
+            lines.append(
+                f"  Nominal control preload differs from reset joint pose for {len(preload)} of "
+                f"{len(per_actuator)} actuators (worst {worst['joint']} "
+                f"{worst['home_preload_deg']:+.1f}deg); this is not policy displacement."
             )
     lines += ["", f"GATE: {'PASS' if report['passed'] else 'FAIL'}"]
     lines += [f"  - {failure}" for failure in report["failures"]]
@@ -1282,9 +1425,7 @@ def write_action_filter_sweep(
     return {"action_filter_sweep_txt": text_path, "action_filter_sweep_json": json_path}
 
 
-def render_constant_hold_probe(
-    reports: list[dict[str, Any]], *, probe_episodes: int
-) -> tuple[str, dict[str, Any]]:
+def render_constant_hold_probe(reports: list[dict[str, Any]], *, probe_episodes: int) -> tuple[str, dict[str, Any]]:
     """Reduce the constant-hold variants to their comparison table and payload.
 
     Split from the writer so the CLI can print the table without depositing
@@ -1473,9 +1614,7 @@ def _ablation_verdicts(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
 _IMPULSE_SPEEDS = (0.5, 1.0, 2.0)
 
 
-def impulse_variants(
-    speeds: "tuple[float, ...] | list[float]", *, step: int
-) -> list[RootImpulse]:
+def impulse_variants(speeds: "tuple[float, ...] | list[float]", *, step: int) -> list[RootImpulse]:
     """One :class:`RootImpulse` per (speed, direction), plus the zero control."""
     variants = [RootImpulse(step=step, delta_v=(0.0, 0.0, 0.0), axis_label="none (control)")]
     for speed in sorted(set(float(value) for value in speeds if float(value) > 0)):
@@ -1599,6 +1738,7 @@ def render_impulse_probe(
     * policy *below* statue -> its pose or its tremor is actively worse than
       standing still under load, which would be a finding about the pose.
     """
+
     def _rows(reports: list[dict[str, Any]]) -> dict[tuple[float, str], dict[str, Any]]:
         return {
             (report["impulse"]["speed"], report["impulse"]["axis_label"]): {
@@ -1670,6 +1810,7 @@ def render_impulse_probe(
         f"  {'impulse':>9} {'direction':<16}{'policy len':>11}{'policy fh':>11}"
         f"{'statue len':>11}{'statue fh':>11}{'margin':>9}",
     ]
+
     def _length(cell: "dict[str, Any] | None") -> str:
         return "-" if cell is None else format(cell["episode_length_mean"], ".1f")
 
@@ -1723,9 +1864,7 @@ def write_impulse_probe(
     return {"impulse_probe_txt": text_path, "impulse_probe_json": json_path}
 
 
-def render_constant_hold_ablation(
-    reports: list[dict[str, Any]], *, probe_episodes: int
-) -> tuple[str, dict[str, Any]]:
+def render_constant_hold_ablation(reports: list[dict[str, Any]], *, probe_episodes: int) -> tuple[str, dict[str, Any]]:
     """Reduce the release ablation to its table, per-group verdicts, and payload.
 
     The ablation walks the path between two already-measured endpoints: the
@@ -2239,9 +2378,7 @@ def main() -> int:
         except StanceGateReportError as exc:
             raise SystemExit(str(exc)) from exc
         source_report = (
-            json.loads(Path(args.hold_from_report).read_text(encoding="utf-8"))
-            if args.hold_from_report
-            else report
+            json.loads(Path(args.hold_from_report).read_text(encoding="utf-8")) if args.hold_from_report else report
         )
         variants = (
             constant_hold_release_variants(

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -171,6 +171,7 @@ def run_panel(
     env_kwargs: dict[str, Any],
     plant_identity: Any = None,
     control_dt: float = 0.01,
+    impulse: "RootImpulse | None" = None,
 ) -> dict[str, Any]:
     """Roll ``episodes`` deterministic episodes and reduce them for the gate.
 
@@ -227,6 +228,7 @@ def run_panel(
             terminations=terminations,
             components=components,
             action_stats=action_stats,
+            impulse=impulse,
         )
     finally:
         env.close()
@@ -482,6 +484,7 @@ def _roll_episodes(
     terminations: dict[str, int],
     components: dict[str, float],
     action_stats: dict[str, Any],
+    impulse: "RootImpulse | None" = None,
 ) -> None:
     """Roll the panel, appending per-episode measurements to the given lists.
 
@@ -502,6 +505,11 @@ def _roll_episodes(
         single = 0
         measured = 0
         while True:
+            # Before the action is commanded, so the policy's first response to
+            # the shove is the step that follows it rather than the one it was
+            # already committed to.
+            if impulse is not None and steps == impulse.step:
+                _apply_root_impulse(env, impulse)
             action = np.asarray(predict(obs), dtype=np.float64).ravel()
             # Post-settle only, the same window the duty uses, so the reset
             # transient does not read as tremor.
@@ -659,6 +667,66 @@ class ConstantHold:
         }
 
 
+@dataclass(frozen=True)
+class RootImpulse:
+    """A shove applied to the animal partway through an episode.
+
+    Stage 1 contains **no in-episode disturbance** -- the only perturbation
+    anywhere is joint-angle noise at reset -- so a policy that learns active
+    postural correction earns nothing over one that stands still, and the
+    zero-action statue is the objective's optimum. That makes "does this policy
+    actively correct?" unanswerable from any training artifact: the task never
+    asks.
+
+    This asks. The impulse is a step change in the root's linear velocity,
+    which is exactly a shove to the torso and needs no force/duration
+    bookkeeping to reproduce -- ``delta_v`` fully specifies it, and the
+    equivalent momentum is ``total_mass * delta_v``.
+
+    The **statue is the control**, and it is what makes the measurement mean
+    something. It commands a constant, so it cannot respond to anything;
+    whatever horizon it survives is the plant's *passive* robustness. Only the
+    margin above that line is active correction. A policy that matches the
+    statue has learned to stand, not to recover.
+
+    Attributes:
+        step: Step at which the impulse lands, normally the settle window so
+            the policy has established its own state first.
+        delta_v: Velocity change in m/s, world frame, applied to the root.
+        axis_label: Human name for the direction, for the artifact.
+    """
+
+    step: int
+    delta_v: tuple[float, float, float]
+    axis_label: str = "lateral"
+
+    @property
+    def speed(self) -> float:
+        return float(np.linalg.norm(np.asarray(self.delta_v, dtype=float)))
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "kind": "root_impulse/v1",
+            "step": self.step,
+            "delta_v": list(self.delta_v),
+            "speed": self.speed,
+            "axis_label": self.axis_label,
+        }
+
+
+def _apply_root_impulse(env: Any, impulse: RootImpulse) -> float:
+    """Add the impulse to the root's linear velocity. Returns the momentum in N*s.
+
+    ``qvel[0:3]`` is the free joint's world-frame linear velocity, and every
+    child body's velocity composes from it, so this translates the whole animal
+    rather than only the root body -- a shove, not a tug on one link.
+    """
+    data = env.unwrapped.data
+    model = env.unwrapped.model
+    data.qvel[0:3] += np.asarray(impulse.delta_v, dtype=data.qvel.dtype)
+    return float(np.sum(model.body_mass)) * impulse.speed
+
+
 def _hold_constant_predict(predict: Any, hold: ConstantHold) -> Any:
     """Wrap *predict* so the plant receives a constant command after handoff.
 
@@ -733,6 +801,7 @@ def build_stance_gate_report(
     allow_legacy_plant: bool = False,
     filter_actions_hz: float | None = None,
     hold_constant: ConstantHold | None = None,
+    impulse: RootImpulse | None = None,
 ) -> dict[str, Any]:
     """Roll a policy and return its gate verdict as a serializable dict.
 
@@ -819,6 +888,7 @@ def build_stance_gate_report(
         env_kwargs=env_kwargs,
         plant_identity=plant_identity,
         control_dt=control_dt,
+        impulse=impulse,
     )
     panel = result["panel"]
     passed, failures = evaluate_stance_gate(panel, thresholds)
@@ -872,6 +942,11 @@ def build_stance_gate_report(
         # held rollout scored a policy whose feedback was cut, so it is a probe
         # and never a verdict, and `_PROBE_MARKERS` keys the filenames off this.
         "hold_constant": None if hold_constant is None else hold_constant.as_dict(),
+        # `None` for an ordinary run. A perturbed rollout scores the UNMODIFIED
+        # policy on a MODIFIED task, which is the opposite direction from the
+        # other two probes but has the same consequence: the gate is defined
+        # without a disturbance, so this verdict is not that verdict.
+        "impulse": None if impulse is None else impulse.as_dict(),
         # Where the commanded pose sits and what the policy does around it,
         # per actuator. `{}` when no post-settle step was measured.
         "action": result.get("action", {}),
@@ -899,6 +974,7 @@ def build_stance_gate_report(
 _PROBE_MARKERS: dict[str, str] = {
     "filter_actions_hz": "stance_gate_probe_filtered",
     "hold_constant": "stance_gate_probe_constant",
+    "impulse": "stance_gate_probe_impulse",
 }
 
 
@@ -924,6 +1000,14 @@ def _probe_banner(report: dict[str, Any]) -> list[str]:
                 + (f", ramped in over {hold['ramp_steps']} steps." if hold.get("ramp_steps") else ".")
             )
         )
+    elif report.get("impulse") is not None:
+        shove = report["impulse"]
+        return [
+            f"PROBE: a {shove['speed']:.2f} m/s {shove['axis_label']} impulse at step {shove['step']}.",
+            "This scores the unmodified policy on a MODIFIED TASK -- stage 1 has no disturbance,",
+            "so the gate below was never defined with one. It is not a gate result.",
+            "",
+        ]
     else:
         return []
     return [
@@ -1380,6 +1464,265 @@ def _ablation_verdicts(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return verdicts
 
 
+#: Lateral impulses, in m/s of root velocity, swept by the recovery probe.
+#: Lateral because that is the axis a biped is least able to catch itself on --
+#: a fore/aft shove can be absorbed by pitching, a sideways one cannot without
+#: moving a foot. Both signs are run, because this policy is asymmetric: its
+#: toes are splayed differently on the two feet, so a one-sided sweep would
+#: measure the easy direction or the hard one and report it as the answer.
+_IMPULSE_SPEEDS = (0.5, 1.0, 2.0)
+
+
+def impulse_variants(
+    speeds: "tuple[float, ...] | list[float]", *, step: int
+) -> list[RootImpulse]:
+    """One :class:`RootImpulse` per (speed, direction), plus the zero control."""
+    variants = [RootImpulse(step=step, delta_v=(0.0, 0.0, 0.0), axis_label="none (control)")]
+    for speed in sorted(set(float(value) for value in speeds if float(value) > 0)):
+        variants.append(RootImpulse(step=step, delta_v=(0.0, speed, 0.0), axis_label="lateral +y"))
+        variants.append(RootImpulse(step=step, delta_v=(0.0, -speed, 0.0), axis_label="lateral -y"))
+    return variants
+
+
+#: A row counts as a recovery when this share of episodes reach the horizon.
+#: Matches the gate's own `min_full_horizon_fraction`, so "recovered" means the
+#: same thing here as "stood" does there.
+_RECOVERY_SHARE = 0.95
+
+
+def _recovery_envelopes(rows: list[dict[str, Any]]) -> dict[str, dict[str, float]]:
+    """Largest impulse each side fully recovers from, per direction.
+
+    This, not a mean margin, is the number the probe exists to produce. Mean
+    margin over directions pools a full recovery with a total failure: on the
+    T-Rex checkpoint the policy reaches the horizon at 0.5 m/s in one direction
+    and falls at 0.5 m/s in the other, which averages to a healthy-looking
+    +135 steps and describes neither.
+    """
+    envelopes: dict[str, dict[str, float]] = {}
+    for row in rows:
+        if row["speed"] <= 0:
+            continue
+        entry = envelopes.setdefault(row["axis_label"], {"policy": 0.0, "statue": 0.0})
+        for who in ("policy", "statue"):
+            cell = row[who]
+            if cell is not None and cell["full_horizon_fraction"] >= _RECOVERY_SHARE:
+                entry[who] = max(entry[who], row["speed"])
+    return envelopes
+
+
+def _recovery_reading(
+    rows: list[dict[str, Any]],
+    envelopes: dict[str, dict[str, float]],
+    disturbed: list[dict[str, Any]],
+    horizon: int,
+) -> list[str]:
+    """The prose verdict, keyed off the envelopes rather than a pooled margin."""
+    lines: list[str] = []
+    policy_best = max((entry["policy"] for entry in envelopes.values()), default=0.0)
+    statue_best = max((entry["statue"] for entry in envelopes.values()), default=0.0)
+    mean_margin = sum(row["margin_steps"] for row in disturbed) / len(disturbed)
+
+    for direction, entry in sorted(envelopes.items()):
+        policy_text = "none" if entry["policy"] == 0 else f"{entry['policy']:.2f} m/s"
+        statue_text = "none" if entry["statue"] == 0 else f"{entry['statue']:.2f} m/s"
+        lines.append(f"  recovery envelope, {direction:<16} policy {policy_text:>9}   statue {statue_text:>9}")
+    lines.append("")
+
+    if policy_best > statue_best:
+        lines += [
+            f"  ACTIVE CORRECTION EXISTS: the policy fully recovers from {policy_best:.2f} m/s where a",
+            "  constant command never recovers from anything. Stage 1 never measured this,",
+            "  because the task has no disturbance to measure it with -- a metric gap, not a",
+            "  reward one.",
+        ]
+        sides = sorted(entry["policy"] for entry in envelopes.values())
+        if len(sides) > 1 and sides[0] < sides[-1]:
+            worst = "none" if sides[0] == 0 else f"{sides[0]:.2f} m/s"
+            lines += [
+                "",
+                f"  But it is ASYMMETRIC: {policy_best:.2f} m/s one way, {worst} the other, at the same",
+                "  magnitude. The envelope is the WEAKER side -- a disturbance does not ask which",
+                "  direction the policy prefers. Treat the smaller number as the capability.",
+            ]
+        beyond = [row["speed"] for row in disturbed if row["speed"] > policy_best]
+        if beyond:
+            lines += [
+                "",
+                f"  Above {policy_best:.2f} m/s it stops mattering: at {min(beyond):.2f} m/s and up the policy and",
+                "  the statue are within noise of each other, so the recovery envelope is narrow",
+                "  rather than merely asymmetric.",
+            ]
+    elif mean_margin < -0.1 * horizon:
+        lines += [
+            f"  The policy does WORSE than the statue by {mean_margin:.0f} steps on average.",
+            "  Standing still beats what this policy does under load, which is a finding about",
+            "  the pose and the tremor rather than about the task.",
+        ]
+    else:
+        lines += [
+            "  Neither side recovers from anything, and the policy's survival is within noise",
+            f"  of the statue's ({mean_margin:+.0f} steps on average). Nothing has learned to recover --",
+            "  exactly what the task structure predicts, since no reward term can pay for a",
+            "  correction that is never needed. No reweighting fixes this; the disturbance has",
+            "  to enter the TASK. See STAGE1_SPLIT_PLAN's 1a stance / 1b recovery split.",
+        ]
+    lines += [
+        "",
+        f"  (Mean step margin over disturbed rows is {mean_margin:+.0f}, reported second because it",
+        "  pools a full recovery with a total failure and can describe neither.)",
+    ]
+    return lines
+
+
+def render_impulse_probe(
+    policy_reports: list[dict[str, Any]],
+    statue_reports: list[dict[str, Any]],
+    *,
+    probe_episodes: int,
+) -> tuple[str, dict[str, Any]]:
+    """Reduce the recovery sweep to a policy-against-statue table.
+
+    The statue is not decoration here, it is the entire measurement. It
+    commands a constant and therefore cannot respond to anything, so whatever
+    horizon it survives is the plant's **passive** robustness -- how much of a
+    shove this body shrugs off with no control at all. The policy's margin
+    above that line is the only part attributable to active correction.
+
+    Three readings, and they lead to different work:
+
+    * policy well above statue -> active correction exists and stage 1 simply
+      never measured it. The gap is a *metric* gap, not a reward one.
+    * policy indistinguishable from statue -> nothing has learned to recover,
+      which is what the task structure predicts, and no reweighting fixes it.
+      Adding a disturbance to the task is the change (1a/1b).
+    * policy *below* statue -> its pose or its tremor is actively worse than
+      standing still under load, which would be a finding about the pose.
+    """
+    def _rows(reports: list[dict[str, Any]]) -> dict[tuple[float, str], dict[str, Any]]:
+        return {
+            (report["impulse"]["speed"], report["impulse"]["axis_label"]): {
+                "speed": report["impulse"]["speed"],
+                "axis_label": report["impulse"]["axis_label"],
+                "episode_length_mean": report["metrics"]["episode_length_mean"],
+                "full_horizon_fraction": report["metrics"]["full_horizon_fraction"],
+                "reward_mean": report["metrics"]["reward_mean"],
+                "terminations": report["terminations"],
+            }
+            for report in reports
+        }
+
+    policy_rows, statue_rows = _rows(policy_reports), _rows(statue_reports)
+    horizon = policy_reports[0]["horizon"]
+    step = policy_reports[0]["impulse"]["step"]
+    policy = str(policy_reports[0]["policy"]).split(" — ")[0]
+    keys = sorted(set(policy_rows) | set(statue_rows))
+    rows = []
+    for key in keys:
+        here, there = policy_rows.get(key), statue_rows.get(key)
+        rows.append(
+            {
+                "speed": key[0],
+                "axis_label": key[1],
+                "policy": here,
+                "statue": there,
+                "margin_full_horizon": (
+                    None
+                    if here is None or there is None
+                    else here["full_horizon_fraction"] - there["full_horizon_fraction"]
+                ),
+                "margin_steps": (
+                    None
+                    if here is None or there is None
+                    else here["episode_length_mean"] - there["episode_length_mean"]
+                ),
+            }
+        )
+    disturbed = [row for row in rows if row["speed"] > 0 and row["margin_steps"] is not None]
+    payload = {
+        "schema": "mesozoic.impulse-recovery-probe/v1",
+        "species": policy_reports[0]["species"],
+        "stage": policy_reports[0]["stage"],
+        "policy": policy,
+        "horizon": horizon,
+        "impulse_step": step,
+        "episodes_per_variant": probe_episodes,
+        "note": (
+            "Each row applies a root-velocity impulse mid-episode and scores the UNMODIFIED "
+            "policy on a MODIFIED task. Stage 1 declares no disturbance, so no row is a gate "
+            "verdict. The statue columns are the control: it commands a constant and cannot "
+            "respond, so its survival is the plant's passive robustness and only the policy's "
+            "margin above it is active correction."
+        ),
+        "rows": rows,
+        "policy_reports": policy_reports,
+        "statue_reports": statue_reports,
+    }
+    lines = [
+        "PROBE: a lateral impulse applied to the root partway through each episode.",
+        "Scores the unmodified policy on a MODIFIED TASK. No row is a gate verdict.",
+        "",
+        f"policy              {policy}",
+        f"stage               {policy_reports[0]['species']} stage {policy_reports[0]['stage']}",
+        f"panel               {probe_episodes} episodes per row, horizon {horizon}, impulse at step {step}",
+        "control             the zero-action statue, which commands a constant and CANNOT respond",
+        "",
+        f"  {'impulse':>9} {'direction':<16}{'policy len':>11}{'policy fh':>11}"
+        f"{'statue len':>11}{'statue fh':>11}{'margin':>9}",
+    ]
+    def _length(cell: "dict[str, Any] | None") -> str:
+        return "-" if cell is None else format(cell["episode_length_mean"], ".1f")
+
+    def _share(cell: "dict[str, Any] | None") -> str:
+        return "-" if cell is None else format(cell["full_horizon_fraction"], ".4f")
+
+    for row in rows:
+        here, there = row["policy"], row["statue"]
+        speed = "none" if row["speed"] == 0 else f"{row['speed']:.2f} m/s"
+        margin = "-" if row["margin_steps"] is None else format(row["margin_steps"], "+.0f")
+        lines.append(
+            f"  {speed:>9} {row['axis_label']:<16}"
+            f"{_length(here):>11}{_share(here):>11}"
+            f"{_length(there):>11}{_share(there):>11}{margin:>9}"
+        )
+    envelopes = _recovery_envelopes(rows)
+    payload["recovery_envelopes"] = envelopes
+    lines += ["", "How to read it:"]
+    if not disturbed:
+        lines.append("  No disturbed row completed; nothing to conclude.")
+    else:
+        lines += _recovery_reading(rows, envelopes, disturbed, horizon)
+    lines += [
+        "",
+        "  Both signs are run because this policy is asymmetric -- its toes are splayed",
+        "  differently on the two feet -- so a one-sided sweep would measure whichever",
+        "  direction it happens to be good at and report that as the answer.",
+        "  The zero-impulse row is the harness check: both columns must reach the horizon.",
+    ]
+    return "\n".join(lines) + "\n", payload
+
+
+def write_impulse_probe(
+    stage_dir: "str | Path",
+    policy_reports: list[dict[str, Any]],
+    statue_reports: list[dict[str, Any]],
+    *,
+    probe_episodes: int,
+) -> dict[str, Path]:
+    """Write the recovery sweep beside the stage's other artifacts."""
+    directory = Path(stage_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    text, payload = render_impulse_probe(policy_reports, statue_reports, probe_episodes=probe_episodes)
+    text_path = directory / "stance_gate_probe_impulse.txt"
+    json_path = directory / "stance_gate_probe_impulse.json"
+    text_path.write_text(text, encoding="utf-8")
+    json_path.write_text(
+        json.dumps(_json_safe(payload), indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return {"impulse_probe_txt": text_path, "impulse_probe_json": json_path}
+
+
 def render_constant_hold_ablation(
     reports: list[dict[str, Any]], *, probe_episodes: int
 ) -> tuple[str, dict[str, Any]]:
@@ -1802,6 +2145,33 @@ def main() -> int:
         "Answers WHICH joints make the pose unholdable, by testing necessity and sufficiency "
         "separately. Implies --hold-constant.",
     )
+    parser.add_argument(
+        "--impulse-probe",
+        action="store_true",
+        help="Shove the animal mid-episode and see whether it recovers, against the zero-action "
+        "statue as the control. Stage 1 declares no disturbance, so nothing in a training "
+        "artifact can say whether a policy learned to CORRECT or only to stand still; this can. "
+        "The statue cannot respond at all, so only the policy's margin over it is active control.",
+    )
+    parser.add_argument(
+        "--impulse-speeds",
+        default=",".join(str(speed) for speed in _IMPULSE_SPEEDS),
+        help=f"Comma-separated impulse magnitudes in m/s (default {','.join(str(s) for s in _IMPULSE_SPEEDS)}). "
+        "Each is run in both lateral directions.",
+    )
+    parser.add_argument(
+        "--impulse-step",
+        type=int,
+        default=None,
+        help="Step at which the impulse lands (default: the stage's settle_steps, so the policy "
+        "has established its own state first).",
+    )
+    parser.add_argument(
+        "--impulse-episodes",
+        type=int,
+        default=8,
+        help="Episodes per impulse row (default 8).",
+    )
     args = parser.parse_args()
     args.hold_constant = args.hold_constant or args.hold_release_ablation
 
@@ -1811,6 +2181,19 @@ def main() -> int:
         parser.error("--hold-constant and --filter-actions are different probes; run them separately")
     if args.hold_episodes < 1:
         parser.error(f"--hold-episodes must be at least 1, got {args.hold_episodes}")
+    if args.impulse_episodes < 1:
+        parser.error(f"--impulse-episodes must be at least 1, got {args.impulse_episodes}")
+    if args.impulse_probe and args.zero_action:
+        # The statue is this probe's CONTROL and is rolled automatically; making
+        # it the subject too would compare it against itself and report a margin
+        # of zero as if it meant something.
+        parser.error("--impulse-probe rolls the statue as its own control; pass --model, not --zero-action")
+    try:
+        impulse_speeds = [float(part) for part in args.impulse_speeds.split(",") if part.strip()]
+    except ValueError:
+        parser.error(f"--impulse-speeds must be comma-separated numbers, got {args.impulse_speeds!r}")
+    if args.impulse_probe and not any(speed > 0 for speed in impulse_speeds):
+        parser.error("--impulse-speeds needs at least one positive magnitude")
     if args.hold_ramp_steps < 0:
         parser.error(f"--hold-ramp-steps cannot be negative, got {args.hold_ramp_steps}")
     if args.filter_actions is not None and args.filter_actions <= 0:
@@ -1897,6 +2280,42 @@ def main() -> int:
         print(text, end="")
         if args.out_dir:
             for path in write(args.out_dir, probes, probe_episodes=args.hold_episodes).values():
+                print(f"written: {path}")
+
+    if args.impulse_probe:
+        step = report["settle_steps"] if args.impulse_step is None else args.impulse_step
+        variants = impulse_variants(impulse_speeds, step=step)
+
+        def _sweep(zero_action: bool) -> list[dict[str, Any]]:
+            return [
+                build_stance_gate_report(
+                    args.species,
+                    args.stage,
+                    stage_config=stage_config,
+                    model_path=None if zero_action else args.model,
+                    vecnorm_path=None if zero_action else args.vecnorm,
+                    zero_action=zero_action,
+                    episodes=args.impulse_episodes,
+                    seed=args.seed,
+                    allow_legacy_plant=args.allow_legacy_plant,
+                    impulse=variant,
+                )
+                for variant in variants
+            ]
+
+        # Rolled once and reused: each sweep is a few thousand simulated steps,
+        # and calling the helper twice per output would silently double the cost
+        # of the probe for nothing.
+        policy_sweep = _sweep(zero_action=False)
+        statue_sweep = _sweep(zero_action=True)
+        text, _ = render_impulse_probe(policy_sweep, statue_sweep, probe_episodes=args.impulse_episodes)
+        print()
+        print(text, end="")
+        if args.out_dir:
+            written = write_impulse_probe(
+                args.out_dir, policy_sweep, statue_sweep, probe_episodes=args.impulse_episodes
+            )
+            for path in written.values():
                 print(f"written: {path}")
 
     declared = report["thresholds"]["min_eval_episodes"]

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -27,6 +27,12 @@ Usage::
     # the do-nothing reference, for the same panel and seeds
     python environments/shared/scripts/stance_gate_report.py trex --zero-action
 
+    # probe: does the pose this policy holds need feedback, or only a constant?
+    python environments/shared/scripts/stance_gate_report.py trex \\
+        --model path/to/robust_best_model.zip \\
+        --vecnorm path/to/robust_best_model_vecnorm.pkl \\
+        --hold-constant
+
 Thresholds come from the stage TOML, so the report re-anchors automatically
 when the gate is retuned.  ``--episodes`` defaults to the stage's own
 ``min_eval_episodes``, because that is the panel size the bound's power is
@@ -41,6 +47,7 @@ import csv
 import json
 import math
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -515,6 +522,124 @@ def _low_pass_predict(predict: Any, cutoff_hz: float, control_dt: float) -> Any:
     return filtered
 
 
+@dataclass(frozen=True)
+class ConstantHold:
+    """A constant command to substitute for the policy, and when to substitute it.
+
+    The probe behind ``docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md`` §5:
+    the passing T-Rex stage-1 policy stands with a 0.366 rms tremor at ~22.7 Hz,
+    and the low-pass probe shows that tremor is load-bearing. That leaves two
+    readings, which the filter probe cannot separate:
+
+    * the *pose* the policy holds needs continuous active stabilisation, or
+    * the pose is holdable by a constant and the tremor is waste the action
+      penalties failed to suppress.
+
+    Replacing the policy with the constant it commands **on average** decides
+    it. If the animal keeps standing, the smooth solution existed and the
+    optimiser did not find it. If it falls, the pose genuinely requires
+    feedback, and the question moves to why the policy chose a pose it then has
+    to fight -- which points at the 13 of 21 actuators no stage-1 term
+    constrains.
+
+    Attributes:
+        actions: The constant command, one entry per actuator.
+        handoff_steps: Steps of real policy before the substitution. ``0``
+            commands the constant from reset; a value at or above the horizon
+            never substitutes at all, which is how the probe rolls its own
+            unmodified control panel without producing a report that could be
+            mistaken for a gate verdict.
+        ramp_steps: Steps to blend from the last commanded action into
+            *actions*. ``0`` switches in one step. The ramp exists to answer
+            the obvious objection to a hard switch -- that the animal fell from
+            the step transient rather than from losing feedback -- with a
+            second measurement instead of an argument.
+        label: Short name for this variant in the probe artifact.
+        source: Where *actions* came from, recorded so a reader can tell a
+            measured hold from a hand-supplied one.
+    """
+
+    actions: tuple[float, ...]
+    handoff_steps: int
+    ramp_steps: int = 0
+    label: str = "hold"
+    source: str = "measured"
+    #: Set for the control variant that never substitutes, so the renderer can
+    #: say "this row is the unmodified policy" rather than implying a hold.
+    holds: bool = field(default=True)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "source": self.source,
+            "holds": self.holds,
+            "handoff_steps": self.handoff_steps,
+            "ramp_steps": self.ramp_steps,
+            "actions": list(self.actions),
+        }
+
+
+def _hold_constant_predict(predict: Any, hold: ConstantHold) -> Any:
+    """Wrap *predict* so the plant receives a constant command after handoff.
+
+    Feedback is cut, not attenuated: past ``handoff_steps`` the returned action
+    no longer depends on the observation at all. That is the point -- a
+    low-pass still lets the policy respond slowly, so it cannot distinguish
+    "needs bandwidth" from "needs feedback", and this can.
+
+    The step counter is per episode and reset by the caller through
+    :func:`reset`, exactly like the low-pass probe: without it the second
+    episode would start already past handoff and the panel would measure
+    something different from the first.
+    """
+    constant = np.asarray(hold.actions, dtype=np.float64)
+    state: dict[str, Any] = {"step": 0, "last": None}
+
+    def held(obs: np.ndarray) -> np.ndarray:
+        step = state["step"]
+        state["step"] = step + 1
+        if step < hold.handoff_steps:
+            action = np.asarray(predict(obs), dtype=np.float64).ravel()
+            state["last"] = action
+            return np.asarray(action, dtype=np.float32)
+        elapsed = step - hold.handoff_steps
+        if hold.ramp_steps > 0 and elapsed < hold.ramp_steps:
+            # Blend from whatever was last commanded. At handoff that is the
+            # policy's own last action; from reset there is none, and zero is
+            # the right start because `action = 0` IS the home keyframe the
+            # episode begins at -- so the ramp starts from the actual pose
+            # rather than jumping to one.
+            previous = state["last"]
+            if previous is None or previous.shape != constant.shape:
+                previous = np.zeros_like(constant)
+            weight = (elapsed + 1) / hold.ramp_steps
+            return np.asarray((1.0 - weight) * previous + weight * constant, dtype=np.float32)
+        return np.asarray(constant, dtype=np.float32)
+
+    held.reset = lambda: state.update(step=0, last=None)  # type: ignore[attr-defined]
+    return held
+
+
+def constant_hold_actions(report: dict[str, Any]) -> tuple[float, ...]:
+    """The per-actuator DC a report measured, as a constant command.
+
+    DC is the time-mean of the commanded action over the post-settle window --
+    under ``home-keyframe-residual/v1`` the static pose the policy holds, since
+    ``action = 0`` is the home keyframe. Holding exactly that is what makes the
+    probe a fair test of the pose rather than of some nearby pose: the animal
+    is asked to stand where it was already standing, with the variation about
+    it removed and nothing else changed.
+    """
+    per_actuator = (report.get("action") or {}).get("per_actuator") or []
+    if not per_actuator:
+        raise StanceGateReportError(
+            "the report carries no per-actuator action statistics, so there is no "
+            "measured pose to hold. It was produced before that block existed, or "
+            "from a panel in which no episode survived the settling window."
+        )
+    return tuple(float(entry["dc"]) for entry in sorted(per_actuator, key=lambda e: e["index"]))
+
+
 def build_stance_gate_report(
     species: str,
     stage: int,
@@ -527,6 +652,7 @@ def build_stance_gate_report(
     seed: int = 3042,
     allow_legacy_plant: bool = False,
     filter_actions_hz: float | None = None,
+    hold_constant: ConstantHold | None = None,
 ) -> dict[str, Any]:
     """Roll a policy and return its gate verdict as a serializable dict.
 
@@ -585,6 +711,23 @@ def build_stance_gate_report(
     if filter_actions_hz is not None:
         predict = _low_pass_predict(predict, filter_actions_hz, control_dt)
         description += f" — actions low-passed at {filter_actions_hz:g} Hz"
+
+    if hold_constant is not None:
+        expected = int(plant_identity.action_dim)
+        if len(hold_constant.actions) != expected:
+            # Checked before the rollout rather than at the first step: numpy
+            # broadcasts a mismatched length silently, which would score a
+            # policy nobody asked for and report it as this one.
+            raise ValueError(
+                f"hold_constant carries {len(hold_constant.actions)} actions but "
+                f"{species} has action_dim {expected}"
+            )
+        predict = _hold_constant_predict(predict, hold_constant)
+        description += (
+            f" — {hold_constant.label}"
+            if not hold_constant.holds
+            else f" — commanded action held constant from step {hold_constant.handoff_steps}"
+        )
 
     result = run_panel(
         species,
@@ -645,6 +788,10 @@ def build_stance_gate_report(
         # a stored report. `render_stance_gate_report` prints it for the same
         # reason.
         "filter_actions_hz": filter_actions_hz,
+        # `None` for an ordinary run. Same contract as `filter_actions_hz`: a
+        # held rollout scored a policy whose feedback was cut, so it is a probe
+        # and never a verdict, and `_PROBE_MARKERS` keys the filenames off this.
+        "hold_constant": None if hold_constant is None else hold_constant.as_dict(),
         # Where the commanded pose sits and what the policy does around it,
         # per actuator. `{}` when no post-settle step was measured.
         "action": result.get("action", {}),
@@ -659,6 +806,53 @@ def build_stance_gate_report(
     }
 
 
+#: Report keys that mark a rollout as a PROBE rather than a verdict, mapped to
+#: the filename stem that probe writes under. Each names a modification applied
+#: between the policy and the plant, so a report carrying any of them scored
+#: something other than the checkpoint -- and must never land on the real
+#: report's filenames or supply the evidence a bundle is certified from.
+#:
+#: A registry rather than a chain of ``if``s because the failure mode is
+#: forgetting to extend the check: the filter probe's guard was written as a
+#: single ``is not None`` test, and a second probe added beside it would have
+#: silently inherited the certification filenames.
+_PROBE_MARKERS: dict[str, str] = {
+    "filter_actions_hz": "stance_gate_probe_filtered",
+    "hold_constant": "stance_gate_probe_constant",
+}
+
+
+def probe_stem(report: dict[str, Any]) -> str | None:
+    """The filename stem a probe report writes under, or ``None`` if it is a verdict."""
+    for key, stem in _PROBE_MARKERS.items():
+        if report.get(key) is not None:
+            return stem
+    return None
+
+
+def _probe_banner(report: dict[str, Any]) -> list[str]:
+    """The warning a probe report must carry above its verdict line."""
+    if report.get("filter_actions_hz") is not None:
+        what = f"actions low-passed at {report['filter_actions_hz']:g} Hz before reaching the plant."
+    elif report.get("hold_constant") is not None:
+        hold = report["hold_constant"]
+        what = (
+            "the policy ran the whole episode; this row is the unmodified control."
+            if not hold.get("holds", True)
+            else (
+                f"the commanded action was frozen to a constant from step {hold['handoff_steps']}"
+                + (f", ramped in over {hold['ramp_steps']} steps." if hold.get("ramp_steps") else ".")
+            )
+        )
+    else:
+        return []
+    return [
+        f"PROBE: {what}",
+        "This scores a MODIFIED policy. The verdict below is not a gate result for this checkpoint.",
+        "",
+    ]
+
+
 def render_stance_gate_report(report: dict[str, Any]) -> str:
     """Render a report dict as the human-readable text form."""
     thresholds = report["thresholds"]
@@ -671,15 +865,10 @@ def render_stance_gate_report(report: dict[str, Any]) -> str:
             "below are reported but are not what this stage advances on."
         )
         lines.append("")
-    # Before the verdict, not after: a filtered rollout scores a MODIFIED
-    # policy, so its PASS/FAIL is not a statement about the checkpoint and a
-    # reader must not reach the verdict line without knowing that.
-    if report.get("filter_actions_hz") is not None:
-        lines += [
-            f"PROBE: actions low-passed at {report['filter_actions_hz']:g} Hz before reaching the plant.",
-            "This scores a MODIFIED policy. The verdict below is not a gate result for this checkpoint.",
-            "",
-        ]
+    # Before the verdict, not after: a probe rollout scores a MODIFIED policy,
+    # so its PASS/FAIL is not a statement about the checkpoint and a reader must
+    # not reach the verdict line without knowing that.
+    lines += _probe_banner(report)
     measured = report["horizon"] - report["settle_steps"]
     lines += [
         f"policy              {report['policy']}",
@@ -787,8 +976,9 @@ def write_stance_gate_report(stage_dir: "str | Path", report: dict[str, Any]) ->
     # because that file is the per-episode evidence `result_bundle.evidence`
     # certifies a stance-gated stage from. Writing a filtered panel there would
     # certify a policy that was never run.
-    probe = report.get("filter_actions_hz") is not None
-    stem = "stance_gate_probe_filtered" if probe else "stance_gate_report"
+    stem = probe_stem(report)
+    probe = stem is not None
+    stem = stem or "stance_gate_report"
     text_path = directory / f"{stem}.txt"
     json_path = directory / f"{stem}.json"
     text_path.write_text(render_stance_gate_report(report) + "\n", encoding="utf-8")
@@ -893,6 +1083,176 @@ def write_action_filter_sweep(
     return {"action_filter_sweep_txt": text_path, "action_filter_sweep_json": json_path}
 
 
+def render_constant_hold_probe(
+    reports: list[dict[str, Any]], *, probe_episodes: int
+) -> tuple[str, dict[str, Any]]:
+    """Reduce the constant-hold variants to their comparison table and payload.
+
+    Split from the writer so the CLI can print the table without depositing
+    files in whatever directory it was run from.
+
+    The rows are only meaningful against each other, which is why they share a
+    file. Two of them are controls that bracket the measurement:
+
+    * the **unmodified policy**, which must reach the horizon or the probe is
+      measuring a broken harness rather than a property of the pose, and
+    * the **zero hold**, the statue -- a constant that is already known to
+      stand all 1000 steps in 40 of 40 episodes.
+
+    Between them sit the held variants. Read them as a single yes/no:
+
+    * held rollouts reach the horizon -> the pose is holdable by a constant.
+      The tremor is not stabilisation; the action penalties simply failed to
+      find the smooth solution, and this is an optimisation problem.
+    * held rollouts fall while both controls stand -> the pose the policy chose
+      genuinely requires feedback. The question then moves to *why* it chose a
+      pose it has to fight, which points at the actuators no stage-1 term
+      constrains rather than at the action penalties.
+
+    The ramped variant exists to close the obvious objection to the hard
+    switch -- that a step transient, not the loss of feedback, is what knocked
+    the animal over -- with a measurement instead of an argument. If the hard
+    switch falls and the ramped one stands, the transient was the cause and
+    neither row says anything about the pose.
+
+    Deliberately does not write ``stance_panel_selected.csv``: no row here
+    scored the policy that would be certified.
+    """
+    rows = [
+        {
+            "label": report["hold_constant"]["label"],
+            "holds": report["hold_constant"]["holds"],
+            "source": report["hold_constant"]["source"],
+            "handoff_steps": report["hold_constant"]["handoff_steps"],
+            "ramp_steps": report["hold_constant"]["ramp_steps"],
+            "episode_length_mean": report["metrics"]["episode_length_mean"],
+            "full_horizon_fraction": report["metrics"]["full_horizon_fraction"],
+            "reward_mean": report["metrics"]["reward_mean"],
+            "mean_unsupported_duty": report["metrics"]["mean_unsupported_duty"],
+            "terminations": report["terminations"],
+        }
+        for report in reports
+    ]
+    horizon = reports[0]["horizon"]
+    policy = str(reports[0]["policy"]).split(" — commanded action held constant")[0].split(" — ")[0]
+    # The rows that hold the POLICY'S measured pose. Deliberately not "every
+    # row that holds something": `hold_zero` holds a constant too, and it is a
+    # control whose standing is already known and proves nothing about this
+    # policy. Folding it in would make an all-falling result read as mixed.
+    held = [row for row in rows if row["source"] == "measured"]
+    hold_actions = next(
+        (report["hold_constant"]["actions"] for report in reports if report["hold_constant"]["source"] == "measured"),
+        [],
+    )
+    payload = {
+        "schema": "mesozoic.constant-hold-probe/v1",
+        "species": reports[0]["species"],
+        "stage": reports[0]["stage"],
+        "policy": policy,
+        "horizon": horizon,
+        "episodes_per_variant": probe_episodes,
+        "hold_actions": hold_actions,
+        "note": (
+            "Each row scored a MODIFIED policy (its commanded action replaced by a "
+            "constant partway through the episode). No row is a gate verdict. The "
+            "question is whether the held rows reach the horizon: if they do, the "
+            "pose is holdable without feedback and the tremor is waste; if they "
+            "fall while both controls stand, the pose requires active stabilisation."
+        ),
+        "variants": rows,
+        "reports": reports,
+    }
+    lines = [
+        "PROBE: the policy's commanded action replaced by a constant partway through the episode.",
+        "Every held row scores a MODIFIED policy. None of them is a gate verdict.",
+        "",
+        f"policy              {policy}",
+        f"stage               {reports[0]['species']} stage {reports[0]['stage']}",
+        f"panel               {probe_episodes} episodes per variant, horizon {horizon}",
+        f"hold                the policy's own post-settle mean action, {len(hold_actions)} actuators",
+        "",
+        f"  {'variant':<26}{'handoff':>8}{'ramp':>6}{'ep length':>11}{'full-horiz':>12}{'reward':>10}   terminations",
+    ]
+    for row in rows:
+        handoff = "never" if not row["holds"] else str(row["handoff_steps"])
+        lines.append(
+            f"  {row['label']:<26}{handoff:>8}{row['ramp_steps']:>6}"
+            f"{row['episode_length_mean']:>11.1f}{row['full_horizon_fraction']:>12.4f}"
+            f"{row['reward_mean']:>10.1f}   {row['terminations']}"
+        )
+    lines += ["", "How to read it:"]
+    if held and all(row["full_horizon_fraction"] >= 0.95 for row in held):
+        lines += [
+            "  Every held variant reached the horizon. The pose the policy holds does NOT",
+            "  need feedback to stand -- a constant command suffices. The tremor is therefore",
+            "  not closed-loop stabilisation, and the gap to the statue is an optimisation",
+            "  failure rather than a missing reward term.",
+        ]
+    elif held and all(row["full_horizon_fraction"] <= 0.0 for row in held):
+        lines += [
+            "  No held variant reached the horizon. The pose the policy holds REQUIRES",
+            "  continuous feedback. The tremor is stabilisation, not waste, and penalising",
+            "  it harder would remove the only thing keeping the animal up. The question",
+            "  becomes why the policy settled on a pose it has to fight -- look at the",
+            "  actuators no stage-1 reward term constrains.",
+        ]
+    else:
+        lines += [
+            "  Mixed. Compare the ramped variant against the hard switch: if only the hard",
+            "  switch falls, the step transient caused it and neither row is evidence about",
+            "  the pose. Re-run with more episodes before drawing a conclusion.",
+        ]
+    lines += [
+        "",
+        "  The two controls bracket the measurement. 'policy' is the unmodified checkpoint",
+        "  and must reach the horizon; 'hold_zero' is the statue, a constant already known",
+        "  to stand. If either misbehaves, the harness is at fault, not the pose.",
+    ]
+    return "\n".join(lines) + "\n", payload
+
+
+def write_constant_hold_probe(
+    stage_dir: "str | Path", reports: list[dict[str, Any]], *, probe_episodes: int
+) -> dict[str, Path]:
+    """Write the constant-hold probe beside the stage's other artifacts.
+
+    Its own filenames, and never ``stance_panel_selected.csv`` -- the same
+    discipline the filtered probe follows, for the same reason: no row here
+    scored the policy a bundle would be certified from.
+    """
+    directory = Path(stage_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    text, payload = render_constant_hold_probe(reports, probe_episodes=probe_episodes)
+    text_path = directory / "stance_gate_probe_constant.txt"
+    json_path = directory / "stance_gate_probe_constant.json"
+    text_path.write_text(text, encoding="utf-8")
+    json_path.write_text(
+        json.dumps(_json_safe(payload), indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return {"constant_hold_probe_txt": text_path, "constant_hold_probe_json": json_path}
+
+
+def constant_hold_variants(
+    hold: tuple[float, ...], *, settle_steps: int, horizon: int, ramp_steps: int = 50
+) -> list[ConstantHold]:
+    """The standard variant set: two controls bracketing three held rollouts.
+
+    ``handoff_steps = horizon`` is how the unmodified control is expressed. It
+    rolls the real policy for the whole episode yet still carries the
+    ``hold_constant`` marker, so it can never be written to the certification
+    filenames by a caller who forgets which report is which.
+    """
+    zero = tuple(0.0 for _ in hold)
+    return [
+        ConstantHold(hold, handoff_steps=horizon, label="policy (control)", source="unmodified", holds=False),
+        ConstantHold(hold, handoff_steps=settle_steps, ramp_steps=0, label="hold_after_settle"),
+        ConstantHold(hold, handoff_steps=settle_steps, ramp_steps=ramp_steps, label="hold_after_settle_ramped"),
+        ConstantHold(hold, handoff_steps=0, ramp_steps=ramp_steps, label="hold_from_reset"),
+        ConstantHold(zero, handoff_steps=0, ramp_steps=0, label="hold_zero (statue control)", source="zeros"),
+    ]
+
+
 #: Column order of ``stance_panel_selected.csv``.  ``unsupported_duty`` is
 #: empty for an episode whose duty could not be measured (one shorter than the
 #: settling window); the auditor treats empty as unmeasured rather than zero,
@@ -975,10 +1335,43 @@ def main() -> int:
         "still stands, the tremor was waste and belongs on the action path; if it falls, the "
         "tremor is closed-loop stabilisation and the fix belongs elsewhere (issue #489).",
     )
+    parser.add_argument(
+        "--hold-constant",
+        action="store_true",
+        help="Replace the policy's action with the constant it commands ON AVERAGE partway through "
+        "each episode, and score THAT, over a standard variant set with two controls. Separates "
+        "'the pose needs feedback' from 'the tremor is waste the action penalties missed' -- the "
+        "one question the low-pass probe cannot answer, because a filtered policy still responds.",
+    )
+    parser.add_argument(
+        "--hold-from-report",
+        metavar="JSON",
+        help="Take the constant from an existing stance_gate_report.json instead of measuring it. "
+        "Skips the measurement panel when you already have one for this checkpoint.",
+    )
+    parser.add_argument(
+        "--hold-episodes",
+        type=int,
+        default=10,
+        help="Episodes per hold variant (default 10). The probe certifies nothing and the effect "
+        "it measures is a fall or a full horizon, so it does not need the gate's panel size.",
+    )
+    parser.add_argument(
+        "--hold-ramp-steps",
+        type=int,
+        default=50,
+        help="Steps to blend into the constant in the ramped variants (default 50).",
+    )
     args = parser.parse_args()
 
     if not args.zero_action and not args.model:
         parser.error("pass --model, or --zero-action for the do-nothing reference")
+    if args.hold_constant and args.filter_actions is not None:
+        parser.error("--hold-constant and --filter-actions are different probes; run them separately")
+    if args.hold_episodes < 1:
+        parser.error(f"--hold-episodes must be at least 1, got {args.hold_episodes}")
+    if args.hold_ramp_steps < 0:
+        parser.error(f"--hold-ramp-steps cannot be negative, got {args.hold_ramp_steps}")
     if args.filter_actions is not None and args.filter_actions <= 0:
         parser.error(f"--filter-actions must be positive, got {args.filter_actions}")
     # `--episodes 0` used to fall through `episodes or min_eval_episodes` to the
@@ -1011,6 +1404,44 @@ def main() -> int:
     if args.out_dir:
         for path in write_stance_gate_report(args.out_dir, report).values():
             print(f"written: {path}")
+
+    if args.hold_constant:
+        try:
+            hold = (
+                constant_hold_actions(json.loads(Path(args.hold_from_report).read_text(encoding="utf-8")))
+                if args.hold_from_report
+                else constant_hold_actions(report)
+            )
+        except StanceGateReportError as exc:
+            raise SystemExit(str(exc)) from exc
+        variants = constant_hold_variants(
+            hold,
+            settle_steps=report["settle_steps"],
+            horizon=report["horizon"],
+            ramp_steps=args.hold_ramp_steps,
+        )
+        probes = [
+            build_stance_gate_report(
+                args.species,
+                args.stage,
+                stage_config=stage_config,
+                model_path=args.model,
+                vecnorm_path=args.vecnorm,
+                zero_action=args.zero_action,
+                episodes=args.hold_episodes,
+                seed=args.seed,
+                allow_legacy_plant=args.allow_legacy_plant,
+                hold_constant=variant,
+            )
+            for variant in variants
+        ]
+        text, _ = render_constant_hold_probe(probes, probe_episodes=args.hold_episodes)
+        print()
+        print(text, end="")
+        if args.out_dir:
+            written = write_constant_hold_probe(args.out_dir, probes, probe_episodes=args.hold_episodes)
+            for path in written.values():
+                print(f"written: {path}")
 
     declared = report["thresholds"]["min_eval_episodes"]
     if args.episodes is not None and args.episodes != declared:

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -894,9 +894,10 @@ def _hold_constant_predict(predict: Any, hold: ConstantHold) -> Any:
         if hold.ramp_steps > 0 and elapsed < hold.ramp_steps:
             # Blend from whatever was last commanded. At handoff that is the
             # policy's own last action; from reset there is none, and zero is
-            # the right start because `action = 0` IS the home keyframe the
-            # episode begins at -- so the ramp starts from the actual pose
-            # rather than jumping to one.
+            # the right start because `action = 0` commands the named home
+            # control -- the targets the episode's reset pose settles under --
+            # so the ramp starts from the actual stance rather than jumping
+            # to one.
             previous = state["last"]
             if previous is None or previous.shape != constant.shape:
                 previous = np.zeros_like(constant)
@@ -912,11 +913,21 @@ def constant_hold_actions(report: dict[str, Any]) -> tuple[float, ...]:
     """The per-actuator DC a report measured, as a constant command.
 
     DC is the time-mean of the commanded action over the post-settle window --
-    under ``home-keyframe-residual/v1`` the static pose the policy holds, since
-    ``action = 0`` is the home keyframe. Holding exactly that is what makes the
-    probe a fair test of the pose rather than of some nearby pose: the animal
+    under ``home-keyframe-residual/v1`` the static target the policy holds,
+    since ``action = 0`` is the named home control. Holding it is what makes
+    the probe a test of the pose rather than of some nearby pose: the animal
     is asked to stand where it was already standing, with the variation about
     it removed and nothing else changed.
+
+    One deliberate approximation, worth knowing when reading the results: the
+    held control is ``f(mean(action))``, not the ``mean(f(action))`` the
+    policy actually commanded -- the same distinction schema v2 draws for the
+    report's degree statistics. The two differ only for an actuator whose
+    action distribution crosses zero AND whose ctrlrange spans differ about
+    its home control; on the current trex plant that is neck/head pitch only,
+    where the measured crossings put the bias near 0.01 degrees. If a future
+    plant makes the gap material, derive the hold by inverting the recorded
+    per-actuator ``ctrl_mean`` through the probed mapping instead.
     """
     per_actuator = (report.get("action") or {}).get("per_actuator") or []
     if not per_actuator:
@@ -1900,7 +1911,7 @@ def render_constant_hold_ablation(reports: list[dict[str, Any]], *, probe_episod
         "falls_threshold": _ABLATION_FALLS,
         "note": (
             "Each row scored a MODIFIED policy: its commanded action frozen to a constant "
-            "with one actuator group returned to the home keyframe (released) or with only "
+            "with one actuator group returned to the home control (released) or with only "
             "that group held. No row is a gate verdict. release_G tests whether G is "
             "NECESSARY for the fall; only_G tests whether G is SUFFICIENT to cause it."
         ),
@@ -1915,7 +1926,7 @@ def render_constant_hold_ablation(reports: list[dict[str, Any]], *, probe_episod
         f"policy              {policy}",
         f"stage               {reports[0]['species']} stage {reports[0]['stage']}",
         f"panel               {probe_episodes} episodes per variant, horizon {horizon}",
-        "released            commanded 0, which IS the home keyframe under home-keyframe-residual/v1",
+        "released            commanded 0, the named home control under home-keyframe-residual/v1",
         "",
         f"  {'variant':<28}{'released':>9}{'ep length':>11}{'full-horiz':>12}{'reward':>10}   terminations",
     ]
@@ -2052,12 +2063,12 @@ def saturated_actuator_indices(report: dict[str, Any], threshold: float = 0.99) 
 
 
 def constant_hold_released(hold: tuple[float, ...], release: "tuple[int, ...] | set[int]") -> tuple[float, ...]:
-    """*hold* with the given actuators returned to the home keyframe.
+    """*hold* with the given actuators returned to the home control.
 
     "Released" means commanded ``0``, which under ``home-keyframe-residual/v1``
-    is exactly the home pose -- so releasing every actuator gives the statue,
-    and releasing none gives the policy's own pose. Every ablation below is a
-    point on the path between a pose that falls and one that stands.
+    is exactly the named home control -- so releasing every actuator gives the
+    statue, and releasing none gives the policy's own pose. Every ablation
+    below is a point on the path between a pose that falls and one that stands.
     """
     released = set(int(index) for index in release)
     return tuple(0.0 if index in released else value for index, value in enumerate(hold))
@@ -2280,7 +2291,7 @@ def main() -> int:
         "--hold-release-ablation",
         action="store_true",
         help="Instead of the standard hold variants, ablate the held pose one actuator group at a "
-        "time -- releasing each group back to the home keyframe, and holding each group alone. "
+        "time -- releasing each group back to the home control, and holding each group alone. "
         "Answers WHICH joints make the pose unholdable, by testing necessity and sufficiency "
         "separately. Implies --hold-constant.",
     )

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -1211,6 +1211,189 @@ def render_constant_hold_probe(
     return "\n".join(lines) + "\n", payload
 
 
+#: A variant is treated as standing when it clears this share of full-horizon
+#: episodes, and as falling at or below :data:`_ABLATION_FALLS`. Two thresholds
+#: with a gap between them on purpose: an ablation that lands in the gap is
+#: reported as inconclusive rather than rounded to whichever side is nearer,
+#: because the conclusions on the two sides are opposite.
+_ABLATION_STANDS = 0.95
+_ABLATION_FALLS = 0.05
+
+
+def _ablation_verdicts(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Classify each ablated group by necessity and sufficiency.
+
+    Necessity and sufficiency are asked separately because either alone
+    misleads. A group that is merely *correlated* with the fall -- the
+    saturated set is the obvious candidate, since saturation is visible and
+    dramatic -- shows up as necessary-and-not-sufficient or as neither, and
+    only the pair distinguishes that from a cause.
+    """
+    by_label = {row["label"]: row for row in rows}
+    stands = lambda row: row is not None and row["full_horizon_fraction"] >= _ABLATION_STANDS  # noqa: E731
+    falls = lambda row: row is not None and row["full_horizon_fraction"] <= _ABLATION_FALLS  # noqa: E731
+    verdicts = []
+    for label in by_label:
+        if not label.startswith("release_"):
+            continue
+        group = label[len("release_") :]
+        release, only = by_label.get(label), by_label.get(f"only_{group}")
+        necessary = stands(release)
+        sufficient = falls(only)
+        if release is None or only is None:
+            verdict = "incomplete (a variant did not run)"
+        elif not (stands(release) or falls(release)) or not (stands(only) or falls(only)):
+            verdict = "inconclusive (a variant landed between the thresholds)"
+        elif necessary and sufficient:
+            verdict = "CAUSE — necessary and sufficient"
+        elif necessary:
+            verdict = "contributes — necessary, not sufficient alone"
+        elif sufficient:
+            verdict = "sufficient alone, but not necessary"
+        else:
+            verdict = "bystander — neither"
+        verdicts.append(
+            {
+                "group": group,
+                "necessary": necessary,
+                "sufficient": sufficient,
+                "verdict": verdict,
+                "release_full_horizon": None if release is None else release["full_horizon_fraction"],
+                "only_full_horizon": None if only is None else only["full_horizon_fraction"],
+            }
+        )
+    return verdicts
+
+
+def render_constant_hold_ablation(
+    reports: list[dict[str, Any]], *, probe_episodes: int
+) -> tuple[str, dict[str, Any]]:
+    """Reduce the release ablation to its table, per-group verdicts, and payload.
+
+    The ablation walks the path between two already-measured endpoints: the
+    policy's full held pose, which falls, and the statue, which stands. Each
+    row moves one actuator group between them, so the table asks which
+    coordinate carries the effect rather than merely restating that the pose
+    is unholdable.
+    """
+    rows = [
+        {
+            "label": report["hold_constant"]["label"],
+            "holds": report["hold_constant"]["holds"],
+            "source": report["hold_constant"]["source"],
+            "episode_length_mean": report["metrics"]["episode_length_mean"],
+            "full_horizon_fraction": report["metrics"]["full_horizon_fraction"],
+            "reward_mean": report["metrics"]["reward_mean"],
+            "terminations": report["terminations"],
+            "n_released": sum(1 for value in report["hold_constant"]["actions"] if value == 0.0),
+        }
+        for report in reports
+    ]
+    verdicts = _ablation_verdicts(rows)
+    horizon = reports[0]["horizon"]
+    policy = str(reports[0]["policy"]).split(" — ")[0]
+    payload = {
+        "schema": "mesozoic.constant-hold-ablation/v1",
+        "species": reports[0]["species"],
+        "stage": reports[0]["stage"],
+        "policy": policy,
+        "horizon": horizon,
+        "episodes_per_variant": probe_episodes,
+        "stands_threshold": _ABLATION_STANDS,
+        "falls_threshold": _ABLATION_FALLS,
+        "note": (
+            "Each row scored a MODIFIED policy: its commanded action frozen to a constant "
+            "with one actuator group returned to the home keyframe (released) or with only "
+            "that group held. No row is a gate verdict. release_G tests whether G is "
+            "NECESSARY for the fall; only_G tests whether G is SUFFICIENT to cause it."
+        ),
+        "variants": rows,
+        "verdicts": verdicts,
+        "reports": reports,
+    }
+    lines = [
+        "PROBE: a held constant pose, ablated one actuator group at a time.",
+        "Every row scores a MODIFIED policy. None of them is a gate verdict.",
+        "",
+        f"policy              {policy}",
+        f"stage               {reports[0]['species']} stage {reports[0]['stage']}",
+        f"panel               {probe_episodes} episodes per variant, horizon {horizon}",
+        "released            commanded 0, which IS the home keyframe under home-keyframe-residual/v1",
+        "",
+        f"  {'variant':<28}{'released':>9}{'ep length':>11}{'full-horiz':>12}{'reward':>10}   terminations",
+    ]
+    for row in rows:
+        released = "-" if not row["holds"] else str(row["n_released"])
+        lines.append(
+            f"  {row['label']:<28}{released:>9}{row['episode_length_mean']:>11.1f}"
+            f"{row['full_horizon_fraction']:>12.4f}{row['reward_mean']:>10.1f}   {row['terminations']}"
+        )
+    if verdicts:
+        lines += [
+            "",
+            "Per group — release_G asks if G is NECESSARY (does removing it rescue the pose?),",
+            "only_G asks if G is SUFFICIENT (does it alone break the statue?):",
+            "",
+            f"  {'group':<14}{'release stands':>16}{'only falls':>12}   verdict",
+        ]
+        for entry in verdicts:
+            release_text = "-" if entry["release_full_horizon"] is None else f"{entry['release_full_horizon']:.4f}"
+            only_text = "-" if entry["only_full_horizon"] is None else f"{entry['only_full_horizon']:.4f}"
+            lines.append(f"  {entry['group']:<14}{release_text:>16}{only_text:>12}   {entry['verdict']}")
+    if verdicts and not any(entry["necessary"] for entry in verdicts):
+        sufficient = [entry["group"] for entry in verdicts if entry["sufficient"]]
+        lines += ["", "Overall:"]
+        if sufficient:
+            lines += [
+                f"  No group is necessary, but {', '.join(sufficient)} " + ("is" if len(sufficient) == 1 else "are"),
+                "  sufficient. The pose is OVER-DETERMINED: more than one subset of it breaks",
+                "  the animal independently, so removing any single group leaves another still",
+                "  able to. 'Which joint is the cause' is therefore the wrong question -- but the",
+                "  sufficient groups are where the effect is concentrated, and a group that holds",
+                "  the full horizon on its own is exonerated no matter how extreme its DC looks.",
+            ]
+        else:
+            lines += [
+                "  No group is necessary and none is sufficient. Whatever makes the pose",
+                "  unholdable is not separated by these groupings -- it may be a combination",
+                "  that crosses them, or a joint outside every group. Regroup before concluding.",
+            ]
+    lines += [
+        "",
+        "Read the pair, never one side. A group can look implicated because it is",
+        "conspicuous -- twelve actuators pinned at exactly +/-1.000 are hard to ignore --",
+        "and still be a bystander. Only necessary AND sufficient identifies a cause;",
+        "necessary alone means it contributes with others, and neither means the",
+        "stabilisation load lives somewhere this ablation did not separate.",
+        "",
+        "The endpoints bound the path: 'hold_all' is the full pose and must fall,",
+        "'hold_zero' is the statue and must stand. If either misbehaves the harness is",
+        "at fault and no row below it means anything.",
+    ]
+    return "\n".join(lines) + "\n", payload
+
+
+def write_constant_hold_ablation(
+    stage_dir: "str | Path", reports: list[dict[str, Any]], *, probe_episodes: int
+) -> dict[str, Path]:
+    """Write the release ablation beside the stage's other artifacts.
+
+    Its own filenames, and never ``stance_panel_selected.csv`` -- same
+    discipline as the other two probes, for the same reason.
+    """
+    directory = Path(stage_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    text, payload = render_constant_hold_ablation(reports, probe_episodes=probe_episodes)
+    text_path = directory / "stance_gate_probe_release.txt"
+    json_path = directory / "stance_gate_probe_release.json"
+    text_path.write_text(text, encoding="utf-8")
+    json_path.write_text(
+        json.dumps(_json_safe(payload), indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return {"constant_hold_ablation_txt": text_path, "constant_hold_ablation_json": json_path}
+
+
 def write_constant_hold_probe(
     stage_dir: "str | Path", reports: list[dict[str, Any]], *, probe_episodes: int
 ) -> dict[str, Path]:
@@ -1231,6 +1414,140 @@ def write_constant_hold_probe(
         encoding="utf-8",
     )
     return {"constant_hold_probe_txt": text_path, "constant_hold_probe_json": json_path}
+
+
+#: Anatomical actuator groups, as substrings matched against joint names. Used
+#: to ablate a held pose one region at a time. Substrings rather than indices so
+#: the same groups resolve on any species whose joints follow the naming
+#: convention, and so adding a joint does not silently fall out of its group.
+_ACTUATOR_GROUPS: dict[str, tuple[str, ...]] = {
+    "tail": ("tail",),
+    "toes": ("toe",),
+    "head_neck": ("head", "neck"),
+    "hip_rolls": ("hip_roll",),
+}
+
+
+def actuator_indices_matching(report: dict[str, Any], patterns: "tuple[str, ...] | list[str]") -> tuple[int, ...]:
+    """Indices whose joint name contains any of *patterns*."""
+    per_actuator = (report.get("action") or {}).get("per_actuator") or []
+    return tuple(
+        int(entry["index"])
+        for entry in sorted(per_actuator, key=lambda e: e["index"])
+        if any(pattern in str(entry["joint"]) for pattern in patterns)
+    )
+
+
+def saturated_actuator_indices(report: dict[str, Any], threshold: float = 0.99) -> tuple[int, ...]:
+    """Indices whose commanded pose sits at or beyond *threshold* of the action range.
+
+    A saturated actuator has no headroom in one direction, so it cannot
+    contribute correction on that axis -- and on the T-Rex stage-1 checkpoint
+    the saturated set is also exactly the set with zero AC, i.e. the joints the
+    policy pins and then never moves.
+    """
+    per_actuator = (report.get("action") or {}).get("per_actuator") or []
+    return tuple(
+        int(entry["index"])
+        for entry in sorted(per_actuator, key=lambda e: e["index"])
+        if abs(float(entry["dc"])) >= threshold
+    )
+
+
+def constant_hold_released(hold: tuple[float, ...], release: "tuple[int, ...] | set[int]") -> tuple[float, ...]:
+    """*hold* with the given actuators returned to the home keyframe.
+
+    "Released" means commanded ``0``, which under ``home-keyframe-residual/v1``
+    is exactly the home pose -- so releasing every actuator gives the statue,
+    and releasing none gives the policy's own pose. Every ablation below is a
+    point on the path between a pose that falls and one that stands.
+    """
+    released = set(int(index) for index in release)
+    return tuple(0.0 if index in released else value for index, value in enumerate(hold))
+
+
+def constant_hold_release_variants(
+    hold: tuple[float, ...],
+    report: dict[str, Any],
+    *,
+    horizon: int,
+    ramp_steps: int = 50,
+) -> list[ConstantHold]:
+    """Ablate the held pose one actuator group at a time, both ways round.
+
+    Every ablated variant is commanded **from reset**, not from a handoff
+    partway through. That is load-bearing and was got wrong the first time:
+    handing off at ``settle_steps`` means the policy first establishes its own
+    displaced pose and velocities, and the ablation then snaps some subset of
+    joints from ``±1.000`` to ``0`` in one step. The transient dominates, every
+    variant lands within noise of every other (311-349 steps across all
+    thirteen), and -- decisively -- the all-released endpoint falls too, at 323
+    steps, when the statue it is supposed to be stands for 1000. Both endpoints
+    on the same side of the answer means the path has no signal to locate.
+
+    From reset the endpoints are the two known measurements: releasing every
+    actuator commands ``0`` throughout, which *is* the statue and stands the
+    full horizon, and releasing none reproduces the probe's own
+    ``hold_from_reset`` at 133 steps. The path then genuinely runs from falling
+    to standing, and an ablation on it locates which coordinate carries the
+    effect.
+
+    Each group gets two variants, because "which joints cause the fall" needs
+    two different questions answered and one of them alone is not evidence:
+
+    * ``release_G`` holds everything *except* G, testing **necessity** -- does
+      taking G away rescue a pose that otherwise falls?
+    * ``only_G`` holds *only* G, testing **sufficiency** -- does adding G alone
+      break the statue, which is known to stand?
+
+    A group that is both necessary and sufficient is the cause. A group that is
+    necessary but not sufficient contributes with others. A group that is
+    neither is a bystander, whatever its DC looks like -- and the saturated
+    joints look dramatic (twelve pinned at exactly +/-1.000) precisely because
+    saturation is visible, not because it was shown to matter.
+
+    The two endpoints of the path are included as controls: ``hold_all`` is the
+    full pose, already measured to fall, and ``hold_zero`` is the statue,
+    already measured to stand. Every ablation sits between them.
+    """
+    zero = tuple(0.0 for _ in hold)
+    groups: dict[str, tuple[int, ...]] = {"saturated": saturated_actuator_indices(report)}
+    for name, patterns in _ACTUATOR_GROUPS.items():
+        indices = actuator_indices_matching(report, patterns)
+        if indices:
+            groups[name] = indices
+    everything = tuple(range(len(hold)))
+
+    variants = [
+        ConstantHold(hold, handoff_steps=horizon, label="policy (control)", source="unmodified", holds=False),
+        ConstantHold(hold, handoff_steps=0, ramp_steps=ramp_steps, label="hold_all"),
+    ]
+    for name, indices in groups.items():
+        if not indices or len(indices) == len(hold):
+            # Releasing everything is the statue and releasing nothing is
+            # `hold_all`; neither is an ablation, and both are already rows.
+            continue
+        complement = tuple(index for index in everything if index not in set(indices))
+        variants.append(
+            ConstantHold(
+                constant_hold_released(hold, indices),
+                handoff_steps=0,
+                ramp_steps=ramp_steps,
+                label=f"release_{name}",
+            )
+        )
+        variants.append(
+            ConstantHold(
+                constant_hold_released(hold, complement),
+                handoff_steps=0,
+                ramp_steps=ramp_steps,
+                label=f"only_{name}",
+            )
+        )
+    variants.append(
+        ConstantHold(zero, handoff_steps=0, ramp_steps=ramp_steps, label="hold_zero (statue control)", source="zeros")
+    )
+    return variants
 
 
 def constant_hold_variants(
@@ -1362,7 +1679,16 @@ def main() -> int:
         default=50,
         help="Steps to blend into the constant in the ramped variants (default 50).",
     )
+    parser.add_argument(
+        "--hold-release-ablation",
+        action="store_true",
+        help="Instead of the standard hold variants, ablate the held pose one actuator group at a "
+        "time -- releasing each group back to the home keyframe, and holding each group alone. "
+        "Answers WHICH joints make the pose unholdable, by testing necessity and sufficiency "
+        "separately. Implies --hold-constant.",
+    )
     args = parser.parse_args()
+    args.hold_constant = args.hold_constant or args.hold_release_ablation
 
     if not args.zero_action and not args.model:
         parser.error("pass --model, or --zero-action for the do-nothing reference")
@@ -1414,11 +1740,25 @@ def main() -> int:
             )
         except StanceGateReportError as exc:
             raise SystemExit(str(exc)) from exc
-        variants = constant_hold_variants(
-            hold,
-            settle_steps=report["settle_steps"],
-            horizon=report["horizon"],
-            ramp_steps=args.hold_ramp_steps,
+        source_report = (
+            json.loads(Path(args.hold_from_report).read_text(encoding="utf-8"))
+            if args.hold_from_report
+            else report
+        )
+        variants = (
+            constant_hold_release_variants(
+                hold,
+                source_report,
+                horizon=report["horizon"],
+                ramp_steps=args.hold_ramp_steps,
+            )
+            if args.hold_release_ablation
+            else constant_hold_variants(
+                hold,
+                settle_steps=report["settle_steps"],
+                horizon=report["horizon"],
+                ramp_steps=args.hold_ramp_steps,
+            )
         )
         probes = [
             build_stance_gate_report(
@@ -1435,12 +1775,13 @@ def main() -> int:
             )
             for variant in variants
         ]
-        text, _ = render_constant_hold_probe(probes, probe_episodes=args.hold_episodes)
+        render = render_constant_hold_ablation if args.hold_release_ablation else render_constant_hold_probe
+        write = write_constant_hold_ablation if args.hold_release_ablation else write_constant_hold_probe
+        text, _ = render(probes, probe_episodes=args.hold_episodes)
         print()
         print(text, end="")
         if args.out_dir:
-            written = write_constant_hold_probe(args.out_dir, probes, probe_episodes=args.hold_episodes)
-            for path in written.values():
+            for path in write(args.out_dir, probes, probe_episodes=args.hold_episodes).values():
                 print(f"written: {path}")
 
     declared = report["thresholds"]["min_eval_episodes"]

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -1656,3 +1656,227 @@ class TestTheConstantHoldProbeIsWiredIntoTrainingArtifacts:
         from environments.shared.curriculum.gate_schema import _DIAGNOSTIC_KEYS
 
         assert "stance_probe_hold_constant" in _DIAGNOSTIC_KEYS
+
+
+def _report_with_actuators(entries):
+    """A report carrying a per-actuator block, for the group selectors."""
+    report = _minimal_stance_report()
+    report["action"] = {
+        "dc_rms": 0.7,
+        "ac_rms": 0.36,
+        "delta_per_step": 2.7,
+        "jerk_per_step": 4.6,
+        "effective_freq_hz": 22.6,
+        "per_actuator": [
+            {"index": index, "joint": joint, "dc": dc, "ac_rms": 0.0}
+            for index, (joint, dc) in enumerate(entries)
+        ],
+    }
+    return report
+
+
+_TREX_ACTUATORS = [
+    ("neck_pitch", -0.433),
+    ("neck_yaw", -0.208),
+    ("head_pitch", -1.0),
+    ("r_hip_pitch", 0.052),
+    ("r_hip_roll", 1.0),
+    ("r_knee", 0.147),
+    ("r_ankle", -0.133),
+    ("r_toe_d2_joint", 1.0),
+    ("l_hip_roll", -1.0),
+    ("tail_1_yaw", 1.0),
+]
+
+
+class TestActuatorGroupSelection:
+    def test_saturation_is_measured_not_named(self):
+        from environments.shared.scripts.stance_gate_report import saturated_actuator_indices
+
+        report = _report_with_actuators(_TREX_ACTUATORS)
+        assert saturated_actuator_indices(report) == (2, 4, 7, 8, 9)
+
+    def test_the_threshold_is_a_magnitude_so_both_limits_count(self):
+        """`l_hip_roll` sits at -1.0 and is exactly as saturated as +1.0."""
+        from environments.shared.scripts.stance_gate_report import saturated_actuator_indices
+
+        report = _report_with_actuators([("a", -1.0), ("b", 0.5)])
+        assert saturated_actuator_indices(report) == (0,)
+
+    def test_groups_match_by_joint_name(self):
+        from environments.shared.scripts.stance_gate_report import actuator_indices_matching
+
+        report = _report_with_actuators(_TREX_ACTUATORS)
+        assert actuator_indices_matching(report, ("tail",)) == (9,)
+        assert actuator_indices_matching(report, ("toe",)) == (7,)
+        assert actuator_indices_matching(report, ("hip_roll",)) == (4, 8)
+        # head and neck are one region: three joints, two prefixes.
+        assert actuator_indices_matching(report, ("head", "neck")) == (0, 1, 2)
+
+    def test_release_returns_the_named_actuators_to_home(self):
+        from environments.shared.scripts.stance_gate_report import constant_hold_released
+
+        assert constant_hold_released((0.5, -0.5, 1.0), (0, 2)) == pytest.approx((0.0, -0.5, 0.0))
+
+    def test_releasing_everything_is_the_statue(self):
+        """The ablation is a path between two measured endpoints; this is one."""
+        from environments.shared.scripts.stance_gate_report import constant_hold_released
+
+        assert constant_hold_released((0.5, -0.5), (0, 1)) == pytest.approx((0.0, 0.0))
+
+    def test_releasing_nothing_leaves_the_pose_alone(self):
+        from environments.shared.scripts.stance_gate_report import constant_hold_released
+
+        assert constant_hold_released((0.5, -0.5), ()) == pytest.approx((0.5, -0.5))
+
+
+class TestReleaseAblationVariants:
+    @staticmethod
+    def _variants():
+        from environments.shared.scripts.stance_gate_report import (
+            constant_hold_actions,
+            constant_hold_release_variants,
+        )
+
+        report = _report_with_actuators(_TREX_ACTUATORS)
+        hold = constant_hold_actions(report)
+        return {v.label: v for v in constant_hold_release_variants(hold, report, horizon=1000)}
+
+    def test_every_group_gets_both_directions(self):
+        """One side alone is not evidence: necessity and sufficiency differ."""
+        variants = self._variants()
+        for group in ("saturated", "tail", "toes", "head_neck", "hip_rolls"):
+            assert f"release_{group}" in variants
+            assert f"only_{group}" in variants
+
+    def test_release_and_only_are_exact_complements(self):
+        variants = self._variants()
+        release = variants["release_tail"].actions
+        only = variants["only_tail"].actions
+        held = variants["hold_all"].actions
+        for index in range(len(held)):
+            # Exactly one side holds each actuator, and together they
+            # reconstruct the full pose. A gap or an overlap would make the
+            # necessity and sufficiency answers incomparable.
+            assert (release[index] == 0.0) != (only[index] == 0.0) or held[index] == 0.0
+            assert release[index] + only[index] == pytest.approx(held[index])
+
+    def test_the_endpoints_are_included_as_controls(self):
+        variants = self._variants()
+        assert not variants["policy (control)"].holds
+        assert all(value == 0.0 for value in variants["hold_zero (statue control)"].actions)
+        assert variants["hold_all"].actions == variants["policy (control)"].actions
+
+    def test_every_ablated_variant_is_commanded_from_reset(self):
+        """A handoff partway through makes the statue endpoint stop being the statue.
+
+        Measured, when this was wrong: handing off at settle_steps snaps some
+        subset of joints from +/-1.000 to 0 in one step, the transient swamps
+        the ablation, all thirteen variants land within 311-349 steps of each
+        other, and the all-released row -- which is supposed to BE the statue
+        and stand for 1000 -- falls at 323. Both endpoints on the same side of
+        the answer leaves the path with no signal to locate.
+        """
+        for label, variant in self._variants().items():
+            if label == "policy (control)":
+                continue
+            assert variant.handoff_steps == 0, f"{label} must be commanded from reset, not after a handoff"
+
+    def test_the_statue_endpoint_commands_home_for_the_whole_episode(self):
+        """Which is what makes it a control the other rows can be read against."""
+        statue = self._variants()["hold_zero (statue control)"]
+        assert statue.handoff_steps == 0
+        assert all(value == 0.0 for value in statue.actions)
+
+    def test_a_group_covering_every_actuator_is_not_an_ablation(self):
+        """Releasing all of them is the statue, which is already a row."""
+        from environments.shared.scripts.stance_gate_report import constant_hold_release_variants
+
+        report = _report_with_actuators([("tail_1_pitch", 1.0), ("tail_2_pitch", 1.0)])
+        labels = {v.label for v in constant_hold_release_variants((1.0, 1.0), report, horizon=1000)}
+        assert "release_tail" not in labels
+        assert "release_saturated" not in labels
+
+
+def _ablation_row(label, full, *, holds=True, length=None, released=0):
+    report = _held_report(label, holds=holds, full=full, length=length if length is not None else (1000.0 if full else 300.0))
+    report["hold_constant"]["actions"] = [0.0] * released + [0.5] * (21 - released)
+    return report
+
+
+class TestAblationVerdicts:
+    @staticmethod
+    def _render(pairs, **extra):
+        from environments.shared.scripts.stance_gate_report import render_constant_hold_ablation
+
+        reports = [_ablation_row("policy (control)", 1.0, holds=False), _ablation_row("hold_all", 0.0)]
+        for group, (release_full, only_full) in pairs.items():
+            reports.append(_ablation_row(f"release_{group}", release_full))
+            reports.append(_ablation_row(f"only_{group}", only_full))
+        reports.append(_ablation_row("hold_zero (statue control)", 1.0, released=21))
+        return render_constant_hold_ablation(reports, probe_episodes=8, **extra)
+
+    def test_necessary_and_sufficient_reads_as_the_cause(self):
+        text, payload = self._render({"tail": (1.0, 0.0)})
+        assert "CAUSE" in text
+        verdict = next(v for v in payload["verdicts"] if v["group"] == "tail")
+        assert verdict["necessary"] and verdict["sufficient"]
+
+    def test_necessary_alone_only_contributes(self):
+        """Removing it rescues the pose, but it cannot break the statue by itself."""
+        text, payload = self._render({"tail": (1.0, 1.0)})
+        assert "contributes" in text
+        verdict = next(v for v in payload["verdicts"] if v["group"] == "tail")
+        assert verdict["necessary"] and not verdict["sufficient"]
+
+    def test_neither_reads_as_a_bystander(self):
+        text, payload = self._render({"saturated": (0.0, 1.0)})
+        assert "bystander" in text
+        verdict = next(v for v in payload["verdicts"] if v["group"] == "saturated")
+        assert not verdict["necessary"] and not verdict["sufficient"]
+
+    def test_a_middling_result_refuses_to_round(self, ):
+        """The two conclusions are opposite, so the gap must not be split."""
+        text, payload = self._render({"tail": (0.5, 0.0)})
+        assert "inconclusive" in text
+        assert next(v for v in payload["verdicts"] if v["group"] == "tail")["verdict"].startswith("inconclusive")
+
+    def test_each_group_is_judged_independently(self):
+        _, payload = self._render({"tail": (1.0, 0.0), "toes": (0.0, 1.0)})
+        by_group = {v["group"]: v["verdict"] for v in payload["verdicts"]}
+        assert by_group["tail"].startswith("CAUSE")
+        assert by_group["toes"].startswith("bystander")
+
+    def test_the_table_warns_against_reading_one_side(self):
+        text, _ = self._render({"tail": (1.0, 0.0)})
+        assert "never one side" in text
+        assert "bystander" in text, "the failure mode must be named, not just the success"
+
+    def test_it_writes_its_own_filenames_and_no_evidence(self, tmp_path):
+        from environments.shared.scripts.stance_gate_report import write_constant_hold_ablation
+
+        reports = [_ablation_row("policy (control)", 1.0, holds=False), _ablation_row("hold_all", 0.0)]
+        written = write_constant_hold_ablation(tmp_path, reports, probe_episodes=8)
+        assert set(written) == {"constant_hold_ablation_txt", "constant_hold_ablation_json"}
+        assert (tmp_path / "stance_gate_probe_release.txt").exists()
+        assert not (tmp_path / "stance_panel_selected.csv").exists()
+        assert not (tmp_path / "stance_gate_report.txt").exists()
+        # The other two probes' artifacts must not be collided with either.
+        assert not (tmp_path / "stance_gate_probe_constant.txt").exists()
+        assert not (tmp_path / "stance_gate_probe_filtered.txt").exists()
+
+    def test_nothing_necessary_but_something_sufficient_reads_as_over_determined(self):
+        """Measured on the T-Rex checkpoint: toes break it alone, yet removing
+        them does not rescue it, because the rest of the pose breaks it too."""
+        text, _ = self._render({"toes": (0.0, 0.0), "tail": (0.0, 1.0)})
+        assert "OVER-DETERMINED" in text
+        assert "toes" in text.split("Overall:")[1]
+        assert "wrong question" in text
+
+    def test_nothing_necessary_and_nothing_sufficient_says_regroup(self):
+        text, _ = self._render({"tail": (0.0, 1.0), "toes": (0.0, 1.0)})
+        assert "Regroup" in text
+
+    def test_a_necessary_group_suppresses_the_over_determined_reading(self):
+        text, _ = self._render({"tail": (1.0, 0.0)})
+        assert "OVER-DETERMINED" not in text

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -1880,3 +1880,117 @@ class TestAblationVerdicts:
     def test_a_necessary_group_suppresses_the_over_determined_reading(self):
         text, _ = self._render({"tail": (1.0, 0.0)})
         assert "OVER-DETERMINED" not in text
+
+
+class TestDeflectionInDegrees:
+    """`|action| = 1` is not one physical event, and the report must not imply it is.
+
+    On the T-Rex a saturated tail joint is 12deg of travel and a saturated toe
+    is 50deg. Ranking the per-actuator table by normalised action put twelve
+    joints at exactly +/-1.000 at the top and gave no way to tell them apart --
+    and the most extreme-looking of them, the tail, was later measured to be
+    mechanically inert while the toes carried the whole effect.
+    """
+
+    @staticmethod
+    def _stats(means, mapping, names=None):
+        from environments.shared.scripts.stance_gate_report import _new_action_stats, _reduce_action_stats
+
+        stats = _new_action_stats()
+        stats["sum"] = np.asarray(means, dtype=float)
+        stats["sq_sum"] = np.asarray(means, dtype=float) ** 2
+        stats["count"] = 1
+        return _reduce_action_stats(stats, names or [f"j{i}" for i in range(len(means))], 0.01, mapping)
+
+    #: tail_1_pitch (+/-12deg, home-centred) and r_toe_d2 (-25..+50deg, home +12.5deg),
+    #: the two real T-Rex actuators the ablation separated.
+    _TAIL = {"ctrl_min": -0.2094, "ctrl_max": 0.2094, "home": 0.0}
+    _TOE = {"ctrl_min": -0.4363, "ctrl_max": 0.8727, "home": 0.2182}
+
+    def test_the_same_saturated_action_is_a_different_angle_per_joint(self):
+        action = self._stats([1.0, 1.0], [self._TAIL, self._TOE], names=["tail_1_pitch", "r_toe_d2_joint"])
+        by_joint = {entry["joint"]: entry for entry in action["per_actuator"]}
+        assert by_joint["tail_1_pitch"]["dc"] == pytest.approx(1.0)
+        assert by_joint["r_toe_d2_joint"]["dc"] == pytest.approx(1.0)
+        # Identical in normalised units, a factor of ~3 apart in the world.
+        assert by_joint["tail_1_pitch"]["dc_deg"] == pytest.approx(12.0, abs=0.1)
+        assert by_joint["r_toe_d2_joint"]["dc_deg"] == pytest.approx(37.5, abs=0.1)
+
+    def test_the_table_is_ordered_by_degrees_not_by_normalised_action(self):
+        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+
+        report = _minimal_stance_report()
+        report["action"] = self._stats(
+            [1.0, 0.6], [self._TAIL, self._TOE], names=["tail_1_pitch", "r_toe_d2_joint"]
+        )
+        text = render_stance_gate_report(report)
+        # The tail saturates and the toe does not, yet the toe moves further.
+        assert text.index("r_toe_d2_joint") < text.index("tail_1_pitch")
+        assert "Ordered by DEGREES" in text
+
+    def test_the_tremor_scales_by_half_the_range(self):
+        """A unit of action spans half the ctrlrange in each direction."""
+        from environments.shared.scripts.stance_gate_report import _new_action_stats, _reduce_action_stats
+
+        stats = _new_action_stats()
+        stats["sum"] = np.zeros(1)
+        stats["sq_sum"] = np.full(1, 0.25)  # mean 0, var 0.25 -> ac_rms 0.5
+        stats["count"] = 1
+        action = _reduce_action_stats(stats, ["r_toe_d2_joint"], 0.01, [self._TOE])
+        assert action["per_actuator"][0]["ac_rms"] == pytest.approx(0.5)
+        # 0.5 x half of 75deg = 18.75deg
+        assert action["per_actuator"][0]["ac_rms_deg"] == pytest.approx(18.75, abs=0.05)
+
+    def test_an_offset_ctrlrange_is_flagged_because_action_zero_is_not_home(self):
+        """`home-keyframe-residual/v1` asserts action 0 IS home; for some it is not.
+
+        On the T-Rex the ankles sit 5.5deg off and head/neck pitch 5.0deg off.
+        Small, but the phrasing is load-bearing -- statue-derived constants and
+        the DC interpretation both rest on it.
+        """
+        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+
+        ankle = {"ctrl_min": 0.5655, "ctrl_max": 2.3108, "home": 1.3422}
+        report = _minimal_stance_report()
+        report["action"] = self._stats([0.0], [ankle], names=["r_ankle"])
+        assert report["action"]["per_actuator"][0]["zero_offset_deg"] == pytest.approx(5.5, abs=0.1)
+        text = render_stance_gate_report(report)
+        assert "action = 0 is not exactly home" in text
+        assert "r_ankle" in text
+
+    def test_a_home_centred_range_is_not_flagged(self):
+        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+
+        report = _minimal_stance_report()
+        report["action"] = self._stats([0.5], [self._TAIL], names=["tail_1_pitch"])
+        assert report["action"]["per_actuator"][0]["zero_offset_deg"] == pytest.approx(0.0, abs=1e-9)
+        assert "action = 0 is not exactly home" not in render_stance_gate_report(report)
+
+    def test_degrees_are_added_not_substituted(self):
+        """`dc` still inverts through the action penalties; the degrees do not."""
+        action = self._stats([0.8], [self._TOE])
+        entry = action["per_actuator"][0]
+        assert entry["dc"] == pytest.approx(0.8)
+        assert "dc_deg" in entry and "range_deg" in entry
+        assert action["dc_rms"] == pytest.approx(0.8)
+        assert "dc_rms_deg" in action and "max_abs_dc_deg" in action
+
+    def test_a_report_without_a_mapping_still_renders(self):
+        """The model is unreachable from some callers; degrees are a convenience."""
+        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+
+        report = _minimal_stance_report()
+        report["action"] = self._stats([1.0], [], names=["tail_1_pitch"])
+        assert "dc_deg" not in report["action"]["per_actuator"][0]
+        assert "dc_rms_deg" not in report["action"]
+        text = render_stance_gate_report(report)
+        assert "tail_1_pitch" in text
+        assert "Ordered by DEGREES" not in text
+
+    def test_the_hold_probe_still_reads_normalised_dc(self):
+        """`constant_hold_actions` commands actions, not angles."""
+        from environments.shared.scripts.stance_gate_report import constant_hold_actions
+
+        report = _minimal_stance_report()
+        report["action"] = self._stats([0.4, -0.7], [self._TAIL, self._TOE])
+        assert constant_hold_actions(report) == pytest.approx((0.4, -0.7))

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -1359,3 +1359,300 @@ class TestPerActuatorActionReporting:
         from environments.shared.scripts.stance_gate_report import render_stance_gate_report
 
         assert "commanded action" not in render_stance_gate_report(_minimal_stance_report())
+
+
+def _held_report(label, *, holds=True, handoff=200, ramp=0, length=1000.0, full=1.0, reward=3004.3, source=None):
+    """A probe report for one constant-hold variant."""
+    report = _minimal_stance_report()
+    report["episodes"] = 10
+    report["hold_constant"] = {
+        "label": label,
+        "source": source or ("measured" if holds else "unmodified"),
+        "holds": holds,
+        "handoff_steps": handoff,
+        "ramp_steps": ramp,
+        "actions": [0.5, -0.25],
+    }
+    report["metrics"] = dict(
+        report["metrics"],
+        episode_length_mean=length,
+        full_horizon_fraction=full,
+        reward_mean=reward,
+    )
+    report["terminations"] = {"truncated": 10} if full > 0 else {"tail_contact": 10}
+    return report
+
+
+class TestConstantHoldWrapper:
+    """`--hold-constant` cuts the feedback, where the low-pass only slows it.
+
+    The distinction is the whole point: a filtered policy still responds to
+    what it sees, so a fall under the filter proves the policy needs bandwidth
+    without saying whether it needs feedback at all. Holding a constant says.
+    """
+
+    @staticmethod
+    def _held(hold, actions=None):
+        from environments.shared.scripts.stance_gate_report import _hold_constant_predict
+
+        seq = iter(actions or [])
+        base = lambda _obs: np.asarray(next(seq), dtype=np.float64)  # noqa: E731
+        return _hold_constant_predict(base, hold)
+
+    def test_the_policy_runs_until_handoff_then_stops_being_consulted(self):
+        from environments.shared.scripts.stance_gate_report import ConstantHold
+
+        hold = ConstantHold((0.5,), handoff_steps=2)
+        # Only two policy actions are supplied: a third call would raise
+        # StopIteration if the wrapper kept consulting it.
+        predict = self._held(hold, actions=[[0.1], [0.2]])
+        assert [float(predict(None)[0]) for _ in range(5)] == pytest.approx([0.1, 0.2, 0.5, 0.5, 0.5])
+
+    def test_a_handoff_at_the_horizon_never_substitutes(self):
+        """This is how the unmodified control variant is expressed."""
+        from environments.shared.scripts.stance_gate_report import ConstantHold
+
+        hold = ConstantHold((9.9,), handoff_steps=1000, holds=False)
+        predict = self._held(hold, actions=[[0.1], [0.2], [0.3]])
+        assert [float(predict(None)[0]) for _ in range(3)] == pytest.approx([0.1, 0.2, 0.3])
+
+    def test_the_ramp_blends_from_the_policys_last_action(self):
+        from environments.shared.scripts.stance_gate_report import ConstantHold
+
+        hold = ConstantHold((1.0,), handoff_steps=1, ramp_steps=4)
+        predict = self._held(hold, actions=[[0.0]])
+        out = [float(predict(None)[0]) for _ in range(6)]
+        assert out[0] == pytest.approx(0.0)
+        # Linear from the last commanded action to the constant, then held.
+        assert out[1:5] == pytest.approx([0.25, 0.5, 0.75, 1.0])
+        assert out[5] == pytest.approx(1.0)
+
+    def test_a_ramp_from_reset_starts_at_the_home_keyframe(self):
+        """There is no previous action at step 0, and `action = 0` IS home.
+
+        Starting the ramp anywhere else would jump the pose on the first step,
+        which is the transient the ramp exists to avoid.
+        """
+        from environments.shared.scripts.stance_gate_report import ConstantHold
+
+        hold = ConstantHold((1.0,), handoff_steps=0, ramp_steps=2)
+        predict = self._held(hold)
+        assert [float(predict(None)[0]) for _ in range(3)] == pytest.approx([0.5, 1.0, 1.0])
+
+    def test_reset_prevents_one_episode_starting_past_handoff(self):
+        from environments.shared.scripts.stance_gate_report import ConstantHold
+
+        hold = ConstantHold((0.5,), handoff_steps=1)
+        predict = self._held(hold, actions=[[0.1], [0.2]])
+        assert float(predict(None)[0]) == pytest.approx(0.1)
+        assert float(predict(None)[0]) == pytest.approx(0.5)
+        predict.reset()
+        # Without the reset the second episode would open already held, and the
+        # panel would average two different experiments.
+        assert float(predict(None)[0]) == pytest.approx(0.2)
+
+
+class TestConstantHoldExtraction:
+    def test_it_reads_the_per_actuator_dc_in_index_order(self):
+        from environments.shared.scripts.stance_gate_report import constant_hold_actions
+
+        report = {
+            "action": {
+                "per_actuator": [
+                    {"index": 2, "joint": "c", "dc": 0.3, "ac_rms": 0.0},
+                    {"index": 0, "joint": "a", "dc": 0.1, "ac_rms": 0.0},
+                    {"index": 1, "joint": "b", "dc": 0.2, "ac_rms": 0.0},
+                ]
+            }
+        }
+        assert constant_hold_actions(report) == pytest.approx((0.1, 0.2, 0.3))
+
+    def test_a_report_without_the_block_fails_loudly(self):
+        """Silently holding zeros would score the statue and call it the policy."""
+        from environments.shared.scripts.stance_gate_report import constant_hold_actions
+
+        with pytest.raises(StanceGateReportError, match="no per-actuator action statistics"):
+            constant_hold_actions(_minimal_stance_report())
+
+
+class TestConstantHoldVariants:
+    def test_the_set_brackets_the_held_rows_with_two_controls(self):
+        from environments.shared.scripts.stance_gate_report import constant_hold_variants
+
+        variants = constant_hold_variants((0.5, -0.5), settle_steps=200, horizon=1000)
+        by_label = {v.label: v for v in variants}
+        assert not by_label["policy (control)"].holds
+        assert by_label["policy (control)"].handoff_steps == 1000, "the control must never substitute"
+        assert by_label["hold_zero (statue control)"].actions == (0.0, 0.0)
+        assert by_label["hold_after_settle"].handoff_steps == 200
+        assert by_label["hold_after_settle"].ramp_steps == 0
+        assert by_label["hold_after_settle_ramped"].ramp_steps > 0
+        assert by_label["hold_from_reset"].handoff_steps == 0
+
+    def test_the_zero_control_matches_the_hold_width(self):
+        from environments.shared.scripts.stance_gate_report import constant_hold_variants
+
+        variants = constant_hold_variants(tuple([0.5] * 21), settle_steps=200, horizon=1000)
+        assert all(len(v.actions) == 21 for v in variants)
+
+
+class TestConstantHoldProbeCannotBeMistakenForTheVerdict:
+    def test_it_writes_its_own_filenames(self, tmp_path):
+        report = _held_report("hold_after_settle")
+        written = write_stance_gate_report(tmp_path, report)
+        assert (tmp_path / "stance_gate_probe_constant.txt").exists()
+        assert not (tmp_path / "stance_gate_report.txt").exists()
+        assert "stance_panel_csv" not in written
+
+    def test_even_the_unmodified_control_is_marked_a_probe(self, tmp_path):
+        """The control rolls the real policy, so nothing else would flag it.
+
+        Ten episodes at the panel seeds is not the gate's 40, and a report on
+        those filenames would be certified as if it were.
+        """
+        report = _held_report("policy (control)", holds=False, handoff=1000)
+        write_stance_gate_report(tmp_path, report)
+        assert (tmp_path / "stance_gate_probe_constant.txt").exists()
+        assert not (tmp_path / "stance_gate_report.txt").exists()
+
+    def test_the_banner_precedes_the_verdict(self):
+        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+
+        text = render_stance_gate_report(_held_report("hold_after_settle"))
+        assert "PROBE" in text
+        assert "not a gate result" in text
+        assert text.index("PROBE") < text.index("GATE:")
+
+    def test_the_control_row_says_it_was_not_held(self):
+        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+
+        text = render_stance_gate_report(_held_report("policy (control)", holds=False, handoff=1000))
+        assert "unmodified control" in text
+
+    def test_every_probe_marker_maps_to_a_distinct_stem(self):
+        """Two probes sharing a stem would overwrite each other's artifact."""
+        from environments.shared.scripts.stance_gate_report import _PROBE_MARKERS
+
+        assert len(set(_PROBE_MARKERS.values())) == len(_PROBE_MARKERS)
+        assert "stance_gate_report" not in set(_PROBE_MARKERS.values())
+
+    def test_an_ordinary_report_is_still_not_a_probe(self):
+        from environments.shared.scripts.stance_gate_report import probe_stem
+
+        assert probe_stem(_minimal_stance_report()) is None
+
+
+class TestConstantHoldProbeTable:
+    @staticmethod
+    def _standard(full_when_held):
+        """The five standard variants, with the three measured holds set to *full_when_held*."""
+        length = 1000.0 if full_when_held > 0 else 231.0
+        return [
+            _held_report("policy (control)", holds=False, handoff=1000),
+            _held_report("hold_after_settle", full=full_when_held, length=length),
+            _held_report("hold_after_settle_ramped", ramp=50, full=full_when_held, length=length),
+            _held_report("hold_from_reset", handoff=0, ramp=50, full=full_when_held, length=length),
+            _held_report("hold_zero (statue control)", handoff=0, source="zeros"),
+        ]
+
+    def test_the_statue_control_is_not_read_as_a_measurement(self, tmp_path):
+        """It holds a constant too, but its standing is a known fact about the plant.
+
+        Counting it among the measured holds would make an all-falling result
+        read as mixed, which is the one reading that stops the probe concluding.
+        """
+        from environments.shared.scripts.stance_gate_report import write_constant_hold_probe
+
+        write_constant_hold_probe(tmp_path, self._standard(0.0), probe_episodes=10)
+        assert "REQUIRES" in (tmp_path / "stance_gate_probe_constant.txt").read_text()
+
+    def test_all_held_rows_standing_reads_as_an_optimisation_failure(self, tmp_path):
+        from environments.shared.scripts.stance_gate_report import write_constant_hold_probe
+
+        write_constant_hold_probe(tmp_path, self._standard(1.0), probe_episodes=10)
+        text = (tmp_path / "stance_gate_probe_constant.txt").read_text()
+        assert "does NOT" in text and "optimisation" in text
+        assert "MODIFIED policy" in text
+
+    def test_all_held_rows_falling_reads_as_load_bearing_feedback(self, tmp_path):
+        from environments.shared.scripts.stance_gate_report import write_constant_hold_probe
+
+        write_constant_hold_probe(tmp_path, self._standard(0.0), probe_episodes=10)
+        text = (tmp_path / "stance_gate_probe_constant.txt").read_text()
+        assert "REQUIRES" in text
+        assert "penalising" in text, "the conclusion must warn against the obvious wrong fix"
+
+    def test_a_mixed_result_refuses_to_conclude(self, tmp_path):
+        from environments.shared.scripts.stance_gate_report import write_constant_hold_probe
+
+        reports = self._standard(1.0)
+        reports[1]["metrics"] = dict(reports[1]["metrics"], full_horizon_fraction=0.0, episode_length_mean=231.0)
+        write_constant_hold_probe(tmp_path, reports, probe_episodes=10)
+        text = (tmp_path / "stance_gate_probe_constant.txt").read_text()
+        assert "Mixed" in text
+        assert "step transient" in text, "the ramped variant is what tells the two apart"
+
+    def test_it_never_writes_the_certification_evidence(self, tmp_path):
+        from environments.shared.scripts.stance_gate_report import write_constant_hold_probe
+
+        written = write_constant_hold_probe(tmp_path, self._standard(1.0), probe_episodes=10)
+        assert set(written) == {"constant_hold_probe_txt", "constant_hold_probe_json"}
+        assert not (tmp_path / "stance_panel_selected.csv").exists()
+        assert not (tmp_path / "stance_gate_report.txt").exists()
+
+    def test_the_json_carries_the_held_vector_not_the_controls_zeros(self, tmp_path):
+        import json
+
+        from environments.shared.scripts.stance_gate_report import write_constant_hold_probe
+
+        write_constant_hold_probe(tmp_path, self._standard(1.0), probe_episodes=10)
+        payload = json.loads((tmp_path / "stance_gate_probe_constant.json").read_text())
+        assert payload["hold_actions"] == [0.5, -0.25]
+        assert payload["episodes_per_variant"] == 10
+        assert [row["label"] for row in payload["variants"]][0] == "policy (control)"
+
+
+class TestTheConstantHoldProbeIsWiredIntoTrainingArtifacts:
+    def test_it_is_skipped_when_unconfigured(self, tmp_path, monkeypatch):
+        from environments.shared.reporting import stage_artifacts
+
+        called = False
+
+        def _boom(*a, **k):
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(stance_gate_report, "build_stance_gate_report", _boom)
+        stage_artifacts._write_constant_hold_probe(
+            species="trex",
+            stage=1,
+            stage_config={"curriculum_kwargs": {}},
+            stage_dir=tmp_path,
+            model_path="m.zip",
+            vecnorm_path="v.pkl",
+            episodes=40,
+            measured=_minimal_stance_report(),
+        )
+        assert not called
+
+    def test_a_measured_report_without_dc_does_not_sink_the_run(self, tmp_path):
+        """The gate report is the caller's return value; a probe must not raise."""
+        from environments.shared.reporting import stage_artifacts
+
+        stage_artifacts._write_constant_hold_probe(
+            species="trex",
+            stage=1,
+            stage_config={"curriculum_kwargs": {"stance_probe_hold_constant": True}},
+            stage_dir=tmp_path,
+            model_path="m.zip",
+            vecnorm_path="v.pkl",
+            episodes=40,
+            measured=_minimal_stance_report(),
+        )
+        assert not (tmp_path / "stance_gate_probe_constant.txt").exists()
+
+    def test_the_config_key_is_reachable_from_a_toml(self):
+        """Unregistered keys are rejected fail-closed, which makes them unreachable."""
+        from environments.shared.curriculum.gate_schema import _DIAGNOSTIC_KEYS
+
+        assert "stance_probe_hold_constant" in _DIAGNOSTIC_KEYS

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -268,7 +268,7 @@ class TestTrainingPipelineHook:
             seen["model_path"] = model_path
             seen["vecnorm_path"] = vecnorm_path
             return {
-                "schema": "mesozoic.stance-gate-report/v1",
+                "schema": "mesozoic.stance-gate-report/v2",
                 "species": species,
                 "stage": stage,
                 "gate_kind": "stance_quality/v1",
@@ -357,7 +357,7 @@ class TestJsonIsParseable:
         }
         metrics.update(metric_overrides)
         return {
-            "schema": "mesozoic.stance-gate-report/v1",
+            "schema": "mesozoic.stance-gate-report/v2",
             "species": "trex",
             "stage": 1,
             "gate_kind": "stance_quality/v1",
@@ -732,7 +732,7 @@ class TestPlantValidation:
         # The flag travels with the number rather than being reconstructable
         # only from whoever happened to read the console.
         report = {
-            "schema": "mesozoic.stance-gate-report/v1",
+            "schema": "mesozoic.stance-gate-report/v2",
             "species": "trex",
             "stage": 1,
             "gate_kind": "stance_quality/v1",
@@ -829,6 +829,7 @@ class TestCheckpointPlantProvenance:
 
     def test_zero_action_records_none_because_there_is_no_checkpoint(self, monkeypatch):
         report = self._report(monkeypatch, zero_action=True)
+        assert report["schema"] == "mesozoic.stance-gate-report/v2"
         assert report["checkpoint_plant_validated"] is None
 
     def test_zero_action_with_allow_legacy_still_records_none(self, monkeypatch):
@@ -850,7 +851,7 @@ class TestStancePanelEvidenceFile:
     @staticmethod
     def _report(episodes):
         return {
-            "schema": "mesozoic.stance-gate-report/v1",
+            "schema": "mesozoic.stance-gate-report/v2",
             "species": "trex",
             "stage": 1,
             "gate_kind": "stance_quality/v1",
@@ -956,7 +957,7 @@ class TestStancePanelEvidenceFile:
 def _minimal_stance_report() -> dict:
     """A report dict complete enough for the renderer."""
     return {
-        "schema": "mesozoic.stance-gate-report/v1",
+        "schema": "mesozoic.stance-gate-report/v2",
         "species": "trex",
         "stage": 1,
         "gate_kind": "stance_quality/v1",
@@ -1668,8 +1669,7 @@ def _report_with_actuators(entries):
         "jerk_per_step": 4.6,
         "effective_freq_hz": 22.6,
         "per_actuator": [
-            {"index": index, "joint": joint, "dc": dc, "ac_rms": 0.0}
-            for index, (joint, dc) in enumerate(entries)
+            {"index": index, "joint": joint, "dc": dc, "ac_rms": 0.0} for index, (joint, dc) in enumerate(entries)
         ],
     }
     return report
@@ -1799,7 +1799,9 @@ class TestReleaseAblationVariants:
 
 
 def _ablation_row(label, full, *, holds=True, length=None, released=0):
-    report = _held_report(label, holds=holds, full=full, length=length if length is not None else (1000.0 if full else 300.0))
+    report = _held_report(
+        label, holds=holds, full=full, length=length if length is not None else (1000.0 if full else 300.0)
+    )
     report["hold_constant"]["actions"] = [0.0] * released + [0.5] * (21 - released)
     return report
 
@@ -1835,7 +1837,9 @@ class TestAblationVerdicts:
         verdict = next(v for v in payload["verdicts"] if v["group"] == "saturated")
         assert not verdict["necessary"] and not verdict["sufficient"]
 
-    def test_a_middling_result_refuses_to_round(self, ):
+    def test_a_middling_result_refuses_to_round(
+        self,
+    ):
         """The two conclusions are opposite, so the gap must not be split."""
         text, payload = self._render({"tail": (0.5, 0.0)})
         assert "inconclusive" in text
@@ -1882,11 +1886,12 @@ class TestAblationVerdicts:
         assert "OVER-DETERMINED" not in text
 
 
-class TestDeflectionInDegrees:
+class TestControlTargetsInDegrees:
     """`|action| = 1` is not one physical event, and the report must not imply it is.
 
-    On the T-Rex a saturated tail joint is 12deg of travel and a saturated toe
-    is 50deg. Ranking the per-actuator table by normalised action put twelve
+    On the T-Rex a saturated tail target moves 12deg from its origin and a toe
+    target moves 37.5deg (to an absolute +50deg endpoint). Ranking the
+    per-actuator table by normalised action put twelve
     joints at exactly +/-1.000 at the top and gave no way to tell them apart --
     and the most extreme-looking of them, the tail, was later measured to be
     mechanically inert while the toes carried the whole effect.
@@ -1894,18 +1899,43 @@ class TestDeflectionInDegrees:
 
     @staticmethod
     def _stats(means, mapping, names=None):
-        from environments.shared.scripts.stance_gate_report import _new_action_stats, _reduce_action_stats
+        from environments.shared.scripts.stance_gate_report import (
+            _commanded_angle,
+            _new_action_stats,
+            _reduce_action_stats,
+        )
 
         stats = _new_action_stats()
         stats["sum"] = np.asarray(means, dtype=float)
         stats["sq_sum"] = np.asarray(means, dtype=float) ** 2
         stats["count"] = 1
+        if len(mapping) == len(means):
+            controls = np.asarray([_commanded_angle(entry, float(action)) for entry, action in zip(mapping, means)])
+            stats["ctrl_sum"] = controls
+            stats["ctrl_sq_sum"] = controls**2
+            stats["ctrl_count"] = 1
         return _reduce_action_stats(stats, names or [f"j{i}" for i in range(len(means))], 0.01, mapping)
 
-    #: tail_1_pitch (+/-12deg, home-centred) and r_toe_d2 (-25..+50deg, home +12.5deg),
-    #: the two real T-Rex actuators the ablation separated.
-    _TAIL = {"ctrl_min": -0.2094, "ctrl_max": 0.2094, "home": 0.0}
-    _TOE = {"ctrl_min": -0.4363, "ctrl_max": 0.8727, "home": 0.2182}
+    #: tail_1_pitch (+/-12deg, home-centred) and r_toe_d2 (-25..+50deg,
+    #: home +12.5deg), the two real T-Rex actuators the ablation separated.
+    _TAIL = {
+        "ctrl_min": -0.2094,
+        "ctrl_max": 0.2094,
+        "action_negative_ctrl": -0.2094,
+        "action_zero_ctrl": 0.0,
+        "action_positive_ctrl": 0.2094,
+        "home_ctrl": 0.0,
+        "home_qpos": 0.0,
+    }
+    _TOE = {
+        "ctrl_min": -0.4363,
+        "ctrl_max": 0.8727,
+        "action_negative_ctrl": -0.4363,
+        "action_zero_ctrl": 0.2182,
+        "action_positive_ctrl": 0.8727,
+        "home_ctrl": 0.2182,
+        "home_qpos": 0.2182,
+    }
 
     def test_the_same_saturated_action_is_a_different_angle_per_joint(self):
         action = self._stats([1.0, 1.0], [self._TAIL, self._TOE], names=["tail_1_pitch", "r_toe_d2_joint"])
@@ -1920,51 +1950,193 @@ class TestDeflectionInDegrees:
         from environments.shared.scripts.stance_gate_report import render_stance_gate_report
 
         report = _minimal_stance_report()
-        report["action"] = self._stats(
-            [1.0, 0.6], [self._TAIL, self._TOE], names=["tail_1_pitch", "r_toe_d2_joint"]
-        )
+        report["action"] = self._stats([1.0, 0.6], [self._TAIL, self._TOE], names=["tail_1_pitch", "r_toe_d2_joint"])
         text = render_stance_gate_report(report)
         # The tail saturates and the toe does not, yet the toe moves further.
         assert text.index("r_toe_d2_joint") < text.index("tail_1_pitch")
         assert "Ordered by DEGREES" in text
 
-    def test_the_tremor_scales_by_half_the_range(self):
-        """A unit of action spans half the ctrlrange in each direction."""
-        from environments.shared.scripts.stance_gate_report import _new_action_stats, _reduce_action_stats
+    def test_a_centred_mapping_reports_applied_control_rms(self):
+        """The physical AC field comes from controls, even in the easy symmetric case."""
+        from environments.shared.scripts.stance_gate_report import (
+            _accumulate_action,
+            _new_action_stats,
+            _reduce_action_stats,
+        )
 
         stats = _new_action_stats()
-        stats["sum"] = np.zeros(1)
-        stats["sq_sum"] = np.full(1, 0.25)  # mean 0, var 0.25 -> ac_rms 0.5
-        stats["count"] = 1
+        half_span = 0.5 * (self._TOE["ctrl_max"] - self._TOE["action_zero_ctrl"])
+        for action, control in (
+            (-0.5, self._TOE["action_zero_ctrl"] - half_span),
+            (0.5, self._TOE["action_zero_ctrl"] + half_span),
+        ):
+            _accumulate_action(stats, np.asarray([action]), np.asarray([control]))
         action = _reduce_action_stats(stats, ["r_toe_d2_joint"], 0.01, [self._TOE])
         assert action["per_actuator"][0]["ac_rms"] == pytest.approx(0.5)
         # 0.5 x half of 75deg = 18.75deg
         assert action["per_actuator"][0]["ac_rms_deg"] == pytest.approx(18.75, abs=0.05)
 
-    def test_an_offset_ctrlrange_is_flagged_because_action_zero_is_not_home(self):
-        """`home-keyframe-residual/v1` asserts action 0 IS home; for some it is not.
+    def test_asymmetric_mapping_uses_actual_control_moments(self):
+        """E[f(a)] and rms(f(a)) cannot be recovered by scaling action moments."""
+        from environments.shared.scripts.stance_gate_report import (
+            _accumulate_action,
+            _new_action_stats,
+            _reduce_action_stats,
+        )
 
-        On the T-Rex the ankles sit 5.5deg off and head/neck pitch 5.0deg off.
-        Small, but the phrasing is load-bearing -- statue-derived constants and
-        the DC interpretation both rest on it.
-        """
-        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+        mapping = {
+            "ctrl_min": -1.0,
+            "ctrl_max": 3.0,
+            "action_negative_ctrl": -1.0,
+            "action_zero_ctrl": 0.0,
+            "action_positive_ctrl": 3.0,
+            "home_ctrl": 0.0,
+            "home_qpos": 0.0,
+        }
+        stats = _new_action_stats()
+        for action, control in ((-0.5, -0.5), (0.25, 0.75)):
+            _accumulate_action(stats, np.asarray([action]), np.asarray([control]))
 
-        ankle = {"ctrl_min": 0.5655, "ctrl_max": 2.3108, "home": 1.3422}
+        entry = _reduce_action_stats(stats, ["joint"], 0.01, [mapping])["per_actuator"][0]
+        assert entry["dc"] == pytest.approx(-0.125)
+        assert entry["ac_rms"] == pytest.approx(0.375)
+        assert entry["dc_deg"] == pytest.approx(math.degrees(0.125))
+        assert entry["ac_rms_deg"] == pytest.approx(math.degrees(0.625))
+
+    def test_missing_applied_controls_does_not_guess_physical_moments(self):
+        from environments.shared.scripts.stance_gate_report import _new_action_stats, _reduce_action_stats
+
+        stats = _new_action_stats()
+        stats["sum"] = np.asarray([0.25])
+        stats["sq_sum"] = np.asarray([0.25])
+        stats["count"] = 1
+        entry = _reduce_action_stats(stats, ["joint"], 0.01, [self._TOE])["per_actuator"][0]
+        assert "dc_deg" not in entry
+        assert "ac_rms_deg" not in entry
+        assert entry["action_zero_ctrl"] == pytest.approx(self._TOE["action_zero_ctrl"])
+
+    def test_trex_mapping_uses_home_control_and_keeps_preload_separate(self):
+        """Action zero is home control; ankle control-vs-pose preload is intentional."""
+        from environments.shared.scripts.stance_gate_report import (
+            _actuator_joint_names,
+            _actuator_pose_mapping,
+            render_stance_gate_report,
+        )
+        from environments.trex.envs.trex_env import TRexEnv
+
+        env = TRexEnv()
+        try:
+            mapping = _actuator_pose_mapping(env)
+            names = _actuator_joint_names(env)
+        finally:
+            env.close()
+
         report = _minimal_stance_report()
-        report["action"] = self._stats([0.0], [ankle], names=["r_ankle"])
-        assert report["action"]["per_actuator"][0]["zero_offset_deg"] == pytest.approx(5.5, abs=0.1)
+        report["action"] = self._stats(np.zeros(len(mapping)), mapping, names=names)
+        by_joint = {entry["joint"]: entry for entry in report["action"]["per_actuator"]}
+        assert all(entry["zero_offset_deg"] == pytest.approx(0.0, abs=1e-9) for entry in by_joint.values())
+        assert by_joint["r_ankle"]["home_preload_deg"] == pytest.approx(5.5, abs=0.1)
+        assert by_joint["l_ankle"]["home_preload_deg"] == pytest.approx(5.5, abs=0.1)
+        assert by_joint["r_ankle"]["action_zero_ctrl"] == pytest.approx(by_joint["r_ankle"]["home_ctrl"])
+        assert by_joint["r_ankle"]["home_ctrl"] != pytest.approx(by_joint["r_ankle"]["home_qpos"])
+        assert by_joint["neck_pitch"]["home_preload_deg"] == pytest.approx(0.0, abs=0.01)
+        assert by_joint["head_pitch"]["home_preload_deg"] == pytest.approx(0.0, abs=0.01)
+
         text = render_stance_gate_report(report)
-        assert "action = 0 is not exactly home" in text
-        assert "r_ankle" in text
+        assert "differs from the named home control" not in text
+        assert "Nominal control preload" in text
+        assert "this is not policy displacement" in text
 
-    def test_a_home_centred_range_is_not_flagged(self):
-        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+    def test_trex_asymmetric_piecewise_mapping_matches_the_environment(self):
+        from environments.shared.scripts.stance_gate_report import (
+            _actuator_joint_names,
+            _actuator_pose_mapping,
+            _commanded_angle,
+        )
+        from environments.trex.envs.trex_env import TRexEnv
 
-        report = _minimal_stance_report()
-        report["action"] = self._stats([0.5], [self._TAIL], names=["tail_1_pitch"])
-        assert report["action"]["per_actuator"][0]["zero_offset_deg"] == pytest.approx(0.0, abs=1e-9)
-        assert "action = 0 is not exactly home" not in render_stance_gate_report(report)
+        env = TRexEnv()
+        try:
+            by_joint = dict(zip(_actuator_joint_names(env), _actuator_pose_mapping(env)))
+            neck = by_joint["neck_pitch"]
+            for action, expected_deg in ((-1.0, -30.0), (-0.5, -15.0), (0.0, 0.0), (0.5, 20.0), (1.0, 40.0)):
+                assert math.degrees(_commanded_angle(neck, action)) == pytest.approx(expected_deg, abs=0.01)
+        finally:
+            env.close()
+
+    def test_trex_cross_zero_controls_are_reduced_after_scaling(self):
+        from environments.shared.scripts.stance_gate_report import (
+            _accumulate_action,
+            _actuator_joint_names,
+            _actuator_pose_mapping,
+            _new_action_stats,
+            _reduce_action_stats,
+        )
+        from environments.trex.envs.trex_env import TRexEnv
+
+        env = TRexEnv()
+        try:
+            names = _actuator_joint_names(env)
+            mapping = _actuator_pose_mapping(env)
+            stats = _new_action_stats()
+            for value in (-0.5, 0.5):
+                action = np.full(env.action_space.shape, value, dtype=np.float64)
+                _accumulate_action(stats, action, env._scale_action(action))
+            by_joint = {
+                entry["joint"]: entry for entry in _reduce_action_stats(stats, names, 0.01, mapping)["per_actuator"]
+            }
+        finally:
+            env.close()
+
+        assert by_joint["neck_pitch"]["dc"] == pytest.approx(0.0)
+        assert by_joint["neck_pitch"]["ac_rms"] == pytest.approx(0.5)
+        assert by_joint["neck_pitch"]["dc_deg"] == pytest.approx(2.5, abs=0.01)
+        assert by_joint["neck_pitch"]["ac_rms_deg"] == pytest.approx(17.5, abs=0.01)
+
+    def test_real_panel_records_the_controls_applied_by_trex(self):
+        from environments.shared.scripts.stance_gate_report import run_panel
+
+        result = run_panel(
+            "trex",
+            predict=lambda obs: np.zeros(21, dtype=np.float32),
+            episodes=1,
+            seed=3042,
+            settle_steps=0,
+            horizon=2,
+            env_kwargs={"max_episode_steps": 2},
+            control_dt=0.01,
+        )
+        by_joint = {entry["joint"]: entry for entry in result["action"]["per_actuator"]}
+        assert by_joint["neck_pitch"]["dc_deg"] == pytest.approx(0.0, abs=1e-12)
+        assert by_joint["r_ankle"]["dc_deg"] == pytest.approx(0.0, abs=1e-12)
+        assert by_joint["r_ankle"]["home_preload_deg"] == pytest.approx(5.5, abs=0.1)
+
+    def test_motor_controls_are_not_mislabeled_as_degrees(self):
+        from environments.shared.scripts.stance_gate_report import run_panel
+
+        action = np.zeros(22, dtype=np.float32)
+        action[[6, 13]] = 1.0  # r/l claw motors, each with gear=50
+        result = run_panel(
+            "velociraptor",
+            predict=lambda obs: action,
+            episodes=1,
+            seed=3042,
+            settle_steps=0,
+            horizon=2,
+            env_kwargs={"max_episode_steps": 2},
+            control_dt=0.01,
+        )
+        by_joint = {entry["joint"]: entry for entry in result["action"]["per_actuator"]}
+        for joint in ("r_claw", "l_claw"):
+            entry = by_joint[joint]
+            assert entry["dc"] == pytest.approx(1.0)
+            assert entry["ctrl_mean"] == pytest.approx(1.0)
+            assert entry["ctrl_ac_rms"] == pytest.approx(0.0)
+            assert not entry["angular_position_ctrl"]
+            assert not {"dc_deg", "ac_rms_deg", "range_deg", "home_qpos", "home_preload_deg"} & entry.keys()
+
+        assert by_joint["r_hip_pitch"]["angular_position_ctrl"]
+        assert "dc_deg" in by_joint["r_hip_pitch"]
 
     def test_degrees_are_added_not_substituted(self):
         """`dc` still inverts through the action penalties; the degrees do not."""

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -2231,3 +2231,137 @@ class TestImpulseRecoveryReading:
         )
         text, _ = render_impulse_probe(policy, statue, probe_episodes=8)
         assert "ACTIVE CORRECTION EXISTS" not in text
+
+
+class TestAllProbesAreWiredIntoTrainingArtifacts:
+    """Every probe must run from `generate_stage_artifacts`, not only the CLI.
+
+    The notebook calls `generate_stage_artifacts` and nothing else, so a probe
+    reachable only from the command line produces nothing on a real run -- and
+    a diagnostic nobody runs is a diagnostic that does not exist.
+    """
+
+    @staticmethod
+    def _artifacts():
+        from environments.shared.reporting import stage_artifacts
+
+        return stage_artifacts
+
+    def test_the_gate_report_calls_every_probe(self):
+        """AST-checked over the real call site, not a mock, so it cannot drift."""
+        import ast
+        import inspect
+
+        source = inspect.getsource(self._artifacts()._write_stance_gate_report)
+        called = {
+            node.func.id
+            for node in ast.walk(ast.parse(source.lstrip()))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        for probe in (
+            "_write_filtered_action_probe",
+            "_write_constant_hold_probe",
+            "_write_constant_hold_ablation",
+            "_write_impulse_probe",
+        ):
+            assert probe in called, f"{probe} is never called from _write_stance_gate_report"
+
+    def test_every_probe_config_key_is_reachable_from_a_toml(self):
+        """Unregistered keys are rejected fail-closed, making them unsettable."""
+        from environments.shared.curriculum.gate_schema import _DIAGNOSTIC_KEYS
+
+        for key in (
+            "stance_probe_filter_hz",
+            "stance_probe_hold_constant",
+            "stance_probe_release_ablation",
+            "stance_probe_impulse_speeds",
+        ):
+            assert key in _DIAGNOSTIC_KEYS
+
+    def test_trex_stage_1_switches_all_four_on(self):
+        """The species this was built for must actually produce the artifacts."""
+        from environments.shared.config import load_stage_config
+
+        curriculum = load_stage_config("trex", 1)["curriculum_kwargs"]
+        assert curriculum.get("stance_probe_filter_hz")
+        assert curriculum.get("stance_probe_hold_constant") is True
+        assert curriculum.get("stance_probe_release_ablation") is True
+        assert curriculum.get("stance_probe_impulse_speeds")
+
+    def test_the_ablation_is_skipped_when_unconfigured(self, tmp_path, monkeypatch):
+        called = False
+
+        def _boom(*a, **k):
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(stance_gate_report, "build_stance_gate_report", _boom)
+        self._artifacts()._write_constant_hold_ablation(
+            species="trex",
+            stage=1,
+            stage_config={"curriculum_kwargs": {}},
+            stage_dir=tmp_path,
+            model_path="m.zip",
+            vecnorm_path="v.pkl",
+            measured=_minimal_stance_report(),
+        )
+        assert not called
+
+    def test_the_impulse_probe_is_skipped_when_unconfigured(self, tmp_path, monkeypatch):
+        called = False
+
+        def _boom(*a, **k):
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(stance_gate_report, "build_stance_gate_report", _boom)
+        self._artifacts()._write_impulse_probe(
+            species="trex",
+            stage=1,
+            stage_config={"curriculum_kwargs": {}},
+            stage_dir=tmp_path,
+            model_path="m.zip",
+            vecnorm_path="v.pkl",
+            settle_steps=200,
+        )
+        assert not called
+
+    def test_unusable_impulse_speeds_are_dropped_not_fatal(self, tmp_path, monkeypatch):
+        called = False
+
+        def _boom(*a, **k):
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(stance_gate_report, "build_stance_gate_report", _boom)
+        self._artifacts()._write_impulse_probe(
+            species="trex",
+            stage=1,
+            stage_config={"curriculum_kwargs": {"stance_probe_impulse_speeds": ["x", -1.0, 0.0]}},
+            stage_dir=tmp_path,
+            model_path="m.zip",
+            vecnorm_path="v.pkl",
+            settle_steps=200,
+        )
+        assert not called, "no usable speed means no sweep, not a crash"
+
+    def test_a_failing_probe_does_not_sink_the_gate_report(self, tmp_path):
+        """The gate report is what certifies the stage; a probe must never cost it."""
+        for name, kwargs in (
+            ("_write_constant_hold_ablation", {"measured": _minimal_stance_report()}),
+            ("_write_impulse_probe", {"settle_steps": 200}),
+        ):
+            getattr(self._artifacts(), name)(
+                species="trex",
+                stage=1,
+                stage_config={
+                    "curriculum_kwargs": {
+                        "stance_probe_release_ablation": True,
+                        "stance_probe_impulse_speeds": [1.0],
+                    }
+                },
+                stage_dir=tmp_path,
+                model_path="does-not-exist.zip",
+                vecnorm_path=None,
+                **kwargs,
+            )

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -1994,3 +1994,240 @@ class TestDeflectionInDegrees:
         report = _minimal_stance_report()
         report["action"] = self._stats([0.4, -0.7], [self._TAIL, self._TOE])
         assert constant_hold_actions(report) == pytest.approx((0.4, -0.7))
+
+
+def _impulse_report(speed, axis, *, length, full, reward=3000.0, step=200):
+    report = _minimal_stance_report()
+    report["episodes"] = 8
+    report["impulse"] = {
+        "kind": "root_impulse/v1",
+        "step": step,
+        "delta_v": [0.0, speed if axis.endswith("+y") else -speed, 0.0],
+        "speed": speed,
+        "axis_label": axis,
+    }
+    report["metrics"] = dict(
+        report["metrics"], episode_length_mean=length, full_horizon_fraction=full, reward_mean=reward
+    )
+    report["terminations"] = {"truncated": 8} if full >= 1.0 else {"fallen": 8}
+    return report
+
+
+class TestRootImpulse:
+    def test_the_impulse_translates_the_whole_animal(self):
+        """qvel[0:3] is the free joint's world velocity; children compose from it."""
+        from environments.shared.scripts.stance_gate_report import RootImpulse, _apply_root_impulse
+
+        class _Data:
+            qvel = np.zeros(10)
+
+        class _Model:
+            body_mass = np.array([1000.0, 500.0, 500.0])
+
+        class _Env:
+            unwrapped = type("U", (), {"data": _Data(), "model": _Model()})()
+
+        env = _Env()
+        momentum = _apply_root_impulse(env, RootImpulse(step=200, delta_v=(0.0, 1.5, 0.0)))
+        assert env.unwrapped.data.qvel[:3] == pytest.approx([0.0, 1.5, 0.0])
+        # Joint velocities are untouched: this is a shove, not a pose change.
+        assert env.unwrapped.data.qvel[3:] == pytest.approx(np.zeros(7))
+        assert momentum == pytest.approx(2000.0 * 1.5)
+
+    def test_it_adds_rather_than_overwriting(self):
+        """The animal is already moving; overwriting would erase its own state."""
+        from environments.shared.scripts.stance_gate_report import RootImpulse, _apply_root_impulse
+
+        class _Env:
+            unwrapped = type(
+                "U",
+                (),
+                {
+                    "data": type("D", (), {"qvel": np.array([0.1, -0.2, 0.3, 0.0])})(),
+                    "model": type("M", (), {"body_mass": np.array([1.0])})(),
+                },
+            )()
+
+        env = _Env()
+        _apply_root_impulse(env, RootImpulse(step=0, delta_v=(0.0, 1.0, 0.0)))
+        assert env.unwrapped.data.qvel[:3] == pytest.approx([0.1, 0.8, 0.3])
+
+    def test_the_speed_is_the_vector_magnitude(self):
+        from environments.shared.scripts.stance_gate_report import RootImpulse
+
+        assert RootImpulse(step=0, delta_v=(3.0, 4.0, 0.0)).speed == pytest.approx(5.0)
+
+    def test_both_directions_are_swept(self):
+        """The policy is asymmetric, so a one-sided sweep measures one side."""
+        from environments.shared.scripts.stance_gate_report import impulse_variants
+
+        labels = [v.axis_label for v in impulse_variants([1.0], step=200)]
+        assert labels.count("lateral +y") == 1
+        assert labels.count("lateral -y") == 1
+        assert "none (control)" in labels
+
+    def test_the_zero_control_is_always_present(self):
+        from environments.shared.scripts.stance_gate_report import impulse_variants
+
+        control = impulse_variants([2.0], step=200)[0]
+        assert control.speed == 0.0
+
+    def test_nonpositive_speeds_are_dropped_not_mirrored(self):
+        from environments.shared.scripts.stance_gate_report import impulse_variants
+
+        speeds = {v.speed for v in impulse_variants([1.0, 0.0, -1.0], step=200)}
+        assert speeds == {0.0, 1.0}
+
+
+class TestImpulseProbeIsNotAVerdict:
+    def test_it_writes_its_own_filenames(self, tmp_path):
+        report = _impulse_report(1.0, "lateral +y", length=400.0, full=0.0)
+        written = write_stance_gate_report(tmp_path, report)
+        assert (tmp_path / "stance_gate_probe_impulse.txt").exists()
+        assert not (tmp_path / "stance_gate_report.txt").exists()
+        assert "stance_panel_csv" not in written
+
+    def test_the_banner_says_the_TASK_was_modified_not_the_policy(self):
+        """Opposite direction from the other two probes, same consequence."""
+        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+
+        text = render_stance_gate_report(_impulse_report(1.0, "lateral +y", length=400.0, full=0.0))
+        assert "MODIFIED TASK" in text
+        assert "stage 1 has no disturbance" in text
+        assert text.index("PROBE") < text.index("GATE:")
+
+    def test_all_three_probes_have_distinct_stems(self):
+        from environments.shared.scripts.stance_gate_report import _PROBE_MARKERS
+
+        assert len(set(_PROBE_MARKERS.values())) == len(_PROBE_MARKERS) == 3
+
+
+class TestImpulseRecoveryReading:
+    @staticmethod
+    def _sweep(policy_lengths, statue_lengths):
+        """Build matched policy/statue sweeps from (length, full) pairs per row."""
+        keys = [(0.0, "none (control)"), (1.0, "lateral +y"), (1.0, "lateral -y")]
+        policy = [
+            _impulse_report(speed, axis, length=length, full=full)
+            for (speed, axis), (length, full) in zip(keys, policy_lengths)
+        ]
+        statue = [
+            _impulse_report(speed, axis, length=length, full=full)
+            for (speed, axis), (length, full) in zip(keys, statue_lengths)
+        ]
+        return policy, statue
+
+    def test_a_large_positive_margin_reads_as_active_correction(self):
+        from environments.shared.scripts.stance_gate_report import render_impulse_probe
+
+        policy, statue = self._sweep(
+            [(1000.0, 1.0), (1000.0, 1.0), (1000.0, 1.0)],
+            [(1000.0, 1.0), (300.0, 0.0), (280.0, 0.0)],
+        )
+        text, payload = render_impulse_probe(policy, statue, probe_episodes=8)
+        assert "ACTIVE CORRECTION EXISTS" in text
+        assert "metric gap" in text
+        assert payload["rows"][1]["margin_steps"] == pytest.approx(700.0)
+        # Keyed off full recovery, not off a step margin.
+        assert payload["recovery_envelopes"]["lateral +y"]["policy"] == pytest.approx(1.0)
+        assert payload["recovery_envelopes"]["lateral +y"]["statue"] == 0.0
+
+    def test_no_margin_reads_as_the_task_gap(self):
+        from environments.shared.scripts.stance_gate_report import render_impulse_probe
+
+        policy, statue = self._sweep(
+            [(1000.0, 1.0), (310.0, 0.0), (295.0, 0.0)],
+            [(1000.0, 1.0), (300.0, 0.0), (290.0, 0.0)],
+        )
+        text, _ = render_impulse_probe(policy, statue, probe_episodes=8)
+        assert "Nothing has learned to recover" in text
+        assert "STAGE1_SPLIT_PLAN" in text
+        assert "No reweighting fixes this" in text
+
+    def test_a_negative_margin_is_reported_as_such(self):
+        """Worse than standing still is a finding, not a rounding of 'no effect'."""
+        from environments.shared.scripts.stance_gate_report import render_impulse_probe
+
+        policy, statue = self._sweep(
+            [(1000.0, 1.0), (120.0, 0.0), (110.0, 0.0)],
+            [(1000.0, 1.0), (400.0, 0.0), (390.0, 0.0)],
+        )
+        text, _ = render_impulse_probe(policy, statue, probe_episodes=8)
+        assert "WORSE" in text
+
+    def test_the_zero_impulse_control_is_excluded_from_the_margin(self):
+        """Both sides reach the horizon there, so including it dilutes the signal."""
+        from environments.shared.scripts.stance_gate_report import render_impulse_probe
+
+        policy, statue = self._sweep(
+            [(1000.0, 1.0), (1000.0, 1.0), (1000.0, 1.0)],
+            [(1000.0, 1.0), (300.0, 0.0), (300.0, 0.0)],
+        )
+        _, payload = render_impulse_probe(policy, statue, probe_episodes=8)
+        disturbed = [row for row in payload["rows"] if row["speed"] > 0]
+        assert len(disturbed) == 2
+        assert all(row["margin_steps"] == pytest.approx(700.0) for row in disturbed)
+
+    def test_it_writes_no_certification_evidence(self, tmp_path):
+        from environments.shared.scripts.stance_gate_report import write_impulse_probe
+
+        policy, statue = self._sweep(
+            [(1000.0, 1.0), (900.0, 0.5), (880.0, 0.5)],
+            [(1000.0, 1.0), (300.0, 0.0), (290.0, 0.0)],
+        )
+        written = write_impulse_probe(tmp_path, policy, statue, probe_episodes=8)
+        assert set(written) == {"impulse_probe_txt", "impulse_probe_json"}
+        assert not (tmp_path / "stance_panel_selected.csv").exists()
+        assert not (tmp_path / "stance_gate_report.txt").exists()
+
+    def test_an_asymmetric_envelope_is_named_and_the_weak_side_governs(self):
+        """Measured on the T-Rex: full recovery at 0.5 m/s one way, none the other.
+
+        Pooled over directions that averages to a healthy-looking +135 steps
+        and describes neither row. The envelope has to be reported per side.
+        """
+        from environments.shared.scripts.stance_gate_report import render_impulse_probe
+
+        policy, statue = self._sweep(
+            [(1000.0, 1.0), (424.0, 0.0), (1000.0, 1.0)],
+            [(1000.0, 1.0), (337.0, 0.0), (337.0, 0.0)],
+        )
+        text, payload = render_impulse_probe(policy, statue, probe_episodes=8)
+        assert "ASYMMETRIC" in text
+        assert "WEAKER side" in text
+        envelopes = payload["recovery_envelopes"]
+        assert envelopes["lateral +y"]["policy"] == 0.0
+        assert envelopes["lateral -y"]["policy"] == pytest.approx(1.0)
+
+    def test_the_pooled_margin_is_reported_second_with_its_caveat(self):
+        from environments.shared.scripts.stance_gate_report import render_impulse_probe
+
+        policy, statue = self._sweep(
+            [(1000.0, 1.0), (424.0, 0.0), (1000.0, 1.0)],
+            [(1000.0, 1.0), (337.0, 0.0), (337.0, 0.0)],
+        )
+        text, _ = render_impulse_probe(policy, statue, probe_episodes=8)
+        assert "reported second" in text
+        assert text.index("recovery envelope") < text.index("Mean step margin")
+
+    def test_a_symmetric_full_recovery_is_not_flagged_asymmetric(self):
+        from environments.shared.scripts.stance_gate_report import render_impulse_probe
+
+        policy, statue = self._sweep(
+            [(1000.0, 1.0), (1000.0, 1.0), (1000.0, 1.0)],
+            [(1000.0, 1.0), (300.0, 0.0), (300.0, 0.0)],
+        )
+        text, _ = render_impulse_probe(policy, statue, probe_episodes=8)
+        assert "ACTIVE CORRECTION EXISTS" in text
+        assert "ASYMMETRIC" not in text
+
+    def test_a_statue_that_recovers_too_does_not_count_as_active_control(self):
+        """Passive robustness is not correction; only the margin over it is."""
+        from environments.shared.scripts.stance_gate_report import render_impulse_probe
+
+        policy, statue = self._sweep(
+            [(1000.0, 1.0), (1000.0, 1.0), (1000.0, 1.0)],
+            [(1000.0, 1.0), (1000.0, 1.0), (1000.0, 1.0)],
+        )
+        text, _ = render_impulse_probe(policy, statue, probe_episodes=8)
+        assert "ACTIVE CORRECTION EXISTS" not in text

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -2247,24 +2247,125 @@ class TestAllProbesAreWiredIntoTrainingArtifacts:
 
         return stage_artifacts
 
-    def test_the_gate_report_calls_every_probe(self):
-        """AST-checked over the real call site, not a mock, so it cannot drift."""
-        import ast
-        import inspect
+    @staticmethod
+    def _probe_models_dir(tmp_path):
+        models = tmp_path / "models"
+        models.mkdir()
+        (models / "robust_best_model.zip").write_bytes(b"x")
+        (models / "robust_best_model_vecnorm.pkl").write_bytes(b"stats")
+        return models
 
-        source = inspect.getsource(self._artifacts()._write_stance_gate_report)
-        called = {
-            node.func.id
-            for node in ast.walk(ast.parse(source.lstrip()))
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    @staticmethod
+    def _probe_stage_config() -> dict:
+        return {
+            "curriculum_kwargs": {"gate_kind": "stance_quality/v1", "min_eval_episodes": 40},
+            "env_kwargs": {"max_episode_steps": 1000},
         }
-        for probe in (
+
+    def _record_probes(self, monkeypatch) -> list:
+        """Replace the four probe helpers with recorders; return the record."""
+        calls: list = []
+        for name in (
             "_write_filtered_action_probe",
             "_write_constant_hold_probe",
             "_write_constant_hold_ablation",
             "_write_impulse_probe",
         ):
-            assert probe in called, f"{probe} is never called from _write_stance_gate_report"
+            monkeypatch.setattr(
+                self._artifacts(),
+                name,
+                lambda _name=name, **kwargs: calls.append((_name, kwargs)),
+            )
+        return calls
+
+    def test_the_probe_runner_calls_every_probe(self, tmp_path, monkeypatch):
+        """A behaviour test through the real call sites, so kwarg drift fails it."""
+        calls = self._record_probes(monkeypatch)
+        report = _minimal_stance_report()
+
+        self._artifacts()._run_stance_probes(
+            species="trex",
+            stage=1,
+            stage_config=self._probe_stage_config(),
+            stage_dir=tmp_path,
+            model_dir=self._probe_models_dir(tmp_path),
+            report=report,
+        )
+
+        assert [name for name, _ in calls] == [
+            "_write_filtered_action_probe",
+            "_write_constant_hold_probe",
+            "_write_constant_hold_ablation",
+            "_write_impulse_probe",
+        ]
+        by_name = dict(calls)
+        # The load-bearing arguments: the probes must annotate THIS report and
+        # score THIS checkpoint, at the panel size the report was rolled at.
+        assert by_name["_write_constant_hold_probe"]["measured"] is report
+        assert by_name["_write_constant_hold_ablation"]["measured"] is report
+        assert by_name["_write_impulse_probe"]["settle_steps"] == 200
+        assert by_name["_write_filtered_action_probe"]["episodes"] == 40
+        for name, kwargs in calls:
+            assert kwargs["model_path"].endswith("robust_best_model.zip"), name
+            assert kwargs["vecnorm_path"].endswith("robust_best_model_vecnorm.pkl"), name
+
+    def test_the_probe_runner_skips_without_a_measured_report(self, tmp_path, monkeypatch):
+        """No panel means nothing to probe -- and no checkpoint loads at all."""
+        calls = self._record_probes(monkeypatch)
+
+        self._artifacts()._run_stance_probes(
+            species="trex",
+            stage=1,
+            stage_config=self._probe_stage_config(),
+            stage_dir=tmp_path,
+            model_dir=tmp_path / "models",
+            report=None,
+        )
+
+        assert calls == []
+
+    def test_a_probe_wiring_failure_costs_that_probe_alone(self, tmp_path, monkeypatch, caplog):
+        """Caller-side failures too: the helpers' internal handlers cannot see a
+        TypeError raised at their own call site, which is exactly how a signature
+        drift presents. The runner's per-probe handler must contain it."""
+        calls = self._record_probes(monkeypatch)
+
+        def _drifted_signature(**kwargs):
+            raise TypeError("unexpected keyword argument")
+
+        monkeypatch.setattr(self._artifacts(), "_write_constant_hold_probe", _drifted_signature)
+
+        with caplog.at_level("WARNING"):
+            self._artifacts()._run_stance_probes(
+                species="trex",
+                stage=1,
+                stage_config=self._probe_stage_config(),
+                stage_dir=tmp_path,
+                model_dir=self._probe_models_dir(tmp_path),
+                report=_minimal_stance_report(),
+            )
+
+        assert [name for name, _ in calls] == [
+            "_write_filtered_action_probe",
+            "_write_constant_hold_ablation",
+            "_write_impulse_probe",
+        ]
+        assert "Stance probe (constant hold) failed" in caplog.text
+
+    def test_the_verdict_is_recorded_before_any_probe_runs(self):
+        """Probes are pure diagnostics and run dead last: the recorded verdict,
+        the summary, and the replays must never sit behind ~300 probe episodes,
+        and a probe failure must have nothing left to sink."""
+        import inspect
+
+        source = inspect.getsource(self._artifacts().generate_stage_artifacts)
+        for call in ("_write_stance_gate_report(", "_apply_stage_gate(", "_run_stance_probes("):
+            assert call in source, f"generate_stage_artifacts no longer calls {call.rstrip('(')}"
+        assert (
+            source.index("_apply_stage_gate(")
+            < source.index("write_stage_summary(")
+            < source.index("_run_stance_probes(")
+        ), "probes must run after the verdict is recorded and the summary written"
 
     def test_every_probe_config_key_is_reachable_from_a_toml(self):
         """Unregistered keys are rejected fail-closed, making them unsettable."""


### PR DESCRIPTION
Four new probes, two measurement defects fixed, a plant audit, and the seed-43 replicate that answers §8's open question. Everything except the run outcomes was measured on saved checkpoints; no training runs were consumed by this PR.

Full record: **[`TREX_STAGE1_BOUNCE_2026_08.md`](docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md)** Addenda 1–6.

---

## Headline: stage 1 is a coin flip

| run | weight | seed | result |
|---|---|---|---|
| `20260804_143747` | 0.5 | 42 | FAIL — 1/6, pre-#487 |
| `20260805_011234` | 0.5 | 42 | **PASS** |
| `20260805_132950` | 1.5 | 42 | FAIL — 1/5 |
| `20260805_221141` | 0.5 | 42 | **PASS** (bitwise replay of `011234`) |
| `20260806_133233` | 0.5 | **43** | **FAIL — 1/5** |

Seed 43 is genuinely independent — **0 of 158 evaluations match seed 42 bitwise** — and it locked at exactly 1/5. Last ten evaluations: duty mean **0.2000**, std **0.00000**. Last twenty: **20/20** within 0.0015 of one fifth, single support **0.0002** against the rule's 0.005 ceiling, bilateral pinned at **0.8000**.

**§8's question — reliable or lucky — has its answer: one pass, one bounce across independent seeds.** #487 helped; it did not make stage 1 reliable.

---

## What the probes established

| probe | question | answer |
|---|---|---|
| `--filter-actions` *(existing)* | is the high-frequency content load-bearing? | yes, at every cutoff 5–35 Hz |
| **`--hold-constant`** | does the pose need *feedback*, or only bandwidth? | **feedback** — every held variant falls |
| **`--hold-release-ablation`** | which joints? | **toes**, sufficient alone; tail and head/neck inert |
| **`--impulse-probe`** | does it actually correct? | **barely** — 0.50 m/s one way, **0.00** the other |

### The pose needs feedback, not just bandwidth

Freezing the action to the constant the policy averages collapses it from every handoff point — 348.9 steps from settle, 330.2 ramped, 133.3 from reset — while both controls reach the horizon (policy 3006.9, statue 3271.0). The ramped variant falling rules out a handoff transient.

The statue holds the *home* pose on a constant forever; the policy stands 0.765 rms away from it and that pose cannot be held. **The tremor is the price of where the policy chose to stand, so raising `smoothness`/`action_jerk` is contraindicated** — it would suppress the only thing holding the animal up.

### It's the toes; the tail is a bystander

| variant | ep length | full-horizon | reward |
|---|---|---|---|
| `hold_all` | 128.6 | 0.0000 | 268.8 |
| **`only_toes`** | **125.5** | 0.0000 | 289.2 |
| **`only_tail`** | **1000.0** | **1.0000** | **3254.0** |
| `only_head_neck` | 1000.0 | 1.0000 | 3286.1 |
| `release_saturated` | 224.6 | 0.0000 | 460.1 |
| `hold_zero` (statue) | 1000.0 | 1.0000 | 3274.4 |

Six of 21 actuators reproduce the whole failure (`tail_contact` 8/8 in both rows). Four tail joints at `±1.000` stand the full horizon within 0.6% of the statue. **This refutes the saturation hypothesis** recorded the same day. No group is *necessary*, so the pose is over-determined.

### The toe splay reproduces across seeds — and is the only thing that does

| joint | seed 42 | seed 43 | 42° | 43° | |
|---|---|---|---|---|---|
| `r_toe_d2` | +1.000 | −0.998 | +37.5 | −37.4 | both pinned |
| `r_toe_d3` | −1.000 | +0.999 | −37.5 | +37.5 | both pinned |
| `r_toe_d4` | +1.000 | +0.999 | +37.5 | +37.5 | **both, same sign** |
| `l_toe_d3` | +1.000 | +0.998 | +37.5 | +37.4 | **both, same sign** |
| `l_toe_d4` | −1.000 | −0.994 | −37.5 | −37.3 | **both, same sign** |
| `tail_1_pitch` | +1.000 | −0.608 | +12.0 | −7.3 | 42 only |
| `r_hip_roll` | +1.000 | −0.540 | +25.0 | −13.5 | 42 only |
| `l_hip_roll` | −1.000 | +0.591 | −25.0 | +14.8 | 42 only |
| `neck_yaw` | −0.177 | +0.996 | −3.5 | +19.9 | 43 only |

Toe \|DC\| mean **0.865 → 0.998**; spread across one foot **75.0°** and **74.9°**, on both feet, in both seeds. The tail flips, the hips flip, the neck flips. **The toes are the one thing two independent seeds agree on.** It does *not* separate pass from fail — the passing policy splays too — so this is plant correctness, not the bounce's cause.

### Two measurement defects, both the same shape

**`|action| = 1` is not one physical event.** A saturated tail joint is **8–12°**; a saturated toe is **37.5°**. Sorted by normalised `|dc|` the table put twelve joints at `±1.000` on top with no way to tell them apart, and the most conspicuous was the inert one. **This is the DC/AC split's error one level down.** The table now reports and sorts by degrees.

**`action = 0` is not exactly the home keyframe** for 4 of 21 actuators — both ankles +5.5°, `head_pitch`/`neck_pitch` +5.0°. `home-keyframe-residual/v1` is *named* for that identity and both statue-derived constants lean on it.

### It corrects — barely, and only one way

| impulse | direction | policy len | policy fh | statue len | statue fh |
|---|---|---|---|---|---|
| none | control | 1000.0 | 1.0000 | 1000.0 | 1.0000 |
| **0.50 m/s** | **lateral −y** | **1000.0** | **1.0000** | 337.5 | 0.0000 |
| 0.50 m/s | lateral +y | 423.9 | 0.0000 | 337.1 | 0.0000 |
| 1.00 m/s | lateral +y | 264.2 | 0.0000 | 272.5 | 0.0000 |
| 2.00 m/s | lateral −y | 249.0 | 0.0000 | 240.2 | 0.0000 |

**Recovery envelope: 0.50 m/s one way, 0.00 the other.** Above 0.5 m/s it is within noise of a statue on both sides.

---

## Recommended next steps

**Addenda 5 and 6 supersede §9**, with a correction: the plan had drifted away from targeting **the bounce**. §4 showed it loses on every reward term — a statement about what *will not* fix it, which got treated as saying it needed no fixing. It does. A policy that stands by dithering at 22.6 Hz in a pose it cannot hold without feedback will not transfer to hardware, and standing is the sim-to-real foundation.

**1. Land the plant revision — first, not last.**

Addendum 5 put this last because seed 42 and 43 were free controls a bump would destroy. **That argument died with seed 43.** At one-in-two, `n = 2` is not a rate; every experiment worth running now needs **several seeds per arm**, and running those on a plant already known to be wrong wastes exactly the runs that matter.

- **Passive toes — delete the six toe actuators** (`action_dim` 21 → 15). Measured basis: at 3.33 m/s in stage 2 the toes carry AC **0.129** against the leg chain's **0.670**, four of six pinned; in stage 1 every saturated toe has AC exactly 0.000. **Toe actuation is authority no policy has ever used productively and every policy abuses.** `leg_joint` already supplies `stiffness = 40`, and the toes carry `damping = 15` / `springref = 12.5`, so an unactuated toe already springs home and complies under load.
  - *A tendon* (21 → 17) repeats the mistake in miniature and adds unanchored modelling decisions; add it later, with evidence, for the same revision cost.
  - *Equality constraints* are rejected — soft, violated under load, and they keep three redundant commandable entries per foot.
- **Re-centre the four off-home `ctrlrange`s.** Same bump.
- Then re-measure the statue and re-derive `min_avg_reward` and `collapse_peak_floor_reference`.

**2. Action filter in the training loop, multi-seed.** Still the candidate *fix* for the bounce — the plant work does not address it. The bounce is 16.7–20 Hz, the tremor 22.6 Hz, the task needs ~1.4 Hz. §5 proved a filter cannot be retrofitted and concluded "so it is not an option"; the correct conclusion is **"so it has to be present during training."** Curriculum the cutoff down from ~30 Hz.

**3. SAC as the discriminator, multi-seed.** `configs/trex/stage1_balance.toml` already has a `[sac]` block. Bounces too → task/plant property. Doesn't → PPO's exploration schedule is the culprit: policy std starts at 1.00 and only reaches **0.42** at 10M *with* `ent_coef` already zero, and `corr(policy std, saturated actuators) = −0.967`. (Note `buffer_size = 300_000` is commented "sufficient for 6M-step Stage 1"; stage 1 is now 10M.)

**4. Impulse as a training-time disturbance**, and the recovery envelope as 1b's acceptance metric. Baseline to beat: **0.00 m/s** on the weaker side.

**Still ruled out:** reweighting the reward (three independent reasons), and chasing the statue — it outscoring the policy is a defect in the reward, not a target, since a statue recovers from nothing.

**Cost, stated plainly:** the plant bump makes the seed-42 stage-1→2 chain historical. With the bounce at one-in-two that chain was luck rather than a reproducible foundation — a weaker asset than it looked before seed 43 landed.

---

## Wiring

All four probes now run from `generate_stage_artifacts`, which is what the notebook calls — **every future run produces them with no notebook change.** Each is gated by its own `[curriculum]` key and individually non-fatal.

| key | panels | episodes |
|---|---|---|
| `stance_probe_filter_hz` | 3 | 10 |
| `stance_probe_hold_constant` | 5 | 10 |
| `stance_probe_release_ablation` | 13 | 8 |
| `stance_probe_impulse_speeds` | 14 | 8 |

All on for trex stage 1; no other stage or species affected. Pinned by an **AST check over the real call site**, not a mock, so a fifth probe cannot go unwired the way two of these nearly did. Probe branding is a registry (`_PROBE_MARKERS`) — each gets its own filenames and none can write `stance_panel_selected.csv`.

## Testing

`environments/shared/tests` and `environments/trex` pass; ruff clean. ~70 new tests, including regression pins for two bugs my own controls caught mid-development:

- the ablation initially handed off at `settle_steps`, so a transient swamped it and the statue control **fell at 323 steps** when it must stand 1000 — both endpoints on the same side of the answer, which would have read as "no group matters";
- the impulse read-out initially pooled the step margin across directions and reported **+135**, of which 82% was one row — the *third* pooled statistic in this investigation to hide the structure it summarised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnEFdfBDkHAnVnxExdrzaG