### PR TITLE
Make the T-Rex toes passive: plant revision, action_dim 21 → 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   between control-boundary samples terminates exactly as MJX's any-substep
   height emulation does; the `head_tip_z`/`snout_tip_z` info keys keep
   reporting the boundary sample.
+  The statue constants get the freshness guard their comments have begged
+  for since #491: the stage TOML now records
+  `statue_constants_physics_revision` = the plant revision the constants
+  were measured on, and `test_statue_constant_freshness.py` cross-checks it
+  against the manifest — so the NEXT plant bump cannot land without either
+  re-measuring the statue or consciously updating the pin where a reviewer
+  sees the constants did not move. And the action-filter probe sweep gains
+  the 30/35 Hz cutoffs (`stance_probe_filter_hz`), closing the survival
+  curve at the control Nyquist's edge instead of stopping at 20 Hz with the
+  measured 22.7 Hz tremor unsampled above it.
 - **Reverted T-Rex stage 1 `leg_home_pose_weight` to 0.5**, and the two statue-
   derived constants with it (`min_avg_reward` 2550 → 1950,
   `collapse_peak_floor_reference` 4250.4 → 3271.8). The 1.5 experiment **could

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] — Reproducible Runs & Velociraptor Stage-1 Diagnosis (v0.3.6)
 
 ### Changed
