### PR TITLE
Fix stance report action mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ankles' +5.5° `key_ctrl - key_qpos` is an intentional gravity preload, now
   reported separately instead of being mislabeled as policy displacement or a
   reason to re-centre the control range.
+  The same correction is now swept through the prose that taught the old
+  identity: docstrings in `eval_diagnostics.py` and the hold/ablation helpers,
+  the rendered ablation header, the CLI help, and the KNOWN_ISSUES saturation
+  entry all say "home control" where they said "home keyframe" for what
+  `action = 0` commands — the keyframe's *pose* keeps its name. The
+  constant-hold docstring also now states its one deliberate approximation:
+  the held command is `f(mean(action))`, not `mean(f(action))`, which differs
+  only on zero-crossing actuators with asymmetric spans (neck/head pitch on
+  this plant, bias ~0.01°).
 - **A release ablation on top of it**, `--hold-release-ablation`, which asks
   *which* joints make a held pose unholdable. Each actuator group gets two
   variants: `release_G` holds everything except G (is G **necessary** — does

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still printed, second, with its caveat attached.
 - **Per-actuator pose reported in degrees, and the table ordered by them.**
   `|action| = 1` is not one physical event: `_scale_action` maps `[-1, 1]` onto
-  each actuator's own `ctrlrange`, and on the T-Rex those differ by 6× — a
+  each actuator's own control span, and on the T-Rex those differ by 6× — a
   saturated tail joint is **8–12°** of deflection while a saturated toe is
   **37.5°**. Sorted by normalised `|dc|`, the per-actuator table put twelve
   joints at exactly `±1.000` at the top with no way to tell them apart, and the
@@ -129,18 +129,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This is the same error the DC/AC split was introduced to fix, one level down:
   a pooled *normalised* offset cannot separate moving 8° from moving 37.5° any
   more than a pooled standard deviation can separate "sitting in the wrong
-  place" from "shaking". The report now carries `dc_deg`, `ac_rms_deg`,
-  `range_deg` and `zero_offset_deg` per actuator plus `dc_rms_deg` overall, and
-  **orders the table by degrees** — which puts the five saturated toes on top at
-  ±37.5° and drops `tail_1_yaw` (±8°) out of the printed twelve. The normalised
-  `dc` is kept alongside, because that is what inverts through the action
-  penalties; the degrees are what say whether a joint moved.
-  It also surfaces that **`action = 0` is not exactly the home keyframe**: it is
-  the `ctrlrange` midpoint, and for four of 21 actuators the two differ — both
-  ankles by +5.5°, `head_pitch`/`neck_pitch` by +5.0°. Small enough that nothing
-  measured is invalidated, but `home-keyframe-residual/v1` is named for that
-  identity and both statue-derived constants lean on it, so the report now
-  prints the offset rather than leaving it to be rediscovered.
+  place" from "shaking". Report schema v2 now records applied `ctrl_mean` and
+  `ctrl_ac_rms` in native units, preserves the separate `action_zero_ctrl` and
+  `home_ctrl` anchors, and marks which actuators are direct angular position
+  controls. Only those receive `dc_deg`, `ac_rms_deg`, `range_deg`,
+  `zero_offset_deg`, `home_qpos`, and `home_preload_deg`; geared motors are not
+  mislabeled as radians. It adds `dc_rms_deg` across the compatible controls
+  and **orders the table by degrees** — which puts the five
+  saturated toes on top at ±37.5° and drops `tail_1_yaw` (±8°) out of the
+  printed twelve. The normalised `dc` is kept alongside, because that is what
+  inverts through the action penalties; the degree fields are reduced from the
+  controls actually applied during rollout.
+  This distinction matters for `home-keyframe-residual/v1`: T-Rex maps the two
+  halves piecewise around `key_ctrl[home]`, so neither the mean nor RMS physical
+  target can be reconstructed from normalised moments with one full-range
+  scale. Action zero maps exactly to the home control for all 21 actuators. The
+  ankles' +5.5° `key_ctrl - key_qpos` is an intentional gravity preload, now
+  reported separately instead of being mislabeled as policy displacement or a
+  reason to re-centre the control range.
 - **A release ablation on top of it**, `--hold-release-ablation`, which asks
   *which* joints make a held pose unholdable. Each actuator group gets two
   variants: `release_G` holds everything except G (is G **necessary** — does

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -124,16 +124,6 @@ tolerance) remains the standing recommendation for the divergences above.
   from home against a 75° range, and adjacent toes on the same foot are driven
   to opposite ends — the foot is splayed into a twist, asymmetrically between
   the two feet. The mechanism survives.
-- **LOW** — **`action = 0` is not exactly the home keyframe for 4 of 21
-  actuators.** It is the `ctrlrange` midpoint, which equals home only where the
-  range was authored centred on it: both ankles sit **+5.5°** off and
-  `head_pitch`/`neck_pitch` **+5.0°** off. Everything else is exact. Small
-  enough that the statue still reaches the horizon 40 of 40, so nothing measured
-  is invalidated — but "`action = 0` **is** the home keyframe" is the phrasing
-  `home-keyframe-residual/v1` is named for, and both statue-derived constants
-  and every DC interpretation rest on it. The stance report now prints the
-  offset. Fix by re-centring those four `ctrlrange`s, which bumps
-  `policy_interface_revision`.
 - **MEDIUM** — **stage 1 contains no in-episode disturbance, so it cannot ask
   for postural correction.** The only perturbation is joint-angle noise at
   reset (`reset_noise_scale 0.05`); nothing applies an external force during an

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -69,8 +69,9 @@ tolerance) remains the standing recommendation for the divergences above.
   Ten to twelve of 21 actuators are pinned at `|action| ≥ 0.99` — tail, neck,
   head, toes — in *both* passing and failing policies.
   **Read this count with care (2026-08-06):** `|action| = 1` is not one physical
-  event. Actions map linearly onto each actuator's own `ctrlrange`, and those
-  differ by 6× — a saturated tail joint is **8–12°** of deflection while a
+  event. Actions map piecewise-affine around each actuator's home control onto
+  its own `ctrlrange`, and those ranges differ by 6× — a saturated tail joint is
+  **8–12°** of deflection while a
   saturated toe is **37.5°**. The saturation count pools them, and the ablation
   showed the tail is mechanically inert while the toes carry the whole effect.
   The stance report now orders per-actuator DC by **degrees**; use that, not the

--- a/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
+++ b/docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md
@@ -494,8 +494,9 @@ the answer means the ablation should not have been necessary to find its result.
 
 ### `|action| = 1` is not one physical event
 
-`_scale_action` maps `[-1, 1]` linearly onto each actuator's own `ctrlrange`.
-Those ranges differ by a factor of six across the T-Rex:
+`_scale_action` maps `[-1, 1]` piecewise-affine around the home keyframe's
+control target, retaining each actuator's `ctrlrange` as its two endpoints.
+Those physical spans differ by a factor of six across the T-Rex:
 
 | group | `action = +1` | `action = −1` | deflection from home | ablation verdict |
 |---|---|---|---|---|
@@ -528,32 +529,35 @@ wrong place from shaking". A pooled *normalised* offset cannot separate moving
 8° from moving 37.5°, and the fix is the same shape: report the physical
 quantity next to the normalised one.
 
-`stance_gate_report.py` now emits `dc_deg`, `ac_rms_deg`, `range_deg` and
-`zero_offset_deg` per actuator, and **orders the table by degrees**. On the
-passing checkpoint that puts the five saturated toes at the top at ±37.5° and
-drops `tail_1_yaw` (±8°) out of the printed twelve entirely — the ablation's
-conclusion, readable directly off the report.
+`stance_gate_report.py` now emits `dc_deg`, `ac_rms_deg`, `range_deg`,
+`zero_offset_deg`, and `home_preload_deg` per actuator, and **orders the table
+by degrees**. The degree moments come from the physical controls actually
+applied during rollout, not from rescaling the normalised mean and variance.
+The shared reporter emits them only for verified angular position servos, so a
+geared motor control cannot be mislabeled or ranked as a joint angle.
+On the passing checkpoint that puts the five saturated toes at the top at
+±37.5° and drops `tail_1_yaw` (±8°) out of the printed twelve entirely — the
+ablation's conclusion, readable directly off the report.
 
 **Lesson: a normalised summary is only as good as the assumption that its units
 mean the same thing everywhere.** Twice now that assumption has been false, and
 both times it hid the answer rather than merely blurring it.
 
-### And `action = 0` is not exactly the home keyframe
+### Action origin, home control, and home pose are different quantities
 
-`action = 0` is the `ctrlrange` **midpoint**, which equals home only where the
-range was authored centred on it. For four of 21 actuators it is not:
+The first version of the degree report duplicated the base environment's
+midpoint formula and compared that target with `key_qpos`. T-Rex does neither:
+its override maps the negative and positive halves independently around
+`key_ctrl[home]`, so **`action = 0` maps exactly to the named home control for
+all 21 actuators**.
 
