### PR TITLE
Wire obs_rms_decay_on_resume and ramp_attr into the JAX library paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -377,7 +377,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was sized for a 6M stage and never revisited when stage 1 became 10M.
 
 ### Fixed
-- **A stance-gated run that passed every gate still could not publish.**
+- **`obs_rms_decay_on_resume` and `ramp_attr` were silently dropped by both
+  JAX library entry points — and the `[jax]` table now rejects unknown keys.**
+  All eight stage-2/3 TOMLs set `obs_rms_decay_on_resume = 0.01` ("lets stats
+  adapt to Stage 2's velocity distribution within ~2 updates"), and only the
+  notebook honored it: `run_curriculum` carried the prior stage's observation
+  statistics into the next stage with their full sample count — millions —
+  so `update_running_stats` was nearly a no-op exactly when the obs
+  distribution shifts, which is the pathology the key exists to prevent.
+  `run_curriculum` now decays the carried count through
+  `decay_running_stats` with the entered stage's configured factor (same
+  0.01 default and `1.0` opt-out as the notebook's resume cell).
+  `ramp_attr` was likewise unread by `_JAX_KEY_MAP` and the CLI; it now
+  reaches `train_jax` → `JaxTrainer`, which honors the one value the MJX
+  path can ramp (`forward_vel_weight` is wired through `env.step` as a
+  runtime scale; other weights are baked into the jitted reward at trace
+  time) and **refuses anything else at construction** — the same contract
+  the notebook's `train()` path already enforced — instead of silently
+  ramping nothing.
+  The mechanism that let both keys rot is closed the way `[curriculum]`
+  closed it: `validate_jax_kwargs` rejects unknown `[jax]` keys fail-closed
+  on both library paths ("silently dropping a misspelled threshold disables
+  it"), `_JAX_KEY_MAP` is hoisted to module level as the single source of
+  truth, and a test pins every mapped name against `train_jax`'s real
+  signature so the map and the function cannot drift apart. One key is
+  grandfathered as known-but-inert: `[jax.policy_kwargs]` is declared in
+  every TOML but no JAX path reads it — the network factory is fixed —
+  which is now documented at the known-key set instead of discovered.
   `result_bundle.evidence` refused any complete bundle whose stage declares
   `stance_quality/v1`, because `evaluation_selected.csv` records per-episode
   reward and length but no unsupported duty, and certifying on `min_avg_reward`

--- a/environments/shared/jax_curriculum.py
+++ b/environments/shared/jax_curriculum.py
@@ -23,6 +23,77 @@ from .curriculum.stance_gate import (
 
 _logger = logging.getLogger(__name__)
 
+#: TOML ``[jax]`` keys mapped to :func:`~environments.shared.jax_training.train_jax`
+#: parameter names.  Module-level so the mapping loop in :func:`run_curriculum`
+#: and :func:`validate_jax_kwargs`'s known-key set cannot drift apart — a key
+#: added to one without the other now fails a test instead of going silently
+#: inert (``ramp_attr`` and ``obs_rms_decay_on_resume`` were both dropped this
+#: way while eight TOML comments asserted they worked).
+_JAX_KEY_MAP = {
+    "num_envs": "num_envs",
+    "rollout_len": "rollout_len",
+    "num_updates": "num_updates",
+    "learning_rate": "learning_rate",
+    "learning_rate_end": "learning_rate_end",
+    "max_grad_norm": "max_grad_norm",
+    "gamma": "gamma",
+    "gae_lambda": "gae_lambda",
+    "clip_range": "clip_range",
+    "vf_clip_range": "vf_clip_range",
+    "ent_coef": "ent_coef",
+    "vf_coef": "vf_coef",
+    "ppo_epochs": "n_epochs",
+    "target_kl": "target_kl",
+    "minibatch_size": "minibatch_size",
+    "warmup_updates": "warmup_updates",
+    "warmup_clip_range": "warmup_clip_range",
+    "warmup_ent_coef": "warmup_ent_coef",
+    "ramp_updates": "ramp_updates",
+    "ramp_start_fraction": "ramp_start_fraction",
+    "ramp_attr": "ramp_attr",
+}
+
+#: ``[jax]`` keys applied as ``[env]`` overrides rather than train kwargs.
+_JAX_ENV_OVERRIDE_KEYS = ("fall_penalty", "reset_noise_scale", "init_qpos_noise", "init_yaw_noise")
+
+#: Every ``[jax]`` key some consumer actually reads.  ``[curriculum]`` keys get
+#: this discipline from ``gate_schema`` ("silently dropping a misspelled
+#: threshold disables it") and ``[env]`` keys fail loudly at env construction;
+#: the ``[jax]`` table had neither, and the configs' own history shows the trap
+#: is real ("species default was leaking into stage 1 via key mismatch bug").
+#: ``policy_kwargs`` is declared in every TOML but consumed by no JAX path
+#: today — the network factory is fixed — kept known so shipped configs
+#: validate; wiring it into ``make_actor_critic`` is its own change.
+KNOWN_JAX_KEYS = (
+    frozenset(_JAX_KEY_MAP)
+    | frozenset(_JAX_ENV_OVERRIDE_KEYS)
+    | frozenset({"obs_rms_decay_on_resume", "policy_kwargs"})
+)
+
+
+def validate_jax_kwargs(jax_kwargs: dict[str, Any], *, source: str) -> None:
+    """Reject unknown ``[jax]`` keys, fail-closed.
+
+    Args:
+        jax_kwargs: The stage config's ``jax_kwargs`` table.
+        source: Human-readable origin for the error message, e.g.
+            ``"trex stage 2 [jax]"``.
+
+    Raises:
+        ValueError: If the table carries a key no consumer reads.  Silently
+            dropping a misspelled or unwired key disables it — the failure
+            mode this module shipped twice (``ramp_attr``,
+            ``obs_rms_decay_on_resume``).
+    """
+    unknown = sorted(set(jax_kwargs) - KNOWN_JAX_KEYS)
+    if unknown:
+        raise ValueError(
+            f"{source} declares keys nothing consumes: {unknown}. "
+            "A [jax] key that no training path reads is silently inert — fix the "
+            "spelling, or add it to _JAX_KEY_MAP / KNOWN_JAX_KEYS in jax_curriculum.py "
+            "alongside the code that consumes it."
+        )
+
 
 def episode_return_for_gate(eval_metrics: dict[str, float], *, threshold: float) -> float:
     """The EPISODE-level mean return the TOML reward thresholds are stated in.
@@ -227,6 +298,9 @@ def run_curriculum(
     obs_stats = None
     for stage in stages:
         stage_config = load_stage_config(species, stage)
+        jax_kwargs = stage_config.get("jax_kwargs", {})
+        env_kwargs = stage_config.get("env_kwargs", {})
+        validate_jax_kwargs(jax_kwargs, source=f"{species} stage {stage} [jax]")
 
         # Pass previous stage's params AND observation-normalization stats to
         # the next stage — carrying only the weights would feed the policy
@@ -235,37 +309,26 @@ def run_curriculum(
         if params is not None:
             train_kwargs["init_params"] = params
         if obs_stats is not None:
+            # Decay the carried normalization count so the entered stage's
+            # shifted obs distribution (near-zero velocity in balance →
+            # sustained velocity in locomotion) re-anchors the stats within a
+            # few updates — with the prior stage's count of millions,
+            # update_running_stats is nearly a no-op exactly when the
+            # distribution moves.  Same default (0.01) and per-stage override
+            # (obs_rms_decay_on_resume, 1.0 disables) as the notebook's
+            # resume cell, which honored this key while both library paths
+            # silently dropped it.
+            decay = float(jax_kwargs.get("obs_rms_decay_on_resume", 0.01))
+            if decay != 1.0:
+                from .jax_normalization import decay_running_stats
+
+                obs_stats = decay_running_stats(obs_stats, decay_factor=decay)
+                _logger.info("Stage %d resume: obs normalization count decayed by %.4g", stage, decay)
             train_kwargs["init_obs_stats"] = obs_stats
 
         # Merge TOML [jax] and [env] sections into train_kwargs so that
         # stage-specific hyperparameters and reward weights reach train_jax.
         stage_train_kwargs = dict(train_kwargs)
-        jax_kwargs = stage_config.get("jax_kwargs", {})
-        env_kwargs = stage_config.get("env_kwargs", {})
-
-        # Map TOML [jax] keys to train_jax parameter names
-        _JAX_KEY_MAP = {
-            "num_envs": "num_envs",
-            "rollout_len": "rollout_len",
-            "num_updates": "num_updates",
-            "learning_rate": "learning_rate",
-            "learning_rate_end": "learning_rate_end",
-            "max_grad_norm": "max_grad_norm",
-            "gamma": "gamma",
-            "gae_lambda": "gae_lambda",
-            "clip_range": "clip_range",
-            "vf_clip_range": "vf_clip_range",
-            "ent_coef": "ent_coef",
-            "vf_coef": "vf_coef",
-            "ppo_epochs": "n_epochs",
-            "target_kl": "target_kl",
-            "minibatch_size": "minibatch_size",
-            "warmup_updates": "warmup_updates",
-            "warmup_clip_range": "warmup_clip_range",
-            "warmup_ent_coef": "warmup_ent_coef",
-            "ramp_updates": "ramp_updates",
-            "ramp_start_fraction": "ramp_start_fraction",
-        }
         for toml_key, param_name in _JAX_KEY_MAP.items():
             if toml_key in jax_kwargs:
                 stage_train_kwargs[param_name] = jax_kwargs[toml_key]

--- a/environments/shared/jax_trainer.py
+++ b/environments/shared/jax_trainer.py
@@ -936,6 +936,13 @@ class JaxTrainer:
             ``ramp_start_fraction`` to 1.0 over the first N updates
             (TOML ``ramp_updates``).  0 disables.
         ramp_start_fraction: Starting fraction of forward_vel_weight.
+        ramp_attr: Reward attribute the ramp applies to (TOML ``ramp_attr``).
+            Only ``"forward_vel_weight"`` is supported on the MJX path — it is
+            the one weight wired through ``env.step`` as a runtime scale;
+            everything else is baked into the jitted reward at trace time.
+            Accepted (and refused loudly for other values) so the TOML key
+            behaves identically here and in the notebook's :func:`train` path,
+            instead of being silently dropped.
     """
 
     def __init__(
@@ -953,7 +960,17 @@ class JaxTrainer:
         warmup_ent_coef: float = 0.02,
         ramp_updates: int = 0,
         ramp_start_fraction: float = 0.1,
+        ramp_attr: str = "forward_vel_weight",
     ):
+        if ramp_updates > 0 and ramp_attr != "forward_vel_weight":
+            # Same contract as the module-level train(): the MJX env captures
+            # most weights as Python constants at trace time, so they cannot
+            # be ramped without recompilation.  Fail loud rather than
+            # silently ramping the wrong attribute (or nothing).
+            raise ValueError(
+                f"Reward ramp on attr={ramp_attr!r} is not supported by the MJX path; "
+                "only 'forward_vel_weight' is dynamic at runtime."
+            )
         self.env = env
         self.network = network
         self.optimizer = optimizer
@@ -966,6 +983,7 @@ class JaxTrainer:
         self.warmup_ent_coef = warmup_ent_coef
         self.ramp_updates = ramp_updates
         self.ramp_start_fraction = ramp_start_fraction
+        self.ramp_attr = ramp_attr
 
         self._collect_rollout: Callable | None = None
         self._scan_ppo_update: Callable | None = None
@@ -1189,7 +1207,8 @@ class JaxTrainer:
             )
         if self.ramp_updates > 0:
             _logger.info(
-                "Ramp: forward_vel scale %s -> 1.0 over %d updates",
+                "Ramp: %s scale %s -> 1.0 over %d updates",
+                self.ramp_attr,
                 self.ramp_start_fraction,
                 self.ramp_updates,
             )

--- a/environments/shared/jax_training.py
+++ b/environments/shared/jax_training.py
@@ -56,6 +56,7 @@ def train_jax(
     warmup_ent_coef: float = 0.02,
     ramp_updates: int = 0,
     ramp_start_fraction: float = 0.1,
+    ramp_attr: str = "forward_vel_weight",
 ) -> tuple[Any, dict[str, float], Any]:
     """Train a species with JAX/MJX PPO.
 
@@ -98,6 +99,9 @@ def train_jax(
         ramp_updates: Ramp forward_vel_weight scale over the first N
             updates (TOML ``ramp_updates``).  0 disables.
         ramp_start_fraction: Starting fraction of forward_vel_weight.
+        ramp_attr: Reward attribute the ramp applies to (TOML ``ramp_attr``).
+            Only ``"forward_vel_weight"`` is supported on the MJX path;
+            anything else raises rather than silently ramping nothing.
 
     Returns:
         ``(params, eval_metrics, obs_stats)`` tuple.  *obs_stats* is the
@@ -183,6 +187,7 @@ def train_jax(
         warmup_ent_coef=warmup_ent_coef,
         ramp_updates=ramp_updates,
         ramp_start_fraction=ramp_start_fraction,
+        ramp_attr=ramp_attr,
     )
 
     params, eval_metrics, _state = trainer.train(
@@ -277,6 +282,10 @@ def main():
         jax_kwargs = stage_config.get("jax_kwargs", {})
         env_kwargs = stage_config.get("env_kwargs", {})
 
+        from .jax_curriculum import validate_jax_kwargs
+
+        validate_jax_kwargs(jax_kwargs, source=f"{args.species} stage {args.stage} [jax]")
+
         # Override fall_penalty / reset noise from [jax] section if specified.
         # Use direct assignment — setdefault is a no-op when [env] already
         # defines the key, which silently ignores the JAX-specific override.
@@ -314,6 +323,7 @@ def main():
             warmup_ent_coef=jax_kwargs.get("warmup_ent_coef", 0.02),
             ramp_updates=jax_kwargs.get("ramp_updates", 0),
             ramp_start_fraction=jax_kwargs.get("ramp_start_fraction", 0.1),
+            ramp_attr=jax_kwargs.get("ramp_attr", "forward_vel_weight"),
             env_kwargs=env_kwargs,
         )
 

--- a/environments/shared/tests/test_jax_curriculum.py
+++ b/environments/shared/tests/test_jax_curriculum.py
@@ -259,3 +259,81 @@ class TestStanceRailUnits:
         config = {"curriculum_kwargs": dict(self.STANCE, min_avg_reward=1950.0)}
         assert check_stage_gate(self._metrics(mean_reward=3.27, mean_episode_return=3271.8), config) is True
         assert check_stage_gate(self._metrics(mean_reward=3.27, mean_episode_return=900.0), config) is False
+
+
+class TestJaxKwargsPlumbing:
+    """[jax] keys must reach train_fn or fail loudly — never go silently inert.
+
+    ``ramp_attr`` and ``obs_rms_decay_on_resume`` were set in eight TOMLs and
+    honored only by the notebook: both library entry points dropped them with
+    no warning, while the config comments asserted they worked. These tests
+    run without JAX installed, like the rest of this file.
+    """
+
+    def test_every_shipped_jax_table_validates(self):
+        from environments.shared.config import load_stage_config
+        from environments.shared.jax_curriculum import validate_jax_kwargs
+
+        for species in ("trex", "velociraptor", "brachiosaurus", "dibothrosuchus"):
+            for stage in (1, 2, 3):
+                cfg = load_stage_config(species, stage)
+                validate_jax_kwargs(cfg.get("jax_kwargs", {}), source=f"{species} stage {stage} [jax]")
+
+    def test_an_unknown_key_is_rejected_by_name(self):
+        from environments.shared.jax_curriculum import validate_jax_kwargs
+
+        with pytest.raises(ValueError, match="obs_rms_decay_on_resmue"):
+            validate_jax_kwargs({"obs_rms_decay_on_resmue": 0.01}, source="test [jax]")
+
+    def test_the_key_map_only_names_train_jax_parameters(self):
+        """A mapping to a parameter train_jax does not accept is a silent drop
+        one level down; inspect the real signature so the two cannot drift."""
+        import inspect
+
+        from environments.shared.jax_curriculum import _JAX_KEY_MAP
+        from environments.shared.jax_training import train_jax
+
+        accepted = set(inspect.signature(train_jax).parameters)
+        unmapped = {param for param in _JAX_KEY_MAP.values() if param not in accepted}
+        assert not unmapped, f"_JAX_KEY_MAP targets parameters train_jax lacks: {sorted(unmapped)}"
+
+    def test_run_curriculum_decays_carried_obs_stats_and_passes_ramp_attr(self, monkeypatch):
+        """The stage-2 resume must decay the carried normalization count with
+        the entered stage's configured factor, and the TOML ramp_attr must
+        reach train_fn instead of being dropped."""
+        import sys
+        import types
+
+        from environments.shared.config import load_stage_config
+        from environments.shared.jax_curriculum import run_curriculum
+
+        decay_calls: list = []
+        stub = types.ModuleType("environments.shared.jax_normalization")
+
+        def _stub_decay(stats, decay_factor):
+            decay_calls.append((stats, decay_factor))
+            return ("decayed", stats)
+
+        stub.decay_running_stats = _stub_decay
+        monkeypatch.setitem(sys.modules, "environments.shared.jax_normalization", stub)
+
+        stage1_gate = load_stage_config("velociraptor", 1)["curriculum_kwargs"]
+        passing_metrics = {
+            "mean_episode_return": float(stage1_gate["min_avg_reward"]) + 1.0,
+            "mean_episode_length": float(stage1_gate["min_avg_episode_length"]) + 1.0,
+        }
+
+        seen: dict[int, dict] = {}
+
+        def fake_train(species, stage, **kwargs):
+            seen[stage] = kwargs
+            return (f"params-s{stage}", dict(passing_metrics), f"stats-s{stage}")
+
+        run_curriculum("velociraptor", fake_train, stages=(1, 2))
+
+        assert "init_obs_stats" not in seen[1], "stage 1 starts from fresh stats"
+        stage2_jax = load_stage_config("velociraptor", 2)["jax_kwargs"]
+        assert decay_calls == [("stats-s1", float(stage2_jax["obs_rms_decay_on_resume"]))]
+        assert seen[2]["init_obs_stats"] == ("decayed", "stats-s1")
+        assert seen[2]["init_params"] == "params-s1"
+        assert seen[2]["ramp_attr"] == stage2_jax["ramp_attr"]

--- a/environments/shared/tests/test_jax_trainer.py
+++ b/environments/shared/tests/test_jax_trainer.py
@@ -499,3 +499,27 @@ class TestJaxTrainerObsStatsRawOnly:
             f"{float(jnp.max(jnp.abs(obs_mean))):.4f}); stats may be "
             "updated from normalized obs"
         )
+
+
+class TestRampAttrGuard:
+    """The TOML ramp_attr key is honored with the same contract everywhere:
+    'forward_vel_weight' works, anything else fails at construction — the MJX
+    env bakes other weights into the jitted reward at trace time, so a
+    different attr cannot ramp and must not pretend to."""
+
+    def test_an_unsupported_ramp_attr_is_refused_at_construction(self):
+        with pytest.raises(ValueError, match="forward_vel_weight"):
+            JaxTrainer(
+                env=None,
+                network=None,
+                optimizer=None,
+                ppo_config=None,
+                ramp_updates=5,
+                ramp_attr="tail_stability_weight",
+            )
+
+    def test_the_supported_attr_and_a_disabled_ramp_construct_fine(self):
+        trainer = JaxTrainer(env=None, network=None, optimizer=None, ppo_config=None, ramp_updates=5)
+        assert trainer.ramp_attr == "forward_vel_weight"
+        # With the ramp disabled the attr is inert, so any value is tolerated.
+        JaxTrainer(env=None, network=None, optimizer=None, ppo_config=None, ramp_updates=0, ramp_attr="whatever")


### PR DESCRIPTION
## Summary

All eight stage-2/3 TOMLs set `obs_rms_decay_on_resume = 0.01` ("lets stats adapt to Stage 2's velocity distribution within ~2 updates") and `ramp_attr`, and only the notebook honored them — both library entry points silently dropped them while the config comments asserted the behavior. (Finding §3.2 of `docs/reviews/RL_PIPELINE_REVIEW_2026_08.md`; `website/docs/training/jax.md` already documented the divergence.)

- `run_curriculum` carried the prior stage's observation statistics into the next stage with their full multi-million sample count, making `update_running_stats` nearly a no-op exactly when the obs distribution shifts — the pathology the key exists to prevent.
- `ramp_attr` was absent from `_JAX_KEY_MAP` and unread by the CLI.

## Fix

- **`run_curriculum` decays the carried normalization count** through `decay_running_stats` with the entered stage's configured factor — same 0.01 default and `1.0` opt-out as the notebook's resume cell, so notebook and library now agree.
- **`ramp_attr` reaches `train_jax` → `JaxTrainer`**, which honors the one value the MJX path can ramp (`forward_vel_weight` is wired through `env.step` as a runtime scale; other weights are baked into the jitted reward at trace time) and **refuses anything else at construction** — the same contract the notebook's `train()` path already enforced — instead of silently ramping nothing.
- **The `[jax]` table now rejects unknown keys fail-closed** (`validate_jax_kwargs`, called on both library paths), closing the mechanism that let both keys rot — the same discipline `gate_schema` gives `[curriculum]`. `_JAX_KEY_MAP` is hoisted to module level as the single source of truth, and a test pins every mapped name against `train_jax`'s real signature so the map and the function cannot drift apart.
- One key is grandfathered as known-but-inert and documented as such: `[jax.policy_kwargs]` is declared in every TOML but no JAX path reads it (the network factory is fixed). Wiring it into `make_actor_critic` is its own change.

## Validation

- New `TestJaxKwargsPlumbing` (runs without JAX, like the rest of the file): all 12 shipped `[jax]` tables validate; an unknown key is rejected by name; the key map is checked against `train_jax`'s signature; a fake-`train_fn` curriculum run asserts stage 2 receives the decayed stats (with the TOML's factor) and the TOML's `ramp_attr`.
- New `TestRampAttrGuard`: an unsupported `ramp_attr` with an active ramp is refused at `JaxTrainer` construction; the supported attr and a disabled ramp construct fine.
- `pytest environments/shared/tests/test_jax_curriculum.py environments/shared/tests/test_jax_trainer.py environments/shared/tests/test_jax_training_utils.py -q` — all pass (JAX-requiring cases skip in this environment, as before).
- `ruff check` / `ruff format --check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb

---
_Generated by [Claude Code](https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb)_