+- **T-Rex toes made passive** (breaking — plant change, physics revision 6 → 7
+  **and** policy interface revision 9 → 10; all existing T-Rex checkpoints are
+  invalidated). The six per-digit `<position>` actuators (kp 60, forcerange
+  ±50 N·m, ctrlrange −0.4363..0.8727) are deleted; the digits keep their
+  hinges, and the `leg_joint` class already supplies the passive stance —
+  stiffness 40 with `springref` 12.5° holds the old commanded home pose,
+  damping 15 dissipates strike energy. Action dimension drops **21 → 15**
+  (3 neck/head + 8 legs + 4 tail); the home-keyframe ctrl vector shrinks with
+  it. The observation is **unchanged at 61** — toe joints stay in qpos/qvel,
+  and all 16 sensors (including the six per-digit touch sensors) keep their
+  indices. `visual_revision` deliberately stays 4: no geom, site, material,
+  camera or light moved, and the visual layer carries no actuator or keyframe
+  fields.
+  Motivation is the stage-1 bounce postmortem
+  (`docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md`): the release ablation
+  showed holding **only the six toes** at their commanded DC reproduces the
+  whole constant-hold failure (125.5 steps vs the full pose's 128.6) while
+  tail, neck and head held alone all stand the full horizon — the policy's
+  learned 0.8727 rad claw curl splayed adjacent digits to opposite ends of a
+  75° range, changing the support polygon. A splayed digit is a pose the
+  passive spring cannot hold, so the failure mode is now structurally
+  impossible rather than merely unrewarded.
+  Statue re-measured on the new plant (`zero_action_baseline.py` seed 3042
+  and `stance_quality_baseline.py 0.05 40` agree): standing reward
+  **3270.3 ± 12.3**, 40/40 full horizon, unsupported duty 0.000 — within one
+  standard error of the r6 figure 3271.8, as expected with the springs
+  holding the same pose the servos did. `collapse_peak_floor_reference`
+  updates to the measured 3270.3; `min_avg_reward` stays 1950 (0.60 × the
+  statue, not re-rounded over a within-noise move). The settled pelvis height
+  is unchanged at 0.9260, so `target_z`, `natural_pitch` and the nosedive
+  threshold keep their pins.
+  Also folded in, completing the substep-aggregation lockstep: the SB3
+  site/body **height terminations** (T-Rex `head_tip_z` < 0.12 / `skull_z` <
+  0.45, dibothrosuchus `snout_tip_z` < 0.04) now consume the per-substep
+  MINIMUM height recorded by the step loop, so a head dip that recovers
+  between control-boundary samples terminates exactly as MJX's any-substep
+  height emulation does; the `head_tip_z`/`snout_tip_z` info keys keep
+  reporting the boundary sample.
 - **Reverted T-Rex stage 1 `leg_home_pose_weight` to 0.5**, and the two statue-
   derived constants with it (`min_avg_reward` 2550 → 1950,
   `collapse_peak_floor_reference` 4250.4 → 3271.8). The 1.5 experiment **could

--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ Apex Predator. **Specialty:** Head-contact attack task.
 | Generated specification | Value |
 |---|---|
 | Observation dimension | 61 |
-| Action dimension / actuators | 21 |
+| Action dimension / actuators | 15 |
 | Generalized coordinates / velocities | nq=28, nv=27 |
 | Compiled dynamic model mass | 85.7 kg |
-| Plant contract revisions | policy r9; physics r6; visual r4 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r10; physics r7; visual r4 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/trex/assets/trex.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |

--- a/configs/plant_manifest.generated.json
+++ b/configs/plant_manifest.generated.json
@@ -84,30 +84,30 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:1d1ddd1efeceb2a2770079e52387d2fd2f38490a8c4527630ebf597264e9a702",
+      "bundle_sha256": "sha256:a3c23d7a84e4b63cab0f4e234d00854bc8eff3380a901b2bf419e1fb4b196722",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
         "nq": 28,
-        "nu": 21,
+        "nu": 15,
         "nv": 27,
-        "revision": 6,
+        "revision": 7,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:7dfa00f5b28a5f562170ba0926e6811208354cb6160b524d9ab58412a37bc2f0"
+        "sha256": "sha256:72c662858639193e24a503b98e06d84737150ae6888a50a3620c2c99804cb97b"
       },
       "policy_interface": {
-        "action_dim": 21,
+        "action_dim": 15,
         "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 9,
+        "revision": 10,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:bacbb3243a7f84f1379e106dd886279ed247c252c143cb5e86500a50725d7020"
+        "sha256": "sha256:d00f24e0d9219878714dc3d2f479c9400fd21c7bc76687bda065f223beb039e9"
       },
       "source": {
-        "closure_sha256": "sha256:2ef85b8c9aef05050e7e407ba9cf6a7a6da62e2c14282c5143366dd0575f2571",
+        "closure_sha256": "sha256:e3919447fc76fbcd6396284afa028ad2831797461d03bbe6c9b52a5fc1c50753",
         "dependencies": [
           {
-            "content_sha256": "sha256:1362fd47f50233ac4fc87b3e6dbaeefb609f5be76530220d541fb598c704fdd8",
+            "content_sha256": "sha256:b77304a2d69cd325a61a95cb85cf870d45af252b9b4701dcf971318f874efef0",
             "kind": "mjcf",
             "logical_path": "environments/trex/assets/trex.xml"
           }

--- a/configs/plant_versions.toml
+++ b/configs/plant_versions.toml
@@ -150,9 +150,30 @@ observation_schema = "bipedal-target/v1"
 #    the new pose and the home control vector -- which is what action zero
 #    commands under home-keyframe-residual/v1 -- moved with them.  Every
 #    existing T-Rex checkpoint is invalidated.
+#
+# 9. T-Rex toes made passive.  The six per-digit position actuators (kp 60,
+#    forcerange +/-50, ctrlrange -0.4363..0.8727) are deleted; the digits keep
+#    their hinges, and the leg_joint class already gives them the passive
+#    stance: stiffness 40 with springref 12.5 deg holds the old commanded home
+#    pose, damping 15 dissipates strike energy.  Motivation is the stage-1
+#    bounce postmortem (docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md):
+#    release-ablation showed holding only the six toes at home reproduces the
+#    whole constant-hold failure, i.e. the policy's learned 0.8727 rad claw
+#    curl -- not the leg servos -- seeded the bounce, and a splayed digit is a
+#    pose the passive spring simply cannot hold.  PHYSICS moves (nu 21 -> 15,
+#    actuator arrays, key ctrl shrinks to 15 entries; qpos/qvel widths and all
+#    16 sensors unchanged).  The POLICY INTERFACE moves (action_dim 21 -> 15
+#    and the home-keyframe-residual origin ctrl vector shrinks with it); the
+#    observation is unchanged at 61 -- toe joints stay in qpos/qvel.  VISUAL is
+#    untouched (no geom, site, material, camera or light moved).  Every
+#    existing T-Rex checkpoint is invalidated, and the statue-derived
+#    constants (min_avg_reward, collapse_peak_floor_reference) must be
+#    re-measured with zero_action_baseline.py / stance_quality_baseline.py on
+#    this plant -- the statue's toes now settle on springs instead of servos,
+#    so the old 3271.8 standing reward may not carry.
 [plants.trex]
-physics_revision = 6
-policy_interface_revision = 9
+physics_revision = 7
+policy_interface_revision = 10
 visual_revision = 4
 observation_schema = "bipedal-target/v1"
 

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -67,9 +67,11 @@ leg_home_pose_weight = 0.5                     # Softly retain the authored p5 t
                                                # REVERTED from 1.5 (issue #491): the 1.5 experiment could not have
                                                # worked, and measurement says why. This term governs 8 joints --
                                                # r/l hip_pitch, hip_roll, knee, ankle -- and those 8 carry only
-                                               # 1.2% of the policy's commanded pose offset. 98.8% sits in the
+                                               # 1.2% of the policy's commanded pose offset. 98.8% sat in the
                                                # tail, neck, head and toes, which no term here touches, and 10-12
-                                               # of 21 actuators are pinned at |action| = 1.000. The governed
+                                               # of 21 actuators were pinned at |action| = 1.000 (measured on the
+                                               # physics-r6 plant; the six toe actuators are gone as of r7, note
+                                               # 9 in plant_versions.toml). The governed
                                                # joints were ALREADY near home (|DC| 0.035-0.263), so tripling the
                                                # weight had nothing to pull on: measured DC moved 0.766 -> 0.738,
                                                # 3.7%, while the run took ~2M extra steps to escape its early
@@ -313,6 +315,13 @@ min_avg_reward = 1950.0                 # Collapse RAIL, not the gate (PLANT_VAL
                                         # re-measure with zero_action_baseline.py and re-derive both. The FRACTION
                                         # is what carries across a rescale; the absolute number does not.
                                         #
+                                        # Re-measured on the passive-toes plant (physics r7, plant_versions
+                                        # note 9): the statue's toes now settle on their springs instead of
+                                        # servos and score 3270.3 +/- 12.3 (zero_action_baseline.py seed 3042
+                                        # and stance_quality_baseline.py agree) -- within one standard error of
+                                        # the r6 figure, so the rail stays at 1950 rather than chasing noise to
+                                        # 0.60 x 3270.3 = 1962.
+                                        #
                                         # Why 0.60 and not §12's 0.89: the measured collapse (run 20260731_132102,
                                         # full-horizon 93% -> 7%) bottomed at 888 = 0.27 x statue, so 0.60 clears
                                         # it by better than 2x. Meanwhile 0.89 = 2900 sat within ~2.4% of a
@@ -388,12 +397,14 @@ collapse_peak_warmup_timesteps = 1000000 # Evaluations before this step cannot S
                                          # post-150k rolling median in that run is 580.5, well under 1472.3. A
                                          # larger warm-up buys nothing and costs coverage: 1.0M leaves 88% of a 10M
                                          # budget protected, 2.5M only 72%.
-collapse_peak_floor_reference = 3271.8   # The zero-action statue's standing reward at noise 0.05, 40 episodes.
-                                         # Briefly 4250.4 while leg_home_pose_weight was 1.5; reverted with it
-                                         # (issue #491). Re-measure this whenever a reward weight changes: the
-                                         # statue commands action = 0 at any weight, so its trajectory never
-                                         # changes and only the affected term rescales -- which makes the new
-                                         # value exact and cheap to obtain, and makes forgetting it silent.
+collapse_peak_floor_reference = 3270.3   # The zero-action statue's standing reward at noise 0.05, 40 episodes,
+                                         # measured on the passive-toes plant (physics r7; was 3271.8 on r6,
+                                         # within one standard error -- the toes settle on springs at the same
+                                         # pose the servos held). Briefly 4250.4 while leg_home_pose_weight was
+                                         # 1.5; reverted with it (issue #491). Re-measure this whenever a reward
+                                         # weight OR the plant changes: a weight change rescales the statue's
+                                         # terms exactly and cheaply; a plant change moves its trajectory, so
+                                         # only a re-run is evidence. Forgetting either is silent.
 stance_probe_filter_hz = [5.0, 10.0, 20.0]  # After the gate report, re-score the SAME checkpoint with its actions
                                          # low-passed at EACH of these cutoffs and write
                                          # stance_gate_probe_filtered.{txt,json} as one curve. Unset to skip.
@@ -459,8 +470,10 @@ stance_probe_release_ablation = true     # Ablate the held pose one actuator gro
                                          # the statue by itself?). One side alone lets a conspicuous group
                                          # masquerade as a cause, which is not hypothetical here: the tail is the
                                          # most extreme entry in the DC table and holding it alone stands the full
-                                         # horizon at 3254.0, while holding only the six toes reproduces the whole
-                                         # failure (125.5 steps against the full pose's 128.6).
+                                         # horizon at 3254.0, while holding only the six toes reproduced the whole
+                                         # failure (125.5 steps against the full pose's 128.6) -- the finding that
+                                         # motivated deleting the toe actuators in physics r7. The 'toes' group
+                                         # matches no actuators on that plant and is skipped gracefully.
                                          #
                                          # 13 panels at 8 episodes -- the most expensive of the four probes, which
                                          # is why it is per-stage opt-in rather than on by default.

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -405,7 +405,14 @@ collapse_peak_floor_reference = 3270.3   # The zero-action statue's standing rew
                                          # weight OR the plant changes: a weight change rescales the statue's
                                          # terms exactly and cheaply; a plant change moves its trajectory, so
                                          # only a re-run is evidence. Forgetting either is silent.
-stance_probe_filter_hz = [5.0, 10.0, 20.0]  # After the gate report, re-score the SAME checkpoint with its actions
+statue_constants_physics_revision = 7    # The trex physics revision the statue-derived constants above
+                                         # (min_avg_reward, collapse_peak_floor_reference) were measured on.
+                                         # test_statue_constant_freshness.py cross-checks this against the
+                                         # plant manifest, so a plant revision bump that forgets to re-measure
+                                         # the statue fails CI instead of silently training against a rail and
+                                         # collapse floor calibrated on a plant that no longer exists. Update
+                                         # it WITH the re-measurement, never alone.
+stance_probe_filter_hz = [5.0, 10.0, 20.0, 30.0, 35.0]  # After the gate report, re-score the SAME checkpoint with its actions
                                          # low-passed at EACH of these cutoffs and write
                                          # stance_gate_probe_filtered.{txt,json} as one curve. Unset to skip.
                                          #
@@ -423,6 +430,12 @@ stance_probe_filter_hz = [5.0, 10.0, 20.0]  # After the gate report, re-score th
                                          # untouched (gain 0.963 at 1.4 Hz even at 5 Hz), while the measured
                                          # 22.7 Hz tremor is cut 13.3 dB at 5 Hz and 3.6 dB at 20. So a short
                                          # episode means dependence on content well above what the task needs.
+                                         #
+                                         # 30/35 added with the passive-toes revision: the r6 sweep's manual
+                                         # probes showed the policy still falling at 35 Hz, but the recorded
+                                         # curve stopped at 20, leaving the top octave -- where a 22.7 Hz
+                                         # tremor passes nearly clean -- unsampled. Five points close the curve
+                                         # at the control Nyquist's edge instead of extrapolating it.
                                          #
                                          # Each cutoff costs a panel, but the probe rolls 10 episodes rather than
                                          # the gate's 40: it certifies nothing, and the effect is enormous

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -66,16 +66,14 @@ tolerance) remains the standing recommendation for the divergences above.
   replicates of the passing configuration**, which is the only thing that
   distinguishes "solved" from "lucky".
 - **MEDIUM** — **half the actuators sit saturated and nothing opposes it.**
-  Ten to twelve of 21 actuators are pinned at `|action| ≥ 0.99` — tail, neck,
-  head, toes — in *both* passing and failing policies.
-  **Read this count with care (2026-08-06):** `|action| = 1` is not one physical
-  event. Actions map piecewise-affine around each actuator's home control onto
-  its own `ctrlrange`, and those ranges differ by 6× — a saturated tail joint is
-  **8–12°** of deflection while a
-  saturated toe is **37.5°**. The saturation count pools them, and the ablation
-  showed the tail is mechanically inert while the toes carry the whole effect.
-  The stance report now orders per-actuator DC by **degrees**; use that, not the
-  saturation count, to decide which joints moved. `energy` charges
+  Ten to twelve of 21 actuators were pinned at `|action| ≥ 0.99` — tail, neck,
+  head, toes — in *both* passing and failing policies, measured on the
+  physics-r6 plant. **The passive-toes revision (physics r7) deleted the six
+  toe actuators**, the group whose 37.5° saturated deflection the release
+  ablation blamed for the unholdable pose (archived in the bounce
+  investigation); the remaining tail/neck/head saturation is 8–12° of
+  deflection and mechanically inert in that ablation. Saturation counts on
+  the 15-actuator plant have not been re-measured. `energy` charges
   ~48/episode against an alive bonus paying ~1000, and `leg_home_pose` governs
   only 8 joints carrying 1.2% of the commanded offset. A saturated actuator has
   no headroom in one direction, so the recovery envelope on those axes is
@@ -96,35 +94,18 @@ tolerance) remains the standing recommendation for the divergences above.
   while both controls reach the horizon (unmodified policy 1000, zero-action
   statue 1000 at reward 3271.0). The ramped variant falling too rules out a
   handoff transient. The statue holds the *home* pose on a constant forever;
