### PR TITLE
Make the stage warm-up's entropy boost survive EntCoefDecayCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -377,6 +377,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was sized for a 6M stage and never revisited when stage 1 became 10M.
 
 ### Fixed
+- **`warmup_ent_coef` never reached a gradient update: `EntCoefDecayCallback`
+  overwrote the stage-entry boost on the very next step.** Every PPO stage-2/3
+  config sets both mechanisms, and they fought: `StageWarmupCallback` set the
+  configured boost (0.02) exactly once at training start and logged "warm-up
+  active … ent_coef=0.020", while the decay callback reassigned
+  `model.ent_coef` from its own schedule on **every** step — from an initial
+  value captured before the warm-up ran — so the boost was gone long before
+  PPO's `train()` first read the attribute, and the warm-up's restore at the
+  end of the window was clobbered identically. Callback order could not save
+  it: a per-step overwrite beats a once-at-start set in either order. The
+  documented anti-catastrophic-forgetting boost therefore never happened on
+  any species' stage-2/3 transition, while the log claimed it was active.
+  The two now hand off through a marker on the model
+  (`ENT_COEF_WARMUP_MARKER`): the warm-up stamps it while it owns `ent_coef`
+  and clears it when it restores, and the decay callback stands aside while
+  it is set, capturing its decay base on the first step after release — so
+  the boost holds for the whole warm-up window and the configured decay
+  continues exactly as before from there. On the model rather than between
+  the callbacks because the two are constructed independently, in no
+  guaranteed order, in all three launch paths (CLI `train`,
+  `train_curriculum`, and the notebook) — which is also why the fix needs no
+  wiring change anywhere. Pinned by tests that drive the two real callbacks
+  together, in both construction orders. SAC is unaffected (no decay
+  callback is built for it, and its warm-up writes `log_ent_coef`);
+  stage-1 runs are unaffected (no warm-up).
 - **A stance-gated run that passed every gate still could not publish.**
   `result_bundle.evidence` refused any complete bundle whose stage declares
   `stance_quality/v1`, because `evaluation_selected.csv` records per-episode

--- a/environments/shared/curriculum/advancement.py
+++ b/environments/shared/curriculum/advancement.py
@@ -18,7 +18,7 @@ from environments.shared.wandb_integration import log_eval_metrics
 from . import sb3_compat
 from .manager import CurriculumManager
 from .sb3_compat import BaseCallback
-from .schedules import _ConstantSchedule
+from .schedules import ENT_COEF_WARMUP_MARKER, _ConstantSchedule
 from .stance_gate import STANCE_GATE_KIND, StancePanel, stance_panel_from_episode_duties
 
 logger = logging.getLogger(__name__)
@@ -516,11 +516,19 @@ class StageWarmupCallback(BaseCallback):  # type: ignore[misc]
                 self.warmup_ent_coef,
             )
         elif hasattr(self.model, "clip_range"):
-            # PPO warmup: reduce clip_range and set entropy coefficient
+            # PPO warmup: reduce clip_range and set entropy coefficient.
+            # The marker tells EntCoefDecayCallback to stand aside while the
+            # warm-up owns ent_coef — without it, the decay's per-step
+            # assignment overwrote this boost on the very next step and the
+            # restore below the same way, so the configured boost never
+            # actually reached a gradient update (it is set on the model, not
+            # the callback, because the two callbacks are constructed
+            # independently in every launch path).
             self._original_clip_range = self.model.clip_range
             self._original_ent_coef = self.model.ent_coef
             self.model.clip_range = _ConstantSchedule(self.warmup_clip_range)
             self.model.ent_coef = self.warmup_ent_coef
