### PR TITLE
Fix the seven mypy errors the stance-report merges left on main

### DIFF
--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -1491,7 +1491,7 @@ def render_constant_hold_probe(reports: list[dict[str, Any]], *, probe_episodes:
     # control whose standing is already known and proves nothing about this
     # policy. Folding it in would make an all-falling result read as mixed.
     held = [row for row in rows if row["source"] == "measured"]
-    hold_actions = next(
+    hold_actions: "list[float] | tuple[float, ...]" = next(
         (report["hold_constant"]["actions"] for report in reports if report["hold_constant"]["source"] == "measured"),
         [],
     )
@@ -1768,7 +1768,7 @@ def render_impulse_probe(
     step = policy_reports[0]["impulse"]["step"]
     policy = str(policy_reports[0]["policy"]).split(" — ")[0]
     keys = sorted(set(policy_rows) | set(statue_rows))
-    rows = []
+    rows: list[dict[str, Any]] = []
     for key in keys:
         here, there = policy_rows.get(key), statue_rows.get(key)
         rows.append(
@@ -2432,7 +2432,9 @@ def main() -> int:
 
     if args.impulse_probe:
         step = report["settle_steps"] if args.impulse_step is None else args.impulse_step
-        variants = impulse_variants(impulse_speeds, step=step)
+        # Its own name: `variants` above holds ConstantHold entries, and
+        # reusing it for RootImpulse entries conflates the two probe types.
+        impulse_sweep = impulse_variants(impulse_speeds, step=step)
 
         def _sweep(zero_action: bool) -> list[dict[str, Any]]:
             return [
@@ -2448,7 +2450,7 @@ def main() -> int:
                     allow_legacy_plant=args.allow_legacy_plant,
                     impulse=variant,
                 )
-                for variant in variants
+                for variant in impulse_sweep
             ]
 
         # Rolled once and reused: each sweep is a few thousand simulated steps,


### PR DESCRIPTION
## Summary

PRs #493/#494 merged without CI ever running — `python-ci.yml`'s triggers didn't fire on them (the zero-check-runs gap noted in `docs/reviews/RL_PIPELINE_REVIEW_2026_08.md` §8.5/§8.9) — and the first PRs to trigger the lint job afterward (#495, #496) inherited seven mypy errors in `environments/shared/scripts/stance_gate_report.py` that now block **every** lint run on the repo, since the job checks the whole tree.

The seven errors, all mechanical:

- `hold_actions` (constant-hold payload) lacked an annotation;
- the impulse read-out's `rows` list holds mixed-type cells, so `row["speed"] > 0` / `row["margin_steps"] is not None` failed operand typing — annotated as `list[dict[str, Any]]`;
- `main()` reused one `variants` variable for a `list[ConstantHold]` and then a `list[RootImpulse]`, which also mistyped the `impulse=` argument — the impulse sweep now has its own name.

Annotations and one rename only; no behavior change.

## Validation

- `mypy environments/ --ignore-missing-imports` (mypy 2.3.0, the version CI resolves): the seven errors are gone. The remaining local-only errors live in sb3/torch-typed files that CI's dependency-light lint env resolves to `Any` — CI's own failing runs on #495/#496 listed exactly the seven fixed here (plus one in #495's own diff, fixed on that branch).
- `pytest environments/shared/tests/test_stance_gate_report.py -q` — all pass, unchanged.
- `ruff check` / `ruff format --check` clean.

Merging this unblocks lint (and therefore the skipped test jobs) for #495 and #496, which then need `main` merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb

---
_Generated by [Claude Code](https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb)_