### PR TITLE
Add distal-leg and per-side groups to the release ablation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   probe did.
 
 ### Added
+- **The passive-toes run postmortem**
+  (`docs/investigations/TREX_STAGE1_PASSIVE_TOES_RUN_2026_08.md`): the first
+  10M stage-1 run on the r7 plant under substep-honest metrics. Best survival
+  ever recorded (100% full-horizon locked from 4.5M, reward 2213 vs the 1950
+  rail, no collapse) and still a gate FAIL at duty 0.41 vs 0.02 — an 18.7 Hz
+  foot chatter the boundary-sampled metric could have passed. The run
+  falsifies the entropy hypothesis (ent_coef reached exactly zero at 7M with
+  no break in tremor or duty), and the regrouped release ablation localizes
+  the unholdable pose to the **left knee and ankle**, parked just inside
+  `leg_home_pose_tolerance`'s penalty-free band. The release ablation gains
+  `knees_ankles` and per-side groups, and the impulse probe's prose no longer
+  attributes asymmetry to toe splay the r7 plant cannot produce.
 - **A constant-hold probe, which separates "needs bandwidth" from "needs
   feedback".** `stance_gate_report.py --hold-constant` replaces the policy's
   commanded action with the constant it commands *on average* — its own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,8 +108,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   foot chatter the boundary-sampled metric could have passed. The run
   falsifies the entropy hypothesis (ent_coef reached exactly zero at 7M with
   no break in tremor or duty), and the regrouped release ablation localizes
-  the unholdable pose to the **left knee and ankle**, parked just inside
-  `leg_home_pose_tolerance`'s penalty-free band. The release ablation gains
+  the unholdable pose to the **left knee and ankle**, priced at ~29 of the
+  home-pose term's 500 points while the chatter stabilising it forfeits
+  ~1030 in support terms. The release ablation gains
   `knees_ankles` and per-side groups, and the impulse probe's prose no longer
   attributes asymmetry to toe splay the r7 plant cannot produce.
 - **A constant-hold probe, which separates "needs bandwidth" from "needs

--- a/docs/investigations/TREX_STAGE1_PASSIVE_TOES_RUN_2026_08.md
+++ b/docs/investigations/TREX_STAGE1_PASSIVE_TOES_RUN_2026_08.md
@@ -41,8 +41,8 @@ Three hypotheses from the previous investigation cycle got definitive answers:
    noise — not noise the policy was forced to carry.
 3. **The stabilisation load is localizable after all** — but only with the
    right ablation groups. It lives in the **left knee and left ankle**
-   (section 5), in a pose parked just inside `leg_home_pose_tolerance`'s
-   penalty-free band (section 6).
+   (section 5), in a pose the home-pose term prices at ~29 points while the
+   chatter it necessitates forfeits ~1030 (section 6).
 
 ---
 
@@ -162,33 +162,41 @@ about saturation being visible rather than causal, repeated on a new plant.
 
 ---
 
-## 6. The tolerance dead zone
+## 6. The home-pose pricing is too flat where the pose hides
 