+            setattr(self.model, ENT_COEF_WARMUP_MARKER, True)
             logger.info(
                 "StageWarmupCallback [PPO]: warm-up active for %d timesteps (clip_range=%.3f, ent_coef=%.3f)",
                 self.warmup_timesteps,
@@ -541,6 +549,10 @@ class StageWarmupCallback(BaseCallback):  # type: ignore[misc]
             else:
                 self.model.clip_range = self._original_clip_range
                 self.model.ent_coef = self._original_ent_coef
+                # Release ent_coef back to EntCoefDecayCallback, which
+                # captures its base value on the next step and continues the
+                # configured schedule from there.
+                setattr(self.model, ENT_COEF_WARMUP_MARKER, False)
             self._warmup_done = True
             logger.info(
                 "StageWarmupCallback: warm-up complete at step %d. Restored original parameters.",

--- a/environments/shared/curriculum/schedules.py
+++ b/environments/shared/curriculum/schedules.py
@@ -13,6 +13,19 @@ from .sb3_compat import BaseCallback
 
 logger = logging.getLogger(__name__)
 
+#: Attribute set on the *model* by ``StageWarmupCallback`` while its PPO
+#: warm-up owns ``ent_coef``, and read by ``EntCoefDecayCallback`` to stand
+#: aside. On the model rather than between the callbacks because the two are
+#: constructed independently in three launch paths (``train``,
+#: ``train_curriculum``, and the notebook) and in no guaranteed order — the
+#: model is the one object both are guaranteed to share. Cleared when the
+#: warm-up restores ``ent_coef``. A checkpoint saved inside a warm-up window
+#: pickles the flag as ``True``; every stage>1 ``--load`` path re-adds the
+#: warm-up callback, which re-stamps it, so a stale flag only matters for a
+#: run that loads a mid-warm-up checkpoint *without* a warm-up — and the
+#: decay callback logs whenever it defers, so that state is visible.
+ENT_COEF_WARMUP_MARKER = "_ent_coef_warmup_active"
+
 
 class _ConstantSchedule:
     """Picklable callable that returns a constant value.
@@ -40,6 +53,15 @@ class EntCoefDecayCallback(BaseCallback):  # type: ignore[misc]
 
     PPO only — SAC's auto-tuned entropy already adapts on its own.
 
+    Defers to ``StageWarmupCallback`` whenever :data:`ENT_COEF_WARMUP_MARKER`
+    is set on the model. Without that guard the per-step assignment here
+    silently overwrote the configured stage-entry entropy boost on the first
+    step after the warm-up set it — every PPO stage-2/3 transition logged
+    "warm-up active … ent_coef=0.020" and then trained at the decaying base
+    value, with the warm-up's restore clobbered the same way. The base value
+    for the decay is captured on the first step after the warm-up releases
+    ``ent_coef``, so the schedule continues exactly as configured from there.
+
     Args:
         end_value: Final entropy coefficient.
         decay_timesteps: Timesteps over which to decay (typically the
@@ -54,19 +76,35 @@ class EntCoefDecayCallback(BaseCallback):  # type: ignore[misc]
         self.end_value = end_value
         self.decay_timesteps = max(1, decay_timesteps)
         self._initial: float | None = None
+        self._started = False
 
-    def _on_training_start(self) -> None:
+    def _capture_initial(self, deferred: bool) -> None:
         self._initial = float(self.model.ent_coef)
         logger.info(
-            "EntCoefDecay: ent_coef %.4f → %.4f over %d timesteps",
+            "EntCoefDecay: ent_coef %.4f → %.4f over %d timesteps%s",
             self._initial,
             self.end_value,
             self.decay_timesteps,
+            " (captured after the stage warm-up released ent_coef)" if deferred else "",
         )
 
+    def _on_training_start(self) -> None:
+        self._started = True
+        if getattr(self.model, ENT_COEF_WARMUP_MARKER, False):
+            # StageWarmupCallback owns ent_coef; the value on the model right
+            # now is (or is about to be) the warm-up boost, not the base this
+            # schedule should decay from.
+            logger.info("EntCoefDecay: deferring to the stage warm-up before capturing the base ent_coef")
+            return
+        self._capture_initial(deferred=False)
+
     def _on_step(self) -> bool:
-        if self._initial is None:
+        if not self._started:
             return True
+        if getattr(self.model, ENT_COEF_WARMUP_MARKER, False):
+            return True
+        if self._initial is None:
+            self._capture_initial(deferred=True)
         frac = min(1.0, self.num_timesteps / self.decay_timesteps)
         self.model.ent_coef = self._initial + frac * (self.end_value - self._initial)
         return True

--- a/environments/shared/curriculum/schedules.py
+++ b/environments/shared/curriculum/schedules.py
@@ -78,15 +78,17 @@ class EntCoefDecayCallback(BaseCallback):  # type: ignore[misc]
         self._initial: float | None = None
         self._started = False
 
-    def _capture_initial(self, deferred: bool) -> None:
-        self._initial = float(self.model.ent_coef)
+    def _capture_initial(self, deferred: bool) -> float:
+        initial = float(self.model.ent_coef)
+        self._initial = initial
         logger.info(
             "EntCoefDecay: ent_coef %.4f → %.4f over %d timesteps%s",
-            self._initial,
+            initial,
             self.end_value,
             self.decay_timesteps,
             " (captured after the stage warm-up released ent_coef)" if deferred else "",
         )
+        return initial
 
     def _on_training_start(self) -> None:
         self._started = True
@@ -103,8 +105,9 @@ class EntCoefDecayCallback(BaseCallback):  # type: ignore[misc]
             return True
         if getattr(self.model, ENT_COEF_WARMUP_MARKER, False):
             return True
-        if self._initial is None:
-            self._capture_initial(deferred=True)
+        initial = self._initial
+        if initial is None:
+            initial = self._capture_initial(deferred=True)
         frac = min(1.0, self.num_timesteps / self.decay_timesteps)
-        self.model.ent_coef = self._initial + frac * (self.end_value - self._initial)
+        self.model.ent_coef = initial + frac * (self.end_value - initial)
         return True

--- a/environments/shared/tests/test_curriculum_advancement.py
+++ b/environments/shared/tests/test_curriculum_advancement.py
@@ -164,6 +164,9 @@ class TestStageWarmupCallbackMocked:
         # clip_range should be replaced with _ConstantSchedule(0.02)
         assert mock_model.clip_range(0.5) == pytest.approx(0.02)
         assert mock_model.ent_coef == 0.02
+        # The marker keeps EntCoefDecayCallback from clobbering the boost on
+        # its next per-step assignment.
+        assert mock_model._ent_coef_warmup_active is True
 
     def test_warmup_restores_original_values(self):
         """After warmup_timesteps, original clip_range and ent_coef should be restored (PPO)."""
@@ -187,6 +190,8 @@ class TestStageWarmupCallbackMocked:
         assert cb._warmup_done is True
         assert mock_model.clip_range == original_clip
         assert mock_model.ent_coef == original_ent
+        # ent_coef is released back to EntCoefDecayCallback.
+        assert mock_model._ent_coef_warmup_active is False
 
     def test_warmup_applies_reduced_lr_for_sac(self):
         """Warmup should reduce LR and seed log_ent_coef for SAC models.

--- a/environments/shared/tests/test_curriculum_schedules.py
+++ b/environments/shared/tests/test_curriculum_schedules.py
@@ -77,8 +77,12 @@ class TestEntCoefDecayCallback:
         cb.end_value = end_value
         cb.decay_timesteps = decay_timesteps
         cb._initial = None
+        cb._started = False
         cb.model = MagicMock()
         cb.model.ent_coef = initial
+        # A fresh model has no warm-up marker; a MagicMock auto-creates a
+        # truthy attribute for it, which would read as "warm-up active".
+        cb.model._ent_coef_warmup_active = False
         cb.num_timesteps = 0
         return cb
 
@@ -110,3 +114,82 @@ class TestEntCoefDecayCallback:
         with patch("environments.shared.curriculum.sb3_compat._SB3_AVAILABLE", False):
             with pytest.raises(ImportError, match="stable-baselines3"):
                 EntCoefDecayCallback()
+
+
+class _FakePPOModel:
+    """A plain object, because the warm-up detects PPO via hasattr checks.
+
+    No ``log_ent_coef`` (so it reads as PPO, not SAC) and no auto-created
+    attributes (a MagicMock would answer the warm-up marker probe with a
+    truthy child mock)."""
+
+    def __init__(self, ent_coef=0.005):
+        self.ent_coef = ent_coef
+        self.clip_range = _ConstantSchedule(0.2)
+
+
+class TestEntCoefDecayDefersToStageWarmup:
+    """The decay must not clobber StageWarmupCallback's stage-entry boost.
+
+    Every PPO stage-2/3 config sets both ``ent_coef_end`` and
+    ``warmup_ent_coef``, and before the marker existed the decay's per-step
+    assignment overwrote the boost on the first step after the warm-up set
+    it: the log claimed "warm-up active … ent_coef=0.020" while training
+    ran at the decaying base value. These tests drive the two REAL callbacks
+    together, in both construction orders."""
+
+    @staticmethod
+    def _callbacks(warmup_timesteps=100):
+        pytest.importorskip("stable_baselines3")
+        from environments.shared.curriculum import EntCoefDecayCallback, StageWarmupCallback
+
+        decay = EntCoefDecayCallback(end_value=0.0, decay_timesteps=1000)
+        warmup = StageWarmupCallback(warmup_timesteps=warmup_timesteps, warmup_clip_range=0.02, warmup_ent_coef=0.02)
+        model = _FakePPOModel(ent_coef=0.005)
+        decay.model = model
+        warmup.model = model
+        return decay, warmup, model
+
+    @staticmethod
+    def _tick(model, *callbacks, step):
+        """One CallbackList tick: every callback sees the same num_timesteps."""
+        for cb in callbacks:
+            cb.num_timesteps = step
+            cb._on_step()
+        return model.ent_coef
+
+    def test_the_boost_holds_for_the_whole_warmup_window(self):
+        decay, warmup, model = self._callbacks(warmup_timesteps=100)
+        # CallbackList fires _on_training_start in list order; the launch
+        # paths append the decay callback first.
+        decay._on_training_start()
+        warmup._on_training_start()
+        assert model.ent_coef == pytest.approx(0.02)
+
+        # Before the marker, the very first _on_step overwrote the boost.
+        for step in (1, 50, 99):
+            assert self._tick(model, decay, warmup, step=step) == pytest.approx(0.02)
+
+    def test_the_decay_resumes_from_the_base_after_the_warmup_ends(self):
+        decay, warmup, model = self._callbacks(warmup_timesteps=100)
+        decay._on_training_start()
+        warmup._on_training_start()
+
+        self._tick(model, decay, warmup, step=100)  # warm-up restores here
+        assert warmup._warmup_done is True
+        # Next tick: the decay owns ent_coef again and continues the
+        # configured schedule from the BASE value, not the boost.
+        value = self._tick(model, decay, warmup, step=101)
+        assert value == pytest.approx(0.005 + (101 / 1000) * (0.0 - 0.005))
+
+    def test_the_base_is_captured_after_a_warmup_that_started_first(self):
+        """Robust to the reverse order: the warm-up boosts ent_coef before the
+        decay ever sees it, so the decay must defer its base capture."""
+        decay, warmup, model = self._callbacks(warmup_timesteps=100)
+        warmup._on_training_start()
+        decay._on_training_start()
+        assert decay._initial is None  # 0.02 must NOT be captured as the base
+
+        self._tick(model, warmup, decay, step=100)  # restore, then decay's step
+        assert model.ent_coef == pytest.approx(0.005 + (100 / 1000) * (0.0 - 0.005))
+        assert decay._initial == pytest.approx(0.005)


### PR DESCRIPTION
## Summary

Every PPO stage-2/3 config sets both `warmup_ent_coef` and `ent_coef_end`, and the two callbacks fought: `StageWarmupCallback` set the configured boost (0.02) exactly once at training start and logged "warm-up active … ent_coef=0.020", while `EntCoefDecayCallback._on_step` reassigned `model.ent_coef` from its own schedule on **every** step — from an initial value captured before the warm-up ran. The boost was gone long before PPO's `train()` first read the attribute (it reads only after a full `n_steps` rollout), and the warm-up's restore at the end of the window was clobbered identically. Callback order cannot save it: a per-step overwrite beats a once-at-start set in either order. The documented anti-catastrophic-forgetting boost therefore never happened on any species' stage-2/3 transition, while the log claimed it was active. (Finding §3.1 of `docs/reviews/RL_PIPELINE_REVIEW_2026_08.md`.)

## Fix

The two callbacks now hand off through a marker on the model (`ENT_COEF_WARMUP_MARKER` in `curriculum/schedules.py`):

- `StageWarmupCallback` stamps it while its PPO warm-up owns `ent_coef` and clears it when it restores.
- `EntCoefDecayCallback` stands aside while it is set, and captures its decay base on the first step after release — so the boost holds for the whole warm-up window and the configured decay continues exactly as before from there.

The marker lives on the model rather than between the callbacks because the two are constructed independently, in no guaranteed order, in all three launch paths (CLI `train`, `train_curriculum`, and the notebook) — which is also why this fix needs **no wiring change anywhere**: the notebook picks it up without edits.

Warm-up `clip_range` was already honored (nothing else assigns it). SAC is unaffected (no decay callback is built for it; its warm-up writes `log_ent_coef`). Stage-1 runs are unaffected (no warm-up).

## Validation

- New `TestEntCoefDecayDefersToStageWarmup` drives the two **real** callbacks together, in both construction orders: the boost holds for the whole window, the decay resumes from the base (not the boost) after restore, and a warm-up that starts first defers the decay's base capture.
- Marker lifecycle asserted in the existing `StageWarmupCallback` PPO tests.
- `pytest environments/shared/tests/test_curriculum_schedules.py environments/shared/tests/test_curriculum_advancement.py environments/shared/tests/test_curriculum_sb3_compat.py -q` — all pass.
- `ruff check` / `ruff format --check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb

---
_Generated by [Claude Code](https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb)_