-  the policy stands 0.765 rms away from home with 12 of 21 actuators pinned at
-  ±1.000, and **that** pose needs active stabilisation. So the tremor is the
-  price of where the policy chose to stand, not a property of the task, and
-  **raising `smoothness`/`action_jerk` is contraindicated** — they would
-  suppress the only thing holding the animal up. The open question is why the
-  policy leaves a pose that is free to hold for one costing 267 reward points
-  plus continuous stabilisation; the candidate answer is that no stage-1 term
-  constrains 13 of the 21 actuators (`leg_home_pose` covers 8 carrying 1.2% of
-  the offset). Measured by `stance_gate_report.py --hold-constant`; see the
-  2026-08-06 addendum in the bounce investigation.
-- **HIGH** — **the toes alone account for the unholdable pose; the tail is a
-  bystander.** Ablating the held pose one actuator group at a time
-  (`--hold-release-ablation`, necessity *and* sufficiency per group): holding
-  only the **six toe joints** at their commanded DC with everything else at
-  home reproduces the whole failure — **125.5 steps against the full pose's
-  128.6, `tail_contact` 8 of 8 in both**. Holding only the **four tail joints**
-  at `±1.000` stands the full horizon at reward **3254.0**, within 0.6% of the
-  statue; head and neck likewise at **3286.1**. No group is *necessary* —
-  releasing all twelve saturated actuators still falls (224.6 steps) — so the
-  pose is over-determined and several subsets break it independently. **This
-  refutes the saturation hypothesis** recorded above it: saturation is
-  conspicuous, not causal. Toes are the ground contact and five of six sit at
-  their stops, which changes the support polygon — a plant effect, not a
-  reward-shaping one. **Not yet a reason to add a toe reward term**: sufficiency
-  says the toe pose breaks a *statue*, not that constraining it would make the
-  policy stand. **Prerequisite now measured:** `±1.000` on a toe is **±37.5°**
-  from home against a 75° range, and adjacent toes on the same foot are driven
-  to opposite ends — the foot is splayed into a twist, asymmetrically between
-  the two feet. The mechanism survives.
+  the policy stood 0.765 rms away from home, and **that** pose needs active
+  stabilisation. So the tremor is the price of where the policy chose to
+  stand, not a property of the task, and **raising
+  `smoothness`/`action_jerk` is contraindicated** — they would suppress the
+  only thing holding the animal up. **Measured on the physics-r6 plant, and
+  the release ablation attributed the whole failure to the six toe actuators
+  the passive-toes revision (r7) has since deleted** — the splayed-claw pose
+  is now structurally impossible, every r6 checkpoint is invalidated, and the
+  hold-constant probe must be re-run on a policy trained on the 15-actuator
+  plant before this item can be called fixed. Measured by
+  `stance_gate_report.py --hold-constant`; see the 2026-08-06 addendum in the
+  bounce investigation.
 - **MEDIUM** — **stage 1 contains no in-episode disturbance, so it cannot ask
   for postural correction.** The only perturbation is joint-angle noise at
   reset (`reset_noise_scale 0.05`); nothing applies an external force during an

--- a/environments/dibothrosuchus/envs/dibothrosuchus_env.py
+++ b/environments/dibothrosuchus/envs/dibothrosuchus_env.py
@@ -242,6 +242,9 @@ class DibothrosuchusEnv(BaseDinoEnv):
         self.imu_site_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_SITE, "imu")
         self.snout_tip_site_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_SITE, "snout_tip")
         self.tail_tip_site_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_SITE, "tail_tip")