-`leg_home_pose_tolerance = 0.2` defines a penalty-free band around the home
-pose for the eight governed leg joints. The checkpoint's statue-breaking
-offsets sit at or just inside it: l_knee DC 0.185 normalised (0.16 rad =
-9.2°), l_ankle 0.081, hip rolls ≈ 0.18. The policy parked its pose precisely
-where the pose penalty cannot see it — `leg_home_pose` still pays +379 of its
-+500 ceiling — and then pays the chatter tax forever to stabilise a pose the
-passive plant cannot hold.
+`leg_home_pose` is not a dead band: it is a per-joint Gaussian bonus,
+``quality = mean_j exp(-(qpos_err_j / tolerance)²)`` with ``tolerance = 0.2``
+rad over the eight governed leg joints (`reward_soft_home_pose`, shared
+verbatim by both backends). The problem is its flatness at this width. The
+left knee's ~0.16 rad offset scores ``exp(-0.64) ≈ 0.53`` — but on **one
+joint of eight**, so the mean quality falls only ~6%, ≈ **29 points of the
+500-point ceiling** (the checkpoint measures +379, consistent with this plus
+the tremor's spread on the other joints). The pose that breaks the statue is
+priced at 29 points while the chatter required to stabilise it forfeits
+~1030 in the support-linked terms. The term sees the pose; it just does not
+care enough for the optimiser to.
 
-This is the same *shape* of finding as the r6 toes (a statue-breaking pose
-living where no term prices it), one level up: the toes were ungoverned by
-construction; the left knee/ankle are governed but hiding inside the
-tolerance. The band was sized to keep reset-noise settling penalty-free, not
-to admit standing 9° off home on one knee.
+This is the same *shape* of finding as the r6 toes — a statue-breaking pose
+living where the reward barely prices it — one level up: the toes were
+ungoverned by construction; the left knee/ankle are governed by a Gaussian
+whose width was sized for balancing corrections ("broad enough for balancing
+corrections without joint locking", per the config comment), not for making
+a 9°-off-home stance uneconomical.
 
 ---
 
 ## 7. Recommendations, ranked
 
-1. **Tighten or reshape `leg_home_pose`'s dead zone.** Mechanism-backed by
-   sections 5–6, one config line, and statue-invariant: the statue sits at
-   zero offset, so `min_avg_reward`/`collapse_peak_floor_reference` need no
-   re-derivation (the freshness pin from #500 stays honest). Candidate:
-   tolerance 0.2 → 0.05–0.10, or a quadratic-from-zero penalty with no band.
-   Verify reset-noise settling still lives inside whatever band remains
-   (reset noise is 0.05 rad ≈ 2.9°).
+1. **Narrow the `leg_home_pose` Gaussian.** Mechanism-backed by sections
+   5–6 and one config line: shrinking `leg_home_pose_tolerance` steepens the
+   pricing of exactly the offsets the ablation convicted (halving the width
+   quadruples the exponent: the 0.16-rad knee goes from quality 0.53 to
+   0.08). The statue is NOT automatically invariant — its settled joints
+   carry small residual offsets, and a narrow-enough Gaussian prices those
+   too — so the width must be chosen from measurement: the statue's
+   post-settle error distribution sets the floor, the checkpoint's convicted
+   offsets set the ceiling, and the statue baseline must be re-run to
+   confirm the constants pinned by #500's freshness check still hold.
 2. **Training-time action low-pass (~10–12 Hz).** The structural complement:
    this checkpoint already tolerates 20 Hz filtering at −180 reward, and a
    10 Hz in-loop filter makes the 18.7 Hz chatter inexpressible — the same

--- a/docs/investigations/TREX_STAGE1_PASSIVE_TOES_RUN_2026_08.md
+++ b/docs/investigations/TREX_STAGE1_PASSIVE_TOES_RUN_2026_08.md
@@ -1,0 +1,210 @@
+# T-Rex Stage 1 on the passive-toes plant: the first honest 10M steps
+
+**Date:** 2026-08-09
+**Run:** `20260808_230537` (seed 42, 10M steps, PPO/SB3, NVIDIA L4) — FAIL at the stance gate
+**Plant:** physics r7 / policy interface r10 (passive toes, action_dim 15)
+**PRs:** #499 (substep contact aggregation), #500 (passive-toes plant revision), #501 (regrouped ablation)
+
+Point-in-time record. Not rewritten — corrections are appended.
+
+---
+
+## 1. Summary
+
+First stage-1 run on the passive-toes plant (#500), and the first run whose
+duty numbers are measured at every physics substep (#499) rather than at the
+control boundary. The headline is a split verdict:
+
+| criterion | required | final | verdict |
+|---|---|---|---|
+| full-horizon fraction | ≥ 0.95 | **1.0000** (locked from 4.5M to the end) | pass |
+| mean reward | ≥ 1950 | **2213.7 ± 18.4** (crossed the rail at ~6.3M) | pass |
+| mean unsupported duty | ≤ 0.02 | **0.4084** | **FAIL** |
+| unsupported duty UCB | ≤ 0.02 | **0.4095** | **FAIL** |
+
+By every survival measure this is the best stage-1 run the repository has
+produced: no collapse, no regression, 40/40 full-horizon panels for the entire
+back half, reward within 68% of the statue's 3270.3 and still climbing at the
+buzzer. The gate still refuses it, for the one thing it now measures honestly:
+the policy stands while unloading both feet at some instant inside **41% of
+its control steps** — a high-frequency foot chatter at 18.7 Hz that the old
+boundary-sampled metric could have scored as near-continuous support.
+
+Three hypotheses from the previous investigation cycle got definitive answers:
+
+1. **The toe mechanism is gone.** No probe implicates anything the r6 toes
+   used to do; the failure moved, it did not survive by another name.
+2. **The entropy hypothesis is falsified.** `ent_coef` reached exactly zero at
+   7M and nothing broke: tremor amplitude stayed at AC ≈ 0.61–0.64, and duty
+   kept its gentle, *decelerating* decline (0.487 at 7.1M → 0.406 at 10M) with
+   no cliff. The chatter is a learned strategy, stable with zero exploration
+   noise — not noise the policy was forced to carry.
+3. **The stabilisation load is localizable after all** — but only with the
+   right ablation groups. It lives in the **left knee and left ankle**
+   (section 5), in a pose parked just inside `leg_home_pose_tolerance`'s
+   penalty-free band (section 6).
+
+---
+
+## 2. Trajectory
+
+Gate checks every 50k steps, 40-episode panels, seeds 3042–3081.
+
+| phase | steps | what happened |
+|---|---|---|
+| init spike | 0–100k | starts near home (≈ statue): 1454 reward, 28% full-horizon at 50k |
+| trough | 100k–800k | exploration pushes off home; bottom 47.8 at 350k, 0% full-horizon |
+| recovery | 800k–1.55M | survival breakthrough; first ≥95% full-horizon panel at 1.55M |
+| survival lock | 1.55M–4.5M | full-horizon pins to ~100% (one transient dip 3.6–3.7M, self-recovered) |
+| reward climb | 4.5M–10M | 1570 → 2213, monotone within noise; duty UCB 0.65 → 0.41 |
+
+Notable singletons:
+
+- The collapse detector armed correctly past the 1M warmup and never fired;
+  the run's peak first exceeded the 1471.6 floor (0.45 × 3270.3) around 4.45M.
+- Bilateral support duty compounded steadily all run: 0.03 at 1.55M → 0.59 at
+  10M, still rising at the end.
+- The commanded offset (DC ≈ 0.49 rms) never returned home, and the tremor
+  amplitude (AC ≈ 0.62 rms, ~18.7 Hz effective) never fell — the reward gains
+  of the back half came from everything *around* the chatter.
+
+**The entropy zero-crossing at 7M is the load-bearing observation.** Duty UCB
+by segment: 0.646 → 0.626 (4.6–5.05M, ent ≈ 0.0017), 0.622 → 0.564
+(5.05–5.65M, the fastest stretch), 0.487 → 0.406 (7.1–10M, ent = 0.000,
+~0.027/M and decelerating). If the tremor were noise-sustained, the final 3M
+would have shown a qualitative break. It showed the same crawl.
+
+---
+
+## 3. Where the reward gap lives
+
+Final panel decomposition (statue reference 3270.3; gap 1057):
+
+| term | policy | note |
+|---|---|---|
+| head_clearance | +350.0 | at ceiling (0.35 × 1000) |
+| height | +596.6 | effectively at ceiling (0.6 × 1000) |
+| neck_posture | +169.3 | near ceiling |
+| leg_home_pose | +379.2 | inside tolerance — see section 6 |
+| alive | +785.4 | of 1000; the missing 215 is the support-conditioned half |
+| bilateral_support | +342.5 | of 600 |
+| foot_load_balance | **−271.5** | largest single penalty; airborne penalty dominates |
+| smoothness + jerk + energy | −123.3 | modest — the chatter is cheap under the action penalties |
+
+Essentially the entire gap to the statue sits in the three support-linked
+terms (≈ 1030 of 1057). The policy solved posture, height, heading and
+survival completely, and pays precisely and only the price of rattling its
+feet. The action-path penalties price that rattle at ~123 points — far less
+than the ~1030 the support terms forfeit — so the pricing is not the reason
+it chatters (section 4 says the tremor is load-bearing, not cheapness).
+
+---
+
+## 4. Probe results
+
+All probes on `robust_best_model.zip` + its VecNormalize stats.
+
+**Hold-constant: the pose requires feedback.** Freezing the commanded mean
+falls from every handoff (141–331 steps, `tail_contact` dominant) while the
+statue control stands at 3269.2. Same verdict as r6: the tremor is active
+stabilisation; penalising it harder removes the only thing keeping the animal
+up.
+
+**Filter sweep: the bandwidth story flipped.** The r6 passing policy fell at
+*every* cutoff from 5 to 35 Hz. This policy:
+
+| cutoff | full-horizon | reward |
+|---|---|---|
+| 5 Hz | 0% (542 steps) | 837 |
+| 10 Hz | 10% (704) | 1126 |
+| 20 Hz | **100%** | 2029 |
+| 30 Hz | 100% | 2094 |
+| 35 Hz | 100% | 2110 |
+
+Its load-bearing content is confined to the band just under 20 Hz — the
+18.7 Hz chatter fundamental — and it loses only ~180 reward when filtered at
+20 Hz. This is one octave away from tolerating a sim-to-real-grade action
+filter, where r6 policies needed unbounded bandwidth.
+
+**Impulse probe: first partial recovery ever recorded.** At 0.5 m/s lateral
+−y the policy recovered to full horizon in 6/8 episodes (statue: 0/8). Every
+stronger shove flattens policy and statue alike (+116-step margin ≈ noise).
+The 1a/1b split argument is unchanged: nothing in stage 1 pays for
+correction, so recovery must enter the task, not the reward.
+
+---
+
+## 5. The release ablation, regrouped
+
+Over the r6-era groups (saturated trio, tail, head/neck, hip rolls) the
+ablation returned **no group necessary, none sufficient** — every release
+still fell, every group held alone still stood near statue reward. The old
+grouping was built for the toe question and never tested the distal leg
+chain as a unit; #501 added `knees_ankles`, `left_leg`, `right_leg`
+(per-side because the tremor is strongly asymmetric). Result (8 eps/variant):
+
+| variant | ep length | full-horizon | reading |
+|---|---|---|---|
+| only_knees_ankles | 118.6 | 0% | **sufficient** — alone breaks the statue |
+| only_left_leg | 164.6 | 0% | **sufficient** |
+| only_right_leg | 903.5 | 87.5% | nearly exonerated |
+| only_hip_rolls | 870.9 | 75% | weakly implicated |
+| only_saturated / tail / head_neck | 1000 | 100% at ~3255–3279 | bystanders |
+| release_knees_ankles | 794.0 | 37.5% | the only release that rescues anything |
+
+Intersection: **the left knee (+9.2° DC, ±26.7° AC) and left ankle (+4.1° DC,
+±39.2° AC)** — also the two largest degree entries in the gate report. The
+right leg's offsets (+0.9°, +1.2°) are benign. The pose is over-determined
+across groupings that *include* these two joints and innocent everywhere
+else. The saturated trio (head_pitch −25.0°, tail_3_pitch +12.0°, tail_1_yaw
+−8.0°, all with zero AC) is conspicuous and fully exonerated — the r6 lesson
+about saturation being visible rather than causal, repeated on a new plant.
+
+---
+
+## 6. The tolerance dead zone
+
+`leg_home_pose_tolerance = 0.2` defines a penalty-free band around the home
+pose for the eight governed leg joints. The checkpoint's statue-breaking
+offsets sit at or just inside it: l_knee DC 0.185 normalised (0.16 rad =
+9.2°), l_ankle 0.081, hip rolls ≈ 0.18. The policy parked its pose precisely
+where the pose penalty cannot see it — `leg_home_pose` still pays +379 of its
++500 ceiling — and then pays the chatter tax forever to stabilise a pose the
+passive plant cannot hold.
+
+This is the same *shape* of finding as the r6 toes (a statue-breaking pose
+living where no term prices it), one level up: the toes were ungoverned by
+construction; the left knee/ankle are governed but hiding inside the
+tolerance. The band was sized to keep reset-noise settling penalty-free, not
+to admit standing 9° off home on one knee.
+
+---
+
+## 7. Recommendations, ranked
+
+1. **Tighten or reshape `leg_home_pose`'s dead zone.** Mechanism-backed by
+   sections 5–6, one config line, and statue-invariant: the statue sits at
+   zero offset, so `min_avg_reward`/`collapse_peak_floor_reference` need no
+   re-derivation (the freshness pin from #500 stays honest). Candidate:
+   tolerance 0.2 → 0.05–0.10, or a quadratic-from-zero penalty with no band.
+   Verify reset-noise settling still lives inside whatever band remains
+   (reset noise is 0.05 rad ≈ 2.9°).
+2. **Training-time action low-pass (~10–12 Hz).** The structural complement:
+   this checkpoint already tolerates 20 Hz filtering at −180 reward, and a
+   10 Hz in-loop filter makes the 18.7 Hz chatter inexpressible — the same
+   "make the failure mode impossible" move as the passive toes. Requires a
+   small feature (the filter exists only as an eval probe today) and a
+   decision about whether filtered actions change the policy-interface
+   contract.
+3. **Seed replicates of this configuration.** Still the cheapest evidence
+   about variance, unchanged from the previous investigation's advice, and
+   now doubly interesting: is the left-leg asymmetry a seed artifact or an
+   attractor?
+4. **The 1a/1b split for recovery.** Unchanged; the impulse probe's first
+   partial recovery does not alter the argument that correction must enter
+   the task.
+
+What this run retires: the toe mechanism (fixed by construction, confirmed by
+absence), the entropy hypothesis (falsified at the 7M zero-crossing), and any
+doubt about the substep-MIN metrics (the gate refused a policy the boundary
+sample might have passed, which is exactly what #499 was for).

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -1620,9 +1620,11 @@ def _ablation_verdicts(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
 #: Lateral impulses, in m/s of root velocity, swept by the recovery probe.
 #: Lateral because that is the axis a biped is least able to catch itself on --
 #: a fore/aft shove can be absorbed by pitching, a sideways one cannot without
-#: moving a foot. Both signs are run, because this policy is asymmetric: its
-#: toes are splayed differently on the two feet, so a one-sided sweep would
-#: measure the easy direction or the hard one and report it as the answer.
+#: moving a foot. Both signs are run, because a learned stance is generally
+#: asymmetric -- the r6 checkpoints splayed their toes differently per foot,
+#: and the r7 passive-toes checkpoint tremors far harder on one leg -- so a
+#: one-sided sweep would measure the easy direction or the hard one and
+#: report it as the answer.
 _IMPULSE_SPEEDS = (0.5, 1.0, 2.0)
 
 
@@ -1847,9 +1849,10 @@ def render_impulse_probe(
         lines += _recovery_reading(rows, envelopes, disturbed, horizon)
     lines += [
         "",
-        "  Both signs are run because this policy is asymmetric -- its toes are splayed",
-        "  differently on the two feet -- so a one-sided sweep would measure whichever",
-        "  direction it happens to be good at and report that as the answer.",
+        "  Both signs are run because a learned stance is generally asymmetric --",
+        "  commanded pose and tremor differ between the left and right legs -- so a",
+        "  one-sided sweep would measure whichever direction it happens to be good at",
+        "  and report that as the answer.",
         "  The zero-impulse row is the harness check: both columns must reach the horizon.",
     ]
     return "\n".join(lines) + "\n", payload
@@ -2034,6 +2037,16 @@ _ACTUATOR_GROUPS: dict[str, tuple[str, ...]] = {
     "toes": ("toe",),
     "head_neck": ("head", "neck"),
     "hip_rolls": ("hip_roll",),
+    # Added for the passive-toes plant (physics r7): the 10M checkpoint's
+    # ablation returned "no group necessary, none sufficient" over the groups
+    # above while its degree table concentrated the tremor in the knees,
+    # ankles and hip rolls -- the distal chain the old grouping never tested
+    # as a unit. Per-side groups because that checkpoint's tremor is strongly
+    # asymmetric (l_ankle +/-39.2deg vs r_ankle far less), so a symmetric
+    # grouping can hide a one-legged mechanism.
+    "knees_ankles": ("knee", "ankle"),
+    "left_leg": ("l_hip", "l_knee", "l_ankle"),
+    "right_leg": ("r_hip", "r_knee", "r_ankle"),
 }
 
 


### PR DESCRIPTION
## Summary

Small probe-tooling PR from the 10M passive-toes run postmortem, plus one stale-prose fix.

**New ablation groups.** The 10M checkpoint's release ablation returned "no group necessary, none sufficient" over the r6-era groups (saturated / tail / head-neck / hip-rolls) while its degree table concentrated the tremor in the knees, ankles, and hip rolls — the distal chain the old grouping never tested as a unit. This adds `knees_ankles`, `left_leg`, and `right_leg` (per-side because the checkpoint's tremor is strongly asymmetric: `l_ankle` ±39.2° AC vs far less on the right, so symmetric grouping can hide a one-legged mechanism).

**Measured result against the checkpoint** (8 episodes/variant, seeds from 3042):

| variant | ep length | full-horizon | verdict |
|---|---|---|---|
| only_knees_ankles | 118.6 | 0% | **sufficient** — alone breaks the statue |
| only_left_leg | 164.6 | 0% | **sufficient** |
| only_right_leg | 903.5 | 87.5% | nearly exonerated |
| release_knees_ankles | 794.0 | 37.5% | the **only** release that rescues anything |
| only_saturated / tail / head_neck | 1000 | 100% (reward ≈ statue) | bystanders |

The unholdable pose localizes to the **left knee + ankle DC offsets** (+9.2° / +4.1°, the two largest leg offsets in the report) — the r7 analogue of the r6 toe finding, now on actuators the reward does govern. Notably, those offsets sit at or just inside `leg_home_pose_tolerance = 0.2`, i.e. inside the penalty-free band.

**Prose fix.** The impulse probe's asymmetry rationale still said "its toes are splayed differently on the two feet" — structurally impossible since physics r7 deleted the toe actuators. The wording now describes measured left/right asymmetry without naming a plant-specific mechanism.

## Verification

- Regrouped ablation run end-to-end against `robust_best_model.zip` + its VecNormalize stats (table above); harness endpoints behaved (`hold_all` falls, `hold_zero` stands at 3272.8, policy control reproduces the Drive report within noise)
- `test_stance_gate_report.py` full suite green
- ruff (CI 0.16.x) format + check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb

---
_Generated by [Claude Code](https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb)_