### PR TITLE
Low-pass the T-Rex command path at 10 Hz (policy interface r11) + narrow-tolerance run postmortem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] — Reproducible Runs & Velociraptor Stage-1 Diagnosis (v0.3.6)
 
 ### Changed
+- **T-Rex commands are low-passed at 10 Hz during training and evaluation**
+  (breaking — plant change, policy interface revision 10 → 11; all existing
+  T-Rex checkpoints are invalidated; physics revision stays 7 and the
+  statue-derived constants carry, since the statue's zero action filters to
+  zero). Both backends now run the commanded action through a first-order
+  low-pass (`environments/shared/action_filter.py`, the same discretization
+  as the stance-gate probe filter), seeded with the first post-reset action;
+  the dynamics **and** the action-derived reward terms (energy, smoothness,
+  jerk) consume the filtered command. The cutoff is plant-level by
+  construction — an SB3 class attribute and a `register_species_mjx` field
+  guarded by `_PLANT_INTERFACE_CONFIG_FIELDS` — so stage TOMLs cannot tune
+  it, and the plant contract records the cutoff plus the filter fingerprint
+  and asserts backend agreement. Motivation
+  (`docs/investigations/TREX_STAGE1_NARROW_TOLERANCE_RUN_2026_08.md`): both
+  2026-08 stage-1 runs converged on statically unstable poses stabilised by
+  16.8–18.7 Hz command chatter — the narrow-tolerance run locked both knees
+  against their stops and pumped the ankles ±28–33°, and its constant-hold
+  probe fell backward onto the tail in 9/10 episodes within ~3 s — while
+  the filter probe puts the balance task's real bandwidth at ~1.1–1.4 Hz.
+  Amplitude penalties cannot price the strategy out (a saturated command is
+  perfectly smooth); removing the bandwidth makes such poses unreachable
+  attractors instead of cheap ones. Other species keep the exact legacy
+  step arithmetic (cutoff 0.0, byte-identical policy fingerprints).
 - **T-Rex stage 1 `leg_home_pose_tolerance` narrowed 0.20 → 0.10 rad**, and the
   two statue-derived constants re-derived with it (`min_avg_reward`
   1950 → 1940, `collapse_peak_floor_reference` 3270.3 → 3241.3, both from a

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Apex Predator. **Specialty:** Head-contact attack task.
 | Action dimension / actuators | 15 |
 | Generalized coordinates / velocities | nq=28, nv=27 |
 | Compiled dynamic model mass | 85.7 kg |
-| Plant contract revisions | policy r10; physics r7; visual r4 ([details](docs/PLANT_CONTRACT.md)) |
+| Plant contract revisions | policy r11; physics r7; visual r4 ([details](docs/PLANT_CONTRACT.md)) |
 | Model | `environments/trex/assets/trex.xml` |
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |

--- a/configs/plant_manifest.generated.json
+++ b/configs/plant_manifest.generated.json
@@ -84,7 +84,7 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:a3c23d7a84e4b63cab0f4e234d00854bc8eff3380a901b2bf419e1fb4b196722",
+      "bundle_sha256": "sha256:c2d5cf4587590d3f6b95e9812ad8300c418729f3fdc3bbe470df0c8860b15043",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
@@ -99,9 +99,9 @@
         "action_dim": 15,
         "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 10,
+        "revision": 11,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:d00f24e0d9219878714dc3d2f479c9400fd21c7bc76687bda065f223beb039e9"
+        "sha256": "sha256:96ef137a211cdb0caa9aa744b1b2c35e37b8d40c96abac5ce9e86c7b3e52acd0"
       },
       "source": {
         "closure_sha256": "sha256:e3919447fc76fbcd6396284afa028ad2831797461d03bbe6c9b52a5fc1c50753",

--- a/configs/plant_versions.toml
+++ b/configs/plant_versions.toml
@@ -171,9 +171,28 @@ observation_schema = "bipedal-target/v1"
 #    re-measured with zero_action_baseline.py / stance_quality_baseline.py on
 #    this plant -- the statue's toes now settle on springs instead of servos,
 #    so the old 3271.8 standing reward may not carry.
+# 10. T-Rex commands are low-passed at 10 Hz.  Both 2026-08 stage-1 runs
+#     converged on statically unstable poses held up by 16.8-18.7 Hz command
+#     chatter (the narrow-tolerance run locked both knees against their
+#     stops and pumped the ankles +-28-33 deg; its constant-hold probe fell
+#     backward onto the tail in 9/10 episodes within ~3 s), while the
+#     balance task itself needs ~1.1-1.4 Hz.  The plant now applies a
+#     first-order low-pass (environments/shared/action_filter.py) to the
+#     commanded action in BOTH backends, seeded with the first post-reset
+#     action.  PHYSICS unchanged (no MJCF edit; the statue's zero action
+#     filters to zero, so the statue-derived constants carry).  The POLICY
+#     INTERFACE moves without any tensor changing shape: an action now means
+#     "pre-filter command", so checkpoints trained unfiltered are
+#     incompatible (the "action meaning" rule in docs/PLANT_CONTRACT.md).
+#     The cutoff is plant-level by construction -- an SB3 class attribute
+#     and a register_species_mjx field guarded by
+#     _PLANT_INTERFACE_CONFIG_FIELDS -- so stage TOMLs cannot tune it, and
+#     the contract records cutoff + filter fingerprint and asserts backend
+#     agreement.  See
+#     docs/investigations/TREX_STAGE1_NARROW_TOLERANCE_RUN_2026_08.md.
 [plants.trex]
 physics_revision = 7
-policy_interface_revision = 10
+policy_interface_revision = 11
 visual_revision = 4
 observation_schema = "bipedal-target/v1"
 

--- a/docs/investigations/TREX_STAGE1_NARROW_TOLERANCE_RUN_2026_08.md
+++ b/docs/investigations/TREX_STAGE1_NARROW_TOLERANCE_RUN_2026_08.md
@@ -1,0 +1,270 @@
+# T-Rex Stage 1 with the narrowed home-pose Gaussian: the knee-lock run
+
+**Date:** 2026-08-10
+**Run:** `20260809_155206` (seed 42, 10,002,432 steps in 10h 29m, PPO/SB3, NVIDIA L4) — FAIL at the stance gate
+**Plant:** physics r7 / policy interface r10 (passive toes, action_dim 15) — unchanged from the previous run
+**Config delta vs previous run:** `leg_home_pose_tolerance` 0.20 → 0.10 rad, rails re-derived (#502)
+**PRs:** #501 (regrouped ablation + previous postmortem), #502 (tolerance + rails)
+**Companion:** `TREX_STAGE1_PASSIVE_TOES_RUN_2026_08.md` (the previous run, hereafter "run 1")
+
+Point-in-time record. Not rewritten — corrections are appended.
+
+---
+
+## 1. Summary
+
+Second stage-1 run on the passive-toes plant, and the controlled test of the
+previous postmortem's recommendation: narrow the home-pose Gaussian from 0.20
+to 0.10 rad so the statue basin out-pays every chattering alternative. The
+gate verdict on the robust-best checkpoint:
+
+| criterion | required | final | verdict |
+|---|---|---|---|
+| full-horizon fraction | ≥ 0.95 | **0.9750** (39/40 truncated, 1 fallen) | pass |
+| mean reward | ≥ 1940 | **1999.9 ± 133.0** | pass |
+| mean unsupported duty | ≤ 0.02 | **0.3987** | **FAIL** |
+| unsupported duty UCB | ≤ 0.02 | **0.4029** | **FAIL** |
+
+The headline number barely moved (run 1: 0.4095), but the run underneath it is
+a different animal, and the probes finally show the failure's shape clearly
+enough to name the exploit. The policy converged to a **deep knee-locked
+crouch**: both knees commanded to −50.0°, hard against the flexion stop, with
+±1.1–1.5° of residual motion — mechanically locked — while the ankles pump
+±28–33° around neutral at ~16.8 Hz and the hip pitches row at +37–40° with
+±19–23° swings. Anyone watching the replay sees exactly what the numbers say:
+a dinosaur standing with locked knees, flexing its feet up and down.
+
+Three findings define this run:
+
+1. **The pose is not statically stable, and the foot-flexing is what holds it
+   up.** The new constant-hold probe (section 4) replaces the policy's output
+   with its own post-settle mean action: every held variant falls within ~3
+   seconds, 9 of 10 times backward onto the tail. The tremor is active
+   stabilisation of a backward-leaning pose, not residual noise.
+2. **The narrowed Gaussian did not pull the policy home — it never felt it.**
+   Home-pose error rose monotonically from 0.20 to 0.545 rad across the entire
+   10M steps (section 5). Outside ~2 tolerance widths the Gaussian's gradient
+   is numerically zero; once early exploration wandered, there was no
+   restoring force at all. The recommendation is falsified as a basin-capture
+   mechanism.
+3. **The policy discovered saturation parking.** A saturated command cannot
+   oscillate, so the smoothness and jerk penalties price a joint pinned at its
+   hard stop as perfectly quiet. One by one, formerly-chattering channels went
+   silent by being driven to a limit: on the gate panel, five of fifteen
+   actuators sit at or within 2% of a stop (both knees, head_pitch,
+   tail_2_pitch, tail_1_yaw). Saturation became the cheapest way to be smooth.
+
+---
+
+## 2. Trajectory
+
+Gate checks every 50k steps, 40-episode panels, seeds 3042–3081. Three acts:
+
+| phase | steps | what happened |
+|---|---|---|
+| statue flash | 0–100k | init lands near home: **2520.7 ± 1116.5 at 50k — the best eval either run ever recorded** — with near-perfect duty. High variance (it falls often), but when it stands, it stands the statue's way |
+| trough + rebuild | 100k–2M | exploration leaves home and never returns; duty UCB peaks at 0.756 (1.9M), worse than run 1's rebuild |
+| crouch consolidation | 2M–8.6M | steady, monotone improvement on every support metric: duty UCB 0.756 → 0.40, bilateral support 0.03 → 0.55, foot-load imbalance 0.99 → 0.50, per-foot contact force 220 → 330 N; full-horizon pinned at ~1.0 for 7M straight steps; reward crosses the 1940 rail at ~7.55M |
+| Goodhart collapse | 8.6M–10M | duty UCB keeps plunging (0.40 → **0.248**) but survival is spent to buy it: full-horizon crashes as low as 0.15, episode length swings 560–1000, eval reward whipsaws 1070–2020, mean tilt climbs from ~4° to ~9° |
+
+Notable singletons:
+
+- **Duty fell straight through the 7M entropy zero-crossing without a
+  kink** — the clean confirmation of run 1's falsification. The decline is
+  driven by the reward landscape, not exploration noise. It also
+  *accelerated* late (~0.03/M through 7–8M, ~0.087/M after 8.25M), which is
+  the collapse announcing itself: the optimizer found that leaning further
+  back unloads the feet faster than balancing better does.
+- **The robust-best selector earned its keep.** The final 10M policy
+  evaluates at 1869.6 ± 607.0 with mean episode length 851; the selected
+  checkpoint (from the ~8.3M plateau) evaluates at 2012.1 ± 57.7 with every
+  episode full-length. The last 1.5M steps of "progress" were not robust, and
+  the selector correctly refused to ship them.
+- Mean tilt angle tells the lean story in one curve: ~15° at init, bottoming
+  at ~3.6° mid-run (4.5–5.5M), then climbing steadily back to ~9° by 10M as
+  the policy traded uprightness for foot-unloading, right up against the
+  tail-contact termination.
+
+---
+
+## 3. Anatomy of the stance
+
+From the gate report's commanded-action table (post-settle, robust-best
+checkpoint, 40 episodes; DC 0.670 rms, AC 0.497 rms, ~16.8 Hz effective):
+
+| actuator | command | swing | reading |
+|---|---|---|---|
+| l_knee / r_knee | −50.0° / −49.9° (of ±50°) | ±1.1° / ±1.5° | locked against the flexion stop |
+| l_ankle / r_ankle | −7.7° / −7.9° | **±33.1° / ±27.6°** | the stabiliser: feet pumping |
+| l_hip_pitch / r_hip_pitch | +37.2° / +39.7° | ±23.1° / ±19.4° | weight-shifting, second stabiliser |
+| neck_pitch | −14.7° | ±20.7° | third stabiliser |
+| head_pitch | −25.0° (stop) | ±0.9° | parked |
+| tail_2_pitch | +12.0° (stop) | ±0.5° | parked |
+| tail_1_yaw | −7.7° (near stop) | ±1.1° | parked |
+| tail_3_pitch | −8.6° | ±8.0° | active counterweight |
+
+The division of labour is total: three joint groups (ankles, hip pitches,
+neck pitch) carry all of the stabilisation bandwidth, everything else is
+parked — mostly at hard stops. The unsupported duty this stance scores (0.40)
+is the pumping itself: at ~16.8 Hz the feet break full contact inside a large
+fraction of control steps, and the substep-honest metric (#499) counts every
+one of them.
+
+Reward accounting per episode (gate panel): alive 761.7, height 592.4,
+head_clearance 348.2, bilateral_support 317.2, foot_load_balance −280.3,
+leg_home_pose 174.4 (of ~500 available), neck_posture 171.4. The support
+terms recovered most of run 1's deficit; what is left on the table is the
+abandoned home pose and the load-balance penalty of the crouch.
+
+---
+
+## 4. The probes: the pose needs its tremor, more than ever
+
+**Constant-hold probe** (new this run): replace the policy's action with a
+constant partway through the episode — its own post-settle mean — and see if
+the pose survives without feedback.
+
+| variant | handoff | ramp | ep length | full-horizon | terminations |
+|---|---|---|---|---|---|
+| policy (control) | never | — | 1000.0 | 1.00 | truncated 10 |
+| hold_after_settle | 200 | 0 | 318.0 | 0.00 | **tail_contact 9**, nosedive 1 |
+| hold_after_settle_ramped | 200 | 50 | 269.3 | 0.00 | tail_contact 7, nosedive 2, fallen 1 |
+| hold_from_reset | 0 | 50 | 96.6 | 0.00 | nosedive 10 |
+| hold_zero (statue control) | 0 | 0 | 1000.0 | 1.00 | truncated 10 |
+
+No held variant reaches the horizon; the statue control does. The chosen pose
+*requires* continuous feedback, and its failure direction is specific:
+backward, onto the tail. The knee-locked crouch sits behind its feet, and the
+ankle pumping is the only thing preventing the animal from sitting down.
+
+**Filter probe** — and this is the run's most important negative result. The
+policy's actions low-passed at eval time:
+
+| cutoff | run 2 ep length (full-horizon) | run 1 (for comparison) |
+|---|---|---|
+| 35 Hz | 790 (0.40) | survived (1.00) |
+| 30 Hz | 633 (0.00) | survived |
+| 20 Hz | 295 (0.00) | survived |
+| 10 Hz | 161 (0.00) | died |
+| 5 Hz | 71 (0.00) | died |
+
+Run 1's stance tolerated everything down to 20 Hz. Run 2's stance dies at
+**every** cutoff tested, with tail-contact and falls splitting the
+terminations. Despite lower AC amplitude (0.50 vs 0.61 rms) and a lower
+effective frequency (16.8 vs 18.7 Hz), this policy is *more* dependent on
+high-bandwidth feedback than its predecessor — the amplitude metrics measure
+the tremor's size, not its necessity. The balance task itself needs ~1.1–1.4
+Hz. The gap between what the task needs and what the policy uses is the
+exploit's whole surface area.
+
+---
+
+## 5. The home-pose Gaussian: falsification, completed
+
+Run 1's postmortem priced the crouch-vs-home tradeoff and recommended
+narrowing the tolerance so the statue basin dominates. Run 2 is the verdict:
+
+- Home-pose error rose **monotonically** from 0.20 rad (init) to 0.545 rad
+  (10M). There is no episode of return, no plateau, no fight. The policy
+  left home in the first 100k steps and drifted further for the remaining
+  9.9M while the term flatlined at ~174/500.
+- The mechanism was named in the previous postmortem's section 6 and operated
+  exactly as written: a Gaussian's gradient at 5 tolerance widths is zero to
+  machine precision. Narrowing the tolerance made the basin *richer* and its
+  gravitational reach *shorter* — the opposite of capture. The term sees the
+  pose; it just cannot pull anything toward it.
+- The 50k statue flash (2520.7, the best eval either run recorded) proves the
+  basin pays exactly as designed — for a policy already inside it. The
+  intervention failed not on the economics but on the reach.
+
+Consequence for the fix list: any home-pose term that must *attract* — not
+merely *reward* — needs a gradient that survives distance: a long-tailed
+component (e.g. Cauchy), a tolerance annealed from wide to narrow, or an
+explicit curriculum that starts episodes inside the basin.
+
+The A/B against run 1 must also be stated honestly: at every matched step
+past 6M, run 2 leads on duty, chatter amplitude, and action frequency, and
+its training frontier (0.248) went far below anything run 1 touched. But with
+one seed per condition and a qualitatively different attractor found, none of
+that is causally attributable to the tolerance change. Seed replicates before
+crediting it.
+
+---
+
+## 6. The actuator question, considered and declined
+
+An obvious response to a policy that stabilises with 17 Hz foot-pumping is to
+ask whether the body is missing an actuator — something in the tail or torso
+that would let it balance "properly." Considered, and declined, for three
+reasons:
+
+1. **The statue is the existence proof that nothing is missing.** Constant
+   zero action, springs only: full horizon, 0.998 bilateral support, 3240
+   reward. Stage-1 balance requires *no* actuation at all from this
+   morphology. A missing-DOF deficit would present as "no statically viable
+   pose exists"; we observe the opposite — the policy declines a statically
+   viable pose in favour of one it must fight.
+2. **The high-frequency movement is a chosen pose's life-support, not a
+   control-authority gap.** Run 1 chattered the toes; after #500 removed
+   them, run 2 chattered the ankles. The channel migrates to wherever
+   bandwidth is free; adding actuators adds channels. The toe motors were
+   this exact experiment run in reverse, and removing them was an
+   improvement.
+3. **This run pinned the actuators the reward prices worst.** By 10M, six of
+   fifteen actuators sat at stops — head_pitch, both knees, and the entire
+   tail yaw/pitch chain — while the top remaining chatter channels were
+   neck_yaw (AC 0.89) and the hip rolls. The audit of what stage 1 actually
+   prices explains the sorting: the tail term penalises tail-*tip angular
+   velocity* only, so a tail parked motionless at a hard stop is *optimal*
+   for it; the neck term covers neck_yaw and head_pitch but at weight 0.20
+   with a 0.35 rad tolerance — as wide as the entire neck_yaw range — so
+   yaw chatter is nearly free; and the legs sit outside the narrowed
+   Gaussian's reach. A new tail or torso actuator would inherit one of
+   these camps — parked at a limit or drafted as the new pump. Authority
+   the reward cannot see is authority the optimizer will spend against us.
+
+One genuine candidate is deferred, not rejected: **ankle roll** (lateral
+ankle strategy) for stage-2 locomotion, where lateral balance currently
+routes entirely through hip roll. That is a stage-2 question, to be answered
+by stage-2 evidence, and any addition should arrive with its reward terms
+already in place.
+
+---
+
+## 7. Recommendations → the fix plan
+
+In priority order (items 1–3 are being implemented now):
+
+1. **Training-time action low-pass filter (~10 Hz).** The structural fix both
+   runs point at. Filter the commanded action inside the environment during
+   training so high-bandwidth stabilisation is not merely priced but
+   *unavailable*; poses that need 17 Hz feedback stop being attractors, and
+   the statically stable basin becomes the cheap one. The eval-side probe
+   already demonstrates the mechanism; this promotes it into the plant's
+   training interface. The task needs ~1.1–1.4 Hz; a ~10 Hz cutoff leaves
+   almost a decade of margin while sitting well below both runs' exploit
+   bands (16.8, 18.7 Hz).
+2. **Price saturation.** A small penalty on the fraction of actuators pinned
+   near |action| = 1 removes the free-smoothness exploit that parked five
+   channels at their stops.
+3. **Price tail pose, not just tail-tip motion.** The tail joints are the
+   one actuator group with no positional term at all — the existing tail
+   term (tip angular velocity) actively prefers a tail frozen at its stops.
+   A soft home term over the four tail joints closes the loophole the whole
+   tail chain disappeared into.
+4. **Give the home-pose term long-range gradient** (Cauchy tail or annealed
+   tolerance), so the basin can attract as well as pay. Without this, items
+   1–3 prevent the exploit but nothing actively routes the policy home.
+5. **Seed replicates** for any future A/B; this run demonstrates how easily
+   one seed's attractor discovery can masquerade as an intervention effect.
+6. Minor: the foot-contact figure renders an empty "diagonal pair" panel for
+   bipeds; skip it for two-footed species.
+
+Items 2–4 change the reward function, which moves the statue baseline; the
+rails (`min_avg_reward`, `collapse_peak_floor_reference`) must be re-derived
+against the new terms in the same PR, per the provenance rules added in #501.
+
+One caution for downstream stages: `robust_best_model.zip` from this run is
+the knee-locked crouch. If stage 2 ever seeds from a stage-1 checkpoint,
+this one imports a stance that cannot survive without ~17 Hz feedback — check
+the filter probe of any checkpoint before promoting it.

--- a/environments/shared/action_filter.py
+++ b/environments/shared/action_filter.py
@@ -1,0 +1,70 @@
+"""First-order low-pass filtering of commanded actions.
+
+The filter is part of the PLANT INTERFACE, not the curriculum.  An enabled
+cutoff changes what a policy's action *means* — the plant responds to the
+filtered command, so a checkpoint trained with the filter is incompatible
+with the unfiltered plant even though every tensor dimension matches
+(docs/PLANT_CONTRACT.md, "action meaning" rule).  Species therefore enable
+it through plant-level declarations only:
+
+- SB3: ``action_filter_cutoff_hz`` class attribute on the species env
+  (deliberately not an ``__init__`` kwarg, so stage TOMLs cannot set it);
+- MJX: ``action_filter_cutoff_hz`` in ``register_species_mjx`` (listed in
+  ``_PLANT_INTERFACE_CONFIG_FIELDS``, so stage TOMLs cannot override it).
+
+The plant contract fingerprints this module and records the cutoff when a
+species enables it, and asserts both backends agree.
+
+Why it exists: both 2026-08 trex stage-1 runs converged on poses that are
+not statically stable and survive only through 16.8–18.7 Hz command
+chatter, while the balance task itself needs ~1.1–1.4 Hz of closed-loop
+bandwidth (measured by the stance-gate filter probe).  Amplitude penalties
+(smoothness/jerk) cannot price that strategy out — a saturated command is
+perfectly smooth — so the filter removes the bandwidth itself: poses that
+need fast stabilisation stop being reachable attractors during training.
+See docs/investigations/TREX_STAGE1_NARROW_TOLERANCE_RUN_2026_08.md.
+
+The discretization matches the eval-side probe filter
+(``_low_pass_predict`` in environments/shared/scripts/stance_gate_report.py):
+a discrete RC filter with ``alpha = dt / (RC + dt)``, ``RC = 1/(2*pi*fc)``,
+state seeded with the first post-reset action so episodes do not open with
+a transient toward zero.
+
+Both functions are fingerprinted by the plant contract: no f-strings
+(digests.py forbids them inside fingerprinted callables), and any edit
+here moves the policy-interface fingerprint of every species with the
+filter enabled — bump their ``policy_interface_revision`` accordingly.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+# Arrays from either backend (numpy or jax.numpy); plain arithmetic only.
+Array = Any
+
+
+def low_pass_alpha(cutoff_hz: float, control_dt: float) -> float:
+    """Return the per-control-step blend factor for a first-order low-pass.
+
+    ``alpha = dt / (RC + dt)`` with ``RC = 1 / (2 * pi * cutoff_hz)`` — the
+    standard discrete RC filter, identical to the stance-gate probe's.
+    """
+    if cutoff_hz <= 0.0:
+        raise ValueError("cutoff_hz must be positive; use no filter instead of a zero cutoff")
+    if control_dt <= 0.0:
+        raise ValueError("control_dt must be positive")
+    rc = 1.0 / (2.0 * math.pi * cutoff_hz)
+    return control_dt / (rc + control_dt)
+
+
+def apply_low_pass(previous: Array, current: Array, alpha: float) -> Array:
+    """One filter update: blend ``current`` into the carried filter state.
+
+    Backend-neutral (numpy and JAX arrays) and trace-safe: arithmetic only.
+    Seeding — returning ``current`` unblended on the first post-reset step —
+    is the caller's job, because the two backends detect the episode
+    boundary differently (Python state vs a traced ``step_count``).
+    """
+    return previous + alpha * (current - previous)

--- a/environments/shared/base_env.py
+++ b/environments/shared/base_env.py
@@ -20,6 +20,8 @@ import gymnasium as gym
 import mujoco
 import numpy as np
 
+from .action_filter import apply_low_pass as _apply_low_pass
+from .action_filter import low_pass_alpha as _low_pass_alpha
 from .constants import SENSOR_ACCEL_START, SENSOR_GYRO_START, SENSOR_QUAT_START, TAIL_ANGULAR_VEL_MAX
 from .reward_functions import check_height_tilt_termination as _check_height_tilt_pure
 from .reward_functions import quat_to_forward_2d as _quat_to_forward_2d_pure
@@ -131,6 +133,14 @@ class BaseDinoEnv(gym.Env, ABC):
     _substep_height_checks: "tuple[tuple[str, int], ...]" = ()
     _substep_min_heights: "np.ndarray | None" = None
 
+    # First-order low-pass on the commanded action, in Hz; 0.0 disables it
+    # and preserves the exact legacy step arithmetic.  Part of the PLANT
+    # INTERFACE, not the curriculum: a class attribute rather than an
+    # __init__ kwarg precisely so stage TOMLs cannot tune it, and the plant
+    # contract records the value and the filter implementation when a
+    # species enables it (see environments/shared/action_filter.py).
+    action_filter_cutoff_hz: float = 0.0
+
     # Optional zero-argument callable invoked after EVERY physics substep in
     # step().  Exists so stance_duty_validation.py and the aggregation
     # regression tests can record per-substep kinematic ground truth through
@@ -176,6 +186,15 @@ class BaseDinoEnv(gym.Env, ABC):
         self.dt = self.model.opt.timestep * frame_skip
         self.max_episode_steps = max_episode_steps
         self._step_count = 0
+
+        # Command low-pass state (see the action_filter_cutoff_hz class
+        # attribute).  The alpha is fixed by the control cadence; the state
+        # is invalidated across reset through _step_count, like the substep
+        # aggregates, so the fingerprinted reset() stays untouched.
+        self._action_filter_alpha = (
+            _low_pass_alpha(self.action_filter_cutoff_hz, self.dt) if self.action_filter_cutoff_hz > 0.0 else 0.0
+        )
+        self._action_filter_state: np.ndarray | None = None
 
         # Distance tracking (cumulative XY path length)
         self._prev_pos_2d: np.ndarray = np.zeros(2)
@@ -941,8 +960,33 @@ class BaseDinoEnv(gym.Env, ABC):
             raise AttributeError(f"{type(self).__name__} has no attribute '{name}'")
         setattr(self, name, value)
 
+    def _filter_action(self, action: np.ndarray) -> np.ndarray:
+        """Low-pass the commanded action (action_filter_cutoff_hz > 0 only).
+
+        Seeded with the first post-reset action so episodes do not open
+        with a transient toward zero; the episode boundary is detected
+        through ``_step_count`` (reset() zeroes it) so the fingerprinted
+        ``reset()`` stays untouched.  Clips first: the filter state must
+        live in the same [-1, 1] box the scaler clips to, or an
+        out-of-range burst would decay through several steps instead of
+        being cut at the boundary.  The MJX step_fn applies the identical
+        update through its ``filtered_action`` carry — keep in lockstep.
+        """
+        clipped = np.clip(np.asarray(action, dtype=np.float64), -1.0, 1.0)
+        if self._step_count == 0 or self._action_filter_state is None:
+            self._action_filter_state = clipped
+        else:
+            self._action_filter_state = _apply_low_pass(self._action_filter_state, clipped, self._action_filter_alpha)
+        return self._action_filter_state.copy()
+
     def step(self, action: np.ndarray) -> tuple[np.ndarray, float, bool, bool, dict]:
         """Execute one environment step."""
+        if self.action_filter_cutoff_hz > 0.0:
+            # Both the dynamics and the action-derived reward terms below
+            # consume the filtered command: raw policy content above the
+            # cutoff never reaches the plant, so pricing it would penalise
+            # a signal with no physical consequence.
+            action = self._filter_action(action)
         # Scale action from [-1, 1] to actuator control ranges
         ctrl = self._scale_action(action)
         self.data.ctrl[:] = ctrl

--- a/environments/shared/data/plant_manifest.generated.json
+++ b/environments/shared/data/plant_manifest.generated.json
@@ -84,7 +84,7 @@
       }
     },
     "trex": {
-      "bundle_sha256": "sha256:a3c23d7a84e4b63cab0f4e234d00854bc8eff3380a901b2bf419e1fb4b196722",
+      "bundle_sha256": "sha256:c2d5cf4587590d3f6b95e9812ad8300c418729f3fdc3bbe470df0c8860b15043",
       "env_entrypoint": "environments.trex.envs.trex_env:TRexEnv",
       "model_path": "environments/trex/assets/trex.xml",
       "physics": {
@@ -99,9 +99,9 @@
         "action_dim": 15,
         "observation_dim": 61,
         "observation_schema": "bipedal-target/v1",
-        "revision": 10,
+        "revision": 11,
         "schema": "mesozoic.policy-interface/v1",
-        "sha256": "sha256:d00f24e0d9219878714dc3d2f479c9400fd21c7bc76687bda065f223beb039e9"
+        "sha256": "sha256:96ef137a211cdb0caa9aa744b1b2c35e37b8d40c96abac5ce9e86c7b3e52acd0"
       },
       "source": {
         "closure_sha256": "sha256:e3919447fc76fbcd6396284afa028ad2831797461d03bbe6c9b52a5fc1c50753",

--- a/environments/shared/jax_eval.py
+++ b/environments/shared/jax_eval.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import numpy as np
 
+from .action_filter import apply_low_pass, low_pass_alpha
 from .reward_functions import reward_lean_aware_posture, reward_posture
 
 
@@ -47,6 +48,10 @@ class EvalConfig:
     sensor_gyro_start: int = 0
     sensor_quat_start: int = 6
     action_mapping: str = "midpoint/v1"
+    # Command low-pass cutoff of the plant interface (0.0 = off).  Eval must
+    # drive the same filtered plant the training kernel does, and feed the
+    # filtered command to the action-derived reward terms.
+    action_filter_cutoff_hz: float = 0.0
     reset_noise_scale: float = 0.01
     init_qpos_noise: float = 0.0
     init_yaw_noise: float = 0.0
@@ -299,6 +304,14 @@ def evaluate_policy_cpu(
     if config.target_body is not None:
         _target_body_id = mujoco.mj_name2id(mj_model, mujoco.mjtObj.mjOBJ_BODY, config.target_body)
 
+    # Command low-pass of the plant interface (see action_filter.py).
+    _filter_alpha: float | None = None
+    if config.action_filter_cutoff_hz > 0.0:
+        _filter_alpha = low_pass_alpha(
+            config.action_filter_cutoff_hz,
+            float(mj_model.opt.timestep) * config.frame_skip,
+        )
+
     for ep in range(config.n_episodes):
         if config.action_mapping == ACTION_MAPPING_HOME_KEYFRAME_RESIDUAL:
             reset_mujoco_data_to_home(mj_model, mj_data)
@@ -322,6 +335,9 @@ def evaluate_policy_cpu(
         ep_success = False
         start_pos = mj_data.xpos[config.root_body_id, :2].copy()
         prev_action = None
+        # Per-episode command low-pass carry (None = seed with first action),
+        # mirroring the training backends' filter state.
+        filtered_action = None
         # Track the target for reward parity with the training env (approach
         # shaping compares against the previous step's distance).
         prev_target_dist: float | None = None
@@ -335,6 +351,13 @@ def evaluate_policy_cpu(
 
             mean, _log_std, _value = network.apply(params, obs)
             action = jnp.clip(mean, -1.0, 1.0)
+            if _filter_alpha is not None:
+                # Same seeding and blend as the training kernels; the
+                # filtered command feeds ctrl, the reward call, and the
+                # prev_action carry below.
+                if filtered_action is not None:
+                    action = apply_low_pass(filtered_action, action, _filter_alpha)
+                filtered_action = action
 
             ctrl = np.array(scale_action_fn(action))
             mj_data.ctrl[:] = ctrl

--- a/environments/shared/jax_setup.py
+++ b/environments/shared/jax_setup.py
@@ -721,6 +721,8 @@ def run_stage_evaluation(
         sensor_quat_start=ctx.sensor_layout.quat_start,
         sensor_gyro_start=ctx.sensor_layout.gyro_start,
         action_mapping=ctx.action_mapping,
+        # Drive the same filtered plant the training kernel does.
+        action_filter_cutoff_hz=float(getattr(env.config, "action_filter_cutoff_hz", 0.0)),
         # Evaluate on the same joint-angle reset distribution used by the
         # instantiated training environment.  This includes the effective
         # [jax] override after registry/[env]/[jax] merging.

--- a/environments/shared/mjx_env.py
+++ b/environments/shared/mjx_env.py
@@ -174,6 +174,12 @@ class MJXEnvConfig:
     sensor_accel_start: int = 3
     sensor_quat_start: int = 6
     action_mapping: str = ACTION_MAPPING_MIDPOINT
+    # First-order low-pass on the commanded action, in Hz; 0.0 disables it.
+    # Plant-interface field (not curriculum-tunable): an enabled cutoff
+    # changes what a checkpoint's action means.  Must equal the SB3 env's
+    # class attribute — the plant contract asserts backend agreement.
+    # See environments/shared/action_filter.py.
+    action_filter_cutoff_hz: float = 0.0
     natural_forward_z: float = 0.0
     # Reward-only target.  ``None`` preserves the vertical posture reward;
     # Velociraptor supplies its natural forward lean.  Absolute-tilt and
@@ -242,6 +248,10 @@ class EnvState:
     prev_action: Any  # jnp.ndarray
     # Second lag, for the frequency-aware jerk term (see reward_action_jerk).
     prev_prev_action: Any  # jnp.ndarray
+    # Command low-pass carry (action_filter_cutoff_hz > 0); seeded with the
+    # first post-reset action via a step_count==0 select, mirroring the SB3
+    # env's _filter_action.  Carried untouched when the filter is off.
+    filtered_action: Any  # jnp.ndarray
     prev_target_distance: Any  # jnp.float32
     target_pos: Any  # jnp.ndarray (3,)
     initial_pos_2d: Any  # jnp.ndarray (2,) — spawn XY for drift penalty
@@ -260,6 +270,7 @@ try:
             "step_count",
             "prev_action",
             "prev_prev_action",
+            "filtered_action",
             "prev_target_distance",
             "target_pos",
             "initial_pos_2d",
@@ -288,6 +299,7 @@ _PLANT_INTERFACE_CONFIG_FIELDS = frozenset(
         "sensor_accel_start",
         "sensor_quat_start",
         "action_mapping",
+        "action_filter_cutoff_hz",
     }
 )
 
@@ -778,6 +790,7 @@ class MJXDinoEnv:
         import jax.numpy as jnp
         import mujoco.mjx as mjx
 
+        from .action_filter import apply_low_pass, low_pass_alpha
         from .mjx_utils import scale_action_around_nominal_jax, scale_action_jax
         from .reward_functions import (
             check_nosedive_termination,
@@ -812,6 +825,10 @@ class MJXDinoEnv:
         nominal_ctrl = self.nominal_ctrl
         frame_skip = config.frame_skip
         dt = float(self.mj_model.opt.timestep) * frame_skip
+        # Trace-time gate: None bakes the legacy unfiltered kernel.
+        action_filter_alpha = (
+            low_pass_alpha(config.action_filter_cutoff_hz, dt) if config.action_filter_cutoff_hz > 0.0 else None
+        )
         # Pre-resolved body-height termination pairs (body_id, z_threshold)
         body_height_checks = tuple(self._termination_body_checks)
         # Pre-resolved site-height termination pairs (site_id, z_threshold)
@@ -840,6 +857,17 @@ class MJXDinoEnv:
             ``forward_vel_weight`` reward at runtime so the trainer can
             ramp it without retracing this kernel.
             """
+            if action_filter_alpha is not None:
+                # Command low-pass, in lockstep with BaseDinoEnv._filter_action:
+                # clip into the scaler's box, seed with the first post-reset
+                # action, then blend.  Dynamics AND the action-derived reward
+                # terms below consume the filtered command.
+                clipped = jnp.clip(action, -1.0, 1.0)
+                action = jnp.where(
+                    state.step_count == 0,
+                    clipped,
+                    apply_low_pass(state.filtered_action, clipped, action_filter_alpha),
+                )
             # Scale action
             if nominal_ctrl is None:
                 ctrl = scale_action_jax(action, ctrl_range)
@@ -1155,6 +1183,7 @@ class MJXDinoEnv:
                 step_count=step_count,
                 prev_action=action,
                 prev_prev_action=state.prev_action,
+                filtered_action=(action if action_filter_alpha is not None else state.filtered_action),
                 prev_target_distance=target_dist,
                 target_pos=target_pos,
                 initial_pos_2d=initial_pos_2d,
@@ -1276,6 +1305,8 @@ class MJXDinoEnv:
                 step_count=jnp.int32(0),
                 prev_action=jnp.zeros(action_dim),
                 prev_prev_action=jnp.zeros(action_dim),
+                # Placeholder until the first step seeds it (step_count==0).
+                filtered_action=jnp.zeros(action_dim),
                 prev_target_distance=target_dist,
                 target_pos=target_pos,
                 initial_pos_2d=pelvis_xpos[:2],

--- a/environments/shared/plant_contract/policy_layer.py
+++ b/environments/shared/plant_contract/policy_layer.py
@@ -226,6 +226,13 @@ def _jax_policy_interface_payload(
             f"SB3 and MJX action mappings diverge for {version.species}: "
             f"sb3={sb3_action_mapping!r}, mjx={registered_action_mapping!r}"
         )
+    registered_filter_cutoff = float(raw_config.get("action_filter_cutoff_hz", 0.0))
+    sb3_filter_cutoff = float(getattr(env, "action_filter_cutoff_hz", 0.0))
+    if registered_filter_cutoff != sb3_filter_cutoff:
+        raise PlantContractError(
+            f"SB3 and MJX action filter cutoffs diverge for {version.species}: "
+            f"sb3={sb3_filter_cutoff!r}, mjx={registered_filter_cutoff!r}"
+        )
 
     probe_data = _deterministic_probe_data(model)
     target_pos = probe_data.mocap_pos[0] if model.nmocap else np.array([1.25, -0.45, 0.8])
@@ -275,6 +282,10 @@ def _jax_policy_interface_payload(
     }
     if registered_action_mapping != _ACTION_MAPPING_MIDPOINT:
         payload["action_mapping"] = registered_action_mapping
+    if registered_filter_cutoff > 0.0:
+        # Conditional so filter-free species keep their payload (and thus
+        # their policy fingerprint) byte-identical.
+        payload["action_filter_cutoff_hz"] = _canonical_float(registered_filter_cutoff)
     return payload
 
 
@@ -362,6 +373,19 @@ def _policy_interface_payload(
             "jax": _module_function_semantics(
                 "environments.shared.mjx_utils",
                 ("reset_mujoco_data_to_home",),
+            ),
+        }
+    action_filter_cutoff = float(getattr(env, "action_filter_cutoff_hz", 0.0))
+    if action_filter_cutoff > 0.0:
+        # Conditional: species without the filter keep their fingerprint.
+        # For species with it, the cutoff and the filter arithmetic are part
+        # of what a checkpoint's action means — edits to action_filter.py
+        # move this fingerprint and force a policy revision bump.
+        interface_implementations["action_low_pass_filter"] = {
+            "cutoff_hz": _canonical_float(action_filter_cutoff),
+            "implementation": _module_function_semantics(
+                "environments.shared.action_filter",
+                ("low_pass_alpha", "apply_low_pass"),
             ),
         }
     return {

--- a/environments/shared/scripts/stance_gate_report.py
+++ b/environments/shared/scripts/stance_gate_report.py
@@ -57,6 +57,7 @@ _repo_root = str(Path(__file__).resolve().parents[3])
 if _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
 
+from environments.shared.action_filter import low_pass_alpha  # noqa: E402
 from environments.shared.config import load_stage_config  # noqa: E402
 from environments.shared.curriculum.stance_gate import (  # noqa: E402
     STANCE_GATE_KIND,
@@ -730,9 +731,13 @@ def _low_pass_predict(predict: Any, cutoff_hz: float, control_dt: float) -> Any:
 
     The state is per-call-sequence and reset by the caller between episodes
     via :func:`reset`, so one episode's tail cannot leak into the next.
+
+    The discretization is shared with the training-time plant filter
+    (environments/shared/action_filter.py) so probe cutoffs and plant
+    cutoffs are directly comparable.  When probing a plant that itself
+    filters (action_filter_cutoff_hz > 0), the two filters stack.
     """
-    rc = 1.0 / (2.0 * math.pi * cutoff_hz)
-    alpha = control_dt / (rc + control_dt)
+    alpha = low_pass_alpha(cutoff_hz, control_dt)
     state: dict[str, Any] = {"y": None}
 
     def filtered(obs: np.ndarray) -> np.ndarray:

--- a/environments/shared/tests/test_action_filter.py
+++ b/environments/shared/tests/test_action_filter.py
@@ -1,0 +1,157 @@
+"""Tests for the training-time command low-pass filter.
+
+The filter is a plant-interface feature (see action_filter.py): trex enables
+it at 10 Hz in both backends, every other species leaves it off and must keep
+the exact legacy step arithmetic.  The SB3 and MJX implementations share the
+alpha formula with the stance-gate probe filter, so probe cutoffs and plant
+cutoffs are directly comparable.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from environments.shared.action_filter import apply_low_pass, low_pass_alpha
+from environments.trex.envs.trex_env import TRexEnv
+
+
+class TestLowPassPrimitives:
+    def test_alpha_matches_probe_discretization(self) -> None:
+        # alpha = dt / (RC + dt), RC = 1 / (2*pi*fc): the formula
+        # _low_pass_predict in stance_gate_report.py has always used.
+        dt = 0.01
+        rc = 1.0 / (2.0 * np.pi * 10.0)
+        assert low_pass_alpha(10.0, dt) == pytest.approx(dt / (rc + dt))
+
+    def test_alpha_rejects_disabled_cutoff(self) -> None:
+        # A zero cutoff means "no filter"; callers gate on that themselves.
+        with pytest.raises(ValueError):
+            low_pass_alpha(0.0, 0.01)
+        with pytest.raises(ValueError):
+            low_pass_alpha(10.0, 0.0)
+
+    def test_dc_passthrough(self) -> None:
+        # A constant input is a fixed point of the update.
+        state = np.full(3, 0.25)
+        assert apply_low_pass(state, np.full(3, 0.25), 0.4) == pytest.approx(state)
+
+    def test_nyquist_alternation_is_attenuated(self) -> None:
+        # +-1 alternation at the control Nyquist rate must decay towards a
+        # small residual around zero once the transient settles.
+        alpha = low_pass_alpha(5.0, 0.01)
+        y = np.array([1.0])
+        for i in range(200):
+            x = np.array([1.0 if i % 2 == 0 else -1.0])
+            y = apply_low_pass(y, x, alpha)
+        assert abs(float(y[0])) < 0.4
+
+
+class TestSB3ActionFilter:
+    def test_trex_declares_ten_hz(self) -> None:
+        env = TRexEnv()
+        assert env.action_filter_cutoff_hz == 10.0
+        assert env._action_filter_alpha == pytest.approx(low_pass_alpha(10.0, env.dt))
+
+    def test_cutoff_is_not_a_constructor_kwarg(self) -> None:
+        # Plant-level by construction: stage TOML [env] tables become
+        # constructor kwargs, so the cutoff must not be accepted there.
+        with pytest.raises(TypeError):
+            TRexEnv(action_filter_cutoff_hz=5.0)  # type: ignore[call-arg]
+
+    def test_first_step_seeds_with_the_action(self) -> None:
+        # No transient toward zero at the episode boundary: the first
+        # filtered command equals the first (clipped) action exactly.
+        env = TRexEnv()
+        env.reset(seed=0)
+        action = np.full(env.action_space.shape, 0.5, dtype=np.float32)
+        env.step(action)
+        expected = env._scale_action(np.full(env.action_space.shape, 0.5))
+        assert env.data.ctrl == pytest.approx(expected)
+
+    def test_blend_and_reseed_across_reset(self) -> None:
+        env = TRexEnv()
+        env.reset(seed=0)
+        up = np.ones(env.action_space.shape, dtype=np.float32)
+        down = -up
+        env.step(up)
+        env.step(down)
+        alpha = env._action_filter_alpha
+        assert env._action_filter_state == pytest.approx(1.0 + alpha * (-1.0 - 1.0))
+        # Reset invalidates the carry through _step_count, like the substep
+        # aggregates; the next episode seeds fresh with its own first action.
+        env.reset(seed=1)
+        env.step(down)
+        assert env._action_filter_state == pytest.approx(-1.0)
+
+    def test_disabled_cutoff_preserves_legacy_arithmetic(self) -> None:
+        class UnfilteredTRexEnv(TRexEnv):
+            action_filter_cutoff_hz = 0.0
+
+        env = UnfilteredTRexEnv()
+        env.reset(seed=0)
+        rng = np.random.default_rng(3)
+        for _ in range(3):
+            action = rng.uniform(-1.0, 1.0, env.action_space.shape).astype(np.float32)
+            env.step(action)
+            # ctrl reflects the raw action every step -- no carried state.
+            assert env.data.ctrl == pytest.approx(env._scale_action(action))
+        assert env._action_filter_state is None
+
+    def test_filtered_command_feeds_the_reward_terms(self) -> None:
+        # The smoothness/jerk history must hold the filtered command, not
+        # the raw policy output: raw content above the cutoff never reaches
+        # the plant, and pricing it would penalise a phantom.
+        env = TRexEnv()
+        env.reset(seed=0)
+        up = np.ones(env.action_space.shape, dtype=np.float32)
+        env.step(up)
+        env.step(-up)
+        assert env._prev_action == pytest.approx(env._action_filter_state)
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+class TestMJXActionFilter:
+    @pytest.fixture(scope="class")
+    def mjx_env(self):
+        pytest.importorskip("jax")
+        pytest.importorskip("mujoco.mjx")
+        import environments.trex.mjx_config  # noqa: F401  (registers trex)
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        return MJXDinoEnv("trex", stage=1, num_envs=1)
+
+    def test_registered_cutoff_matches_sb3(self, mjx_env) -> None:
+        assert mjx_env.config.action_filter_cutoff_hz == TRexEnv.action_filter_cutoff_hz
+
+    def test_stage_toml_cannot_override_the_cutoff(self) -> None:
+        pytest.importorskip("jax")
+        pytest.importorskip("mujoco.mjx")
+        import environments.trex.mjx_config  # noqa: F401
+        from environments.shared.mjx_env import MJXDinoEnv
+
+        with pytest.raises(ValueError, match="versioned plant interface"):
+            MJXDinoEnv("trex", stage=1, num_envs=1, env_kwargs={"action_filter_cutoff_hz": 5.0})
+
+    def test_step_seeds_then_blends_in_lockstep_with_sb3(self, mjx_env) -> None:
+        import jax
+        import jax.numpy as jnp
+
+        rng = jax.random.PRNGKey(0)
+        state = mjx_env._reset_single(rng)
+        assert state.filtered_action.shape == (mjx_env.action_dim,)
+
+        up = jnp.ones(mjx_env.action_dim)
+        state1, _, _, _ = mjx_env._step_single(state, up, rng, jnp.float32(1.0))
+        # Seeded: the first filtered command is the clipped action itself,
+        # and prev_action carries the filtered signal for the reward lags.
+        np.testing.assert_allclose(np.asarray(state1.filtered_action), 1.0, atol=1e-6)
+        np.testing.assert_allclose(np.asarray(state1.prev_action), 1.0, atol=1e-6)
+
+        alpha = low_pass_alpha(10.0, float(mjx_env.mj_model.opt.timestep) * mjx_env.config.frame_skip)
+        state2, _, _, _ = mjx_env._step_single(state1, -up, rng, jnp.float32(1.0))
+        np.testing.assert_allclose(
+            np.asarray(state2.filtered_action),
+            1.0 + alpha * (-1.0 - 1.0),
+            atol=1e-6,
+        )

--- a/environments/shared/tests/test_action_filter.py
+++ b/environments/shared/tests/test_action_filter.py
@@ -64,15 +64,15 @@ class TestSB3ActionFilter:
         # filtered command equals the first (clipped) action exactly.
         env = TRexEnv()
         env.reset(seed=0)
-        action = np.full(env.action_space.shape, 0.5, dtype=np.float32)
+        action = np.full(env.model.nu, 0.5, dtype=np.float32)
         env.step(action)
-        expected = env._scale_action(np.full(env.action_space.shape, 0.5))
+        expected = env._scale_action(np.full(env.model.nu, 0.5))
         assert env.data.ctrl == pytest.approx(expected)
 
     def test_blend_and_reseed_across_reset(self) -> None:
         env = TRexEnv()
         env.reset(seed=0)
-        up = np.ones(env.action_space.shape, dtype=np.float32)
+        up = np.ones(env.model.nu, dtype=np.float32)
         down = -up
         env.step(up)
         env.step(down)
@@ -92,7 +92,7 @@ class TestSB3ActionFilter:
         env.reset(seed=0)
         rng = np.random.default_rng(3)
         for _ in range(3):
-            action = rng.uniform(-1.0, 1.0, env.action_space.shape).astype(np.float32)
+            action = rng.uniform(-1.0, 1.0, env.model.nu).astype(np.float32)
             env.step(action)
             # ctrl reflects the raw action every step -- no carried state.
             assert env.data.ctrl == pytest.approx(env._scale_action(action))
@@ -104,7 +104,7 @@ class TestSB3ActionFilter:
         # the plant, and pricing it would penalise a phantom.
         env = TRexEnv()
         env.reset(seed=0)
-        up = np.ones(env.action_space.shape, dtype=np.float32)
+        up = np.ones(env.model.nu, dtype=np.float32)
         env.step(up)
         env.step(-up)
         assert env._prev_action == pytest.approx(env._action_filter_state)

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -98,7 +98,7 @@ def test_catalog_publishes_layered_plant_contract() -> None:
     # appended, pad + meta summed per leg on both backends; the physics layer
     # fingerprints nsite/nsensor, so new sites move it even though dynamics
     # are unchanged).
-    expected_policy_revisions = {"velociraptor": 8, "trex": 10, "brachiosaurus": 6, "dibothrosuchus": 5}
+    expected_policy_revisions = {"velociraptor": 8, "trex": 11, "brachiosaurus": 6, "dibothrosuchus": 5}
     expected_physics_revisions = {"velociraptor": 2, "trex": 7, "brachiosaurus": 4, "dibothrosuchus": 1}
     expected_visual_revisions = {"velociraptor": 3, "trex": 4, "brachiosaurus": 2, "dibothrosuchus": 1}
     digest_pattern = re.compile(r"sha256:[0-9a-f]{64}")

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -81,6 +81,16 @@ class TRexEnv(BaseDinoEnv):
     """Tyrannosaurus Rex bipedal locomotion and bite-attack environment."""
 
     action_mapping = "home-keyframe-residual/v1"
+    # 10 Hz command low-pass (plant interface r11).  Stage-1 balance needs
+    # ~1.1-1.4 Hz of closed-loop bandwidth (stance-gate filter probe), but
+    # both 2026-08 stage-1 runs converged on statically unstable poses kept
+    # up by 16.8-18.7 Hz command chatter that amplitude penalties cannot
+    # price out.  The cutoff removes that bandwidth during training, with
+    # nearly a decade of margin above the task's needs.  Must match the MJX
+    # registration in environments/trex/mjx_config.py (the plant contract
+    # asserts it).  See
+    # docs/investigations/TREX_STAGE1_NARROW_TOLERANCE_RUN_2026_08.md.
+    action_filter_cutoff_hz = 10.0
     _camera_distance = 3.0
     _camera_azimuth = 135
     _camera_elevation = -20

--- a/environments/trex/mjx_config.py
+++ b/environments/trex/mjx_config.py
@@ -36,6 +36,11 @@ _SENSOR_TAIL_GYRO_START = 21
 register_species_mjx(
     species="trex",
     action_mapping="home-keyframe-residual/v1",
+    # 10 Hz command low-pass (plant interface r11); must equal
+    # TRexEnv.action_filter_cutoff_hz — the plant contract asserts backend
+    # agreement.  Rationale in environments/shared/action_filter.py and the
+    # 2026-08 stage-1 postmortems.
+    action_filter_cutoff_hz=10.0,
     frame_skip=5,
     max_episode_steps=1000,
     healthy_z_range=(0.70, 1.55),

--- a/environments/trex/tests/test_trex_env.py
+++ b/environments/trex/tests/test_trex_env.py
@@ -467,7 +467,16 @@ class TestSubstepContactAggregation:
     def test_info_carries_the_min_across_substeps_and_catches_hidden_unloading(self):
         """Two pins in one rollout: info == min(per-substep sums) exactly, and
         the aggregate catches unloading the boundary sample misses."""
-        env = TRexEnv(reset_noise_scale=0.0, nosedive_termination_threshold=0.35)
+
+        class UnfilteredTRexEnv(TRexEnv):
+            # The witness drive below is a 20 Hz control-clock-locked hop
+            # tuned on the unfiltered plant; the r11 command low-pass would
+            # attenuate it ~2.2x and hide the very unloading this regression
+            # guards.  The aggregation machinery under test is independent
+            # of the filter, so probe it with the filter off.
+            action_filter_cutoff_hz = 0.0
+
+        env = UnfilteredTRexEnv(reset_noise_scale=0.0, nosedive_termination_threshold=0.35)
         try:
             env.reset(seed=0)
             substep_forces: list[tuple[float, float]] = []

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -366,13 +366,13 @@
         "nu": 15,
         "dynamic_mass_kg": 85.72,
         "plant_contract": {
-          "bundle_sha256": "sha256:a3c23d7a84e4b63cab0f4e234d00854bc8eff3380a901b2bf419e1fb4b196722",
+          "bundle_sha256": "sha256:c2d5cf4587590d3f6b95e9812ad8300c418729f3fdc3bbe470df0c8860b15043",
           "source_closure_sha256": "sha256:e3919447fc76fbcd6396284afa028ad2831797461d03bbe6c9b52a5fc1c50753",
           "policy_interface": {
             "schema": "mesozoic.policy-interface/v1",
-            "revision": 10,
+            "revision": 11,
             "observation_schema": "bipedal-target/v1",
-            "sha256": "sha256:d00f24e0d9219878714dc3d2f479c9400fd21c7bc76687bda065f223beb039e9"
+            "sha256": "sha256:96ef137a211cdb0caa9aa744b1b2c35e37b8d40c96abac5ce9e86c7b3e52acd0"
           },
           "physics": {
             "schema": "mesozoic.mujoco-physics/v1",


### PR DESCRIPTION
## What

Two things, one motivation:

1. **The run-2 postmortem** (`docs/investigations/TREX_STAGE1_NARROW_TOLERANCE_RUN_2026_08.md`): the knee-lock run in full — gate FAIL at duty 0.4029, the deep knee-locked crouch stabilised by ±28–33° ankle pumping, the new constant-hold probe showing the pose falls backward onto the tail in 9/10 episodes within ~3 s without its tremor, the filter-fragility regression (dies at every cutoff run 1 survived), saturation parking (6 of 15 actuators pinned at stops by 10M), the monotone abandonment of the home pose that falsifies the narrowed-Gaussian hypothesis, the late-run Goodhart collapse the robust-best selector correctly refused to ship, and a considered-and-declined decision record on adding tail/torso actuators (the statue is the existence proof that nothing is missing).

2. **The structural fix both runs point at**: a first-order 10 Hz low-pass on the commanded action, applied inside both backends during training and evaluation. The balance task needs ~1.1–1.4 Hz; both runs' exploits lived at 16.8–18.7 Hz. Amplitude penalties can't price the strategy out — a saturated command is perfectly smooth — so this removes the bandwidth instead: poses that need fast stabilisation stop being reachable attractors.

## How

- New `environments/shared/action_filter.py` — the probe filter's exact discretization (`alpha = dt/(RC+dt)`, `RC = 1/(2π·fc)`), seeded with the first post-reset action, shared by both backends and by the eval probe.
- **SB3**: `BaseDinoEnv.step` filters when `action_filter_cutoff_hz > 0` — a **class attribute**, deliberately not an `__init__` kwarg, so stage TOMLs cannot tune it. Episode boundary detected via `_step_count`, so the fingerprinted `reset()` is untouched. Dynamics **and** the action-derived reward terms (energy, smoothness, jerk) consume the filtered command — raw content above the cutoff never reaches the plant, and pricing it would penalise a phantom.
- **MJX**: `EnvState` gains a `filtered_action` carry; the step kernel applies the identical clip → seed → blend under a trace-time gate; the cutoff is a `register_species_mjx` field guarded by `_PLANT_INTERFACE_CONFIG_FIELDS` (a TOML override raises).
- **CPU eval** (`jax_eval`) drives the same filtered plant and feeds the filtered command to the reward composers.
- **Plant contract**: records the cutoff + filter fingerprint (conditionally, so filter-free species keep byte-identical fingerprints) and asserts SB3/MJX agreement. Future edits to the filter arithmetic move the fingerprint and force a revision bump.

## Contract consequences

- **T-Rex `policy_interface_revision` 10 → 11** (the "action meaning" rule in `docs/PLANT_CONTRACT.md`: tensors keep their shapes, but an action now means "pre-filter command"). **All existing trex checkpoints are invalidated** — which is also correct on the merits: both existing checkpoints encode strategies this plant exists to preclude.
- **Physics stays r7** and the statue-derived rails carry unchanged: the statue's zero action filters to zero, so its dynamics and reward are bit-identical (`test_statue_constant_freshness` passes untouched).
- Velociraptor/brachiosaurus/dibothrosuchus: cutoff 0.0, exact legacy step arithmetic, byte-identical policy fingerprints (verified — only the trex manifest entries moved).

## Tests

- New `environments/shared/tests/test_action_filter.py` (13 tests): alpha formula vs the probe's, DC passthrough, Nyquist attenuation, SB3 seed/blend/reseed-across-reset, cutoff-0 legacy-arithmetic preservation, filtered-command-feeds-reward-history, TOML-override rejection on both backends, MJX seed/blend in the real jitted kernel.
- The substep-aggregation witness test now drives its 20 Hz hop on an unfiltered subclass — the aggregation machinery under test is filter-independent, and the cutoff would have hidden the hidden-unloading witness that regression exists to keep.
- Suites run green locally: contract/manifest/catalog (63), MJX env + reward parity + species integration (157), trex env + stance gate + gate report + reward functions + jax eval (382), other species' suites, plus the new filter tests.

## What this sets up

The reward-shaping pack (saturation cost, tail home-pose term, long-range home gradient) follows in a separate PR — those change the reward and need the statue rails re-derived, which this PR deliberately does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb

---
_Generated by [Claude Code](https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb)_