+        # Snout-height termination sampled at every physics substep by the
+        # base step loop; _is_terminated reads the substep MIN.
+        self._substep_height_checks = (("site", self.snout_tip_site_id),)
 
         # Foot site IDs
         self.foot_site_ids = {
@@ -569,10 +572,12 @@ class DibothrosuchusEnv(BaseDinoEnv):
             return True, info
 
         # Site-height termination: the snout tip must stay off the ground.
-        # Catches snout-propping that geom contact detection may miss.
+        # Catches snout-propping that geom contact detection may miss.  Reads
+        # the substep MIN so a dip that recovers between control-boundary
+        # samples still terminates; the info key keeps the boundary sample.
         snout_tip_z = self.data.site_xpos[self.snout_tip_site_id, 2]
         info["snout_tip_z"] = snout_tip_z
-        if snout_tip_z < 0.04:
+        if self._aggregated_min_height(0, snout_tip_z) < 0.04:
             info["termination_reason"] = "head_contact"
             return True, info
 

--- a/environments/dibothrosuchus/tests/test_dibothrosuchus_env.py
+++ b/environments/dibothrosuchus/tests/test_dibothrosuchus_env.py
@@ -179,6 +179,26 @@ class TestSnoutTerminations:
         assert not terminated
         assert info["snout_tip_z"] > 0.04
 
+    def test_between_sample_snout_dip_terminates_while_boundary_reads_healthy(self, env):
+        """The snout gate consumes the substep MIN recorded by the base step
+        loop, so a dip that recovers before the control boundary still
+        terminates; the info key keeps the boundary sample."""
+        env.reset(seed=0)
+        env.step(np.zeros(env.action_space.shape, dtype=np.float32))
+        boundary_snout = float(env.data.site_xpos[env.snout_tip_site_id, 2])
+        assert boundary_snout > 0.04
+
+        env._substep_min_heights = np.array([0.03])
+        env._substep_contact_step = env._step_count
+        terminated, info = env._is_terminated()
+        assert terminated
+        assert info["termination_reason"] == "head_contact"
+        assert info["snout_tip_z"] == pytest.approx(boundary_snout)
+
+        env.reset(seed=1)
+        terminated, info = env._is_terminated()
+        assert not terminated, f"stale height aggregate survived reset: {info}"
+
     def test_snap_target_clears_the_snout_prop_gate(self, env):
         """A successful snap must never be reported as snout-propping.
 

--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -121,6 +121,16 @@ class BaseDinoEnv(gym.Env, ABC):
     _substep_contact_step: int = -1
     _ground_geom_array: "np.ndarray | None" = None
 
+    # Site/body height checks aggregated per substep, declared per species in
+    # _cache_ids as ("site" | "body", entity_id) pairs; () means "none".  The
+    # step loop records each entity's MINIMUM z across the substeps so the
+    # species' height terminations (trex head_tip/skull, dibothrosuchus
+    # snout_tip) fire on a between-samples dip exactly like the MJX
+    # height-emulation checks, which became any-substep with the contact
+    # aggregation.  Info keys keep reporting the boundary sample.
+    _substep_height_checks: "tuple[tuple[str, int], ...]" = ()
+    _substep_min_heights: "np.ndarray | None" = None
+
     # Optional zero-argument callable invoked after EVERY physics substep in
     # step().  Exists so stance_duty_validation.py and the aggregation
     # regression tests can record per-substep kinematic ground truth through
@@ -792,6 +802,19 @@ class BaseDinoEnv(gym.Env, ABC):
             return self._foot_contact_forces()
         return tuple(float(value) for value in self._substep_min_foot_forces)
 
+    def _aggregated_min_height(self, check_index: int, instantaneous: float) -> float:
+        """MIN z of a ``_substep_height_checks`` entry across the last step.
+
+        Returns ``min(aggregate, instantaneous)`` when a fresh aggregate
+        exists so a hand-posed-lower state can still terminate, and the bare
+        instantaneous value otherwise (before any step, after reset, or for a
+        species that declares no checks).  Termination reads this; info keys
+        keep the boundary sample.
+        """
+        if self._substep_min_heights is None or self._substep_contact_step != self._step_count:
+            return instantaneous
+        return float(min(self._substep_min_heights[check_index], instantaneous))
+
     def _invalidate_substep_aggregates(self) -> None:
         """Drop the last step's contact aggregates and strike latch.
 
@@ -805,6 +828,7 @@ class BaseDinoEnv(gym.Env, ABC):
         """
         self._substep_min_foot_forces = None
         self._substep_floor_hit_geom = None
+        self._substep_min_heights = None
         self._substep_contact_step = -1
 
     def _check_floor_contact(
@@ -932,8 +956,10 @@ class BaseDinoEnv(gym.Env, ABC):
         # _check_floor_contact.  The MJX step_fn carries the same aggregates
         # through its fori_loop -- keep the two in lockstep.
         min_forces: "np.ndarray | None" = None
+        min_heights: "np.ndarray | None" = None
         self._substep_floor_hit_geom = None
         track_feet = bool(self._foot_sensor_groups)
+        height_checks = self._substep_height_checks
         track_strikes = getattr(self, "_body_ground_geoms", None)
         floor_geom_id = getattr(self, "floor_geom_id", None)
         ground_geoms: "np.ndarray | None" = None
@@ -952,6 +978,16 @@ class BaseDinoEnv(gym.Env, ABC):
             if track_feet:
                 forces = np.asarray(self._foot_contact_forces(), dtype=np.float64)
                 min_forces = forces if min_forces is None else np.minimum(min_forces, forces)
+            if height_checks:
+                heights = np.fromiter(
+                    (
+                        self.data.site_xpos[entity_id, 2] if kind == "site" else self.data.xpos[entity_id, 2]
+                        for kind, entity_id in height_checks
+                    ),
+                    dtype=np.float64,
+                    count=len(height_checks),
+                )
+                min_heights = heights if min_heights is None else np.minimum(min_heights, heights)
             if ground_geoms is not None and self._substep_floor_hit_geom is None:
                 pairs = self.data.contact.geom
                 if len(pairs):
@@ -970,6 +1006,7 @@ class BaseDinoEnv(gym.Env, ABC):
         # Tag the aggregates with the step they were measured at; the tag is
         # what invalidates them across reset (which zeroes _step_count).
         self._substep_min_foot_forces = min_forces
+        self._substep_min_heights = min_heights
         self._substep_contact_step = self._step_count
 
         # Update cumulative distance traveled (XY path length)

--- a/environments/shared/curriculum/gate_schema.py
+++ b/environments/shared/curriculum/gate_schema.py
@@ -174,6 +174,15 @@ _DIAGNOSTIC_KEYS = frozenset(
 #: the only place it is meant to be set.
 _RETENTION_KEYS = frozenset({"max_checkpoints"})
 
+#: Keys that record measurement provenance rather than configure anything.
+#: ``statue_constants_physics_revision`` pins the plant revision the stage's
+#: statue-derived constants (``min_avg_reward``,
+#: ``collapse_peak_floor_reference``) were measured on;
+#: test_statue_constant_freshness.py cross-checks it against the plant
+#: manifest so a plant bump that forgets the re-measurement fails CI.  No
+#: trainer reads it.
+_PROVENANCE_KEYS = frozenset({"statue_constants_physics_revision"})
+
 #: The schema's own declaration keys.
 _SCHEMA_KEYS = frozenset({"gate_schema_version", "gate_kind"})
 
@@ -247,7 +256,15 @@ def validate_gate_config(
             that its declared kind does not consume, or omits the gate
             declaration entirely while advancement is enabled.
     """
-    known = _SCHEMA_KEYS | _SCHEDULE_KEYS | _COLLAPSE_KEYS | _RETENTION_KEYS | _DIAGNOSTIC_KEYS | _ALL_THRESHOLD_KEYS
+    known = (
+        _SCHEMA_KEYS
+        | _SCHEDULE_KEYS
+        | _COLLAPSE_KEYS
+        | _RETENTION_KEYS
+        | _DIAGNOSTIC_KEYS
+        | _PROVENANCE_KEYS
+        | _ALL_THRESHOLD_KEYS
+    )
     unknown = sorted(set(curriculum_kwargs) - known)
     if unknown:
         raise GateSchemaError(

--- a/environments/shared/data/plant_manifest.generated.json
+++ b/environments/shared/data/plant_manifest.generated.json
@@ -84,30 +84,30 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:1d1ddd1efeceb2a2770079e52387d2fd2f38490a8c4527630ebf597264e9a702",
+      "bundle_sha256": "sha256:a3c23d7a84e4b63cab0f4e234d00854bc8eff3380a901b2bf419e1fb4b196722",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
         "nq": 28,
-        "nu": 21,
+        "nu": 15,
         "nv": 27,
-        "revision": 6,
+        "revision": 7,
         "schema": "mesozoic.mujoco-physics/v1",
-        "sha256": "sha256:7dfa00f5b28a5f562170ba0926e6811208354cb6160b524d9ab58412a37bc2f0"
+        "sha256": "sha256:72c662858639193e24a503b98e06d84737150ae6888a50a3620c2c99804cb97b"
       },
       "policy_interface": {
-        "action_dim": 21,
+        "action_dim": 15,
         "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 9,
+        "revision": 10,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:bacbb3243a7f84f1379e106dd886279ed247c252c143cb5e86500a50725d7020"
+        "sha256": "sha256:d00f24e0d9219878714dc3d2f479c9400fd21c7bc76687bda065f223beb039e9"
       },
       "source": {
-        "closure_sha256": "sha256:2ef85b8c9aef05050e7e407ba9cf6a7a6da62e2c14282c5143366dd0575f2571",
+        "closure_sha256": "sha256:e3919447fc76fbcd6396284afa028ad2831797461d03bbe6c9b52a5fc1c50753",
         "dependencies": [
           {
-            "content_sha256": "sha256:1362fd47f50233ac4fc87b3e6dbaeefb609f5be76530220d541fb598c704fdd8",
+            "content_sha256": "sha256:b77304a2d69cd325a61a95cb85cf870d45af252b9b4701dcf971318f874efef0",
             "kind": "mjcf",
             "logical_path": "environments/trex/assets/trex.xml"
           }

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -767,8 +767,9 @@ class ConstantHold:
     it. If the animal keeps standing, the smooth solution existed and the
     optimiser did not find it. If it falls, the pose genuinely requires
     feedback, and the question moves to why the policy chose a pose it then has
-    to fight -- which points at the 13 of 21 actuators no stage-1 term
-    constrains.
+    to fight -- which pointed at the actuators no stage-1 term constrains (13
+    of 21 on the physics-r6 plant that measurement was made on; the six toe
+    actuators are gone as of r7).
 
     Attributes:
         actions: The constant command, one entry per actuator.

--- a/environments/shared/tests/test_mjcf_assets.py
+++ b/environments/shared/tests/test_mjcf_assets.py
@@ -23,7 +23,7 @@ ENVIRONMENTS_DIR = Path(__file__).resolve().parents[2]
 EXPECTED_MODELS = {
     "brachiosaurus/assets/brachiosaurus.xml": ModelExpectations(38, 37, 30, 175.3),
     "dibothrosuchus/assets/dibothrosuchus.xml": ModelExpectations(35, 34, 27, 8.65),
-    "trex/assets/trex.xml": ModelExpectations(28, 27, 21, 85.72),
+    "trex/assets/trex.xml": ModelExpectations(28, 27, 15, 85.72),
     "velociraptor/assets/raptor.xml": ModelExpectations(31, 30, 22, 13.5),
 }
 

--- a/environments/shared/tests/test_mjx_env.py
+++ b/environments/shared/tests/test_mjx_env.py
@@ -35,7 +35,7 @@ class TestMJXDinoEnv:
         from environments.shared.mjx_env import MJXDinoEnv
 
         env = MJXDinoEnv("trex", stage=1, num_envs=4)
-        assert env.action_dim == 21
+        assert env.action_dim == 15
         assert env.num_envs == 4
         assert env.config.posture_target_forward_z is None
         assert env.config.action_mapping == "home-keyframe-residual/v1"

--- a/environments/shared/tests/test_plant_contract_manifest.py
+++ b/environments/shared/tests/test_plant_contract_manifest.py
@@ -55,7 +55,7 @@ def test_runtime_identity_falls_back_to_bundled_manifest(monkeypatch, tmp_path):
 
 @pytest.mark.parametrize(
     ("species", "observation_dim", "action_dim"),
-    [("velociraptor", 67, 22), ("trex", 61, 21), ("brachiosaurus", 83, 30)],
+    [("velociraptor", 67, 22), ("trex", 61, 15), ("brachiosaurus", 83, 30)],
 )
 def test_current_identity_matches_each_executable_environment(species, observation_dim, action_dim):
     # Identity generation requires exact SB3/MJX observation parity.

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -41,7 +41,7 @@ def test_catalog_derives_current_model_and_stage_facts() -> None:
         for species_id, entry in species.items()
     } == {
         "velociraptor": (67, 22, 31, 30, 22, 13.5),
-        "trex": (61, 21, 28, 27, 21, 85.72),
+        "trex": (61, 15, 28, 27, 15, 85.72),
         "brachiosaurus": (83, 30, 38, 37, 30, 175.3),
         "dibothrosuchus": (77, 27, 35, 34, 27, 8.65),
     }
@@ -98,8 +98,8 @@ def test_catalog_publishes_layered_plant_contract() -> None:
     # appended, pad + meta summed per leg on both backends; the physics layer
     # fingerprints nsite/nsensor, so new sites move it even though dynamics
     # are unchanged).
-    expected_policy_revisions = {"velociraptor": 8, "trex": 9, "brachiosaurus": 6, "dibothrosuchus": 5}
-    expected_physics_revisions = {"velociraptor": 2, "trex": 6, "brachiosaurus": 4, "dibothrosuchus": 1}
+    expected_policy_revisions = {"velociraptor": 8, "trex": 10, "brachiosaurus": 6, "dibothrosuchus": 5}
+    expected_physics_revisions = {"velociraptor": 2, "trex": 7, "brachiosaurus": 4, "dibothrosuchus": 1}
     expected_visual_revisions = {"velociraptor": 3, "trex": 4, "brachiosaurus": 2, "dibothrosuchus": 1}
     digest_pattern = re.compile(r"sha256:[0-9a-f]{64}")
     for species in catalog["species"]:
@@ -153,9 +153,10 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
     # Stage-1 reward gates are COLLAPSE RAILS: 0.60 x each species' zero-action
     # statue standing reward at the 1a operating point (reset noise 0.05),
     # measured over 40 episodes with
-    # environments/shared/scripts/stance_quality_baseline.py -- trex 3271.8,
-    # velociraptor 1745.8, brachiosaurus 1739.1 (on the plant repaired by
-    # plant_versions notes 7-8), dibothrosuchus 2598.3.
+    # environments/shared/scripts/stance_quality_baseline.py -- trex 3270.3
+    # (passive-toes plant, physics r7; 3271.8 on r6, within one standard
+    # error), velociraptor 1745.8, brachiosaurus 1739.1 (on the plant repaired
+    # by plant_versions notes 7-8), dibothrosuchus 2598.3.
     #
     # A rail sits BELOW its statue deliberately. Section 9 showed the statue
     # is the reward optimum -- it collects 97.0% of the theoretical maximum
@@ -175,6 +176,8 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
         # 0.60 x the statue's standing reward at leg_home_pose_weight 0.5.
         # Was briefly 2550 while that weight was 1.5 (statue 4250.4), reverted
         # with it in issue #491. The FRACTION is the invariant, not the reward.
+        # Unchanged by the passive-toes plant (r7): the statue re-measured
+        # within one standard error of the r6 figure.
         "trex": 1950.0,
         "velociraptor": 1050.0,
         "brachiosaurus": 1040.0,

--- a/environments/shared/tests/test_species_integration.py
+++ b/environments/shared/tests/test_species_integration.py
@@ -33,7 +33,7 @@ SPECIES_ENVS = [
 # Expected observation and action dimensions per species
 SPECIES_DIMS = {
     "velociraptor": {"obs": 67, "act": 22},
-    "trex": {"obs": 61, "act": 21},
+    "trex": {"obs": 61, "act": 15},
     "brachiosaurus": {"obs": 83, "act": 30},
     "dibothrosuchus": {"obs": 77, "act": 27},
 }

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -1269,7 +1269,7 @@ class TestTheProbeIsWiredIntoTrainingArtifacts:
         from environments.shared.curriculum.gate_schema import validate_gate_config
 
         curriculum = load_stage_config("trex", 1)["curriculum_kwargs"]
-        assert curriculum["stance_probe_filter_hz"] == [5.0, 10.0, 20.0]
+        assert curriculum["stance_probe_filter_hz"] == [5.0, 10.0, 20.0, 30.0, 35.0]
         validate_gate_config(1, curriculum)
 
 

--- a/environments/shared/tests/test_stance_gate_report.py
+++ b/environments/shared/tests/test_stance_gate_report.py
@@ -2098,7 +2098,7 @@ class TestControlTargetsInDegrees:
 
         result = run_panel(
             "trex",
-            predict=lambda obs: np.zeros(21, dtype=np.float32),
+            predict=lambda obs: np.zeros(15, dtype=np.float32),
             episodes=1,
             seed=3042,
             settle_steps=0,

--- a/environments/shared/tests/test_statue_constant_freshness.py
+++ b/environments/shared/tests/test_statue_constant_freshness.py
@@ -1,0 +1,80 @@
+"""Cross-check statue-derived gate constants against the plant manifest.
+
+``min_avg_reward`` and ``collapse_peak_floor_reference`` are DERIVED from the
+zero-action statue and neither updates itself -- their TOML comments have
+said so since issue #491, and forgetting is silent: training proceeds against
+a collapse floor and rail calibrated on a plant that no longer exists.  A
+reward-weight change at least leaves the statue's trajectory intact, but a
+plant revision moves the trajectory itself, so only a re-run of
+``zero_action_baseline.py`` / ``stance_quality_baseline.py`` is evidence.
+
+The cross-check is a repo test rather than a runtime hook because plants can
+only change through a PR: the manifest generator refuses a changed physics
+fingerprint without a revision increase, and CI re-checks monotonicity
+against the PR base.  Any plant bump therefore lands exactly where this test
+runs, and a bump that forgets the statue re-measurement fails the PR instead
+of the training run it would have silently mis-calibrated.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MANIFEST_PATH = REPO_ROOT / "configs" / "plant_manifest.generated.json"
+CONFIGS_ROOT = REPO_ROOT / "configs"
+
+
+def _stage_curriculum_tables() -> list[tuple[str, Path, dict]]:
+    """Every per-species stage TOML's [curriculum] table, with its species."""
+    tables = []
+    for species_dir in sorted(p for p in CONFIGS_ROOT.iterdir() if p.is_dir()):
+        for toml_path in sorted(species_dir.glob("*.toml")):
+            config = tomllib.loads(toml_path.read_text())
+            if "curriculum" in config:
+                tables.append((species_dir.name, toml_path, config["curriculum"]))
+    return tables
+
+
+def test_statue_derived_constants_record_the_plant_they_were_measured_on() -> None:
+    """Every stage that sets the statue-derived collapse reference must pin
+    the physics revision it was measured on, and that pin must match the
+    manifest -- so a plant revision bump cannot land without either
+    re-measuring the statue or consciously updating the provenance pin in
+    the same diff (where a reviewer sees the constants did NOT move)."""
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    plants = manifest["plants"]
+
+    checked = 0
+    for species, toml_path, curriculum in _stage_curriculum_tables():
+        if "collapse_peak_floor_reference" not in curriculum:
+            assert "statue_constants_physics_revision" not in curriculum, (
+                f"{toml_path}: statue_constants_physics_revision without "
+                "collapse_peak_floor_reference records provenance for a "
+                "constant the stage does not set"
+            )
+            continue
+        assert "statue_constants_physics_revision" in curriculum, (
+            f"{toml_path}: collapse_peak_floor_reference is statue-derived "
+            "and must record the plant it was measured on -- set "
+            "statue_constants_physics_revision alongside it (and re-measure "
+            "with zero_action_baseline.py if the plant moved)"
+        )
+        recorded = curriculum["statue_constants_physics_revision"]
+        current = plants[species]["physics"]["revision"]
+        assert recorded == current, (
+            f"{toml_path}: statue constants were measured on physics "
+            f"revision {recorded}, but the manifest is at revision {current}. "
+            "Re-measure the statue on the current plant "
+            "(zero_action_baseline.py / stance_quality_baseline.py), "
+            "re-derive min_avg_reward and collapse_peak_floor_reference, and "
+            "update this pin in the same commit."
+        )
+        checked += 1
+
+    # The check must never pass vacuously: trex stage 1 carries the reference
+    # today, and losing it without a conscious edit here means the constants
+    # lost their only freshness guard.
+    assert checked >= 1, "no stage TOML carries collapse_peak_floor_reference; update this test's premise"

--- a/environments/trex/README.md
+++ b/environments/trex/README.md
@@ -16,7 +16,7 @@ manifest, executable environment, compiled MJCF, current TOML stage configs, and
 
 ### Body Structure
 - **Head/Neck**: Heavy head with a fixed contact geom, 3 actuated joints (neck pitch/yaw, head pitch), and no jaw joint
-- **Legs**: Powerful digitigrade legs with 7 joints each (hip pitch/roll, knee, ankle, toe d2/d3/d4)
+- **Legs**: Powerful digitigrade legs with 7 joints each (hip pitch/roll, knee, ankle, toe d2/d3/d4); the 4 proximal joints are actuated, the 3 toe digits ride passive springs
 - **Tail**: 5 segments, 4 actuated (pitch 1, yaw 1, pitch 2, pitch 3), heavy counterbalance to skull
 
 ### Reward Components

--- a/environments/trex/assets/trex.xml
+++ b/environments/trex/assets/trex.xml
@@ -428,18 +428,18 @@
     <position name="r_hip_roll_act" joint="r_hip_roll" kp="150" forcerange="-120 120" ctrlrange="-0.4363 0.4363"/>
     <position name="r_knee_act" joint="r_knee" kp="1500" forcerange="-2250 2250" ctrlrange="-1.30550 0.43982"/>
     <position name="r_ankle_act" joint="r_ankle" kp="900" forcerange="-1350 1350" ctrlrange="0.56549 2.31081"/>
-    <position name="r_toe_d2_act" joint="r_toe_d2_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
-    <position name="r_toe_d3_act" joint="r_toe_d3_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
-    <position name="r_toe_d4_act" joint="r_toe_d4_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
+    <!-- Toes are passive: leg_joint stiffness 40 with springref 12.5 holds
+         the digits at the old commanded home, and damping 15 dissipates
+         strike energy.  The removed position actuators let the policy splay
+         the digits into the 0.8727 rad claw-curl that seeded the stage-1
+         bounce; see docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md. -->
+
 
     <!-- Left leg -->
     <position name="l_hip_pitch_act" joint="l_hip_pitch" kp="1200" forcerange="-1800 1800" ctrlrange="-1.17984 1.08908"/>
     <position name="l_hip_roll_act" joint="l_hip_roll" kp="150" forcerange="-120 120" ctrlrange="-0.4363 0.4363"/>
     <position name="l_knee_act" joint="l_knee" kp="1500" forcerange="-2250 2250" ctrlrange="-1.30550 0.43982"/>
     <position name="l_ankle_act" joint="l_ankle" kp="900" forcerange="-1350 1350" ctrlrange="0.56549 2.31081"/>
-    <position name="l_toe_d2_act" joint="l_toe_d2_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
-    <position name="l_toe_d3_act" joint="l_toe_d3_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
-    <position name="l_toe_d4_act" joint="l_toe_d4_joint" kp="60" forcerange="-50 50" ctrlrange="-0.4363 0.8727"/>
 
     <!-- Tail actuators for active balance control (counterbalance to massive skull) -->
     <position name="tail_1_pitch_act" joint="tail_1_pitch" kp="100" forcerange="-80 80" ctrlrange="-0.2094 0.2094"/>
@@ -461,10 +461,11 @@
 
     <!-- Foot contact forces.  These two see the plantar pad ONLY: a touch
          sensor sums contacts on geoms belonging to its site's own body, and
-         the digits are child bodies (they carry actuated hinges, so they
-         cannot be merged into the metatarsus).  The per-digit sensors at the
-         end of this block carry the rest; the envs sum pad + 3 digits into
-         one contact value per foot.  See sensor_foot_aux_indices. -->
+         the digits are child bodies (they articulate on their own passive
+         hinges, so they cannot be merged into the metatarsus).  The
+         per-digit sensors at the end of this block carry the rest; the envs
+         sum pad + 3 digits into one contact value per foot.  See
+         sensor_foot_aux_indices. -->
     <touch name="r_foot_touch" site="r_foot"/>
     <touch name="l_foot_touch" site="l_foot"/>
 
@@ -563,8 +564,8 @@
                -0.045379 0 -0.432842 1.342158 0.218166 0.218166 0.218166
                -0.045379 0 -0.432842 1.342158 0.218166 0.218166 0.218166"
          ctrl="0 0 0
-               -0.04538 0 -0.43284 1.43815 0.2182 0.2182 0.2182
-               -0.04538 0 -0.43284 1.43815 0.2182 0.2182 0.2182
+               -0.04538 0 -0.43284 1.43815
+               -0.04538 0 -0.43284 1.43815
                0 0 0 0"/>
   </keyframe>
 

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -18,9 +18,12 @@ Observation space (total dimension is generated in the public species catalog):
 
 Action space (total dimension is generated in the public species catalog):
     - Neck/head: neck pitch, neck yaw, head pitch (3)
-    - Right leg: hip pitch/roll, knee, ankle, toe d2/d3/d4 (7)
-    - Left leg: hip pitch/roll, knee, ankle, toe d2/d3/d4 (7)
+    - Right leg: hip pitch/roll, knee, ankle (4)
+    - Left leg: hip pitch/roll, knee, ankle (4)
     - Tail: pitch 1, yaw 1, pitch 2, pitch 3 (4)
+
+The six toe hinges are passive (spring-loaded at the home pose); they stay
+in qpos/qvel so the observation still senses toe posture.
 
 Reward components:
     - Forward velocity (toward prey)
@@ -313,6 +316,14 @@ class TRexEnv(BaseDinoEnv):
         self.l_foot_site_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_SITE, "l_foot")
         self.tail_tip_site_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_SITE, "tail_tip")
         self.head_tip_site_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_SITE, "head_tip")
+        # Height terminations sampled at every physics substep by the base
+        # step loop; _is_terminated reads the per-check MIN so a between-
+        # samples head dip terminates like the MJX height emulation does.
+        # Order is consumed by index there.
+        self._substep_height_checks = (
+            ("site", self.head_tip_site_id),
+            ("body", self.skull_body_id),
+        )
 
         # Prey mocap body
         self.prey_mocap_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, "prey")
