### PR TITLE
Narrow the leg_home_pose Gaussian to 0.10 rad and re-derive the rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] — Reproducible Runs & Velociraptor Stage-1 Diagnosis (v0.3.6)
 
 ### Changed
+- **T-Rex stage 1 `leg_home_pose_tolerance` narrowed 0.20 → 0.10 rad**, and the
+  two statue-derived constants re-derived with it (`min_avg_reward`
+  1950 → 1940, `collapse_peak_floor_reference` 3270.3 → 3241.3, both from a
+  fresh 40-episode zero-action baseline at seed 3042). Motivated by the
+  passive-toes run postmortem: the 10M checkpoint stands on a pose the
+  release ablation convicts (left knee 0.21 rad, left ankle 0.17 rad off
+  home) that the 0.20-wide Gaussian priced at only ~29 of the term's 500
+  points, while the chatter stabilising that pose forfeits ~1030 in the
+  support-linked terms. The width was chosen from measurement, not taste:
+  0.10 doubles the statue-vs-chatterer pricing differential (109 → 180
+  points) while staying 2× above the statue's own p99 settle error
+  (~0.05 rad hip-pitch gravity sag); 0.075 and 0.05 sit past the knee of
+  the curve, paying −26/−83 more statue reward for +23/+33 differential.
+  The statue remains the reward optimum with a wider margin over the
+  measured chatterer (~1128 vs ~1057 points).
 - **T-Rex toes made passive** (breaking — plant change, physics revision 6 → 7
   **and** policy interface revision 9 → 10; all existing T-Rex checkpoints are
   invalidated). The six per-digit `<position>` actuators (kp 60, forcerange

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Apex Predator. **Specialty:** Head-contact attack task.
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
 |---|---|---:|---:|
-| 1 — Balance | Learn to stand and balance without falling | 10M | reward ≥ 1950; full-horizon episodes ≥ 95.0%; unsupported duty ≤ 0.02; unsupported duty 95% upper bound ≤ 0.02; ≥ 40 episodes/evaluation; 3 consecutive passes |
+| 1 — Balance | Learn to stand and balance without falling | 10M | reward ≥ 1940; full-horizon episodes ≥ 95.0%; unsupported duty ≤ 0.02; unsupported duty 95% upper bound ≤ 0.02; ≥ 40 episodes/evaluation; 3 consecutive passes |
 | 2 — Locomotion | Learn forward walking/running | 8M | reward ≥ 100; episode length ≥ 750; avg. velocity ≥ 2 m/s; ≥ 10 episodes/evaluation; 3 consecutive passes |
 | 3 — Bite | Sprint to prey and make contact with the head bite proxy | 8M | reward ≥ 100; task success ≥ 50.0%; ≥ 10 episodes/evaluation; 3 consecutive passes |
 

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -76,7 +76,16 @@ leg_home_pose_weight = 0.5                     # Softly retain the authored p5 t
                                                # weight had nothing to pull on: measured DC moved 0.766 -> 0.738,
                                                # 3.7%, while the run took ~2M extra steps to escape its early
                                                # collapse. The list, not the weight, is the problem (#491).
-leg_home_pose_tolerance = 0.20                 # rad; broad enough for balancing corrections without joint locking
+leg_home_pose_tolerance = 0.10                 # rad; Gaussian width of the home-pose bonus, narrowed from 0.20
+                                               # after the 20260808 run (postmortem: TREX_STAGE1_PASSIVE_TOES_RUN_
+                                               # 2026_08.md section 6). At 0.20 the statue-breaking left-knee/ankle
+                                               # offsets the release ablation convicted (0.21/0.17 rad measured)
+                                               # cost only ~29 of this term's 500 points; measured pricing at 0.10
+                                               # doubles the statue-vs-chatterer differential (109 -> 180 points)
+                                               # while staying 2x above the statue's own p99 settle error
+                                               # (~0.05 rad, hip-pitch gravity sag). 0.075/0.05 are past the knee:
+                                               # +23/+33 more differential for -26/-83 more statue reward. The
+                                               # statue-derived constants below are re-measured at this width.
 head_clearance_weight = 0.35                   # Prevent the learned head-droop posture
 head_clearance_target = 0.90                   # m; settled home head tip is ~0.94 m
 head_clearance_tolerance = 0.15                # Smooth transition from zero credit at 0.75 m
@@ -301,7 +310,7 @@ settle_steps = 200                       # [inferred], NOT measured. Duty is sco
 min_eval_episodes = 40                   # The panel size every figure above is specified at. n_eval_episodes must
                                          # match: at n=30 the bound's power and the 28%-rejection analysis no longer
                                          # describe this gate.
-min_avg_reward = 1950.0                 # Collapse RAIL, not the gate (PLANT_VALIDATION §9/§12): no reward threshold
+min_avg_reward = 1940.0                 # Collapse RAIL, not the gate (PLANT_VALIDATION §9/§12): no reward threshold
                                         # can separate a competent policy from a statue, because the statue is the
                                         # reward optimum. Sized to the one job a rail CAN do — rejecting a policy
                                         # that discarded most of the available return — at 0.60 x the statue's
@@ -321,6 +330,12 @@ min_avg_reward = 1950.0                 # Collapse RAIL, not the gate (PLANT_VAL
                                         # and stance_quality_baseline.py agree) -- within one standard error of
                                         # the r6 figure, so the rail stays at 1950 rather than chasing noise to
                                         # 0.60 x 3270.3 = 1962.
+                                        #
+                                        # Re-derived again when leg_home_pose_tolerance narrowed 0.20 -> 0.10
+                                        # (the statue's own hip-pitch gravity sag of ~0.048 rad now costs it
+                                        # ~29 points): statue 3241.3 +/- 14.6, zero_action_baseline.py seed
+                                        # 3042, 40 episodes. 0.60 x 3241.3 = 1944.8, rounded to 1940 per the
+                                        # nearest-10 convention the species table uses.
                                         #
                                         # Why 0.60 and not §12's 0.89: the measured collapse (run 20260731_132102,
                                         # full-horizon 93% -> 7%) bottomed at 888 = 0.27 x statue, so 0.60 clears
@@ -397,10 +412,12 @@ collapse_peak_warmup_timesteps = 1000000 # Evaluations before this step cannot S
                                          # post-150k rolling median in that run is 580.5, well under 1472.3. A
                                          # larger warm-up buys nothing and costs coverage: 1.0M leaves 88% of a 10M
                                          # budget protected, 2.5M only 72%.
-collapse_peak_floor_reference = 3270.3   # The zero-action statue's standing reward at noise 0.05, 40 episodes,
-                                         # measured on the passive-toes plant (physics r7; was 3271.8 on r6,
-                                         # within one standard error -- the toes settle on springs at the same
-                                         # pose the servos held). Briefly 4250.4 while leg_home_pose_weight was
+collapse_peak_floor_reference = 3241.3   # The zero-action statue's standing reward at noise 0.05, 40 episodes,
+                                         # measured on the passive-toes plant (physics r7) at
+                                         # leg_home_pose_tolerance 0.10. History: 3271.8 on the r6 plant,
+                                         # 3270.3 on r7 at tolerance 0.20; the -29 from narrowing the
+                                         # tolerance is the statue's own hip-pitch settle sag being priced by
+                                         # the sharper Gaussian, measured, not assumed. Briefly 4250.4 while leg_home_pose_weight was
                                          # 1.5; reverted with it (issue #491). Re-measure this whenever a reward
                                          # weight OR the plant changes: a weight change rescales the statue's
                                          # terms exactly and cheaply; a plant change moves its trajectory, so

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -153,10 +153,10 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
     # Stage-1 reward gates are COLLAPSE RAILS: 0.60 x each species' zero-action
     # statue standing reward at the 1a operating point (reset noise 0.05),
     # measured over 40 episodes with
-    # environments/shared/scripts/stance_quality_baseline.py -- trex 3270.3
-    # (passive-toes plant, physics r7; 3271.8 on r6, within one standard
-    # error), velociraptor 1745.8, brachiosaurus 1739.1 (on the plant repaired
-    # by plant_versions notes 7-8), dibothrosuchus 2598.3.
+    # environments/shared/scripts/stance_quality_baseline.py -- trex 3241.3
+    # (physics r7 at leg_home_pose_tolerance 0.10; 3270.3 at tolerance 0.20,
+    # 3271.8 on the r6 plant), velociraptor 1745.8, brachiosaurus 1739.1 (on
+    # the plant repaired by plant_versions notes 7-8), dibothrosuchus 2598.3.
     #
     # A rail sits BELOW its statue deliberately. Section 9 showed the statue
     # is the reward optimum -- it collects 97.0% of the theoretical maximum
@@ -176,9 +176,10 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
         # 0.60 x the statue's standing reward at leg_home_pose_weight 0.5.
         # Was briefly 2550 while that weight was 1.5 (statue 4250.4), reverted
         # with it in issue #491. The FRACTION is the invariant, not the reward.
-        # Unchanged by the passive-toes plant (r7): the statue re-measured
-        # within one standard error of the r6 figure.
-        "trex": 1950.0,
+        # Re-derived when leg_home_pose_tolerance narrowed to 0.10: the
+        # sharper Gaussian prices the statue's own settle sag, statue
+        # 3270.3 -> 3241.3, x0.60 = 1944.8 -> 1940 nearest-10.
+        "trex": 1940.0,
         "velociraptor": 1050.0,
         "brachiosaurus": 1040.0,
         "dibothrosuchus": 1560.0,

--- a/environments/trex/tests/test_trex_mjx_reward_parity.py
+++ b/environments/trex/tests/test_trex_mjx_reward_parity.py
@@ -43,7 +43,7 @@ def _stance_only_env():
         foot_load_balance_weight=0.3,
         support_conditioned_alive_fraction=0.5,
         leg_home_pose_weight=0.5,
-        leg_home_pose_tolerance=0.20,
+        leg_home_pose_tolerance=0.10,
         head_clearance_weight=0.35,
         head_clearance_target=0.90,
         head_clearance_tolerance=0.15,

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -417,7 +417,7 @@
           "config_path": "configs/trex/stage1_balance.toml",
           "timesteps": 10000000,
           "advancement_gate": {
-            "min_avg_reward": 1950.0,
+            "min_avg_reward": 1940.0,
             "min_avg_episode_length": null,
             "min_avg_forward_velocity": null,
             "min_success_rate": null,


### PR DESCRIPTION
## Summary

The intervention PR from the passive-toes run postmortem (see #501's investigation doc): **`leg_home_pose_tolerance` 0.20 → 0.10 rad** for T-Rex stage 1, with the statue-derived constants re-derived at the new width.

**Why.** The 10M checkpoint's regrouped release ablation convicted the **left knee (0.21 rad off home) and left ankle (0.17 rad)** of making the learned stance unholdable. The home-pose term is a per-joint Gaussian bonus, and at width 0.20 that pose cost only **~29 of the term's 500 points** — while the 18.7 Hz chatter required to stabilize it forfeits ~1030 in support-linked terms. The term saw the pose; it didn't care enough for the optimizer to.

**Why 0.10 specifically — measured, not chosen by taste.** Statue joint errors measured over 40 seeds, checkpoint errors over 8 episodes, quality computed at five candidate widths:

| width | statue earns | checkpoint earns | differential |
|---|---|---|---|
| 0.20 (before) | 489.5 | 380.9 | 108.6 |
| 0.15 | 481.7 | 344.1 | 137.6 |
| **0.10** | **460.9** | **281.4** | **179.5** |
| 0.075 | 435.0 | 232.0 | 203.0 |
| 0.05 | 377.8 | 165.6 | 212.2 |

0.10 doubles the statue-vs-chatterer pricing differential and stays 2× above the statue's own p99 settle error (the statue is *not* automatically invariant — it carries a ~0.048 rad hip-pitch gravity sag that a sharper Gaussian prices). 0.075/0.05 are past the knee: −26/−83 more statue reward for +23/+33 more differential.

**Constants re-derived per their standing instructions.** `zero_action_baseline.py` (seed 3042, 40 episodes) and `stance_quality_baseline.py 0.05 40` agree: statue **3241.3 ± 14.6** (was 3270.3 at width 0.20). So:
- `collapse_peak_floor_reference` 3270.3 → **3241.3**
- `min_avg_reward` 1950 → **1940** (0.60 × 3241.3 = 1944.8, nearest-10 per the species-table convention)
- Species catalog / README / website JSON regenerated; `test_species_catalog` pin and provenance updated; the parity fixture mirrors the live config
- Other species' figures unchanged (confirmed by the full stance-quality run); plant untouched, so the #500 freshness pin stays at physics r7 correctly

The statue remains the reward optimum with a *wider* margin over the measured chatterer (~1128 vs ~1057 points).

## Verification

- Focused suites green: `test_species_catalog`, `test_trex_mjx_reward_parity`, `test_trex_rewards`, `test_curriculum_manager`, `test_statue_constant_freshness`
- `species_catalog --check` current after regen
- ruff (CI 0.16.x) format + check clean
- Measurement scripts and raw error distributions archived in the session scratchpad (`tolerance_study.py` / `.npz`)

Companion to #501 (probe regrouping + postmortem); independent to merge, but the postmortem doc gives this PR its full context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb

---
_Generated by [Claude Code](https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb)_