### PR TITLE
Aggregate contact across physics substeps on both backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -377,6 +377,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was sized for a 6M stage and never revisited when stage 1 became 10M.
 
 ### Fixed
+- **Contact is now measured at every physics substep, not one in five — the
+  stance-duty gate certifies airborne time instead of a sampled duty.**
+  Physics runs at 500 Hz and control at 100 Hz (`frame_skip = 5`), and every
+  contact-derived quantity — the `r/l_foot_contact` info keys the
+  `stance_quality/v1` gate certifies from, the bilateral-support /
+  foot-load-balance / support-conditioned-alive rewards, gait-symmetry
+  touchdown detection, and floor-strike termination — read only the **last**
+  substep's state. The seed-43 stage-1 run exposed the consequence
+  mechanically: a 20 Hz control-clock-locked hop put exactly one unloaded
+  sample in every five (`bilateral_support_duty` exactly 0.8000 in all 40
+  panel episodes, every duty a multiple of 1/800), so the gated 0.1958 was a
+  sample-phase statistic, not airborne time — and the false-PASS direction
+  was open: a policy sharpening its unloading to fall *between* the 10 ms
+  samples would have read duty 0.000 and passed the 0.02 ceiling while
+  unloading every cycle. Reward, obs, and gate all shared the stroboscope,
+  and the run proved policies phase-lock to it.
+  Both backends now aggregate inside the substep loop, in lockstep: per-foot
+  **MIN** touch force across the substeps (min of per-substep per-foot
+  *sums* — never per-sensor minima, which under-report when load shifts
+  between pad and digits) feeds the rewards and info keys, and the first
+  floor strike is latched (SB3: contact-pair latch in `BaseDinoEnv.step`;
+  MJX: the height-emulation checks OR-ed per substep through the `fori_loop`
+  carry). One residual asymmetry is deliberate and documented rather than
+  closed: SB3's explicit site/body **height** terminations (T-Rex
+  `head_tip_z`/`skull_z`, dibothrosuchus `snout_tip_z`) remain
+  boundary-sampled — SB3's any-substep coverage is the *contact* latch,
+  MJX's is the *height* emulation, so a transient head dip that touches
+  nothing can terminate on MJX/eval while surviving SB3. The divergence
+  direction is MJX-stricter (conservative for training); folding SB3's
+  height checks into the substep loop is left for the plant-revision PR.
+  `evaluate_policy_cpu` aggregates identically and passes the
+  substep-MIN through a new `aggregated_foot_forces` override on the reward
+  composers, so stage-gate evaluation scores the same quantity training
+  optimizes; the override defaults to single-state semantics, which is what
+  the SB3-vs-JAX parity test pins. **Observations deliberately stay on the
+  boundary sample**: the obs builders are source-fingerprinted by the plant
+  contract, so aggregating them would bump every species' policy interface —
+  and the defect lives in what the gate and reward *price*, not in what the
+  policy senses.
+  `stance_duty_validation.py` gains the regime that certifies this: a
+  control-clock-locked 20 Hz hop (period 5 = the aliasing regime its 2.5 Hz
+  driver could never express), with per-substep kinematic ground truth
+  recorded through a new step-loop probe hook and a within-control-step
+  aliasing column. A regression test drives the same hop and pins both that
+  `info` equals the min of the per-substep sums exactly and that steps exist
+  where the boundary sample read supported while a substep was airborne —
+  structurally impossible to catch before this change. The statue is
+  measurably unaffected (settled-stance substep ripple is below the
+  1e-6-relative equality tests' tolerance; a statue-duty test pins
+  unsupported 0.0 / bilateral 1.0), but **duty histories are pre/post
+  apples-to-oranges for hopping policies** — the chatterer's 0.319 and the
+  seed runs' 0.1958 were boundary-sampled and would measure higher now; the
+  statue-derived constants are re-derived with the passive-toes plant
+  revision that follows.
 - **`obs_rms_decay_on_resume` and `ramp_attr` were silently dropped by both
   JAX library entry points — and the `[jax]` table now rejects unknown keys.**
   All eight stage-2/3 TOMLs set `obs_rms_decay_on_resume = 0.01` ("lets stats

--- a/environments/brachiosaurus/envs/brachio_env.py
+++ b/environments/brachiosaurus/envs/brachio_env.py
@@ -256,6 +256,14 @@ class BrachioEnv(BaseDinoEnv):
         self._sensor_fl_meta = 27
         self._sensor_rr_meta = 28
         self._sensor_rl_meta = 29
+        # Per-foot groups for the base class's substep MIN aggregation --
+        # mirrors mjx_config's sensor_foot_indices + sensor_foot_aux_indices.
+        self._foot_sensor_groups = (
+            (self._sensor_fr_foot, self._sensor_fr_meta),
+            (self._sensor_fl_foot, self._sensor_fl_meta),
+            (self._sensor_rr_foot, self._sensor_rr_meta),
+            (self._sensor_rl_foot, self._sensor_rl_meta),
+        )
 
     def _foot_contact_forces(self) -> tuple[float, float, float, float]:
         """Total floor contact force under each leg: foot pad plus meta."""
@@ -405,8 +413,9 @@ class BrachioEnv(BaseDinoEnv):
         reward_height = self.height_weight * height_frac
         info["reward_height"] = reward_height
 
-        # 9. Gait symmetry (reward alternating diagonal pair contacts)
-        fr_contact, fl_contact, rr_contact, rl_contact = self._foot_contact_forces()
+        # 9. Gait symmetry (reward alternating diagonal pair contacts).
+        # Substep-MIN aggregated -- see BaseDinoEnv._aggregated_foot_contact_forces.
+        fr_contact, fl_contact, rr_contact, rl_contact = self._aggregated_foot_contact_forces()
         info["r_foot_contact"] = float(fr_contact)
         info["l_foot_contact"] = float(fl_contact)
         info["rr_foot_contact"] = float(rr_contact)

--- a/environments/dibothrosuchus/envs/dibothrosuchus_env.py
+++ b/environments/dibothrosuchus/envs/dibothrosuchus_env.py
@@ -263,6 +263,14 @@ class DibothrosuchusEnv(BaseDinoEnv):
         self._sensor_fl_foot = 11
         self._sensor_rr_foot = 12
         self._sensor_rl_foot = 13
+        # Per-foot groups for the base class's substep MIN aggregation --
+        # mirrors mjx_config's sensor_foot_indices (no aux sensors here).
+        self._foot_sensor_groups = (
+            (self._sensor_fr_foot,),
+            (self._sensor_fl_foot,),
+            (self._sensor_rr_foot,),
+            (self._sensor_rl_foot,),
+        )
 
     def _scale_action(self, action: np.ndarray) -> np.ndarray:
         """Map normalized residual actions around the XML home controls.
@@ -445,11 +453,9 @@ class DibothrosuchusEnv(BaseDinoEnv):
         reward_height = self.height_weight * height_frac
         info["reward_height"] = reward_height
 
-        # 11. Gait symmetry (reward alternating diagonal pair touchdowns)
-        fr_contact = self.data.sensordata[self._sensor_fr_foot]
-        fl_contact = self.data.sensordata[self._sensor_fl_foot]
-        rr_contact = self.data.sensordata[self._sensor_rr_foot]
-        rl_contact = self.data.sensordata[self._sensor_rl_foot]
+        # 11. Gait symmetry (reward alternating diagonal pair touchdowns).
+        # Substep-MIN aggregated -- see BaseDinoEnv._aggregated_foot_contact_forces.
+        fr_contact, fl_contact, rr_contact, rl_contact = self._aggregated_foot_contact_forces()
         info["r_foot_contact"] = float(fr_contact)
         info["l_foot_contact"] = float(fl_contact)
         info["rr_foot_contact"] = float(rr_contact)

--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -13,6 +13,7 @@ across all dinosaur species. Subclasses override species-specific methods:
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import Any
 
 import gymnasium as gym
@@ -63,17 +64,35 @@ _GROUND_PROBE_DISTANCE = 10.0
 class BaseDinoEnv(gym.Env, ABC):
     """Abstract base class for dinosaur locomotion environments.
 
-    Optional species hook, documented here because it has no base
-    implementation and its shape is easy to get wrong:
+    Species hook with a base implementation driven by ``_foot_sensor_groups``:
 
     ``_foot_contact_forces() -> tuple[float, ...]``
-        Total floor-contact force under each foot, in a stable per-species
-        order, summing every sensor that sees that foot (T-Rex: plantar pad +
-        three digits; brachiosaurus: pad + meta).  **The arity is the number
-        of feet** -- 2 on the bipeds, 4 on the quadrupeds -- so callers must
-        either sum it or check ``len`` before unpacking.  Species that expose
-        no foot sensors simply do not define it, which is why consumers guard
-        with ``hasattr`` rather than calling a base stub."""
+        INSTANTANEOUS total floor-contact force under each foot from the
+        current ``data.sensordata``, in a stable per-species order, summing
+        every sensor that sees that foot (T-Rex: plantar pad + three digits;
+        brachiosaurus: pad + meta).  **The arity is the number of feet** -- 2
+        on the bipeds, 4 on the quadrupeds -- so callers must either sum it
+        or check ``len`` before unpacking.  Species declare their sensor
+        groups via ``_foot_sensor_groups`` in ``_cache_ids``; a species with
+        no groups gets an empty tuple, which is why consumers check the
+        arity.  Kept an overridable METHOD (tests monkeypatch it to steer
+        the contact-shaped rewards), and it stays the per-substep primitive:
+        :meth:`step` calls it once per physics substep to build the
+        aggregated value below.
+
+    ``_aggregated_foot_contact_forces() -> tuple[float, ...]``
+        The per-foot MIN across the ``frame_skip`` physics substeps of the
+        current control step -- what the contact-shaped rewards, the
+        ``*_foot_contact`` info keys, and therefore the stance-duty gate
+        consume.  Physics runs at 1/``model.opt.timestep`` Hz while control
+        runs ``frame_skip`` times slower; reading only the final substep let
+        a control-clock-locked hop unload between samples and read as
+        continuous support (the seed-43 stage-1 bounce measured exactly one
+        unloaded sample per 5).  MIN over per-substep per-foot SUMS -- never
+        a sum of per-sensor minima, which under-reports when load shifts
+        between pad and digits within a control step.  Falls back to the
+        instantaneous read when no step has run (reset, direct calls, the
+        SB3/MJX single-state parity tests)."""
 
     # Ground-settling caches, all derived from the model and so fixed for the
     # lifetime of the instance.  Declared here rather than assigned via getattr
@@ -81,6 +100,34 @@ class BaseDinoEnv(gym.Env, ABC):
     _root_subtree_geom_ids: "np.ndarray | None" = None
     _static_floor_geom_ids: "np.ndarray | None" = None
     _home_ground_clearance_m: float | None = None
+
+    # Per-foot touch-sensor groups (sensordata indices), declared per species
+    # in _cache_ids; () means "no foot sensors".  Mirrors the MJX registry's
+    # sensor_foot_indices + sensor_foot_aux_indices so both backends aggregate
+    # the same sensors.
+    _foot_sensor_groups: "tuple[tuple[int, ...], ...]" = ()
+
+    # Substep aggregation state, populated by step()'s frame-skip loop.
+    # Tagged with the _step_count it was measured at rather than cleared in
+    # reset(): reset() zeroes _step_count anyway, which invalidates the tag,
+    # and reset()'s SOURCE is fingerprinted by the plant contract's
+    # home_reset interface -- touching it would bump every species' policy
+    # interface for a bookkeeping detail.  None / a stale tag both mean "no
+    # aggregate for the current step", and consumers fall back to the
+    # instantaneous read (__init__ and reset call _get_obs() before any step
+    # has run, and several tests score hand-posed states directly).
+    _substep_min_foot_forces: "np.ndarray | None" = None
+    _substep_floor_hit_geom: "int | None" = None
+    _substep_contact_step: int = -1
+    _ground_geom_array: "np.ndarray | None" = None
+
+    # Optional zero-argument callable invoked after EVERY physics substep in
+    # step().  Exists so stance_duty_validation.py and the aggregation
+    # regression tests can record per-substep kinematic ground truth through
+    # the REAL step path instead of replicating the loop on a shadow env
+    # that can silently drift from it.  None (the default) costs one
+    # comparison per substep.
+    _substep_probe_hook: "Callable[[], None] | None" = None
 
     metadata = {
         "render_modes": ["human", "rgb_array"],
@@ -720,10 +767,57 @@ class BaseDinoEnv(gym.Env, ABC):
         """
         return _check_height_tilt_pure(body_z, tilt_angle, self.healthy_z_range, self.max_tilt_angle)
 
+    def _foot_contact_forces(self) -> "tuple[float, ...]":
+        """Instantaneous per-foot touch-force sums from the current sensordata.
+
+        See the class docstring for the contract.  This is the per-substep
+        primitive; the contact-shaped rewards and info keys consume
+        :meth:`_aggregated_foot_contact_forces` instead.
+        """
+        sensordata = self.data.sensordata
+        return tuple(float(sum(sensordata[index] for index in group)) for group in self._foot_sensor_groups)
+
+    def _aggregated_foot_contact_forces(self) -> "tuple[float, ...]":
+        """Per-foot MIN force across the current control step's substeps.
+
+        Falls back to the instantaneous read when no aggregate exists for the
+        CURRENT step count (before any step, or after reset zeroes the count)
+        so those callers keep today's semantics on both backends.  The tag
+        cannot see EXTERNAL state mutation: hand-posing ``self.data`` after a
+        completed step and scoring directly reads that step's minima, not the
+        posed state -- call :meth:`_invalidate_substep_aggregates` after
+        out-of-band mutation.
+        """
+        if self._substep_min_foot_forces is None or self._substep_contact_step != self._step_count:
+            return self._foot_contact_forces()
+        return tuple(float(value) for value in self._substep_min_foot_forces)
+
+    def _invalidate_substep_aggregates(self) -> None:
+        """Drop the last step's contact aggregates and strike latch.
+
+        The step-count tag cannot detect EXTERNAL state mutation: a caller
+        that hand-poses ``self.data`` after a completed step (keyframe reset,
+        qpos surgery + ``mj_forward``) and then scores the state directly
+        would otherwise read the pre-mutation step's minima and latch.  Call
+        this after mutating the state out-of-band; ordinary ``step``/``reset``
+        flows never need it (reset zeroes ``_step_count``, which the tag
+        already fails against).
+        """
+        self._substep_min_foot_forces = None
+        self._substep_floor_hit_geom = None
+        self._substep_contact_step = -1
+
     def _check_floor_contact(
         self, body_ground_geoms: set, floor_geom_id: int, geom_categories: "dict[str, set] | None" = None
     ) -> "tuple[bool, str | None]":
         """Check if any body geom contacts the floor.
+
+        Consults the step loop's ANY-substep latch first: contacts are
+        recomputed by every physics substep, so a strike during substeps
+        1..N-1 is invisible to a scan of the final substep's ``data.contact``
+        -- a tail slap that resolves within 8 ms used to go unterminated.
+        The live scan remains as the fallback for callers outside step()
+        (tests, hand-posed states).
 
         Args:
             body_ground_geoms: Set of geom IDs that should terminate on floor contact.
@@ -735,6 +829,13 @@ class BaseDinoEnv(gym.Env, ABC):
         Returns:
             (terminated, reason) where reason is None if not terminated.
         """
+        latched = self._substep_floor_hit_geom if self._substep_contact_step == self._step_count else None
+        if latched is not None and latched in body_ground_geoms:
+            if geom_categories:
+                for category_name, category_geoms in geom_categories.items():
+                    if latched in category_geoms:
+                        return True, f"{category_name}_contact"
+            return True, "body_contact"
         for i in range(self.data.ncon):
             contact = self.data.contact[i]
             geom1, geom2 = contact.geom1, contact.geom2
@@ -822,11 +923,54 @@ class BaseDinoEnv(gym.Env, ABC):
         ctrl = self._scale_action(action)
         self.data.ctrl[:] = ctrl
 
-        # Step physics
+        # Step physics, aggregating contact across the substeps: each mj_step
+        # recomputes sensordata and data.contact, so after the loop only the
+        # final substep survives -- and a control-clock-locked hop can unload
+        # (or a tail can strike the floor) entirely between control-boundary
+        # samples.  MIN per-foot force feeds the contact-shaped rewards and
+        # the stance-duty gate; the first floor strike is latched for
+        # _check_floor_contact.  The MJX step_fn carries the same aggregates
+        # through its fori_loop -- keep the two in lockstep.
+        min_forces: "np.ndarray | None" = None
+        self._substep_floor_hit_geom = None
+        track_feet = bool(self._foot_sensor_groups)
+        track_strikes = getattr(self, "_body_ground_geoms", None)
+        floor_geom_id = getattr(self, "floor_geom_id", None)
+        ground_geoms: "np.ndarray | None" = None
+        if track_strikes and floor_geom_id is not None:
+            if self._ground_geom_array is None:
+                # Cached sorted array of the terminating geoms for the
+                # vectorized per-substep scan below -- a Python loop over
+                # data.contact costs ~50 us per substep on the training hot
+                # path.
+                self._ground_geom_array = np.fromiter(sorted(track_strikes), dtype=np.int64)
+            ground_geoms = self._ground_geom_array
         for _ in range(self.frame_skip):
             mujoco.mj_step(self.model, self.data)
-
+            if self._substep_probe_hook is not None:
+                self._substep_probe_hook()
+            if track_feet:
+                forces = np.asarray(self._foot_contact_forces(), dtype=np.float64)
+                min_forces = forces if min_forces is None else np.minimum(min_forces, forces)
+            if ground_geoms is not None and self._substep_floor_hit_geom is None:
+                pairs = self.data.contact.geom
+                if len(pairs):
+                    g1, g2 = pairs[:, 0], pairs[:, 1]
+                    hits = ((g2 == floor_geom_id) & np.isin(g1, ground_geoms)) | (
+                        (g1 == floor_geom_id) & np.isin(g2, ground_geoms)
+                    )
+                    hit_indices = np.flatnonzero(hits)
+                    if hit_indices.size:
+                        # First matching contact, matching the live scan's
+                        # iteration order for categorization ties.
+                        first = int(hit_indices[0])
+                        struck = g1[first] if g2[first] == floor_geom_id else g2[first]
+                        self._substep_floor_hit_geom = int(struck)
         self._step_count += 1
+        # Tag the aggregates with the step they were measured at; the tag is
+        # what invalidates them across reset (which zeroes _step_count).
+        self._substep_min_foot_forces = min_forces
+        self._substep_contact_step = self._step_count
 
         # Update cumulative distance traveled (XY path length)
         current_pos_2d = self.data.qpos[0:2].copy()

--- a/environments/shared/jax_eval.py
+++ b/environments/shared/jax_eval.py
@@ -338,8 +338,37 @@ def evaluate_policy_cpu(
 
             ctrl = np.array(scale_action_fn(action))
             mj_data.ctrl[:] = ctrl
+            # Substep-aggregated contact, in lockstep with both training
+            # backends (BaseDinoEnv.step and the MJX step_fn carry): per-foot
+            # MIN touch force across the frame_skip substeps, and an
+            # any-substep OR of the body/site floor-strike checks.  The
+            # boundary sample alone let a control-clock-locked hop unload
+            # between samples and still read as continuous support -- eval
+            # must score the same quantity training optimizes.
+            min_foot_forces: "list[float] | None" = None
+            substep_struck = False
             for _ in range(config.frame_skip):
                 mujoco.mj_step(mj_model, mj_data)
+                substep_forces = []
+                for i, idx in enumerate(foot_sensor_indices):
+                    if len(mj_data.sensordata) <= idx:
+                        continue
+                    force = float(mj_data.sensordata[idx])
+                    if i < len(foot_aux_indices):
+                        force += sum(
+                            float(mj_data.sensordata[aux])
+                            for aux in foot_aux_indices[i]
+                            if len(mj_data.sensordata) > aux
+                        )
+                    substep_forces.append(force)
+                if min_foot_forces is None:
+                    min_foot_forces = substep_forces
+                else:
+                    min_foot_forces = [min(prev, cur) for prev, cur in zip(min_foot_forces, substep_forces)]
+                if not substep_struck:
+                    substep_struck = any(mj_data.xpos[bid, 2] < zt for bid, zt in _body_checks) or any(
+                        mj_data.site_xpos[sid, 2] < zt for sid, zt in _site_checks
+                    )
 
             # Per-step diagnostics
             fwd_vel = float(mj_data.qvel[0])
@@ -356,23 +385,19 @@ def evaluate_policy_cpu(
             results.diag_tilt.append(tilt)
             results.diag_pelvis_h.append(body_z)
             results.diag_energy.append(energy)
-            body_height_terminated = any(mj_data.xpos[bid, 2] < zt for bid, zt in _body_checks)
-            site_height_terminated = any(mj_data.site_xpos[sid, 2] < zt for sid, zt in _site_checks)
+            # Any-substep strike, from the aggregation loop above -- the
+            # boundary-only checks missed strikes resolving mid-control-step.
+            strike_terminated = substep_struck
 
-            # Foot contacts — sensor order alternates right/left (bipeds:
-            # R, L; quadrupeds: R, L, RR, RL), so split by parity rather
-            # than lumping every non-first foot into the left series.
-            for i, idx in enumerate(foot_sensor_indices):
-                if len(mj_data.sensordata) > idx:
-                    force = float(mj_data.sensordata[idx])
-                    if i < len(foot_aux_indices):
-                        force += sum(
-                            float(mj_data.sensordata[aux])
-                            for aux in foot_aux_indices[i]
-                            if len(mj_data.sensordata) > aux
-                        )
-                    target_list = results.diag_r_foot if i % 2 == 0 else results.diag_l_foot
-                    target_list.append(force)
+            # Foot contacts — substep-MIN per foot, from the aggregation loop.
+            # Sensor order alternates right/left (bipeds: R, L; quadrupeds:
+            # R, L, RR, RL), so split by parity rather than lumping every
+            # non-first foot into the left series.  These series feed the
+            # stance-duty reconstruction, so they must carry the same
+            # aggregated quantity the gate certifies.
+            for i, force in enumerate(min_foot_forces or []):
+                target_list = results.diag_r_foot if i % 2 == 0 else results.diag_l_foot
+                target_list.append(force)
 
             # Reward decomposition — all active components
             fwd_norm = float(np.clip(fwd_vel / config.forward_vel_max, -1.0, 1.0))
@@ -456,9 +481,16 @@ def evaluate_policy_cpu(
                 "initial_pos_2d": jnp.asarray(start_pos),
                 # Pelvis/tilt/nosedive termination is handled inside the
                 # canonical scalar reward.  Supply only the extra body/site
-                # checks so its fall penalty is applied exactly once.
-                "additional_terminated": jnp.asarray(body_height_terminated or site_height_terminated),
+                # checks (any-substep) so its fall penalty is applied exactly once.
+                "additional_terminated": jnp.asarray(strike_terminated),
             }
+            if min_foot_forces:
+                # Score the substep-MIN forces, not the boundary snapshot's --
+                # eval must price the same quantity the training loop does.
+                # Truthiness, not `is not None`: with no foot sensors declared
+                # the list is empty, and a shape-(0,) override would replace
+                # the composer's own foot-force derivation with nothing.
+                step_kwargs["aggregated_foot_forces"] = jnp.asarray(min_foot_forces, dtype=jnp.float32)
             if _target_body_id >= 0:
                 target_pos_np = np.array(mj_data.xpos[_target_body_id])
                 pelvis_np = np.array(mj_data.xpos[config.root_body_id])
@@ -527,12 +559,8 @@ def evaluate_policy_cpu(
             if forward_z < config.natural_forward_z - config.nosedive_threshold:
                 break
 
-            # Body-height floor contact termination
-            if body_height_terminated:
-                break
-
-            # Site-height termination (extremities like snout tip)
-            if site_height_terminated:
+            # Body/site-height floor-strike termination, any-substep
+            if strike_terminated:
                 break
 
             # Stage 3 success: proximity-based contact detection

--- a/environments/shared/jax_reward_termination.py
+++ b/environments/shared/jax_reward_termination.py
@@ -102,6 +102,7 @@ def compute_total_reward(
     success_threshold: float = 0.3,
     success_bonus: float = 0.0,
     additional_terminated: Array | None = None,
+    aggregated_foot_forces: Array | None = None,
 ) -> Array:
     """Compute total scalar reward matching ``mjx_env.py`` step logic.
 
@@ -129,7 +130,15 @@ def compute_total_reward(
         reward_cfg.get("forward_vel_weight", 0.0),
     )
 
-    foot_forces = _per_foot_forces(data, foot_indices, foot_sensor_groups)
+    # Substep-MIN override: the training backends aggregate touch force
+    # across the frame_skip physics substeps (see mjx_env step_fn and
+    # BaseDinoEnv.step); a caller scoring a stepped trajectory passes the
+    # aggregate so eval prices the same quantity training optimizes.
+    # Default None keeps single-state semantics for the parity tests.
+    if aggregated_foot_forces is not None:
+        foot_forces = aggregated_foot_forces
+    else:
+        foot_forces = _per_foot_forces(data, foot_indices, foot_sensor_groups)
     has_foot_contact = jnp.any(foot_forces > 0.1)
     r_bilateral_support, bilateral_support_quality = reward_bilateral_support(
         foot_forces,
@@ -356,6 +365,7 @@ def compute_reward_components(
     initial_pos_2d: Array | None = None,
     sensor_tail_gyro_start: int | None = None,
     forward_ref_2d: Array | None = None,
+    aggregated_foot_forces: Array | None = None,
 ) -> dict[str, Array]:
     """Compute per-component reward breakdown for diagnostics.
 
@@ -376,7 +386,15 @@ def compute_reward_components(
         reward_cfg.get("forward_vel_weight", 0.0),
     )
 
-    foot_forces = _per_foot_forces(data, foot_indices, foot_sensor_groups)
+    # Substep-MIN override: the training backends aggregate touch force
+    # across the frame_skip physics substeps (see mjx_env step_fn and
+    # BaseDinoEnv.step); a caller scoring a stepped trajectory passes the
+    # aggregate so eval prices the same quantity training optimizes.
+    # Default None keeps single-state semantics for the parity tests.
+    if aggregated_foot_forces is not None:
+        foot_forces = aggregated_foot_forces
+    else:
+        foot_forces = _per_foot_forces(data, foot_indices, foot_sensor_groups)
     has_foot_contact = jnp.any(foot_forces > 0.1)
     r_bilateral_support, bilateral_support_quality = reward_bilateral_support(
         foot_forces,
@@ -559,7 +577,15 @@ def is_terminated(
     site_height_checks: tuple[tuple[int, float], ...] = (),
     sensor_quat_start: int = 6,
 ) -> Array:
-    """Composite termination check matching ``mjx_env.py`` step logic."""
+    """Composite termination check over ONE data snapshot.
+
+    Scores the state it is handed -- a boundary sample.  The training step in
+    ``mjx_env.py`` additionally evaluates the body/site height checks at
+    EVERY physics substep through its ``fori_loop`` carry, so a strike that
+    resolves between control boundaries terminates training but is invisible
+    to this single-snapshot checker; auditing a training termination from
+    post-step data alone can therefore disagree with the trainer.
+    """
     root_quat = data.sensordata[sensor_quat_start : sensor_quat_start + 4]
     body_z = data.xpos[root_body_id, 2]
     tilt = quat_to_tilt(root_quat)

--- a/environments/shared/jax_setup.py
+++ b/environments/shared/jax_setup.py
@@ -621,7 +621,11 @@ def make_reward_fns(ctx: SpeciesContext):
 
     def compute_reward_detailed(data, action, reward_cfg, **step_kwargs):
         # compute_reward_components takes a subset of the per-step kwargs.
-        allowed = {k: v for k, v in step_kwargs.items() if k in ("prev_action", "forward_ref_2d", "initial_pos_2d")}
+        allowed = {
+            k: v
+            for k, v in step_kwargs.items()
+            if k in ("prev_action", "forward_ref_2d", "initial_pos_2d", "aggregated_foot_forces")
+        }
         detail_kw = {
             k: v
             for k, v in reward_kw.items()

--- a/environments/shared/mjx_env.py
+++ b/environments/shared/mjx_env.py
@@ -847,11 +847,43 @@ class MJXDinoEnv:
                 ctrl = scale_action_around_nominal_jax(action, ctrl_range, nominal_ctrl)
             data = state.data.replace(ctrl=ctrl)
 
-            # Physics step with frame skip
-            def body_fn(_, d):
-                return mjx.step(model, d)
+            # Physics step with frame skip, aggregating contact across the
+            # substeps in lockstep with BaseDinoEnv.step: physics runs
+            # frame_skip times per control step, and reading only the final
+            # substep let a control-clock-locked hop unload between samples
+            # (the seed-43 stage-1 bounce measured exactly one unloaded
+            # sample in 5).  The carry accumulates the per-foot MIN touch
+            # force and an any-substep OR of the height-emulated floor-strike
+            # checks; both backends read sensors at the same per-substep
+            # phase, so the five snapshots match the SB3 loop's.
+            def _foot_force_totals(d):
+                totals = []
+                for sensor_group in foot_sensor_groups:
+                    total = jnp.float32(0.0)
+                    for sensor_idx in sensor_group:
+                        total = total + d.sensordata[sensor_idx]
+                    totals.append(total)
+                return jnp.stack(totals)
 
-            data = jax.lax.fori_loop(0, frame_skip, body_fn, data)
+            def _height_strike(d):
+                struck = jnp.bool_(False)
+                for body_id, z_thresh in body_height_checks:
+                    struck = struck | (d.xpos[body_id, 2] < z_thresh)
+                for site_id, z_thresh in site_height_checks:
+                    struck = struck | (d.site_xpos[site_id, 2] < z_thresh)
+                return struck
+
+            def body_fn(_, carry):
+                d, carry_min, carry_struck = carry
+                d = mjx.step(model, d)
+                return (d, jnp.minimum(carry_min, _foot_force_totals(d)), carry_struck | _height_strike(d))
+
+            data, min_foot_forces, substep_struck = jax.lax.fori_loop(
+                0,
+                frame_skip,
+                body_fn,
+                (data, jnp.full((len(foot_sensor_groups),), jnp.inf, dtype=jnp.float32), jnp.bool_(False)),
+            )
 
             # Build observation
             pelvis_id = config.body_ids.get("pelvis", config.body_ids.get("torso", 0))
@@ -873,18 +905,15 @@ class MJXDinoEnv:
             r_forward, fwd_vel = reward_forward_velocity(
                 vel_2d, forward_ref, config.forward_vel_max, forward_vel_weight
             )
-            # Foot contact: read touch sensors.  Each foot's reading is the
-            # pad sensor plus any per-toe sensors declared for it, because a
-            # touch sensor cannot see geoms on child bodies -- without the
-            # aux terms a T-Rex standing on its digits reads as airborne.
+            # Foot contact: the substep-MIN aggregate from the physics loop's
+            # carry.  Each foot's per-substep reading is the pad sensor plus
+            # any per-toe sensors declared for it, because a touch sensor
+            # cannot see geoms on child bodies -- without the aux terms a
+            # T-Rex standing on its digits reads as airborne.  MIN over
+            # per-substep per-foot SUMS, matching
+            # BaseDinoEnv._aggregated_foot_contact_forces exactly.
             foot_contact_threshold = 0.1  # Newtons
-            foot_force_values = []
-            for sensor_group in foot_sensor_groups:
-                foot_force = jnp.float32(0.0)
-                for sensor_idx in sensor_group:
-                    foot_force = foot_force + data.sensordata[sensor_idx]
-                foot_force_values.append(foot_force)
-            foot_forces = jnp.stack(foot_force_values)
+            foot_forces = min_foot_forces
             has_foot_contact = jnp.any(foot_forces > foot_contact_threshold)
             r_bilateral_support, bilateral_support_quality = reward_bilateral_support(
                 foot_forces,
@@ -1097,13 +1126,13 @@ class MJXDinoEnv:
             )
             terminated = terminated | nosedive_terminated
 
-            # Body-height floor contact termination
-            for body_id, z_thresh in body_height_checks:
-                terminated = terminated | (data.xpos[body_id, 2] < z_thresh)
-
-            # Site-height floor contact termination (more precise for extremities)
-            for site_id, z_thresh in site_height_checks:
-                terminated = terminated | (data.site_xpos[site_id, 2] < z_thresh)
+            # Body/site-height floor-strike termination, evaluated at EVERY
+            # physics substep via the fori_loop carry (substep_struck already
+            # includes the final substep's state).  A strike that resolves
+            # within one control step -- a tail slap that bounces back up --
+            # used to be invisible to the boundary sample; the SB3 backend
+            # latches the analogous any-substep contact in its step loop.
+            terminated = terminated | substep_struck
 
             # Stage 3 success: proximity-based contact detection
             success = jnp.bool_(False)

--- a/environments/shared/scripts/foot_sensor_report.py
+++ b/environments/shared/scripts/foot_sensor_report.py
@@ -61,7 +61,13 @@ def _foot_sensor_sum(env) -> float | None:
     import mujoco  # noqa: F401  (imported for parity with the env module)
 
     if hasattr(env, "_foot_contact_forces"):
-        return float(np.sum(env._foot_contact_forces()))
+        forces = env._foot_contact_forces()
+        # The base class now defines this method for every species, returning
+        # () when no _foot_sensor_groups are declared -- an empty tuple means
+        # "no sensors", not "0.0 N of contact", so fall through instead of
+        # reporting a spurious sensor-vs-force disagreement.
+        if forces:
+            return float(np.sum(forces))
     for group in _FOOT_SENSOR_ATTRS:
         if all(hasattr(env, attr) for attr in group):
             return float(sum(env.data.sensordata[getattr(env, attr)] for attr in group))

--- a/environments/shared/scripts/stance_duty_validation.py
+++ b/environments/shared/scripts/stance_duty_validation.py
@@ -70,6 +70,30 @@ def _foot_geom_ids(model) -> list[int]:
     return ids
 
 
+def _foot_geom_ids_by_side(model) -> "tuple[list[int], list[int]]":
+    """The foot geoms split right/left, for per-foot kinematic truth.
+
+    The duty metric takes each foot's MIN force over the control step's
+    substeps INDEPENDENTLY -- foot R unloading at substep 2 and foot L at
+    substep 4 classifies as unsupported even though the animal was never
+    simultaneously airborne.  That is the stricter, fail-closed certification
+    ("each foot continuously loaded"), and the kinematic truth must use the
+    same per-foot semantics or violent regimes read as misclassification.
+    """
+    import mujoco
+
+    right: list[int] = []
+    left: list[int] = []
+    for gid in _foot_geom_ids(model):
+        body = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, model.geom_bodyid[gid]) or ""
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, gid) or ""
+        side = body or name
+        (right if side.startswith("r_") else left).append(gid)
+    if not right or not left:
+        raise ValueError("could not split foot geoms into r_/l_ sides; fix the name heuristic before trusting truth")
+    return right, left
+
+
 def _probe(env, foot_gids, floor_gid):
     import mujoco
 
@@ -117,34 +141,107 @@ def _collect(driver, episodes, max_steps, spawn_dz=0.0):
         try:
             floor_gid = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_GEOM, "floor")
             foot_gids = _foot_geom_ids(env.model)
+            r_gids, l_gids = _foot_geom_ids_by_side(env.model)
             env.reset(seed=1000 + episode)
             if spawn_dz:
                 env.data.qpos[2] += spawn_dz
                 mujoco.mj_forward(env.model, env.data)
             rng = np.random.default_rng(episode)
+
+            # Per-substep, per-foot kinematic ground truth, recorded through
+            # the REAL step path via the base env's probe hook -- physics runs
+            # frame_skip times per control step, and a boundary-only probe
+            # samples the same instant the (pre-fix) metric did, making
+            # within-control-step unloading invisible to metric and truth
+            # alike.  A shadow env stepped substep-wise could drift from the
+            # primary; the hook cannot.
+            substep_clearances: list[tuple[float, float]] = []
+
+            def _side_clearance(gids):
+                return min(
+                    float(mujoco.mj_geomDistance(env.model, env.data, gid, floor_gid, 2.0, None)) for gid in gids
+                )
+
+            def _probe_substep():
+                substep_clearances.append((_side_clearance(r_gids), _side_clearance(l_gids)))
+
+            env._substep_probe_hook = _probe_substep
+
             for t in range(max_steps):
-                _, _, terminated, truncated, _ = env.step(driver(t, env, rng))
-                sensors, foot_f, other_f, clearance, right, left = _probe(env, foot_gids, floor_gid)
-                stance = derive_stance_info({"r_foot_contact": right, "l_foot_contact": left}, DUTY_THRESHOLD)
-                rows.append((sensors, foot_f, other_f, clearance, stance["unsupported_duty"]))
+                substep_clearances.clear()
+                _, _, terminated, truncated, info = env.step(driver(t, env, rng))
+                if len(substep_clearances) != env.frame_skip:
+                    # A certification that silently measures nothing is worse
+                    # than none: if the probe hook stops firing per substep,
+                    # every truth column degenerates to False and the gates
+                    # pass vacuously.
+                    raise RuntimeError(
+                        f"probe hook fired {len(substep_clearances)} times for a "
+                        f"frame_skip={env.frame_skip} step; the per-substep ground "
+                        "truth is not being recorded"
+                    )
+                sensors, foot_f, other_f, clearance, right_b, left_b = _probe(env, foot_gids, floor_gid)
+
+                # The duty classification the gate certifies from: the
+                # substep-MIN aggregated forces carried by the info keys.
+                stance = derive_stance_info(
+                    {"r_foot_contact": info["r_foot_contact"], "l_foot_contact": info["l_foot_contact"]},
+                    DUTY_THRESHOLD,
+                )
+                # The classification the pre-fix metric would have made,
+                # from the control-boundary sample alone.
+                boundary = derive_stance_info({"r_foot_contact": right_b, "l_foot_contact": left_b}, DUTY_THRESHOLD)
+                # Kinematic truth with the metric's own per-foot semantics:
+                # each foot's clearance judged independently across substeps.
+                r_unloaded = any(rc > 1e-6 for rc, _ in substep_clearances)
+                l_unloaded = any(lc > 1e-6 for _, lc in substep_clearances)
+                truth_unsupported = r_unloaded and l_unloaded
+                # Physically airborne: BOTH feet clear at the SAME substep --
+                # the quantity the seed-43 bounce hid from boundary sampling.
+                any_airborne = any(rc > 1e-6 and lc > 1e-6 for rc, lc in substep_clearances)
+                rows.append(
+                    (
+                        sensors,
+                        foot_f,
+                        other_f,
+                        clearance,
+                        stance["unsupported_duty"],
+                        float(truth_unsupported),
+                        # Aliased step: some substep was kinematically
+                        # airborne but the boundary sample read as supported
+                        # -- the exact blindness the aggregation closes.
+                        float(any_airborne and not boundary["unsupported_duty"]),
+                    )
+                )
                 if terminated or truncated:
                     break
         finally:
+            env._substep_probe_hook = None
             env.close()
     return np.array(rows)
 
 
 def _summarize(label, rows):
-    sensors, foot_f, other_f, clearance = rows[:, 0], rows[:, 1], rows[:, 2], rows[:, 3]
+    sensors, foot_f, other_f = rows[:, 0], rows[:, 1], rows[:, 2]
     unsupported = rows[:, 4].astype(bool)
-    airborne = clearance > 1e-6
+    # Kinematic truth with the metric's per-foot semantics: each foot judged
+    # independently across the substeps (see _foot_geom_ids_by_side).
+    airborne = rows[:, 5].astype(bool)
+    aliased = rows[:, 6].astype(bool)  # simultaneous-airborne substep the boundary sample missed
     n = len(rows)
     peak = max(float(np.max(foot_f)), 1.0)
     err = np.abs(sensors - foot_f)
 
-    false_airborne = int(np.sum(unsupported & ~airborne))  # overstates airtime
-    false_supported = int(np.sum(~unsupported & airborne))  # understates airtime
-    disagreement = 100 * (false_airborne + false_supported) / n
+    # The two error directions are NOT symmetric for a ceiling-gated metric:
+    # false-supported understates airtime and can certify a hopping policy
+    # (the failure the substep aggregation exists to close); false-airborne
+    # merely overstates it -- the fail-closed direction, inflated by grazing
+    # instants (geometric contact bearing < 0.1 N) that a 5-instant MIN
+    # samples more often than the old boundary probe did.
+    false_airborne = int(np.sum(unsupported & ~airborne))  # overstates airtime (conservative)
+    false_supported = int(np.sum(~unsupported & airborne))  # understates airtime (DANGEROUS)
+    false_airborne_pct = 100 * false_airborne / n
+    false_supported_pct = 100 * false_supported / n
 
     print(f"\n=== {label} ===")
     print(f"  steps {n:6}   kinematically airborne {airborne.mean():7.2%}   duty-unsupported {unsupported.mean():7.2%}")
@@ -157,15 +254,21 @@ def _summarize(label, rows):
             f" (max {other_f.max():.1f} N) -- excluded"
         )
     print(
-        f"  misclassified: {false_airborne} false-airborne, {false_supported} false-supported"
-        f"  -> {disagreement:.3f}% of steps"
+        f"  within-control-step aliasing: {int(aliased.sum())} steps ({aliased.mean():7.2%}) were airborne at some"
+        f" substep while the boundary sample read supported -- caught by the substep-MIN aggregation"
+    )
+    print(
+        f"  misclassified: {false_airborne} false-airborne ({false_airborne_pct:.3f}%, conservative), "
+        f"{false_supported} false-supported ({false_supported_pct:.3f}%, dangerous)"
     )
     return {
         "label": label,
         "steps": n,
         "airborne": float(airborne.mean()),
         "unsupported_duty": float(unsupported.mean()),
-        "disagreement_pct": disagreement,
+        "aliased_pct": 100 * float(aliased.mean()),
+        "false_airborne_pct": false_airborne_pct,
+        "false_supported_pct": false_supported_pct,
     }
 
 
@@ -182,6 +285,19 @@ def _hop(t, env, rng):
     return np.full(env.action_space.shape, 0.9 * np.sin(2 * np.pi * t / 40.0))
 
 
+def _hop20(t, env, rng):
+    """Control-clock-locked hop: period 5 control steps = 20 Hz at 100 Hz control.
+
+    The regime the seed-43 stage-1 bounce actually occupies -- a cycle
+    commensurate with the frame_skip=5 substep structure, which is exactly
+    where a boundary-sampled duty metric aliases (one sample per cycle lands
+    wherever the phase puts it).  The 2.5 Hz ``_hop`` above cannot express
+    this; every earlier certification of the metric swept only regimes where
+    metric and truth were sampled at the same instant.
+    """
+    return np.full(env.action_space.shape, 0.9 * np.sin(2 * np.pi * t / 5.0))
+
+
 def _thrash(t, env, rng):
     return rng.uniform(-1.0, 1.0, size=env.action_space.shape)
 
@@ -191,6 +307,7 @@ REGIMES = (
     ("settled stance (zero action)", _zero, dict(episodes=8, max_steps=400)),
     ("low-amplitude jitter", _jitter, dict(episodes=40, max_steps=1000)),
     ("forced hop (sinusoidal leg drive)", _hop, dict(episodes=40, max_steps=1000)),
+    ("control-locked hop (20 Hz, period-5)", _hop20, dict(episodes=40, max_steps=1000)),
     ("random thrash", _thrash, dict(episodes=40, max_steps=1000)),
 )
 
@@ -202,7 +319,18 @@ def main() -> int:
         "--max-disagreement",
         type=float,
         default=5.0,
-        help="fail if any regime misclassifies more than this %% of steps",
+        help="fail if any regime UNDERSTATES airtime (false-supported) on more than this %% of steps",
+    )
+    parser.add_argument(
+        "--max-conservatism",
+        type=float,
+        default=15.0,
+        help=(
+            "fail if any regime OVERSTATES airtime (false-airborne) on more than this %% of steps. "
+            "Looser than --max-disagreement on purpose: a ceiling-gated duty that overstates can only "
+            "fail policies conservatively, and the substep MIN samples grazing instants (geometric "
+            "contact bearing < 0.1 N) five times as often as the old boundary probe"
+        ),
     )
     args = parser.parse_args()
 
@@ -212,14 +340,30 @@ def main() -> int:
             kwargs = {**kwargs, "episodes": args.episodes}
         results.append(_summarize(label, _collect(driver, **kwargs)))
 
-    worst = max(results, key=lambda r: r["disagreement_pct"])
+    # The 20 Hz regime is the aliasing certifier: if it stopped producing
+    # airborne substeps (drive too weak for a revised plant, or episodes dying
+    # immediately), its 0% false-supported is vacuous, not reassuring.
+    control_locked = next(r for r in results if "control-locked" in r["label"])
+    if control_locked["airborne"] < 0.10:
+        print(
+            f"FAILED: the control-locked regime measured only {control_locked['airborne']:.1%} airborne "
+            "steps -- the aliasing certification is vacuous; retune the drive for this plant."
+        )
+        return 1
+
+    worst_dangerous = max(results, key=lambda r: r["false_supported_pct"])
+    worst_conservative = max(results, key=lambda r: r["false_airborne_pct"])
     span = (min(r["airborne"] for r in results), max(r["airborne"] for r in results))
     print(
-        f"\nAirborne fraction swept {span[0]:.1%} to {span[1]:.1%};"
-        f" worst misclassification {worst['disagreement_pct']:.3f}% ({worst['label']})."
+        f"\nAirborne fraction swept {span[0]:.1%} to {span[1]:.1%}; worst understatement "
+        f"{worst_dangerous['false_supported_pct']:.3f}% ({worst_dangerous['label']}), worst overstatement "
+        f"{worst_conservative['false_airborne_pct']:.3f}% ({worst_conservative['label']})."
     )
-    if worst["disagreement_pct"] > args.max_disagreement:
-        print("FAILED: the duty metrics do not track kinematic ground truth closely enough.")
+    if worst_dangerous["false_supported_pct"] > args.max_disagreement:
+        print("FAILED: the duty metrics UNDERSTATE airtime -- a hopping policy could certify as supported.")
+        return 1
+    if worst_conservative["false_airborne_pct"] > args.max_conservatism:
+        print("FAILED: the duty metrics overstate airtime beyond the accepted conservatism bound.")
         return 1
     print("The support-duty metrics track kinematic ground truth across the swept range.")
     return 0

--- a/environments/shared/tests/test_jax_reward_termination.py
+++ b/environments/shared/tests/test_jax_reward_termination.py
@@ -626,3 +626,100 @@ class TestIsTerminated:
             natural_forward_z=0.0,
         )
         assert bool(terminated)
+
+
+class TestAggregatedFootForcesOverride:
+    """The composers must price the substep-MIN forces when a stepped caller
+    supplies them, and keep single-state semantics when it does not.
+
+    The training backends aggregate touch force across the frame_skip physics
+    substeps; ``evaluate_policy_cpu`` passes the aggregate through this
+    override so eval scores the same quantity training optimizes.  The
+    single-state default is what the SB3-vs-JAX parity test scores.
+    """
+
+    _COMMON = dict(
+        root_body_id=1,
+        healthy_z_min=0.5,
+        healthy_z_max=1.5,
+        max_tilt_angle=1.0,
+        natural_forward_z=0.0,
+        n_actuators=5,
+        foot_sensor_groups=((10,), (11,)),
+    )
+
+    @staticmethod
+    def _stance_cfg():
+        return {
+            "forward_vel_weight": 0.0,
+            "alive_bonus": 0.0,
+            "energy_penalty_weight": 0.0,
+            "posture_weight": 0.0,
+            "bilateral_support_weight": 1.0,
+            "foot_contact_saturation_force": 100.0,
+        }
+
+    def _snapshot_data(self):
+        sensordata = np.zeros(20)
+        sensordata[6:10] = (1.0, 0.0, 0.0, 0.0)
+        # The boundary snapshot reads both feet fully loaded...
+        sensordata[10:12] = (100.0, 100.0)
+        return _make_mock_data(pelvis_z=0.9, sensordata=sensordata)
+
+    def test_the_override_replaces_the_snapshot_forces(self):
+        import jax.numpy as jnp
+
+        from environments.shared.jax_reward_termination import compute_reward_components
+
+        data = self._snapshot_data()
+        snapshot = compute_reward_components(data, np.zeros(5), self._stance_cfg(), **self._COMMON)
+        # ...but the substep MIN saw the right foot unload mid-control-step.
+        aggregated = compute_reward_components(
+            data,
+            np.zeros(5),
+            self._stance_cfg(),
+            aggregated_foot_forces=jnp.asarray([0.0, 100.0]),
+            **self._COMMON,
+        )
+        assert float(snapshot["bilateral_support"]) == pytest.approx(1.0)
+        assert float(aggregated["bilateral_support"]) == pytest.approx(0.0)
+
+    def test_default_none_keeps_single_state_semantics(self):
+        from environments.shared.jax_reward_termination import compute_total_reward
+
+        data = self._snapshot_data()
+        without = compute_total_reward(data, np.zeros(5), self._stance_cfg(), **self._COMMON)
+        explicit = compute_total_reward(
+            data, np.zeros(5), self._stance_cfg(), aggregated_foot_forces=None, **self._COMMON
+        )
+        assert float(without) == pytest.approx(float(explicit))
+
+    def test_the_override_moves_the_total_reward_and_survives_the_setup_filter(self):
+        """Two pins the components test cannot give: the SCALAR eval reward
+        consumes the override, and jax_setup's kwarg whitelist forwards it --
+        dropping either silently reverts eval to boundary-snapshot forces."""
+        import inspect
+
+        import jax.numpy as jnp
+
+        from environments.shared import jax_setup
+        from environments.shared.jax_reward_termination import compute_total_reward
+
+        data = self._snapshot_data()
+        snapshot_total = compute_total_reward(data, np.zeros(5), self._stance_cfg(), **self._COMMON)
+        aggregated_total = compute_total_reward(
+            data,
+            np.zeros(5),
+            self._stance_cfg(),
+            aggregated_foot_forces=jnp.asarray([0.0, 100.0]),
+            **self._COMMON,
+        )
+        # bilateral_support_weight 1.0 drops from quality 1.0 to 0.0.
+        assert float(snapshot_total) - float(aggregated_total) == pytest.approx(1.0)
+
+        source = inspect.getsource(jax_setup)
+        assert '"aggregated_foot_forces"' in source, (
+            "jax_setup's compute_reward_detailed kwarg whitelist no longer forwards "
+            "aggregated_foot_forces -- evaluate_policy_cpu's reward decomposition would "
+            "silently revert to boundary-snapshot forces"
+        )

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -332,6 +332,13 @@ class TRexEnv(BaseDinoEnv):
         # a measured 500.4 N of floor contact.
         self._sensor_r_foot_digits = (24, 25, 26)
         self._sensor_l_foot_digits = (27, 28, 29)
+        # Per-foot groups for the base class's substep MIN aggregation --
+        # mirrors mjx_config's sensor_foot_indices + sensor_foot_aux_indices
+        # so both backends aggregate the same sensors.
+        self._foot_sensor_groups = (
+            (self._sensor_r_foot, *self._sensor_r_foot_digits),
+            (self._sensor_l_foot, *self._sensor_l_foot_digits),
+        )
 
         # Stage-1 pose targets come from the named home keyframe instead of
         # duplicating angles in Python.  This keeps the reward centred on the
@@ -519,7 +526,12 @@ class TRexEnv(BaseDinoEnv):
         # full plantar-plus-digit load for each foot.  Saturation prevents
         # impact spikes from being more valuable than quiet support, while the
         # minimum requires both feet to carry load.
-        r_contact, l_contact = self._foot_contact_forces()
+        # AGGREGATED across the control step's physics substeps (per-foot MIN):
+        # the last-substep read let the seed-43 bounce unload for 4 of every 5
+        # substeps and still collect full support reward, and the same sample
+        # feeds the r/l_foot_contact info keys the stance-duty gate certifies
+        # from.  Falls back to the instantaneous read on un-stepped states.
+        r_contact, l_contact = self._aggregated_foot_contact_forces()
         info["r_foot_contact"] = r_contact
         info["l_foot_contact"] = l_contact
 

--- a/environments/trex/tests/test_trex_env.py
+++ b/environments/trex/tests/test_trex_env.py
@@ -225,9 +225,9 @@ class TestFootContactSensors:
             # Guard the specific regression: the pad alone must not be
             # mistaken for the whole foot while the digits bear load.
             pad_only = float(env.data.sensordata[env._sensor_r_foot])
-            assert (
-                pad_only < truth["r"]
-            ), "digits carry no load at stance, so this test can no longer detect a pad-only foot-contact signal"
+            assert pad_only < truth["r"], (
+                "digits carry no load at stance, so this test can no longer detect a pad-only foot-contact signal"
+            )
         finally:
             env.close()
 
@@ -364,9 +364,9 @@ class TestHeightTargetTracksStance:
                 f"height reward is saturated while sagging ({rewards} at {sagged}) -- target_z is "
                 f"below the settled stance {settled:.4f}, so the term is a constant, not a gradient"
             )
-            assert (
-                rewards[0] > rewards[1] > rewards[2]
-            ), f"height reward must fall monotonically as the pelvis sags, got {rewards}"
+            assert rewards[0] > rewards[1] > rewards[2], (
+                f"height reward must fall monotonically as the pelvis sags, got {rewards}"
+            )
         finally:
             env.close()
 

--- a/environments/trex/tests/test_trex_env.py
+++ b/environments/trex/tests/test_trex_env.py
@@ -225,9 +225,9 @@ class TestFootContactSensors:
             # Guard the specific regression: the pad alone must not be
             # mistaken for the whole foot while the digits bear load.
             pad_only = float(env.data.sensordata[env._sensor_r_foot])
-            assert pad_only < truth["r"], (
-                "digits carry no load at stance, so this test can no longer detect a pad-only foot-contact signal"
-            )
+            assert (
+                pad_only < truth["r"]
+            ), "digits carry no load at stance, so this test can no longer detect a pad-only foot-contact signal"
         finally:
             env.close()
 
@@ -364,9 +364,9 @@ class TestHeightTargetTracksStance:
                 f"height reward is saturated while sagging ({rewards} at {sagged}) -- target_z is "
                 f"below the settled stance {settled:.4f}, so the term is a constant, not a gradient"
             )
-            assert rewards[0] > rewards[1] > rewards[2], (
-                f"height reward must fall monotonically as the pelvis sags, got {rewards}"
-            )
+            assert (
+                rewards[0] > rewards[1] > rewards[2]
+            ), f"height reward must fall monotonically as the pelvis sags, got {rewards}"
         finally:
             env.close()
 
@@ -449,5 +449,186 @@ class TestStage1ResetStaysInsideTheHealthyEnvelope:
             assert float(env.data.qpos[2]) > env.healthy_z_range[0]
             _, _, terminated, _, _ = env.step(np.zeros(env.action_space.shape))
             assert not terminated, "seed 3077 must survive one zero-action step"
+        finally:
+            env.close()
+
+
+class TestSubstepContactAggregation:
+    """The duty signal must see every physics substep, not one in frame_skip.
+
+    Physics runs at 500 Hz, control at 100 Hz.  Before the substep-MIN
+    aggregation, every contact consumer read only the final substep, so a
+    control-clock-locked hop could unload for 4 of every 5 substeps and
+    still read as continuous support -- the seed-43 stage-1 bounce measured
+    exactly one unloaded sample per 5 and the gate certified a sampled duty,
+    not airborne time.
+    """
+
+    def test_info_carries_the_min_across_substeps_and_catches_hidden_unloading(self):
+        """Two pins in one rollout: info == min(per-substep sums) exactly, and
+        the aggregate catches unloading the boundary sample misses."""
+        env = TRexEnv(reset_noise_scale=0.0, nosedive_termination_threshold=0.35)
+        try:
+            env.reset(seed=0)
+            substep_forces: list[tuple[float, float]] = []
+            env._substep_probe_hook = lambda: substep_forces.append(env._foot_contact_forces())
+
+            # Settle, then drive a control-clock-locked hop (period 5 control
+            # steps = 20 Hz): the cycle is commensurate with frame_skip=5, the
+            # regime where boundary sampling aliases.
+            for _ in range(200):
+                _, _, terminated, _, _ = env.step(np.zeros(env.action_space.shape, dtype=np.float32))
+                if terminated:
+                    pytest.fail("statue fell during settle")
+
+            # Amplitude tuned empirically (mujoco 3.10, seed 0): 0.3 survives
+            # ~157 steps and yields 9 caught events; 0.9 dies at step 36 with
+            # a single-event margin that any solver drift could delete.
+            caught = 0
+            for t in range(400):
+                action = np.full(env.action_space.shape, 0.3 * np.sin(2 * np.pi * t / 5.0), dtype=np.float32)
+                substep_forces.clear()
+                _, _, terminated, _, info = env.step(action)
+
+                assert len(substep_forces) == env.frame_skip
+                r_min = min(f[0] for f in substep_forces)
+                l_min = min(f[1] for f in substep_forces)
+                assert info["r_foot_contact"] == pytest.approx(r_min, abs=1e-9)
+                assert info["l_foot_contact"] == pytest.approx(l_min, abs=1e-9)
+
+                # Boundary sample = the final substep's instantaneous read --
+                # what the pre-aggregation metric consumed.
+                r_last, l_last = substep_forces[-1]
+                boundary_supported = r_last > 0.1 and l_last > 0.1
+                aggregated_unsupported = info["r_foot_contact"] <= 0.1 and info["l_foot_contact"] <= 0.1
+                if boundary_supported and aggregated_unsupported:
+                    caught += 1
+                if terminated:
+                    break
+
+            # Structurally zero before the aggregation existed: info equalled
+            # the boundary sample, so no step could diverge.  Measured 9 at
+            # the tuned drive; >= 3 leaves solver-drift headroom while still
+            # proving the mechanism fires repeatedly, not by fluke.
+            assert caught >= 3, (
+                f"only {caught} control steps unloaded between boundary samples in "
+                "this rollout -- the aggregation regression has lost its witness; "
+                "retune the drive before trusting the duty metric"
+            )
+        finally:
+            env._substep_probe_hook = None
+            env.close()
+
+    def test_statue_duty_is_unchanged_by_aggregation(self):
+        """The statue stands continuously: MIN across substeps must not move
+        its duty, and its per-foot drift from the boundary sample stays small."""
+        from environments.shared.stance_diagnostics import derive_stance_info
+
+        env = TRexEnv(reset_noise_scale=0.0, nosedive_termination_threshold=0.35)
+        try:
+            env.reset(seed=0)
+            zeros = np.zeros(env.action_space.shape, dtype=np.float32)
+            for _ in range(200):
+                _, _, terminated, _, _ = env.step(zeros)
+                assert not terminated
+            for _ in range(200):
+                _, _, terminated, _, info = env.step(zeros)
+                assert not terminated
+                stance = derive_stance_info(info)
+                assert stance["unsupported_duty"] == 0.0
+                assert stance["bilateral_support_duty"] == 1.0
+                # The MIN property itself, not a ripple bound: a future plant
+                # (e.g. passive toes) may legitimately oscillate within the
+                # control step while both feet stay far above the duty
+                # threshold, and the claim under test is the duty invariants.
+                r_last, l_last = env._foot_contact_forces()
+                assert info["r_foot_contact"] <= r_last + 1e-9
+                assert info["l_foot_contact"] <= l_last + 1e-9
+        finally:
+            env.close()
+
+    def test_aggregate_is_invalidated_by_reset(self):
+        """The first observation of an episode must not inherit the previous
+        episode's minima.  Invalidation rides the step-count tag rather than
+        code in reset(): reset()'s source is fingerprinted by the plant
+        contract's home_reset interface, and it already zeroes _step_count."""
+        env = TRexEnv(reset_noise_scale=0.0)
+        try:
+            env.reset(seed=0)
+            env.step(np.zeros(env.action_space.shape, dtype=np.float32))
+            assert env._substep_min_foot_forces is not None
+            assert env._substep_contact_step == env._step_count
+            # Arm the strike latch as a striking episode would have left it --
+            # a zero-action statue never strikes, so without this the latch
+            # half of the pin would be vacuous.
+            env._substep_floor_hit_geom = next(iter(env._body_ground_geoms))
+            env._substep_contact_step = env._step_count
+            env.reset(seed=1)
+            # The stale aggregate's tag no longer matches the zeroed count,
+            # so the accessor falls back to the instantaneous read.
+            assert env._substep_contact_step != env._step_count
+            assert env._aggregated_foot_contact_forces() == env._foot_contact_forces()
+            # The stale strike latch must not terminate the fresh episode.
+            terminated, _ = env._is_terminated()
+            assert not terminated
+        finally:
+            env.close()
+
+
+class TestFootSensorGroupLockstep:
+    """Each species' SB3 _foot_sensor_groups must mirror its MJX registration.
+
+    The substep-MIN aggregation runs on both backends from these two
+    declarations; if they drift, the backends silently aggregate different
+    sensors and every cross-backend duty/reward comparison goes quietly
+    wrong.  Built from the registered MJX config, so a new species or an
+    index edit on either side fails here."""
+
+    @pytest.mark.parametrize(
+        "species, env_factory",
+        [
+            ("trex", lambda: TRexEnv(reset_noise_scale=0.0)),
+            (
+                "velociraptor",
+                lambda: __import__("environments.velociraptor.envs.raptor_env", fromlist=["RaptorEnv"]).RaptorEnv(
+                    reset_noise_scale=0.0
+                ),
+            ),
+            (
+                "brachiosaurus",
+                lambda: __import__("environments.brachiosaurus.envs.brachio_env", fromlist=["BrachioEnv"]).BrachioEnv(
+                    reset_noise_scale=0.0
+                ),
+            ),
+            (
+                "dibothrosuchus",
+                lambda: __import__(
+                    "environments.dibothrosuchus.envs.dibothrosuchus_env", fromlist=["DibothrosuchusEnv"]
+                ).DibothrosuchusEnv(reset_noise_scale=0.0),
+            ),
+        ],
+    )
+    def test_sb3_groups_match_mjx_registration(self, species, env_factory):
+        import importlib
+
+        from environments.shared.mjx_env import _SPECIES_CONFIGS
+
+        # Registration happens at mjx_config import time; the SB3 env class
+        # never imports it, so pull it in explicitly (idempotent).
+        importlib.import_module(f"environments.{species}.mjx_config")
+        config = _SPECIES_CONFIGS[species]
+
+        foot_indices = config["sensor_foot_indices"]
+        aux_groups = config.get("sensor_foot_aux_indices", ()) or ()
+        expected = tuple(
+            (foot_idx, *(aux_groups[i] if i < len(aux_groups) else ())) for i, foot_idx in enumerate(foot_indices)
+        )
+
+        def norm(groups):
+            return tuple(tuple(int(i) for i in group) for group in groups)
+
+        env = env_factory()
+        try:
+            assert norm(env._foot_sensor_groups) == norm(expected)
         finally:
             env.close()

--- a/environments/velociraptor/envs/raptor_env.py
+++ b/environments/velociraptor/envs/raptor_env.py
@@ -225,6 +225,9 @@ class RaptorEnv(BaseDinoEnv):
         # are inherited from BaseDinoEnv (0, 3, 6 respectively).
         self._sensor_r_foot = 10
         self._sensor_l_foot = 11
+        # Per-foot groups for the base class's substep MIN aggregation --
+        # mirrors mjx_config's sensor_foot_indices (no aux sensors here).
+        self._foot_sensor_groups = ((self._sensor_r_foot,), (self._sensor_l_foot,))
 
     def _scale_action(self, action: np.ndarray) -> np.ndarray:
         """Map normalized residual actions around the XML home controls.
@@ -435,9 +438,11 @@ class RaptorEnv(BaseDinoEnv):
         info["spin_instability"] = spin_instability
         info["reward_spin"] = reward_spin
 
-        # 9. Gait symmetry (reward alternating foot contacts, shared helper)
-        r_contact = self.data.sensordata[self._sensor_r_foot]
-        l_contact = self.data.sensordata[self._sensor_l_foot]
+        # 9. Gait symmetry (reward alternating foot contacts, shared helper).
+        # Substep-MIN aggregated: the info keys feed the stance diagnostics,
+        # and a touchdown that unloads between control-boundary samples must
+        # not read as continuous support.
+        r_contact, l_contact = self._aggregated_foot_contact_forces()
         info["r_foot_contact"] = float(r_contact)
         info["l_foot_contact"] = float(l_contact)
 


### PR DESCRIPTION
## Summary

Physics runs at 500 Hz and control at 100 Hz (`frame_skip = 5`), but every contact-derived quantity — the `r/l_foot_contact` info keys the `stance_quality/v1` gate certifies from, the bilateral-support / foot-load-balance / support-conditioned-alive rewards, gait-symmetry touchdown detection, and floor-strike termination — read only the **last** physics substep. The seed-43 stage-1 run demonstrated the failure mechanically: a 20 Hz control-clock-locked hop put exactly one unloaded sample in every five, so `bilateral_support_duty` was exactly 0.8000 in all 40 panel episodes and the gated 0.1958 was a sample-phase statistic, not airborne time. The false-PASS direction was open too: a policy unloading *between* the 10 ms boundary samples would read duty 0.000 and pass the 0.02 ceiling while hopping every cycle.

This PR makes both backends aggregate contact **inside** the substep loop, in lockstep:

- **Per-foot MIN touch force** across the substeps (min of per-substep per-foot *sums*, never per-sensor minima) feeds the contact rewards and the `r/l_foot_contact` info keys.
- **Any-substep floor-strike latch** — SB3 latches the first terminating contact pair in `BaseDinoEnv.step`; MJX ORs its height-emulation checks through the `fori_loop` carry.
- **Eval scores what training optimizes** — `evaluate_policy_cpu` aggregates identically and passes the substep-MIN through a new `aggregated_foot_forces` override on both reward composers (default `None` keeps single-state semantics, which the SB3-vs-JAX parity test pins).
- **Observations deliberately stay boundary-sampled** — the obs builders are source-fingerprinted by the plant contract; aggregating them would bump every species' policy interface. The defect lives in what the gate and rewards *price*, not what the policy senses. `plant_contract --check` passes with a byte-identical manifest.

## Validation

`stance_duty_validation.py` gains a control-clock-locked 20 Hz hop regime (period 5 — the exact aliasing regime), per-substep kinematic ground truth via a step-loop probe hook, a within-control-step aliasing column, and asymmetric gates (false-supported is dangerous, false-airborne is conservative). Current run:

| regime | airborne | aliased steps caught | dangerous misclassification |
|---|---|---|---|
| statue | 0.2% | — | 0.000% |
| walk drive | ~34% | 6.3% | 0.031% |
| forced hop | 54.5% | 4.9% | 0.000% |
| **20 Hz locked hop** | 68.8% | **14.6%** | 0.099% |
| random thrash | 68.3% | 11.8% | 0.257% |

All under the 5% dangerous-understatement gate; the driver fails vacuous runs (probe-hook count mismatch, or a locked hop that never gets airborne).

New regression tests: `TestSubstepContactAggregation` (pins `info == min(per-substep sums)` exactly under a hop that the boundary sample misclassifies; statue invariants; reset invalidation of both the aggregate and the strike latch), `TestFootSensorGroupLockstep` (each species' SB3 `_foot_sensor_groups` must mirror its MJX `sensor_foot_indices`/`sensor_foot_aux_indices` registration), and `TestAggregatedFootForcesOverride` (composer override changes components and total by exactly the injected delta and survives the `jax_setup` kwarg whitelist).

## Residual (documented, deferred)

SB3's explicit site/body **height** terminations (T-Rex `head_tip_z`/`skull_z`, dibothrosuchus `snout_tip_z`) remain boundary-sampled; MJX's height emulation is now any-substep, so a transient no-contact head dip can terminate on MJX/eval while surviving SB3. Divergence direction is MJX-stricter (conservative). Folding these into the substep loop is left for the passive-toes plant-revision PR, along with re-deriving the statue-derived gate constants — pre/post duty histories are apples-to-oranges for hopping policies (the chatterer's 0.319 and seed runs' 0.1958 would measure higher under substep-MIN).

## Test plan

- [x] Full `pytest environments/` battery (SB3 + MJX + parity) green
- [x] `environments/shared/tests/test_jax_trainer.py` green
- [x] `stance_duty_validation.py` exit 0 across all five regimes
- [x] `python -m environments.shared.plant_contract --check` — manifest current, byte-identical
- [x] `ruff format --check`, `ruff check`, `mypy` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb

---
_Generated by [Claude Code](https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb)_