@@ -326,7 +337,7 @@ class TRexEnv(BaseDinoEnv):
         self._sensor_l_foot = 11
         # The pad sensors above see the plantar box only: a touch sensor sums
         # contacts on geoms of its site's own body, and the three digits are
-        # child bodies (they carry actuated hinges).  Their own sensors are
+        # child bodies on their own passive hinges.  Their own sensors are
         # appended after the tail block, so pad + digits is the force the foot
         # actually transmits -- at the home keyframe 388.4 N + 112.0 N against
         # a measured 500.4 N of floor contact.
@@ -809,16 +820,20 @@ class TRexEnv(BaseDinoEnv):
             return True, info
 
         # Site-height termination: snout tip must stay above threshold
-        # This catches nose-balancing that geom contact detection may miss
+        # This catches nose-balancing that geom contact detection may miss.
+        # The check reads the substep MIN (indices match the
+        # _substep_height_checks declaration) so a dip that recovers between
+        # control-boundary samples still terminates; the info key keeps the
+        # boundary sample.
         head_tip_z = self.data.site_xpos[self.head_tip_site_id, 2]
         info["head_tip_z"] = head_tip_z
-        if head_tip_z < 0.12:
+        if self._aggregated_min_height(0, head_tip_z) < 0.12:
             info["termination_reason"] = "head_contact"
             return True, info
 
         # Body-height termination: skull origin must stay above threshold
         skull_z = self.data.xpos[self.skull_body_id, 2]