-| actuator | `action = 0` minus home |
-|---|---|
-| `r_ankle`, `l_ankle` | **+5.5°** |
-| `head_pitch`, `neck_pitch` | **+5.0°** |
-
-Everything else is exact to floating point. The magnitude is small and the
-statue still stands 40 of 40, so nothing measured here is invalidated. But
-"`action = 0` **is** the home keyframe" is the phrasing the residual mapping is
-named for, and both statue-derived constants and every DC interpretation in
-this document rest on it. It is inexact for those four, and the report now says
-so rather than leaving it to be rediscovered.
+The two ankle home controls are 5.5° above their home joint poses. That is the
+intentional gravity preload documented beside the XML actuator ranges, not an
+action-mapping defect; head and neck have no such offset. Report schema v2 now
+keeps `action_zero_ctrl`, `home_ctrl`, and `home_qpos` separate, records applied
+control moments per sample, and reports the ankle difference neutrally as
+`home_preload_deg`. There is no basis here for re-centring any control range or
+bumping the policy interface.
 
 ---
 
@@ -667,9 +671,11 @@ the probe work changes that.
 | `--hold-release-ablation` | which joints? | **toes**, sufficient alone; tail and head/neck inert |
 | `--impulse-probe` | does it actually correct? | **barely** — 0.50 m/s one way, 0.00 the other |
 
-Plus two measurement defects found on the way: `|action| = 1` means 8° on a tail
-joint and 37.5° on a toe (Addendum 3), and `action = 0` is not exactly home for
-four actuators.
+Plus one measurement defect found on the way: `|action| = 1` means 8° on a tail
+joint and 37.5° on a toe (Addendum 3). The follow-up action-mapping audit also
+fixed the reporter itself: T-Rex action zero already mapped exactly to the
+named home control, while the ankle's control-vs-pose difference is intentional
+preload.
 
 ### The changes that target the bounce and the tremor
 
@@ -724,17 +730,16 @@ the plant work below if it is done at all.
 
 ### The plant work
 
-**4. One `policy_interface_revision` bump carrying two fixes**, prepared now and
-merged after the in-flight lineage finishes:
+**4. Couple the toe digits in the next plant revision**, prepared now and
+merged after the in-flight lineage finishes.
 
-- **Couple the toe digits.** Three independent actuators per foot let the policy
-  command adjacent digits **75° apart**, which no theropod foot can do — the
-  digital flexors and transverse ligaments couple them. And because the model
-  lumps each digit into one rigid hinge instead of a four-phalanx chain,
-  commanding digit III to its limit lifts the primary weight-bearing toe
-  **~11.6 cm** off the floor rather than curling it.
-- **Re-centre the four off-home `ctrlrange`s** so `action = 0` is the home
-  keyframe the residual mapping is named for.
+Three independent actuators per foot let the policy command adjacent digits
+**75° apart**, which no theropod foot can do — the digital flexors and
+transverse ligaments couple them. And because the model lumps each digit into
+one rigid hinge instead of a four-phalanx chain, commanding digit III to its
+limit lifts the primary weight-bearing toe **~11.6 cm** off the floor rather
+than curling it. The action-mapping audit found no second plant change to batch
+with this: action zero already is the named home control.
 
 Stated honestly: **this does not fix the current policy's pose** — returning the
 toes to home still falls at 198.5 steps, because the pose is over-determined.
@@ -902,11 +907,13 @@ Bernoulli nobody can estimate from. Every experiment worth running now
 arm**, and running those on a plant already known to be wrong wastes precisely
 the runs that matter most.
 
-1. **Land the plant revision** — passive toes, plus re-centring the four
-   off-home `ctrlrange`s (both ankles +5.5°, `head_pitch`/`neck_pitch` +5.0°).
-   One `policy_interface_revision` bump. Re-measure the statue with
-   `zero_action_baseline.py` and re-derive `min_avg_reward` and
-   `collapse_peak_floor_reference`.
+1. **Land the plant revision** — passive toes. This changes both physics and
+   the action dimension, so bump the relevant plant/interface revisions.
+   Re-measure the statue with `zero_action_baseline.py` and re-derive
+   `min_avg_reward` and `collapse_peak_floor_reference`. Do not alter the four
+   ranges previously called "off-home": the action-mapping audit showed action
+   zero already reaches every named home control, and the ankle difference is
+   intentional preload.
 2. **Action filter in the training loop, multi-seed.** Still the candidate fix
    for the bounce; the plant work does not address it. Curriculum the cutoff
    down from ~30 Hz.

--- a/environments/shared/eval_diagnostics.py
+++ b/environments/shared/eval_diagnostics.py
@@ -105,8 +105,8 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         # Action statistics for the DETERMINISTIC policy, which is what the
         # gate scores. `diagnostics.npz` records actions from training
         # rollouts, so every number in it carries exploration noise; the
-        # quantities that matter here -- how far the commanded pose sits from
-        # the home keyframe, and how much the policy shakes about it -- are
+        # quantities that matter here -- how far the commanded target sits from
+        # the home control (action = 0), and how much the policy shakes about it -- are
         # properties of the mean action and are unrecoverable from a noisy
         # sample. Issue #489 had to invert them out of per-episode reward
         # totals under a narrowband assumption. These measure them.
@@ -280,8 +280,10 @@ class StageAwareEvalCallback(_EvalCallback):  # type: ignore[misc]
         """Reduce one evaluation's accumulators into the published series.
 
         The DC/AC split is the whole point. ``mean(a)`` per actuator is the
-        static pose the policy commands -- the distance from the home keyframe,
-        which under ``home-keyframe-residual/v1`` is exactly ``action = 0``.
+        static target the policy commands -- the distance from the home
+        control, which under ``home-keyframe-residual/v1`` is exactly
+        ``action = 0`` (the home keyframe's control targets, not necessarily
+        its joint pose: the trex ankles carry an authored preload).
         ``sqrt(mean(a^2) - mean(a)^2)`` is what it does *around* that pose. The
         two answer different questions and a pooled standard deviation over
         actuators and time (which is what ``diagnostics.action_std`` computes)
@@ -722,7 +724,7 @@ class StageGatePlateauCallback(_BaseCallback):  # type: ignore[misc]
     def _action_statistics(self, index: int) -> dict[str, float]:
         """Scalar summaries of the deterministic policy's action.
 
-        ``action_dc_rms`` is the distance from the home keyframe and
+        ``action_dc_rms`` is the distance from the home control (``action = 0``) and
         ``action_ac_rms`` is the tremor about it; keeping them apart is the
         point, because they have different causes and different fixes
         (issue #489). The per-actuator vectors go to `gate_progress.npz`

--- a/environments/shared/reporting/gates.py
+++ b/environments/shared/reporting/gates.py
@@ -236,7 +236,7 @@ def evaluate_stage_gate(
             checkpoint's metrics (``best_model_*``, falling back to
             ``best_eval_*`` and then the live-eval means).
         stage: Stage identifier, used only in failure messages.
-        stance_report: The ``mesozoic.stance-gate-report/v1`` dict produced for
+        stance_report: The ``mesozoic.stance-gate-report/v2`` dict produced for
             this stage, required by ``stance_quality/v1`` and ignored by every
             other kind.
 

--- a/environments/shared/reporting/stage_artifacts.py
+++ b/environments/shared/reporting/stage_artifacts.py
@@ -525,9 +525,7 @@ def _write_constant_hold_ablation(
         )
 
         hold = constant_hold_actions(measured)
-        for variant in constant_hold_release_variants(
-            hold, measured, horizon=int(measured["horizon"])
-        ):
+        for variant in constant_hold_release_variants(hold, measured, horizon=int(measured["horizon"])):
             probe = build_stance_gate_report(
                 species,
                 stage,
@@ -539,8 +537,7 @@ def _write_constant_hold_ablation(
             )
             entries.append(probe)
             logger.info(
-                "Release ablation %s: episode length %.1f, full-horizon %.4f. "
-                "MODIFIED policy -- not a gate verdict.",
+                "Release ablation %s: episode length %.1f, full-horizon %.4f. MODIFIED policy -- not a gate verdict.",
                 variant.label,
                 probe["metrics"]["episode_length_mean"],
                 probe["metrics"]["full_horizon_fraction"],
@@ -551,9 +548,7 @@ def _write_constant_hold_ablation(
         try:
             from environments.shared.scripts.stance_gate_report import write_constant_hold_ablation
 
-            written = write_constant_hold_ablation(
-                stage_dir, entries, probe_episodes=_ABLATION_EPISODES
-            )
+            written = write_constant_hold_ablation(stage_dir, entries, probe_episodes=_ABLATION_EPISODES)
             logger.info("Release ablation -> %s", written["constant_hold_ablation_txt"])
         except Exception:  # noqa: BLE001 - a diagnostic must not sink the run
             logger.warning("Could not write the release ablation", exc_info=True)
@@ -629,17 +624,14 @@ def _write_impulse_probe(
 
         policy_sweep = _sweep(zero_action=False)
         statue_sweep = _sweep(zero_action=True)
-        written = write_impulse_probe(
-            stage_dir, policy_sweep, statue_sweep, probe_episodes=_IMPULSE_EPISODES
-        )
+        written = write_impulse_probe(stage_dir, policy_sweep, statue_sweep, probe_episodes=_IMPULSE_EPISODES)
         envelopes = {
             row["impulse"]["axis_label"]: row["metrics"]["full_horizon_fraction"]
             for row in policy_sweep
             if row["impulse"]["speed"] > 0
         }
         logger.info(
-            "Impulse recovery probe -> %s (policy full-horizon by direction: %s). "
-            "MODIFIED task -- not a gate verdict.",
+            "Impulse recovery probe -> %s (policy full-horizon by direction: %s). MODIFIED task -- not a gate verdict.",
             written["impulse_probe_txt"],
             envelopes,
         )

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -209,7 +209,7 @@ def run_panel(
     # is invisible to it and unfixable by it (issue #489).
     action_stats = _new_action_stats()
     joint_names: list[str] = []
-    pose_mapping: list[dict[str, float]] = []
+    pose_mapping: list[dict[str, Any]] = []
 
     try:
         joint_names = _actuator_joint_names(env)
@@ -291,6 +291,14 @@ def _new_action_stats() -> dict[str, Any]:
         "sum": None,
         "sq_sum": None,
         "count": 0,
+        # Physical controls actually applied by the environment.  These stay
+        # separate from normalized actions because the species mapping can be
+        # piecewise about its home control; in that case E[f(a)] != f(E[a])
+        # and a normalized variance cannot be converted with one range-wide
+        # scale factor.
+        "ctrl_sum": None,
+        "ctrl_sq_sum": None,
+        "ctrl_count": 0,
         "delta": 0.0,
         "jerk": 0.0,
         # Counted separately: a difference needs two samples and a second
@@ -304,8 +312,12 @@ def _new_action_stats() -> dict[str, Any]:
     }
 
 
-def _accumulate_action(stats: dict[str, Any], action: np.ndarray) -> None:
-    """Accumulate one post-settle action into the per-actuator statistics."""
+def _accumulate_action(
+    stats: dict[str, Any],
+    action: np.ndarray,
+    applied_ctrl: "np.ndarray | None" = None,
+) -> None:
+    """Accumulate one post-settle action and its applied physical control."""
     if stats["sum"] is None or stats["sum"].shape != action.shape:
         stats["sum"] = np.zeros_like(action)
         stats["sq_sum"] = np.zeros_like(action)
@@ -324,6 +336,17 @@ def _accumulate_action(stats: dict[str, Any], action: np.ndarray) -> None:
             stats["jerk_count"] += 1
     stats["prev_prev"] = prev
     stats["prev"] = action
+
+    if applied_ctrl is not None:
+        ctrl = np.asarray(applied_ctrl, dtype=np.float64).ravel()
+        if ctrl.shape == action.shape:
+            if stats["ctrl_sum"] is None or stats["ctrl_sum"].shape != ctrl.shape:
+                stats["ctrl_sum"] = np.zeros_like(ctrl)
+                stats["ctrl_sq_sum"] = np.zeros_like(ctrl)
+                stats["ctrl_count"] = 0
+            stats["ctrl_sum"] += ctrl
+            stats["ctrl_sq_sum"] += ctrl * ctrl
+            stats["ctrl_count"] += 1
 
 
 def _actuator_joint_names(env: Any) -> list[str]:
@@ -349,31 +372,81 @@ def _actuator_joint_names(env: Any) -> list[str]:
         return []
 
 
-def _actuator_pose_mapping(env: Any) -> list[dict[str, float]]:
-    """Per actuator, what a commanded action means as a joint angle.
+def _is_angular_position_control(model: Any, index: int, joint_id: int) -> bool:
+    """Whether actuator control values are directly interpretable as radians.
 
-    Returns ``ctrl_min``/``ctrl_max`` (radians) and the ``home`` angle from the
-    keyframe the environment actually resets to, or ``[]`` when the model
-    cannot be reached.
+    A joint transmission alone is not enough: Velociraptor's claw actuators
+    are geared motors, where ``ctrl=1`` is a dimensionless motor command rather
+    than a one-radian target.  Restrict degree fields to the canonical direct,
+    unit-gear hinge position servo compiled by MuJoCo's ``<position>`` shortcut.
+    Anything else keeps normalized and native-control statistics only.
+    """
+    import mujoco
+
+    gain = float(model.actuator_gainprm[index, 0])
+    bias = np.asarray(model.actuator_biasprm[index], dtype=np.float64)
+    gear = np.asarray(model.actuator_gear[index], dtype=np.float64)
+    return bool(
+        int(model.actuator_trntype[index]) == int(mujoco.mjtTrn.mjTRN_JOINT)
+        and int(model.jnt_type[joint_id]) == int(mujoco.mjtJoint.mjJNT_HINGE)
+        and int(model.actuator_gaintype[index]) == int(mujoco.mjtGain.mjGAIN_FIXED)
+        and int(model.actuator_biastype[index]) == int(mujoco.mjtBias.mjBIAS_AFFINE)
+        and np.isfinite(gain)
+        and gain > 0.0
+        and np.isclose(bias[0], 0.0)
+        and np.isclose(bias[1], -gain)
+        and np.isclose(gear[0], 1.0)
+        and np.allclose(gear[1:], 0.0)
+    )
+
+
+def _actuator_pose_mapping(env: Any) -> list[dict[str, Any]]:
+    """Per actuator, separate action origin, home control, and home pose.
+
+    Returns the physical control at normalized actions -1, 0, and +1, the
+    named home keyframe's control target, and the joint pose in that keyframe.
+    These are deliberately distinct: T-Rex maps residuals piecewise around
+    ``key_ctrl['home']``, while its ankles use an intentional control preload
+    relative to ``key_qpos['home']``.
 
     This exists because ``|action| = 1`` is **not one physical event**.
-    ``_scale_action`` maps ``[-1, 1]`` linearly onto each actuator's own
-    ``ctrlrange``, and on the T-Rex those ranges differ by a factor of six: a
-    saturated tail joint is 8-12 degrees of deflection while a saturated toe is
-    50. Counting both as "saturated" pools them into one number, which is the
-    same mistake the DC/AC split was introduced to fix one level up -- a
-    normalized-unit summary hiding a physical distinction. Measured, it hid the
-    answer: the tail looked like the most extreme thing in the DC table and is
-    provably inert, while the toes carry the whole effect.
+    ``_scale_action`` maps ``[-1, 1]`` onto each actuator's own physical
+    control targets, and on the T-Rex those spans differ by a factor of six: a
+    saturated tail target is 8-12 degrees from its origin while a saturated toe
+    target is 37.5 degrees away. Counting both as "saturated" pools them into
+    one number, which is the same mistake the DC/AC split was introduced to fix
+    one level up -- a normalized-unit summary hiding a physical distinction.
+    Measured, it hid the answer: the tail looked like the most extreme thing in
+    the DC table and is provably inert, while the toes carry the whole effect.
     """
     try:
-        # No `mujoco` import needed, unlike the joint-name lookup: everything
-        # below is attribute access on a model the environment already holds.
-        model = env.unwrapped.model
-        keyframe = int(getattr(env.unwrapped, "_reset_keyframe_id", 0))
+        # Probe the environment's own mapping instead of duplicating a shared
+        # midpoint formula.  T-Rex overrides that formula with a piecewise
+        # home-control residual mapping, and future action interfaces may do
+        # the same.
+        unwrapped = env.unwrapped
+        model = unwrapped.model
+        action_shape = tuple(unwrapped.action_space.shape)
+        negative_ctrl = np.asarray(
+            unwrapped._scale_action(-np.ones(action_shape, dtype=np.float64)),
+            dtype=np.float64,
+        ).ravel()
+        action_zero_ctrl = np.asarray(
+            unwrapped._scale_action(np.zeros(action_shape, dtype=np.float64)),
+            dtype=np.float64,
+        ).ravel()
+        positive_ctrl = np.asarray(
+            unwrapped._scale_action(np.ones(action_shape, dtype=np.float64)),
+            dtype=np.float64,
+        ).ravel()
+        if any(values.shape != (model.nu,) for values in (negative_ctrl, action_zero_ctrl, positive_ctrl)):
+            return []
+
+        keyframe = int(getattr(unwrapped, "_reset_keyframe_id", 0))
         if not 0 <= keyframe < model.nkey:
             keyframe = 0
         home_qpos = model.key_qpos[keyframe] if model.nkey else None
+        home_ctrl = model.key_ctrl[keyframe] if model.nkey else action_zero_ctrl
         mapping = []
         for index in range(model.nu):
             joint_id = int(model.actuator_trnid[index, 0])
@@ -383,10 +456,17 @@ def _actuator_pose_mapping(env: Any) -> list[dict[str, float]]:
                 {
                     "ctrl_min": low,
                     "ctrl_max": high,
-                    # Falls back to the ctrlrange midpoint -- i.e. `action = 0`
-                    # -- when the model has no keyframe, which makes the
-                    # reported deflection zero rather than wrong.
-                    "home": float(home_qpos[address]) if home_qpos is not None else 0.5 * (low + high),
+                    "action_negative_ctrl": float(negative_ctrl[index]),
+                    "action_zero_ctrl": float(action_zero_ctrl[index]),
+                    "action_positive_ctrl": float(positive_ctrl[index]),
+                    "angular_position_ctrl": _is_angular_position_control(model, index, joint_id),
+                    # With no keyframe, use action zero for both anchors so the
+                    # optional offsets read as unavailable/zero rather than
+                    # inventing a nominal posture.
+                    "home_ctrl": float(home_ctrl[index]),
+                    "home_qpos": (
+                        float(home_qpos[address]) if home_qpos is not None else float(action_zero_ctrl[index])
+                    ),
                 }
             )
         return mapping
@@ -394,25 +474,39 @@ def _actuator_pose_mapping(env: Any) -> list[dict[str, float]]:
         return []
 
 
-def _commanded_angle(entry: dict[str, float], action: float) -> float:
-    """The joint angle an action commands, mirroring ``BaseDinoEnv._scale_action``."""
-    return entry["ctrl_min"] + (action + 1.0) * 0.5 * (entry["ctrl_max"] - entry["ctrl_min"])
+def _commanded_angle(entry: dict[str, Any], action: float) -> float:
+    """The control target for an action, using the probed piecewise mapping.
+
+    Real reports use the applied-control moments recorded during rollout.  The
+    helper remains useful for endpoint display, fixtures, and legacy reports,
+    but must still mirror ``home-keyframe-residual/v1`` on both sides of zero.
+    """
+    clipped = float(np.clip(action, -1.0, 1.0))
+    zero = float(
+        entry.get(
+            "action_zero_ctrl",
+            entry.get("home_ctrl", entry.get("home", 0.5 * (entry["ctrl_min"] + entry["ctrl_max"]))),
+        )
+    )
+    negative = float(entry.get("action_negative_ctrl", entry["ctrl_min"]))
+    positive = float(entry.get("action_positive_ctrl", entry["ctrl_max"]))
+    return zero + clipped * (zero - negative if clipped < 0.0 else positive - zero)
 
 
 def _reduce_action_stats(
     stats: dict[str, Any],
     names: list[str],
     control_dt: float,
-    pose_mapping: "list[dict[str, float]] | None" = None,
+    pose_mapping: "list[dict[str, Any]] | None" = None,
 ) -> dict[str, Any]:
     """Reduce the accumulators into the report's ``action`` block.
 
-    The DC/AC split is the point. ``mean(a)`` per actuator is the static pose
-    the policy commands -- under ``home-keyframe-residual/v1`` the distance
-    from the home keyframe, since ``action = 0`` *is* that keyframe -- and the
-    spread about it is what the policy does on top. They have different causes
-    and different fixes, and a single pooled number cannot tell them apart
-    (issue #489).
+    The DC/AC split is the point. ``mean(a)`` per actuator is the policy's
+    static normalized residual and the spread about it is what the policy does
+    on top. Applied-control moments are reduced independently, because the
+    residual-to-control mapping can have different slopes on either side of
+    zero. Static offset and variation have different causes and fixes, and a
+    single pooled number cannot tell them apart (issue #489).
     """
     count = stats["count"]
     if not count or stats["sum"] is None:
@@ -429,6 +523,19 @@ def _reduce_action_stats(
     if delta > 0.0:
         freq = math.asin(min(1.0, math.sqrt(jerk / delta) / 2.0)) / (math.pi * control_dt)
     mapping = pose_mapping or []
+    ctrl_count = int(stats.get("ctrl_count", 0))
+    ctrl_mean: "np.ndarray | None" = None
+    ctrl_ac: "np.ndarray | None" = None
+    if (
+        ctrl_count == count
+        and stats.get("ctrl_sum") is not None
+        and stats.get("ctrl_sq_sum") is not None
+        and stats["ctrl_sum"].shape == mean.shape
+        and stats["ctrl_sq_sum"].shape == mean.shape
+    ):
+        ctrl_mean = stats["ctrl_sum"] / ctrl_count
+        ctrl_var = np.maximum(stats["ctrl_sq_sum"] / ctrl_count - ctrl_mean * ctrl_mean, 0.0)
+        ctrl_ac = np.sqrt(ctrl_var)
     per_actuator = []
     for index in range(mean.size):
         entry: dict[str, Any] = {
@@ -439,17 +546,41 @@ def _reduce_action_stats(
         }
         if index < len(mapping):
             scale = mapping[index]
-            span = scale["ctrl_max"] - scale["ctrl_min"]
-            entry["dc_deg"] = math.degrees(_commanded_angle(scale, float(mean[index])) - scale["home"])
-            # A unit of action is HALF the range, so that is what the tremor
-            # scales by.
-            entry["ac_rms_deg"] = math.degrees(float(ac[index]) * 0.5 * span)
-            entry["range_deg"] = math.degrees(span)
-            # Where `action = 0` sits relative to home. Non-zero means
-            # "action = 0 IS the home keyframe" -- which the residual mapping's
-            # name asserts and several derived constants lean on -- is inexact
-            # for this actuator.
-            entry["zero_offset_deg"] = math.degrees(_commanded_angle(scale, 0.0) - scale["home"])
+            action_zero_ctrl = float(
+                scale.get(
+                    "action_zero_ctrl",
+                    scale.get("home_ctrl", scale.get("home", 0.5 * (scale["ctrl_min"] + scale["ctrl_max"]))),
+                )
+            )
+            home_ctrl = float(scale.get("home_ctrl", action_zero_ctrl))
+            home_qpos = float(scale.get("home_qpos", scale.get("home", home_ctrl)))
+            angular_position_ctrl = bool(scale.get("angular_position_ctrl", True))
+            # Preserve control anchors in native units so the report is
+            # auditable without reloading the exact plant model.  Control and
+            # qpos units are comparable only for the verified position-servo
+            # case below.
+            entry["angular_position_ctrl"] = angular_position_ctrl
+            entry["action_zero_ctrl"] = action_zero_ctrl
+            entry["home_ctrl"] = home_ctrl
+            # Applied-control moments are authoritative.  Mapping the action
+            # mean and variance after reduction is not equivalent when the
+            # negative and positive residual slopes differ, so omit physical
+            # DC/AC rather than fabricate them when controls were unavailable.
+            if ctrl_mean is not None and ctrl_ac is not None:
+                entry["ctrl_mean"] = float(ctrl_mean[index])
+                entry["ctrl_ac_rms"] = float(ctrl_ac[index])
+            if angular_position_ctrl:
+                entry["home_qpos"] = home_qpos
+                entry["range_deg"] = math.degrees(scale["ctrl_max"] - scale["ctrl_min"])
+                if ctrl_mean is not None and ctrl_ac is not None:
+                    entry["dc_deg"] = math.degrees(float(ctrl_mean[index]) - action_zero_ctrl)
+                    entry["ac_rms_deg"] = math.degrees(float(ctrl_ac[index]))
+                # A mapping-contract check, not a posture offset.  Under
+                # home-keyframe-residual/v1 this must be zero even when the
+                # home actuator target intentionally preloads a joint against
+                # gravity.
+                entry["zero_offset_deg"] = math.degrees(action_zero_ctrl - home_ctrl)
+                entry["home_preload_deg"] = math.degrees(home_ctrl - home_qpos)
         per_actuator.append(entry)
     reduced = {
         "dc_rms": float(np.sqrt(np.mean(mean * mean))),
@@ -463,7 +594,7 @@ def _reduce_action_stats(
     if degrees:
         # Reported alongside `dc_rms` rather than replacing it: the normalized
         # figure is what inverts through the action penalties, and the degrees
-        # are what says whether a saturated actuator moved anything.
+        # say how far the physical control targets moved.
         reduced["dc_rms_deg"] = float(np.sqrt(np.mean(np.square(degrees))))
         reduced["max_abs_dc_deg"] = float(np.max(np.abs(degrees)))
     return reduced
@@ -513,15 +644,24 @@ def _roll_episodes(
             action = np.asarray(predict(obs), dtype=np.float64).ravel()
             # Post-settle only, the same window the duty uses, so the reset
             # transient does not read as tremor.
-            if steps >= settle_steps:
-                _accumulate_action(action_stats, action)
+            measure_step = steps >= settle_steps
             obs, reward, terminated, truncated, info = env.step(action)
+            if measure_step:
+                # ``data.ctrl`` is the target the environment actually
+                # applied.  Reading it after ``step`` avoids a second call to
+                # a potentially species-specific mapping and also remains
+                # correct if plant-side action dynamics are added later.
+                try:
+                    applied_ctrl = np.asarray(env.unwrapped.data.ctrl, dtype=np.float64).copy()
+                except Exception:  # noqa: BLE001 - normalized stats remain useful without it
+                    applied_ctrl = None
+                _accumulate_action(action_stats, action, applied_ctrl)
             total += float(reward)
             for key, value in info.items():
                 if key.startswith("reward_") and key != "reward_total":
                     components[key] = components.get(key, 0.0) + float(value)
             stance = derive_stance_info(info)
-            if stance and steps >= settle_steps:
+            if stance and measure_step:
                 measured += 1
                 unsupported += int(stance["unsupported_duty"])
                 # The gate bounds unsupported duty only. Reporting the full
@@ -548,7 +688,7 @@ def _roll_episodes(
 
 
 #: Bumped when the JSON report's field meanings change.
-REPORT_SCHEMA = "mesozoic.stance-gate-report/v1"
+REPORT_SCHEMA = "mesozoic.stance-gate-report/v2"
 
 
 def thresholds_from_curriculum(curriculum: dict[str, Any]) -> StanceGateThresholds:
@@ -868,8 +1008,7 @@ def build_stance_gate_report(
             # broadcasts a mismatched length silently, which would score a
             # policy nobody asked for and report it as this one.
             raise ValueError(
-                f"hold_constant carries {len(hold_constant.actions)} actions but "
-                f"{species} has action_dim {expected}"
+                f"hold_constant carries {len(hold_constant.actions)} actions but {species} has action_dim {expected}"
             )
         predict = _hold_constant_predict(predict, hold_constant)
         description += (
@@ -1062,26 +1201,24 @@ def render_stance_gate_report(report: dict[str, Any]) -> str:
                 lines.append(f"  {key:28s} {components[key]:10.2f}")
     action = report.get("action") or {}
     if action:
-        summary = (
-            f"DC {action['dc_rms']:.3f} rms, AC {action['ac_rms']:.3f} rms, "
-            f"~{action['effective_freq_hz']:.1f} Hz"
-        )
+        summary = f"DC {action['dc_rms']:.3f} rms, AC {action['ac_rms']:.3f} rms, ~{action['effective_freq_hz']:.1f} Hz"
         if "dc_rms_deg" in action:
-            summary += f"; {action['dc_rms_deg']:.1f}deg rms of joint deflection"
+            summary += f"; {action['dc_rms_deg']:.1f}deg rms across angular position controls"
         lines += [
             "",
             f"commanded action, post-settle ({summary}):",
-            "  DC is the distance from the home keyframe; AC is what the policy does",
-            "  around it. Different causes, different fixes.",
+            "  Normalised DC is the mean policy action; degree DC is the applied control",
+            "  target relative to action zero. AC is variation around each mean.",
         ]
         per_actuator = action.get("per_actuator") or []
         has_degrees = any("dc_deg" in entry for entry in per_actuator)
         if has_degrees:
             lines += [
                 "  Ordered by DEGREES, not by normalised action: |action| = 1 maps onto each",
-                "  actuator's own ctrlrange, so a saturated joint can be 8deg or 50deg of",
-                "  deflection. Ranking by the normalised value pools those and hides which",
-                "  joints actually moved.",
+                "  actuator's own control span, so saturation can move a target 8deg or 37.5deg",
+                "  from its nominal target. Ranking by the normalised value pools those and",
+                "  hides which targets moved. Degree fields are emitted for verified angular",
+                "  position controls only; motors retain native control units in the JSON.",
             ]
         # Largest physical offset first when it can be computed. That ordering
         # is the point: sorted by |dc| this table put twelve joints at exactly
@@ -1098,19 +1235,25 @@ def render_stance_gate_report(report: dict[str, Any]) -> str:
             lines.append(line)
         if len(per_actuator) > 12:
             lines.append(f"  ... {len(per_actuator) - 12} more (full list in the JSON)")
-        # `action = 0` is the ctrlrange MIDPOINT, which equals the home keyframe
-        # only where the range was authored centred on it. Where it is not, the
-        # residual mapping's own name is inexact for that actuator and anything
-        # derived from "the statue commands home" carries the same small error.
-        offset = [
-            entry for entry in per_actuator if abs(entry.get("zero_offset_deg", 0.0)) > 0.05
-        ]
+        # Contract check: under the home-keyframe residual mapping action zero
+        # must be the named home CONTROL.  Keep that distinct from a deliberate
+        # control-vs-qpos preload, which is a plant property rather than policy
+        # displacement or an action-mapping error.
+        offset = [entry for entry in per_actuator if abs(entry.get("zero_offset_deg", 0.0)) > 0.05]
         if offset:
             worst = max(offset, key=lambda e: abs(e["zero_offset_deg"]))
             lines.append(
-                f"  NOTE: action = 0 is not exactly home for {len(offset)} of {len(per_actuator)} "
-                f"actuators (worst {worst['joint']} {worst['zero_offset_deg']:+.1f}deg); "
-                "ctrlrange is centred elsewhere."
+                f"  NOTE: action = 0 differs from the named home control for {len(offset)} of "
+                f"{len(per_actuator)} actuators (worst {worst['joint']} "
+                f"{worst['zero_offset_deg']:+.1f}deg); inspect the action-mapping contract."
+            )
+        preload = [entry for entry in per_actuator if abs(entry.get("home_preload_deg", 0.0)) > 0.05]
+        if preload:
+            worst = max(preload, key=lambda e: abs(e["home_preload_deg"]))
+            lines.append(
+                f"  Nominal control preload differs from reset joint pose for {len(preload)} of "
+                f"{len(per_actuator)} actuators (worst {worst['joint']} "
+                f"{worst['home_preload_deg']:+.1f}deg); this is not policy displacement."
             )
     lines += ["", f"GATE: {'PASS' if report['passed'] else 'FAIL'}"]
     lines += [f"  - {failure}" for failure in report["failures"]]
@@ -1282,9 +1425,7 @@ def write_action_filter_sweep(
     return {"action_filter_sweep_txt": text_path, "action_filter_sweep_json": json_path}
 
 
-def render_constant_hold_probe(
-    reports: list[dict[str, Any]], *, probe_episodes: int
-) -> tuple[str, dict[str, Any]]:
+def render_constant_hold_probe(reports: list[dict[str, Any]], *, probe_episodes: int) -> tuple[str, dict[str, Any]]:
     """Reduce the constant-hold variants to their comparison table and payload.
 
     Split from the writer so the CLI can print the table without depositing
@@ -1473,9 +1614,7 @@ def _ablation_verdicts(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
 _IMPULSE_SPEEDS = (0.5, 1.0, 2.0)
 
 
-def impulse_variants(
-    speeds: "tuple[float, ...] | list[float]", *, step: int
-) -> list[RootImpulse]:
+def impulse_variants(speeds: "tuple[float, ...] | list[float]", *, step: int) -> list[RootImpulse]:
     """One :class:`RootImpulse` per (speed, direction), plus the zero control."""
     variants = [RootImpulse(step=step, delta_v=(0.0, 0.0, 0.0), axis_label="none (control)")]
     for speed in sorted(set(float(value) for value in speeds if float(value) > 0)):
@@ -1599,6 +1738,7 @@ def render_impulse_probe(
     * policy *below* statue -> its pose or its tremor is actively worse than
       standing still under load, which would be a finding about the pose.
     """
+
     def _rows(reports: list[dict[str, Any]]) -> dict[tuple[float, str], dict[str, Any]]:
         return {
             (report["impulse"]["speed"], report["impulse"]["axis_label"]): {
@@ -1670,6 +1810,7 @@ def render_impulse_probe(
         f"  {'impulse':>9} {'direction':<16}{'policy len':>11}{'policy fh':>11}"
         f"{'statue len':>11}{'statue fh':>11}{'margin':>9}",
     ]
+
     def _length(cell: "dict[str, Any] | None") -> str:
         return "-" if cell is None else format(cell["episode_length_mean"], ".1f")
 
@@ -1723,9 +1864,7 @@ def write_impulse_probe(
     return {"impulse_probe_txt": text_path, "impulse_probe_json": json_path}
 
 
-def render_constant_hold_ablation(
-    reports: list[dict[str, Any]], *, probe_episodes: int
-) -> tuple[str, dict[str, Any]]:
+def render_constant_hold_ablation(reports: list[dict[str, Any]], *, probe_episodes: int) -> tuple[str, dict[str, Any]]:
     """Reduce the release ablation to its table, per-group verdicts, and payload.
 
     The ablation walks the path between two already-measured endpoints: the
@@ -2239,9 +2378,7 @@ def main() -> int:
         except StanceGateReportError as exc:
             raise SystemExit(str(exc)) from exc
         source_report = (
-            json.loads(Path(args.hold_from_report).read_text(encoding="utf-8"))
-            if args.hold_from_report
-            else report
+            json.loads(Path(args.hold_from_report).read_text(encoding="utf-8")) if args.hold_from_report else report
         )
         variants = (
             constant_hold_release_variants(

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -894,9 +894,10 @@ def _hold_constant_predict(predict: Any, hold: ConstantHold) -> Any:
         if hold.ramp_steps > 0 and elapsed < hold.ramp_steps:
             # Blend from whatever was last commanded. At handoff that is the
             # policy's own last action; from reset there is none, and zero is
-            # the right start because `action = 0` IS the home keyframe the
-            # episode begins at -- so the ramp starts from the actual pose
-            # rather than jumping to one.
+            # the right start because `action = 0` commands the named home
+            # control -- the targets the episode's reset pose settles under --
+            # so the ramp starts from the actual stance rather than jumping
+            # to one.
             previous = state["last"]
             if previous is None or previous.shape != constant.shape:
                 previous = np.zeros_like(constant)
@@ -912,11 +913,21 @@ def constant_hold_actions(report: dict[str, Any]) -> tuple[float, ...]:
     """The per-actuator DC a report measured, as a constant command.
 
     DC is the time-mean of the commanded action over the post-settle window --
-    under ``home-keyframe-residual/v1`` the static pose the policy holds, since
-    ``action = 0`` is the home keyframe. Holding exactly that is what makes the
-    probe a fair test of the pose rather than of some nearby pose: the animal
+    under ``home-keyframe-residual/v1`` the static target the policy holds,
+    since ``action = 0`` is the named home control. Holding it is what makes
+    the probe a test of the pose rather than of some nearby pose: the animal
     is asked to stand where it was already standing, with the variation about
     it removed and nothing else changed.
+
+    One deliberate approximation, worth knowing when reading the results: the
+    held control is ``f(mean(action))``, not the ``mean(f(action))`` the
+    policy actually commanded -- the same distinction schema v2 draws for the
+    report's degree statistics. The two differ only for an actuator whose
+    action distribution crosses zero AND whose ctrlrange spans differ about
+    its home control; on the current trex plant that is neck/head pitch only,
+    where the measured crossings put the bias near 0.01 degrees. If a future
+    plant makes the gap material, derive the hold by inverting the recorded
+    per-actuator ``ctrl_mean`` through the probed mapping instead.
     """
     per_actuator = (report.get("action") or {}).get("per_actuator") or []
     if not per_actuator:
@@ -1900,7 +1911,7 @@ def render_constant_hold_ablation(reports: list[dict[str, Any]], *, probe_episod
         "falls_threshold": _ABLATION_FALLS,
         "note": (
             "Each row scored a MODIFIED policy: its commanded action frozen to a constant "
-            "with one actuator group returned to the home keyframe (released) or with only "
+            "with one actuator group returned to the home control (released) or with only "
             "that group held. No row is a gate verdict. release_G tests whether G is "
             "NECESSARY for the fall; only_G tests whether G is SUFFICIENT to cause it."
         ),
@@ -1915,7 +1926,7 @@ def render_constant_hold_ablation(reports: list[dict[str, Any]], *, probe_episod
         f"policy              {policy}",
         f"stage               {reports[0]['species']} stage {reports[0]['stage']}",
         f"panel               {probe_episodes} episodes per variant, horizon {horizon}",
-        "released            commanded 0, which IS the home keyframe under home-keyframe-residual/v1",
+        "released            commanded 0, the named home control under home-keyframe-residual/v1",
         "",
         f"  {'variant':<28}{'released':>9}{'ep length':>11}{'full-horiz':>12}{'reward':>10}   terminations",
     ]
@@ -2052,12 +2063,12 @@ def saturated_actuator_indices(report: dict[str, Any], threshold: float = 0.99) 
 
 
 def constant_hold_released(hold: tuple[float, ...], release: "tuple[int, ...] | set[int]") -> tuple[float, ...]:
-    """*hold* with the given actuators returned to the home keyframe.
+    """*hold* with the given actuators returned to the home control.
 
     "Released" means commanded ``0``, which under ``home-keyframe-residual/v1``
-    is exactly the home pose -- so releasing every actuator gives the statue,
-    and releasing none gives the policy's own pose. Every ablation below is a
-    point on the path between a pose that falls and one that stands.
+    is exactly the named home control -- so releasing every actuator gives the
+    statue, and releasing none gives the policy's own pose. Every ablation
+    below is a point on the path between a pose that falls and one that stands.
     """
     released = set(int(index) for index in release)
     return tuple(0.0 if index in released else value for index, value in enumerate(hold))
@@ -2280,7 +2291,7 @@ def main() -> int:
         "--hold-release-ablation",
         action="store_true",
         help="Instead of the standard hold variants, ablate the held pose one actuator group at a "
-        "time -- releasing each group back to the home keyframe, and holding each group alone. "
+        "time -- releasing each group back to the home control, and holding each group alone. "
         "Answers WHICH joints make the pose unholdable, by testing necessity and sufficiency "
         "separately. Implies --hold-constant.",
     )

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -268,7 +268,7 @@ class TestTrainingPipelineHook:
             seen["model_path"] = model_path
             seen["vecnorm_path"] = vecnorm_path
             return {
-                "schema": "mesozoic.stance-gate-report/v1",
+                "schema": "mesozoic.stance-gate-report/v2",
                 "species": species,
                 "stage": stage,
                 "gate_kind": "stance_quality/v1",
@@ -357,7 +357,7 @@ class TestJsonIsParseable:
         }
         metrics.update(metric_overrides)
         return {
-            "schema": "mesozoic.stance-gate-report/v1",
+            "schema": "mesozoic.stance-gate-report/v2",
             "species": "trex",
             "stage": 1,
             "gate_kind": "stance_quality/v1",
@@ -732,7 +732,7 @@ class TestPlantValidation:
         # The flag travels with the number rather than being reconstructable
         # only from whoever happened to read the console.
         report = {
-            "schema": "mesozoic.stance-gate-report/v1",
+            "schema": "mesozoic.stance-gate-report/v2",
             "species": "trex",
             "stage": 1,
             "gate_kind": "stance_quality/v1",
@@ -829,6 +829,7 @@ class TestCheckpointPlantProvenance:
 
     def test_zero_action_records_none_because_there_is_no_checkpoint(self, monkeypatch):
         report = self._report(monkeypatch, zero_action=True)
+        assert report["schema"] == "mesozoic.stance-gate-report/v2"
         assert report["checkpoint_plant_validated"] is None
 
     def test_zero_action_with_allow_legacy_still_records_none(self, monkeypatch):
@@ -850,7 +851,7 @@ class TestStancePanelEvidenceFile:
     @staticmethod
     def _report(episodes):
         return {
-            "schema": "mesozoic.stance-gate-report/v1",
+            "schema": "mesozoic.stance-gate-report/v2",
             "species": "trex",
             "stage": 1,
             "gate_kind": "stance_quality/v1",
@@ -956,7 +957,7 @@ class TestStancePanelEvidenceFile:
 def _minimal_stance_report() -> dict:
     """A report dict complete enough for the renderer."""
     return {
-        "schema": "mesozoic.stance-gate-report/v1",
+        "schema": "mesozoic.stance-gate-report/v2",
         "species": "trex",
         "stage": 1,
         "gate_kind": "stance_quality/v1",
@@ -1668,8 +1669,7 @@ def _report_with_actuators(entries):
         "jerk_per_step": 4.6,
         "effective_freq_hz": 22.6,
         "per_actuator": [
-            {"index": index, "joint": joint, "dc": dc, "ac_rms": 0.0}
-            for index, (joint, dc) in enumerate(entries)
+            {"index": index, "joint": joint, "dc": dc, "ac_rms": 0.0} for index, (joint, dc) in enumerate(entries)
         ],
     }
     return report
@@ -1799,7 +1799,9 @@ class TestReleaseAblationVariants:
 
 
 def _ablation_row(label, full, *, holds=True, length=None, released=0):
-    report = _held_report(label, holds=holds, full=full, length=length if length is not None else (1000.0 if full else 300.0))
+    report = _held_report(
+        label, holds=holds, full=full, length=length if length is not None else (1000.0 if full else 300.0)
+    )
     report["hold_constant"]["actions"] = [0.0] * released + [0.5] * (21 - released)
     return report
 
@@ -1835,7 +1837,9 @@ class TestAblationVerdicts:
         verdict = next(v for v in payload["verdicts"] if v["group"] == "saturated")
         assert not verdict["necessary"] and not verdict["sufficient"]
 
-    def test_a_middling_result_refuses_to_round(self, ):
+    def test_a_middling_result_refuses_to_round(
+        self,
+    ):
         """The two conclusions are opposite, so the gap must not be split."""
         text, payload = self._render({"tail": (0.5, 0.0)})
         assert "inconclusive" in text
@@ -1882,11 +1886,12 @@ class TestAblationVerdicts:
         assert "OVER-DETERMINED" not in text
 
 
-class TestDeflectionInDegrees:
+class TestControlTargetsInDegrees:
     """`|action| = 1` is not one physical event, and the report must not imply it is.
 
-    On the T-Rex a saturated tail joint is 12deg of travel and a saturated toe
-    is 50deg. Ranking the per-actuator table by normalised action put twelve
+    On the T-Rex a saturated tail target moves 12deg from its origin and a toe
+    target moves 37.5deg (to an absolute +50deg endpoint). Ranking the
+    per-actuator table by normalised action put twelve
     joints at exactly +/-1.000 at the top and gave no way to tell them apart --
     and the most extreme-looking of them, the tail, was later measured to be
     mechanically inert while the toes carried the whole effect.
@@ -1894,18 +1899,43 @@ class TestDeflectionInDegrees:
 
     @staticmethod
     def _stats(means, mapping, names=None):
-        from environments.shared.scripts.stance_gate_report import _new_action_stats, _reduce_action_stats
+        from environments.shared.scripts.stance_gate_report import (
+            _commanded_angle,
+            _new_action_stats,
+            _reduce_action_stats,
+        )
 
         stats = _new_action_stats()
         stats["sum"] = np.asarray(means, dtype=float)
         stats["sq_sum"] = np.asarray(means, dtype=float) ** 2
         stats["count"] = 1
+        if len(mapping) == len(means):
+            controls = np.asarray([_commanded_angle(entry, float(action)) for entry, action in zip(mapping, means)])
+            stats["ctrl_sum"] = controls
+            stats["ctrl_sq_sum"] = controls**2
+            stats["ctrl_count"] = 1
         return _reduce_action_stats(stats, names or [f"j{i}" for i in range(len(means))], 0.01, mapping)
 
-    #: tail_1_pitch (+/-12deg, home-centred) and r_toe_d2 (-25..+50deg, home +12.5deg),
-    #: the two real T-Rex actuators the ablation separated.
-    _TAIL = {"ctrl_min": -0.2094, "ctrl_max": 0.2094, "home": 0.0}
-    _TOE = {"ctrl_min": -0.4363, "ctrl_max": 0.8727, "home": 0.2182}
+    #: tail_1_pitch (+/-12deg, home-centred) and r_toe_d2 (-25..+50deg,
+    #: home +12.5deg), the two real T-Rex actuators the ablation separated.
+    _TAIL = {
+        "ctrl_min": -0.2094,
+        "ctrl_max": 0.2094,
+        "action_negative_ctrl": -0.2094,
+        "action_zero_ctrl": 0.0,
+        "action_positive_ctrl": 0.2094,
+        "home_ctrl": 0.0,
+        "home_qpos": 0.0,
+    }
+    _TOE = {
+        "ctrl_min": -0.4363,
+        "ctrl_max": 0.8727,
+        "action_negative_ctrl": -0.4363,
+        "action_zero_ctrl": 0.2182,
+        "action_positive_ctrl": 0.8727,
+        "home_ctrl": 0.2182,
+        "home_qpos": 0.2182,
+    }
 
     def test_the_same_saturated_action_is_a_different_angle_per_joint(self):
         action = self._stats([1.0, 1.0], [self._TAIL, self._TOE], names=["tail_1_pitch", "r_toe_d2_joint"])
@@ -1920,51 +1950,193 @@ class TestDeflectionInDegrees:
         from environments.shared.scripts.stance_gate_report import render_stance_gate_report
 
         report = _minimal_stance_report()
-        report["action"] = self._stats(
-            [1.0, 0.6], [self._TAIL, self._TOE], names=["tail_1_pitch", "r_toe_d2_joint"]
-        )
+        report["action"] = self._stats([1.0, 0.6], [self._TAIL, self._TOE], names=["tail_1_pitch", "r_toe_d2_joint"])
         text = render_stance_gate_report(report)
         # The tail saturates and the toe does not, yet the toe moves further.
         assert text.index("r_toe_d2_joint") < text.index("tail_1_pitch")
         assert "Ordered by DEGREES" in text
 
-    def test_the_tremor_scales_by_half_the_range(self):
-        """A unit of action spans half the ctrlrange in each direction."""
-        from environments.shared.scripts.stance_gate_report import _new_action_stats, _reduce_action_stats
+    def test_a_centred_mapping_reports_applied_control_rms(self):
+        """The physical AC field comes from controls, even in the easy symmetric case."""
+        from environments.shared.scripts.stance_gate_report import (
+            _accumulate_action,
+            _new_action_stats,
+            _reduce_action_stats,
+        )
 
         stats = _new_action_stats()
-        stats["sum"] = np.zeros(1)
-        stats["sq_sum"] = np.full(1, 0.25)  # mean 0, var 0.25 -> ac_rms 0.5
-        stats["count"] = 1
+        half_span = 0.5 * (self._TOE["ctrl_max"] - self._TOE["action_zero_ctrl"])
+        for action, control in (
+            (-0.5, self._TOE["action_zero_ctrl"] - half_span),
+            (0.5, self._TOE["action_zero_ctrl"] + half_span),
+        ):
+            _accumulate_action(stats, np.asarray([action]), np.asarray([control]))
         action = _reduce_action_stats(stats, ["r_toe_d2_joint"], 0.01, [self._TOE])
         assert action["per_actuator"][0]["ac_rms"] == pytest.approx(0.5)
         # 0.5 x half of 75deg = 18.75deg
         assert action["per_actuator"][0]["ac_rms_deg"] == pytest.approx(18.75, abs=0.05)
 
-    def test_an_offset_ctrlrange_is_flagged_because_action_zero_is_not_home(self):
-        """`home-keyframe-residual/v1` asserts action 0 IS home; for some it is not.
+    def test_asymmetric_mapping_uses_actual_control_moments(self):
+        """E[f(a)] and rms(f(a)) cannot be recovered by scaling action moments."""
+        from environments.shared.scripts.stance_gate_report import (
+            _accumulate_action,
+            _new_action_stats,
+            _reduce_action_stats,
+        )
 
-        On the T-Rex the ankles sit 5.5deg off and head/neck pitch 5.0deg off.
-        Small, but the phrasing is load-bearing -- statue-derived constants and
-        the DC interpretation both rest on it.
-        """
-        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+        mapping = {
+            "ctrl_min": -1.0,
+            "ctrl_max": 3.0,
+            "action_negative_ctrl": -1.0,
+            "action_zero_ctrl": 0.0,
+            "action_positive_ctrl": 3.0,
+            "home_ctrl": 0.0,
+            "home_qpos": 0.0,
+        }
+        stats = _new_action_stats()
+        for action, control in ((-0.5, -0.5), (0.25, 0.75)):
+            _accumulate_action(stats, np.asarray([action]), np.asarray([control]))
 
-        ankle = {"ctrl_min": 0.5655, "ctrl_max": 2.3108, "home": 1.3422}
+        entry = _reduce_action_stats(stats, ["joint"], 0.01, [mapping])["per_actuator"][0]
+        assert entry["dc"] == pytest.approx(-0.125)
+        assert entry["ac_rms"] == pytest.approx(0.375)
+        assert entry["dc_deg"] == pytest.approx(math.degrees(0.125))
+        assert entry["ac_rms_deg"] == pytest.approx(math.degrees(0.625))
+
+    def test_missing_applied_controls_does_not_guess_physical_moments(self):
+        from environments.shared.scripts.stance_gate_report import _new_action_stats, _reduce_action_stats
+
+        stats = _new_action_stats()
+        stats["sum"] = np.asarray([0.25])
+        stats["sq_sum"] = np.asarray([0.25])
+        stats["count"] = 1
+        entry = _reduce_action_stats(stats, ["joint"], 0.01, [self._TOE])["per_actuator"][0]
+        assert "dc_deg" not in entry
+        assert "ac_rms_deg" not in entry
+        assert entry["action_zero_ctrl"] == pytest.approx(self._TOE["action_zero_ctrl"])
+
+    def test_trex_mapping_uses_home_control_and_keeps_preload_separate(self):
+        """Action zero is home control; ankle control-vs-pose preload is intentional."""
+        from environments.shared.scripts.stance_gate_report import (
+            _actuator_joint_names,
+            _actuator_pose_mapping,
+            render_stance_gate_report,
+        )
+        from environments.trex.envs.trex_env import TRexEnv
+
+        env = TRexEnv()
+        try:
+            mapping = _actuator_pose_mapping(env)
+            names = _actuator_joint_names(env)
+        finally:
+            env.close()
+
         report = _minimal_stance_report()
-        report["action"] = self._stats([0.0], [ankle], names=["r_ankle"])
-        assert report["action"]["per_actuator"][0]["zero_offset_deg"] == pytest.approx(5.5, abs=0.1)
+        report["action"] = self._stats(np.zeros(len(mapping)), mapping, names=names)
+        by_joint = {entry["joint"]: entry for entry in report["action"]["per_actuator"]}
+        assert all(entry["zero_offset_deg"] == pytest.approx(0.0, abs=1e-9) for entry in by_joint.values())
+        assert by_joint["r_ankle"]["home_preload_deg"] == pytest.approx(5.5, abs=0.1)
+        assert by_joint["l_ankle"]["home_preload_deg"] == pytest.approx(5.5, abs=0.1)
+        assert by_joint["r_ankle"]["action_zero_ctrl"] == pytest.approx(by_joint["r_ankle"]["home_ctrl"])
+        assert by_joint["r_ankle"]["home_ctrl"] != pytest.approx(by_joint["r_ankle"]["home_qpos"])
+        assert by_joint["neck_pitch"]["home_preload_deg"] == pytest.approx(0.0, abs=0.01)
+        assert by_joint["head_pitch"]["home_preload_deg"] == pytest.approx(0.0, abs=0.01)
+
         text = render_stance_gate_report(report)
-        assert "action = 0 is not exactly home" in text
-        assert "r_ankle" in text
+        assert "differs from the named home control" not in text
+        assert "Nominal control preload" in text
+        assert "this is not policy displacement" in text
 
-    def test_a_home_centred_range_is_not_flagged(self):
-        from environments.shared.scripts.stance_gate_report import render_stance_gate_report
+    def test_trex_asymmetric_piecewise_mapping_matches_the_environment(self):
+        from environments.shared.scripts.stance_gate_report import (
+            _actuator_joint_names,
+            _actuator_pose_mapping,
+            _commanded_angle,
+        )
+        from environments.trex.envs.trex_env import TRexEnv
 
-        report = _minimal_stance_report()
-        report["action"] = self._stats([0.5], [self._TAIL], names=["tail_1_pitch"])
-        assert report["action"]["per_actuator"][0]["zero_offset_deg"] == pytest.approx(0.0, abs=1e-9)
-        assert "action = 0 is not exactly home" not in render_stance_gate_report(report)
+        env = TRexEnv()
+        try:
+            by_joint = dict(zip(_actuator_joint_names(env), _actuator_pose_mapping(env)))
+            neck = by_joint["neck_pitch"]
+            for action, expected_deg in ((-1.0, -30.0), (-0.5, -15.0), (0.0, 0.0), (0.5, 20.0), (1.0, 40.0)):
+                assert math.degrees(_commanded_angle(neck, action)) == pytest.approx(expected_deg, abs=0.01)
+        finally:
+            env.close()
+
+    def test_trex_cross_zero_controls_are_reduced_after_scaling(self):
+        from environments.shared.scripts.stance_gate_report import (
+            _accumulate_action,
+            _actuator_joint_names,
+            _actuator_pose_mapping,
+            _new_action_stats,
+            _reduce_action_stats,
+        )
+        from environments.trex.envs.trex_env import TRexEnv
+
+        env = TRexEnv()
+        try:
+            names = _actuator_joint_names(env)
+            mapping = _actuator_pose_mapping(env)
+            stats = _new_action_stats()
+            for value in (-0.5, 0.5):
+                action = np.full(env.action_space.shape, value, dtype=np.float64)
+                _accumulate_action(stats, action, env._scale_action(action))
+            by_joint = {
+                entry["joint"]: entry for entry in _reduce_action_stats(stats, names, 0.01, mapping)["per_actuator"]
+            }
+        finally:
+            env.close()
+
+        assert by_joint["neck_pitch"]["dc"] == pytest.approx(0.0)
+        assert by_joint["neck_pitch"]["ac_rms"] == pytest.approx(0.5)
+        assert by_joint["neck_pitch"]["dc_deg"] == pytest.approx(2.5, abs=0.01)
+        assert by_joint["neck_pitch"]["ac_rms_deg"] == pytest.approx(17.5, abs=0.01)
+
+    def test_real_panel_records_the_controls_applied_by_trex(self):
+        from environments.shared.scripts.stance_gate_report import run_panel
+
+        result = run_panel(
+            "trex",
+            predict=lambda obs: np.zeros(21, dtype=np.float32),
+            episodes=1,
+            seed=3042,
+            settle_steps=0,
+            horizon=2,
+            env_kwargs={"max_episode_steps": 2},
+            control_dt=0.01,
+        )
+        by_joint = {entry["joint"]: entry for entry in result["action"]["per_actuator"]}
+        assert by_joint["neck_pitch"]["dc_deg"] == pytest.approx(0.0, abs=1e-12)
+        assert by_joint["r_ankle"]["dc_deg"] == pytest.approx(0.0, abs=1e-12)
+        assert by_joint["r_ankle"]["home_preload_deg"] == pytest.approx(5.5, abs=0.1)
+
+    def test_motor_controls_are_not_mislabeled_as_degrees(self):
+        from environments.shared.scripts.stance_gate_report import run_panel
+
+        action = np.zeros(22, dtype=np.float32)
+        action[[6, 13]] = 1.0  # r/l claw motors, each with gear=50
+        result = run_panel(
+            "velociraptor",
+            predict=lambda obs: action,
+            episodes=1,
+            seed=3042,
+            settle_steps=0,
+            horizon=2,
+            env_kwargs={"max_episode_steps": 2},
+            control_dt=0.01,
+        )
+        by_joint = {entry["joint"]: entry for entry in result["action"]["per_actuator"]}
+        for joint in ("r_claw", "l_claw"):
+            entry = by_joint[joint]
+            assert entry["dc"] == pytest.approx(1.0)
+            assert entry["ctrl_mean"] == pytest.approx(1.0)
+            assert entry["ctrl_ac_rms"] == pytest.approx(0.0)
+            assert not entry["angular_position_ctrl"]
+            assert not {"dc_deg", "ac_rms_deg", "range_deg", "home_qpos", "home_preload_deg"} & entry.keys()
+
+        assert by_joint["r_hip_pitch"]["angular_position_ctrl"]
+        assert "dc_deg" in by_joint["r_hip_pitch"]
 
     def test_degrees_are_added_not_substituted(self):
         """`dc` still inverts through the action penalties; the degrees do not."""


### PR DESCRIPTION
## Summary

Stacked on #493 and targeted at its head branch so this PR contains only the action-mapping correction.

- make stance diagnostics use each environment's real action mapping
- reduce degree-space DC/AC from controls actually applied during rollout
- separate action zero, home control, and home joint pose
- emit degree fields only for verified angular position servos
- correct the T-Rex investigation and remove the ctrlrange-recentering recommendation
- sweep the remaining "action = 0 is the home keyframe" phrasing out of the prose that taught it (eval_diagnostics docstrings, the hold/ablation helpers, the rendered ablation header, the CLI help, and KNOWN_ISSUES' "map linearly"), and state the constant-hold probe's one deliberate approximation — the held command is `f(mean(action))`, not `mean(f(action))`, which differs only on zero-crossing actuators with asymmetric spans (neck/head pitch on this plant, bias ~0.01°)

## Why

PR #493's report duplicated the inherited midpoint mapping, but T-Rex uses `home-keyframe-residual/v1`: negative and positive residuals are scaled independently around `key_ctrl["home"]`. The old report therefore mislabeled the intentional 5.5° ankle control preload as a mapping defect and miscomputed asymmetric head/neck commands. Rescaling normalized moments was also insufficient because `E[f(a)] != f(E[a])` across a piecewise mapping.

The shared reporter also treated Velociraptor's geared claw motors as radian position targets. Schema v2 now preserves native control statistics and only emits degree fields for compatible position servos.

## Impact

- T-Rex action zero is correctly reported as the named home control for all 21 actuators.
- The ankle offset is reported separately as authored preload.
- Existing toe/tail endpoint conclusions remain unchanged.
- Existing v1 artifacts are historical and should be regenerated before comparing aggregate/head-neck degree fields.
- No plant or policy-interface change is required for the four ctrlranges previously called "off-home."

## Validation

All under the canonical `mujoco==3.10.0` — the version `pyproject.toml` pins and `plant_versions.toml` declares:

- `pytest environments/shared/tests/test_stance_gate_report.py environments/shared/tests/test_reporting_stage_artifacts.py -q` — pass
- `pytest environments/trex/tests/test_trex_env.py environments/velociraptor/tests/test_raptor_env.py environments/shared/tests/test_plant_contract_layers.py -q` — pass
- `pytest environments/shared/tests -k "plant_manifest or manifest" -q` — 23/23 pass
- `ruff check environments/` — clean
- `ruff format --check` — clean on every file this PR touches

**Correction to this section's earlier claim:** the "two pre-existing stale plant-manifest failures already present on the base branch" were an environment artifact, not a base-branch defect — they reproduce only under MuJoCo 3.11.x, where the physics fingerprints legitimately differ from the committed manifest. Under the pinned 3.10.0 the committed plant manifest is byte-current for all four species and the manifest suite passes. (A follow-up should make `current_plant_identity` report version skew as version skew instead of "manifest is stale".)

The branch also carries a merge of its base, which now runs the four stance probes after the gate verdict is recorded rather than inside the report's `try` — see the base branch's latest commit for the rationale.