-        if skull_z < 0.45:
+        if self._aggregated_min_height(1, skull_z) < 0.45:
             info["termination_reason"] = "skull_low"
             return True, info
 

--- a/environments/trex/mjx_config.py
+++ b/environments/trex/mjx_config.py
@@ -24,7 +24,7 @@ _NATURAL_PITCH = 0.027
 _SENSOR_R_FOOT = 10
 _SENSOR_L_FOOT = 11
 # The two sensors above cover the plantar pad only.  Each digit is its own
-# body (it carries an actuated hinge), and a touch sensor cannot see geoms on
+# body (it articulates on a passive hinge), and a touch sensor cannot see geoms on
 # child bodies, so the digits carry their own sensors -- appended after the
 # tail block so every index above keeps its position.  Summed per foot, they
 # restore the reading to the force the foot actually transmits.

--- a/environments/trex/tests/test_trex_env.py
+++ b/environments/trex/tests/test_trex_env.py
@@ -575,6 +575,86 @@ class TestSubstepContactAggregation:
             env.close()
 
 
+class TestSubstepHeightTermination:
+    """Height terminations must see every physics substep, like contact does.
+
+    MJX's height-emulation termination went any-substep with the contact
+    aggregation; these pin the SB3 side of that lockstep: the step loop
+    records each declared entity's MIN z, and _is_terminated consumes it by
+    declaration index while the info keys keep the boundary sample.
+    """
+
+    def test_min_heights_track_the_probe_and_the_declaration_order(self):
+        """env._substep_min_heights == per-substep elementwise min of
+        (head_tip_z, skull_z), in the declared order."""
+        env = TRexEnv(reset_noise_scale=0.0, nosedive_termination_threshold=0.35)
+        try:
+            env.reset(seed=0)
+            substep_heights: list[tuple[float, float]] = []
+            env._substep_probe_hook = lambda: substep_heights.append(
+                (
+                    float(env.data.site_xpos[env.head_tip_site_id, 2]),
+                    float(env.data.xpos[env.skull_body_id, 2]),
+                )
+            )
+            for t in range(20):
+                action = np.full(env.action_space.shape, 0.3 * np.sin(2 * np.pi * t / 5.0), dtype=np.float32)
+                substep_heights.clear()
+                env.step(action)
+                assert len(substep_heights) == env.frame_skip
+                assert env._substep_min_heights is not None
+                assert env._substep_min_heights[0] == pytest.approx(min(h[0] for h in substep_heights), abs=1e-12)
+                assert env._substep_min_heights[1] == pytest.approx(min(h[1] for h in substep_heights), abs=1e-12)
+        finally:
+            env._substep_probe_hook = None
+            env.close()
+
+    def test_between_sample_dip_terminates_while_boundary_reads_healthy(self):
+        """A substep-only dip must terminate with the per-check reason even
+        when the boundary sample is healthy -- the direction the boundary
+        scan could never see.  The aggregate is armed by hand because a
+        statue never dips; the witness that real rollouts populate it is the
+        probe test above."""
+        env = TRexEnv(reset_noise_scale=0.0)
+        try:
+            env.reset(seed=0)
+            env.step(np.zeros(env.action_space.shape, dtype=np.float32))
+
+            boundary_head = float(env.data.site_xpos[env.head_tip_site_id, 2])
+            boundary_skull = float(env.data.xpos[env.skull_body_id, 2])
+            assert boundary_head > 0.12 and boundary_skull > 0.45
+
+            # Index 0 = head_tip site check.
+            env._substep_min_heights = np.array([0.11, boundary_skull])
+            env._substep_contact_step = env._step_count
+            terminated, info = env._is_terminated()
+            assert terminated
+            assert info["termination_reason"] == "head_contact"
+            assert info["head_tip_z"] == pytest.approx(boundary_head)
+
+            # Index 1 = skull body check.
+            env._substep_min_heights = np.array([boundary_head, 0.44])
+            env._substep_contact_step = env._step_count
+            terminated, info = env._is_terminated()
+            assert terminated
+            assert info["termination_reason"] == "skull_low"
+        finally:
+            env.close()
+
+    def test_reset_invalidates_the_height_aggregate(self):
+        env = TRexEnv(reset_noise_scale=0.0)
+        try:
+            env.reset(seed=0)
+            env.step(np.zeros(env.action_space.shape, dtype=np.float32))
+            env._substep_min_heights = np.array([0.0, 0.0])
+            env._substep_contact_step = env._step_count
+            env.reset(seed=1)
+            terminated, info = env._is_terminated()
+            assert not terminated, f"stale height aggregate terminated a fresh episode: {info}"
+        finally:
+            env.close()
+
+
 class TestFootSensorGroupLockstep:
     """Each species' SB3 _foot_sensor_groups must mirror its MJX registration.
 

--- a/environments/trex/tests/test_trex_mjx_reward_parity.py
+++ b/environments/trex/tests/test_trex_mjx_reward_parity.py
@@ -146,7 +146,7 @@ def test_mjx_zero_defaults_preserve_p5_p7_policy_dimensions():
     state = env.reset(jax.random.PRNGKey(9))
     weights = env.config.reward_weights
 
-    assert env.action_dim == 21
+    assert env.action_dim == 15
     assert state.obs.shape == (1, 61)
     assert weights["bilateral_support_weight"] == 0.0
     assert weights["foot_load_balance_weight"] == 0.0
@@ -171,7 +171,7 @@ def test_stage1_factory_enables_stance_terms_without_changing_dimensions():
     state = env.reset(jax.random.PRNGKey(10))
     weights = env.config.reward_weights
 
-    assert env.action_dim == 21
+    assert env.action_dim == 15
     assert state.obs.shape == (1, 61)
     assert weights["bilateral_support_weight"] == pytest.approx(0.6)
     assert weights["foot_contact_saturation_force"] == pytest.approx(350.0)

--- a/environments/trex/tests/test_trex_rewards.py
+++ b/environments/trex/tests/test_trex_rewards.py
@@ -240,10 +240,10 @@ class TestTRexRewardWeightEffects:
         env.close()
 
     def test_actuator_count(self):
-        """21 actuators: 3 neck/head + 14 legs + 4 tail (no arms)."""
+        """15 actuators: 3 neck/head + 8 legs + 4 tail (no arms; toes passive)."""
         env = TRexEnv()
-        assert env.model.nu == 21, f"Expected 21 actuators, got {env.model.nu}"
-        assert env.action_space.shape == (21,)
+        assert env.model.nu == 15, f"Expected 15 actuators, got {env.model.nu}"
+        assert env.action_space.shape == (15,)
         env.close()
 
 

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -357,27 +357,27 @@
       "environment": {
         "entrypoint": "environments.trex.envs.trex_env:TRexEnv",
         "observation_dim": 61,
-        "action_dim": 21
+        "action_dim": 15
       },
       "model": {
         "path": "environments/trex/assets/trex.xml",
         "nq": 28,
         "nv": 27,
-        "nu": 21,
+        "nu": 15,
         "dynamic_mass_kg": 85.72,
         "plant_contract": {
-          "bundle_sha256": "sha256:1d1ddd1efeceb2a2770079e52387d2fd2f38490a8c4527630ebf597264e9a702",
-          "source_closure_sha256": "sha256:2ef85b8c9aef05050e7e407ba9cf6a7a6da62e2c14282c5143366dd0575f2571",
+          "bundle_sha256": "sha256:a3c23d7a84e4b63cab0f4e234d00854bc8eff3380a901b2bf419e1fb4b196722",
+          "source_closure_sha256": "sha256:e3919447fc76fbcd6396284afa028ad2831797461d03bbe6c9b52a5fc1c50753",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 9,
+            "revision": 10,
             "observation_schema": "bipedal-target/v1",
-            "sha256": "sha256:bacbb3243a7f84f1379e106dd886279ed247c252c143cb5e86500a50725d7020"
+            "sha256": "sha256:d00f24e0d9219878714dc3d2f479c9400fd21c7bc76687bda065f223beb039e9"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",
-            "revision": 6,
-            "sha256": "sha256:7dfa00f5b28a5f562170ba0926e6811208354cb6160b524d9ab58412a37bc2f0"
+            "revision": 7,
+            "sha256": "sha256:72c662858639193e24a503b98e06d84737150ae6888a50a3620c2c99804cb97b"
           },
           "visual": {
             "schema": "mesozoic.mujoco-visual/v1",


### PR DESCRIPTION
## Summary

**Breaking plant change: T-Rex physics revision 6 → 7, policy interface revision 9 → 10. All existing T-Rex checkpoints are invalidated.** Originally stacked on #499 (substep contact aggregation), now retargeted to main after its merge.

The stage-1 bounce postmortem's release ablation (`docs/investigations/TREX_STAGE1_BOUNCE_2026_08.md`) showed that holding **only the six toe actuators** at their commanded DC reproduces the whole constant-hold failure (125.5 steps vs the full pose's 128.6) while tail, neck, and head held alone all stand the full horizon: the policy's learned 0.8727 rad claw curl — adjacent digits driven to opposite ends of a 75° range — changed the support polygon and seeded the bounce. This PR implements the investigation's step 1: delete the six per-digit `<position>` actuators. The digits keep their hinges; the `leg_joint` class already supplies the passive stance (stiffness 40, `springref` 12.5°, damping 15), so a splayed digit becomes structurally impossible rather than merely unrewarded.

- **Action dimension 21 → 15** (3 neck/head + 8 legs + 4 tail); home-keyframe ctrl shrinks with it. Env code, action mapping, energy normalization, and the MJX path are all width-dynamic — only test pins changed.
- **Observation unchanged at 61** — toe joints stay in qpos/qvel; all 16 sensors (incl. six per-digit touch) keep their indices.
- **`visual_revision` deliberately stays 4** — no geom, site, material, camera, or light moved.
- Both plant manifests regenerated under canonical MuJoCo 3.10.0 (byte-identical pair verified); species catalog / README / website JSON regenerated; `plant_versions.toml` gains narrative note 9.

## Statue re-measured on the new plant

`zero_action_baseline.py trex --episodes 40 --seed 3042` and `stance_quality_baseline.py 0.05 40` agree: standing reward **3270.3 ± 12.3**, 40/40 full horizon, unsupported duty 0.000, settled pelvis z 0.9260 (unchanged, so `target_z` / `natural_pitch` / nosedive pins hold). That is within one standard error of the r6 figure (3271.8) — the springs hold the same pose the servos did.

- `collapse_peak_floor_reference` 3271.8 → **3270.3** (the comment requires it be the measured statue on the current plant).
- `min_avg_reward` **stays 1950** — 0.60 × 3270.3 = 1962; the rail isn't re-rounded over a within-noise move.

## Statue constants get a freshness guard (second commit)

The constants' comments have said since #491 that they never update themselves and forgetting is silent. The TOML now records **`statue_constants_physics_revision = 7`** — the plant revision the constants were measured on — and the new `test_statue_constant_freshness.py` cross-checks it against the plant manifest. Plants only change through a PR (revision monotonicity is generator- and CI-enforced), so the next plant bump fails CI unless the statue is re-measured or the pin is consciously updated in a reviewable diff. The key is registered in the gate schema's fail-closed allowlist as a provenance key no trainer reads.

Also: **`stance_probe_filter_hz` extends to `[5, 10, 20, 30, 35]`** — the r6 sweep's manual probes showed the policy still falling at 35 Hz, but the recorded curve stopped at 20, leaving the octave where the measured 22.7 Hz tremor passes nearly clean unsampled. Five points close the survival curve at the control Nyquist's edge.

## Height terminations join the substep lockstep

Completes the residual documented in #499: SB3's site/body height terminations (T-Rex `head_tip_z` < 0.12 / `skull_z` < 0.45, dibothrosuchus `snout_tip_z` < 0.04) now consume the per-substep **MIN** height recorded by the step loop (`_substep_height_checks` declarations + `_aggregated_min_height` accessor, tag-invalidated across reset like the contact aggregates), matching MJX's any-substep height emulation. Info keys keep reporting the boundary sample.

New tests: `TestSubstepHeightTermination` (probe-hook witness that `_substep_min_heights` equals the per-substep elementwise min in declaration order; a between-samples dip terminates with the per-check reason while the boundary reads healthy; reset invalidation) and a dibothrosuchus counterpart.

## Verification

- Full `pytest environments/` battery green (re-run after each commit)
- `plant_contract --check` current; bundled manifest byte-identical; CI's base-manifest monotonicity check sees r6→r7 / r9→r10 increases
- `species_catalog --check` current
- `foot_sensor_report.py trex`: sensors/contact 1.000, contact/weight 1.002 on the new plant
- `stance_duty_validation.py` re-certified on the new plant: worst dangerous understatement 0.194% (gate 5%)
- Freshness guard verified in both directions (passes at 7 == 7; fires on a simulated stale pin)
- ruff (CI's 0.16.x) format+check clean; mypy clean on changed files

Not touched, deliberately: velociraptor's toe actuators (this revision is T-Rex-only per the investigation); the synthetic 21-wide fixtures in `test_stance_gate_report.py` (they don't load the real model and still pass — flagged as optional hygiene); archival investigation docs (convention: records are not rewritten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb