### PR TITLE
Stage-1 reward shaping pack: saturation cost, tail home pose, long-range home gradient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] — Reproducible Runs & Velociraptor Stage-1 Diagnosis (v0.3.6)
 
 ### Changed
+- **T-Rex stage-1 reward shaping pack** — three measured responses to the
+  knee-lock run (`docs/investigations/TREX_STAGE1_NARROW_TOLERANCE_RUN_2026_08.md`),
+  each opt-in with zero defaults in both backends:
+  - **`action_saturation` penalty** (weight 0.5, threshold 0.9): prices
+    commands parked past 90% of their range. A saturated command cannot
+    oscillate, so it was invisible to smoothness/jerk — the run parked six
+    of fifteen actuators at hard stops. The parked stance now pays
+    ~−200/episode; the statue commands zero and pays nothing.
+  - **`tail_home_pose` term** (weight 0.25, tolerance 0.05 rad): prices tail
+    *joint positions*; the existing tail term reads only tail-tip angular
+    velocity, which a tail frozen against a stop satisfies perfectly.
+    Targets are the measured **settled droop**, not the keyframe — the
+    passive tail rests on its ventral stops under gravity
+    (−0.2107/−0.2029/−0.0926 rad with sub-milliradian spread, 40 seeds),
+    so the authored zeros are unreachable and would cap the ideal statue at
+    ~0.25 quality (`TRexEnv._TAIL_SETTLED_QPOS` = MJX registry
+    `tail_home_pose_targets`, pinned equal by the stage-1 factory test).
+  - **Long-range gradient for `leg_home_pose`** (`broad_fraction` 0.25,
+    `broad_scale` 6): mixes a 6×-wider Gaussian into the term so distant
+    poses still feel a pull. The narrow Gaussian's gradient is zero a few
+    widths out, which the run demonstrated by drifting monotonically from
+    0.20 to 0.545 rad of home error without ever being pulled back; at the
+    measured crouch distance the mixture still pays 0.44 quality with live
+    gradient. At home both components are 1, so the maximum is unchanged.
+  Statue rails re-derived with the pack (zero_action_baseline.py seed 3042,
+  40 episodes, noise 0.05; stance_quality_baseline.py agrees): statue
+  3241.3 → **3495.2 ± 13.9** (+250 tail term at its settled targets, ~+4
+  broad-leg at the statue's own sag, +0 saturation), `min_avg_reward`
+  1940 → **2100** (0.60×, nearest 10), `collapse_peak_floor_reference`
+  3241.3 → **3495.2**. Physics stays r7; `statue_constants_physics_revision`
+  unchanged.
 - **T-Rex stage 1 `leg_home_pose_tolerance` narrowed 0.20 → 0.10 rad**, and the
   two statue-derived constants re-derived with it (`min_avg_reward`
   1950 → 1940, `collapse_peak_floor_reference` 3270.3 → 3241.3, both from a

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Apex Predator. **Specialty:** Head-contact attack task.
 
 | Current stage | Objective | SB3 configured budget | SB3 early-advancement gate |
 |---|---|---:|---:|
-| 1 — Balance | Learn to stand and balance without falling | 10M | reward ≥ 1940; full-horizon episodes ≥ 95.0%; unsupported duty ≤ 0.02; unsupported duty 95% upper bound ≤ 0.02; ≥ 40 episodes/evaluation; 3 consecutive passes |
+| 1 — Balance | Learn to stand and balance without falling | 10M | reward ≥ 2100; full-horizon episodes ≥ 95.0%; unsupported duty ≤ 0.02; unsupported duty 95% upper bound ≤ 0.02; ≥ 40 episodes/evaluation; 3 consecutive passes |
 | 2 — Locomotion | Learn forward walking/running | 8M | reward ≥ 100; episode length ≥ 750; avg. velocity ≥ 2 m/s; ≥ 10 episodes/evaluation; 3 consecutive passes |
 | 3 — Bite | Sprint to prey and make contact with the head bite proxy | 8M | reward ≥ 100; task success ≥ 50.0%; ≥ 10 episodes/evaluation; 3 consecutive passes |
 

--- a/configs/trex/stage1_balance.toml
+++ b/configs/trex/stage1_balance.toml
@@ -86,6 +86,37 @@ leg_home_pose_tolerance = 0.10                 # rad; Gaussian width of the home
                                                # (~0.05 rad, hip-pitch gravity sag). 0.075/0.05 are past the knee:
                                                # +23/+33 more differential for -26/-83 more statue reward. The
                                                # statue-derived constants below are re-measured at this width.
+leg_home_pose_broad_fraction = 0.25            # Mixes a second Gaussian 6x wider into the leg term:
+                                               # 0.75*exp(-(e/0.10)^2) + 0.25*exp(-(e/0.60)^2). The 20260809 run
+                                               # falsified the narrow Gaussian as a capture mechanism: home error
+                                               # rose monotonically 0.20 -> 0.545 rad because the gradient is zero
+                                               # a few widths out (narrow-tolerance postmortem section 5). The
+                                               # broad component keeps a pull alive at the crouch's measured
+                                               # distances (0.44 quality at 0.545 rad vs numerically zero) while
+                                               # the narrow one still prices precision; at home both are 1, so the
+                                               # maximum and the statue's near-home pricing are unchanged.
+leg_home_pose_broad_scale = 6.0                # Width multiplier of the broad component. 6x0.10 = 0.60 rad
+                                               # reaches the measured knee-lock offsets (~0.87 rad commanded)
+                                               # with usable gradient; 4x dies by 0.6 rad.
+tail_home_pose_weight = 0.25                   # Prices tail JOINT positions. tail_stability reads only the
+                                               # tail-tip gyro, so a tail parked motionless against a hard stop is
+                                               # optimal for it -- the 20260809 run parked tail_1_yaw, tail_2_pitch
+                                               # and tail_3_pitch exactly that way (all three at stops by 10M).
+tail_home_pose_tolerance = 0.05                # rad; around the SETTLED droop, not the keyframe: the passive tail
+                                               # rests on its ventral stops (tail_1/2 pitch -0.2107/-0.2029, tail_3
+                                               # -0.0926; sub-milliradian spread over 40 seeds at noise 0.05), so
+                                               # the keyframe zeros are unreachable and would cap the statue at
+                                               # ~0.25 quality. Targets live plant-side (TRexEnv._TAIL_SETTLED_QPOS
+                                               # = MJX registry tail_home_pose_targets). At 0.05 the statue scores
+                                               # ~1.0 and every parked-tail pose from the 20260809 run scores ~0.
+action_saturation_weight = 0.5                 # Prices commands parked past |action| = threshold (linear ramp to
+                                               # full range). A saturated command cannot oscillate, so it is
+                                               # invisible to smoothness/jerk -- parking at stops was the cheapest
+                                               # way to be smooth, and the 20260809 run parked 6 of 15 actuators
+                                               # (both knees, head_pitch, the tail chain). At 0.5 that stance pays
+                                               # ~-200/episode; transient corrective saturation of one actuator
+                                               # costs 0.5/15 per step. The statue commands zero and pays nothing.
+action_saturation_threshold = 0.9              # Ramp start; below this saturation is free.
 head_clearance_weight = 0.35                   # Prevent the learned head-droop posture
 head_clearance_target = 0.90                   # m; settled home head tip is ~0.94 m
 head_clearance_tolerance = 0.15                # Smooth transition from zero credit at 0.75 m
@@ -310,7 +341,7 @@ settle_steps = 200                       # [inferred], NOT measured. Duty is sco
 min_eval_episodes = 40                   # The panel size every figure above is specified at. n_eval_episodes must
                                          # match: at n=30 the bound's power and the 28%-rejection analysis no longer
                                          # describe this gate.
-min_avg_reward = 1940.0                 # Collapse RAIL, not the gate (PLANT_VALIDATION §9/§12): no reward threshold
+min_avg_reward = 2100.0                 # Collapse RAIL, not the gate (PLANT_VALIDATION §9/§12): no reward threshold
                                         # can separate a competent policy from a statue, because the statue is the
                                         # reward optimum. Sized to the one job a rail CAN do — rejecting a policy
                                         # that discarded most of the available return — at 0.60 x the statue's
@@ -336,6 +367,15 @@ min_avg_reward = 1940.0                 # Collapse RAIL, not the gate (PLANT_VAL
                                         # ~29 points): statue 3241.3 +/- 14.6, zero_action_baseline.py seed
                                         # 3042, 40 episodes. 0.60 x 3241.3 = 1944.8, rounded to 1940 per the
                                         # nearest-10 convention the species table uses.
+                                        #
+                                        # Re-derived for the 20260810 shaping pack (tail_home_pose 0.25 with
+                                        # settled-droop targets, action_saturation 0.5, leg broad fraction
+                                        # 0.25): statue 3495.2 +/- 13.9, zero_action_baseline.py seed 3042,
+                                        # 40 episodes (stance_quality_baseline.py agrees). The +254 over
+                                        # 3241.3 decomposes as ~+250 tail term (statue tail quality ~1.0 at
+                                        # the settled targets) + ~+4 broad-leg component at the statue's own
+                                        # sag; saturation adds 0 (the statue commands zero). 0.60 x 3495.2 =
+                                        # 2097.1, rounded to 2100 per the nearest-10 convention.
                                         #
                                         # Why 0.60 and not §12's 0.89: the measured collapse (run 20260731_132102,
                                         # full-horizon 93% -> 7%) bottomed at 888 = 0.27 x statue, so 0.60 clears
@@ -412,12 +452,13 @@ collapse_peak_warmup_timesteps = 1000000 # Evaluations before this step cannot S
                                          # post-150k rolling median in that run is 580.5, well under 1472.3. A
                                          # larger warm-up buys nothing and costs coverage: 1.0M leaves 88% of a 10M
                                          # budget protected, 2.5M only 72%.
-collapse_peak_floor_reference = 3241.3   # The zero-action statue's standing reward at noise 0.05, 40 episodes,
-                                         # measured on the passive-toes plant (physics r7) at
-                                         # leg_home_pose_tolerance 0.10. History: 3271.8 on the r6 plant,
-                                         # 3270.3 on r7 at tolerance 0.20; the -29 from narrowing the
-                                         # tolerance is the statue's own hip-pitch settle sag being priced by
-                                         # the sharper Gaussian, measured, not assumed. Briefly 4250.4 while leg_home_pose_weight was
+collapse_peak_floor_reference = 3495.2   # The zero-action statue's standing reward at noise 0.05, 40 episodes,
+                                         # measured on the passive-toes plant (physics r7) with the 20260810
+                                         # shaping pack. History: 3271.8 on the r6 plant, 3270.3 on r7 at
+                                         # tolerance 0.20, 3241.3 at tolerance 0.10; now +254 from the tail
+                                         # home-pose term paying ~1.0 at its settled-droop targets plus the
+                                         # broad-leg component at the statue's own sag, measured, not
+                                         # assumed. Briefly 4250.4 while leg_home_pose_weight was
                                          # 1.5; reverted with it (issue #491). Re-measure this whenever a reward
                                          # weight OR the plant changes: a weight change rescales the statue's
                                          # terms exactly and cheaply; a plant change moves its trajectory, so

--- a/environments/shared/diagnostics.py
+++ b/environments/shared/diagnostics.py
@@ -123,6 +123,8 @@ class DiagnosticsCallback(_BaseCallback):
         "reward_leg_home_pose",
         "reward_head_clearance",
         "reward_neck_posture",
+        "reward_tail_home_pose",
+        "reward_action_saturation",
         "reward_total",
     ]
     INFO_KEYS = [
@@ -163,6 +165,9 @@ class DiagnosticsCallback(_BaseCallback):
         "head_food_distance",  # Brachiosaurus
         "torso_height",  # Brachiosaurus
         "jaw_distance",  # T-Rex
+        # Fraction of actuators parked past the saturation threshold — the
+        # raw signal behind reward_action_saturation.
+        "action_saturation",
         *STANCE_INFO_KEYS,
     ]
 

--- a/environments/shared/jax_reward_termination.py
+++ b/environments/shared/jax_reward_termination.py
@@ -20,6 +20,7 @@ from .reward_functions import (
     quat_to_forward_2d,
     quat_to_forward_z,
     quat_to_tilt,
+    reward_action_saturation,
     reward_action_smoothness,
     reward_alive,
     reward_angular_velocity_penalty,
@@ -88,6 +89,8 @@ def compute_total_reward(
     leg_home_pose_targets: Array | None = None,
     neck_posture_qpos_indices: tuple[int, ...] = (),
     neck_posture_targets: Array | None = None,
+    tail_home_pose_qpos_indices: tuple[int, ...] = (),
+    tail_home_pose_targets: Array | None = None,
     head_clearance_site_id: int | None = None,
     prev_action: Array | None = None,
     initial_pos_2d: Array | None = None,
@@ -223,6 +226,8 @@ def compute_total_reward(
             leg_home_pose_targets,
             reward_cfg.get("leg_home_pose_tolerance", 0.35),
             leg_home_pose_w,
+            reward_cfg.get("leg_home_pose_broad_fraction", 0.0),
+            reward_cfg.get("leg_home_pose_broad_scale", 6.0),
         )
         total = total + r_leg_home_pose
 
@@ -246,6 +251,26 @@ def compute_total_reward(
             neck_posture_w,
         )
         total = total + r_neck_posture
+
+    tail_home_pose_w = reward_cfg.get("tail_home_pose_weight", 0.0)
+    if tail_home_pose_w > 0 and tail_home_pose_targets is not None:
+        tail_joint_positions = jnp.take(data.qpos, jnp.asarray(tail_home_pose_qpos_indices))
+        r_tail_home_pose, _, _ = reward_soft_home_pose(
+            tail_joint_positions,
+            tail_home_pose_targets,
+            reward_cfg.get("tail_home_pose_tolerance", 0.10),
+            tail_home_pose_w,
+        )
+        total = total + r_tail_home_pose
+
+    action_saturation_w = reward_cfg.get("action_saturation_weight", 0.0)
+    if action_saturation_w > 0:
+        r_action_saturation, _ = reward_action_saturation(
+            action,
+            action_saturation_w,
+            reward_cfg.get("action_saturation_threshold", 0.9),
+        )
+        total = total + r_action_saturation
 
     nosedive_w = reward_cfg.get("nosedive_weight", 0.0)
     if nosedive_w > 0:
@@ -360,6 +385,8 @@ def compute_reward_components(
     leg_home_pose_targets: Array | None = None,
     neck_posture_qpos_indices: tuple[int, ...] = (),
     neck_posture_targets: Array | None = None,
+    tail_home_pose_qpos_indices: tuple[int, ...] = (),
+    tail_home_pose_targets: Array | None = None,
     head_clearance_site_id: int | None = None,
     prev_action: Array | None = None,
     initial_pos_2d: Array | None = None,
@@ -470,6 +497,8 @@ def compute_reward_components(
             leg_home_pose_targets,
             reward_cfg.get("leg_home_pose_tolerance", 0.35),
             reward_cfg.get("leg_home_pose_weight", 0.0),
+            reward_cfg.get("leg_home_pose_broad_fraction", 0.0),
+            reward_cfg.get("leg_home_pose_broad_scale", 6.0),
         )
         components["leg_home_pose"] = r_leg_home_pose
         components["_leg_home_pose_error"] = leg_home_pose_error
@@ -499,6 +528,28 @@ def compute_reward_components(
         components["neck_posture"] = r_neck_posture
         components["_neck_posture_error"] = neck_posture_error
         components["_neck_posture_quality"] = neck_posture_quality
+
+    if tail_home_pose_targets is not None:
+        tail_joint_positions = jnp.take(data.qpos, jnp.asarray(tail_home_pose_qpos_indices))
+        r_tail_home_pose, tail_home_pose_error, tail_home_pose_quality = reward_soft_home_pose(
+            tail_joint_positions,
+            tail_home_pose_targets,
+            reward_cfg.get("tail_home_pose_tolerance", 0.10),
+            reward_cfg.get("tail_home_pose_weight", 0.0),
+        )
+        components["tail_home_pose"] = r_tail_home_pose
+        components["_tail_home_pose_error"] = tail_home_pose_error
+        components["_tail_home_pose_quality"] = tail_home_pose_quality
+
+    action_saturation_w = reward_cfg.get("action_saturation_weight", 0.0)
+    if action_saturation_w > 0:
+        r_action_saturation, action_saturation = reward_action_saturation(
+            action,
+            action_saturation_w,
+            reward_cfg.get("action_saturation_threshold", 0.9),
+        )
+        components["action_saturation"] = r_action_saturation
+        components["_action_saturation_fraction"] = action_saturation
 
     nosedive_w = reward_cfg.get("nosedive_weight", 0.0)
     if nosedive_w > 0:

--- a/environments/shared/jax_setup.py
+++ b/environments/shared/jax_setup.py
@@ -551,6 +551,14 @@ def make_reward_fns(ctx: SpeciesContext):
         ctx.mj_model,
         tuple(geometry_value("neck_posture_joint_names", ())),
     )
+    tail_home_pose_qpos_indices, tail_home_pose_targets = _resolve_home_pose_joints(
+        ctx.mj_model,
+        tuple(geometry_value("tail_home_pose_joint_names", ())),
+    )
+    explicit_tail_targets = tuple(geometry_value("tail_home_pose_targets", ()))
+    if explicit_tail_targets:
+        # Statue-derived settled pose overrides the keyframe (see MJXEnvConfig).
+        tail_home_pose_targets = tuple(float(v) for v in explicit_tail_targets)
     head_clearance_site_id = None
     head_clearance_site = geometry_value("head_clearance_site")
     if head_clearance_site is not None:
@@ -594,6 +602,8 @@ def make_reward_fns(ctx: SpeciesContext):
         leg_home_pose_targets=jnp.asarray(leg_home_pose_targets) if leg_home_pose_targets else None,
         neck_posture_qpos_indices=neck_posture_qpos_indices,
         neck_posture_targets=jnp.asarray(neck_posture_targets) if neck_posture_targets else None,
+        tail_home_pose_qpos_indices=tail_home_pose_qpos_indices,
+        tail_home_pose_targets=jnp.asarray(tail_home_pose_targets) if tail_home_pose_targets else None,
         head_clearance_site_id=head_clearance_site_id,
         sensor_tail_gyro_start=ctx.sensor_tail_gyro_start,
         forward_vel_max=ctx.forward_vel_max,

--- a/environments/shared/mjx_env.py
+++ b/environments/shared/mjx_env.py
@@ -100,6 +100,12 @@ _KNOWN_REWARD_KEYS: frozenset = frozenset(
         "head_clearance_tolerance",
         "neck_posture_weight",
         "neck_posture_tolerance",
+        "tail_home_pose_weight",
+        "tail_home_pose_tolerance",
+        "action_saturation_weight",
+        "action_saturation_threshold",
+        "leg_home_pose_broad_fraction",
+        "leg_home_pose_broad_scale",
         "height_target_tolerance",
     }
 )
@@ -222,6 +228,12 @@ class MJXEnvConfig:
     # weights does not change the checkpoint-facing plant interface.
     leg_home_pose_joint_names: tuple[str, ...] = ()
     neck_posture_joint_names: tuple[str, ...] = ()
+    tail_home_pose_joint_names: tuple[str, ...] = ()
+    # Optional explicit targets for tail_home_pose_joint_names, in the same
+    # order.  Empty falls back to the home keyframe.  Exists because a
+    # passive tail's reachable rest pose is the settled droop, not the
+    # authored keyframe (statue-derived, like target_standing_z).
+    tail_home_pose_targets: tuple[float, ...] = ()
     head_clearance_site: str | None = None
     # Reset noise parameters
     reset_noise_scale: float = 0.0  # Joint angle perturbation range
@@ -674,8 +686,17 @@ class MJXDinoEnv:
             self._neck_posture_qpos_indices,
             neck_posture_targets,
         ) = _resolve_home_pose_joints(self.mj_model, self.config.neck_posture_joint_names)
+        (
+            self._tail_home_pose_qpos_indices,
+            tail_home_pose_targets,
+        ) = _resolve_home_pose_joints(self.mj_model, self.config.tail_home_pose_joint_names)
+        if self.config.tail_home_pose_targets:
+            if len(self.config.tail_home_pose_targets) != len(self.config.tail_home_pose_joint_names):
+                raise ValueError("tail_home_pose_targets must match tail_home_pose_joint_names in length")
+            tail_home_pose_targets = tuple(float(v) for v in self.config.tail_home_pose_targets)
         self._leg_home_pose_targets = jnp.asarray(leg_home_pose_targets)
         self._neck_posture_targets = jnp.asarray(neck_posture_targets)
+        self._tail_home_pose_targets = jnp.asarray(tail_home_pose_targets)
         self._head_clearance_site_id: int | None = None
         if self.config.head_clearance_site is not None:
             head_clearance_site_id = mujoco.mj_name2id(
@@ -692,6 +713,8 @@ class MJXDinoEnv:
             raise ValueError("leg_home_pose_weight requires configured leg_home_pose_joint_names")
         if reward_weights.get("neck_posture_weight", 0.0) > 0 and not self._neck_posture_qpos_indices:
             raise ValueError("neck_posture_weight requires configured neck_posture_joint_names")
+        if reward_weights.get("tail_home_pose_weight", 0.0) > 0 and not self._tail_home_pose_qpos_indices:
+            raise ValueError("tail_home_pose_weight requires configured tail_home_pose_joint_names")
         if reward_weights.get("head_clearance_weight", 0.0) > 0 and self._head_clearance_site_id is None:
             raise ValueError("head_clearance_weight requires a configured head_clearance_site")
         if (
@@ -708,6 +731,7 @@ class MJXDinoEnv:
             ("leg_home_pose_weight", "leg_home_pose_tolerance"),
             ("head_clearance_weight", "head_clearance_tolerance"),
             ("neck_posture_weight", "neck_posture_tolerance"),
+            ("tail_home_pose_weight", "tail_home_pose_tolerance"),
         ):
             if reward_weights.get(weight_key, 0.0) > 0 and reward_weights.get(tolerance_key, 0.0) <= 0:
                 raise ValueError(f"{tolerance_key} must be positive when {weight_key} is enabled")
@@ -784,6 +808,7 @@ class MJXDinoEnv:
             quat_to_forward_2d,
             quat_to_forward_z,
             reward_action_jerk,
+            reward_action_saturation,
             reward_action_smoothness,
             reward_alive,
             reward_angular_velocity_penalty,
@@ -831,6 +856,8 @@ class MJXDinoEnv:
         leg_home_pose_targets = self._leg_home_pose_targets
         neck_posture_qpos_indices = self._neck_posture_qpos_indices
         neck_posture_targets = self._neck_posture_targets
+        tail_home_pose_qpos_indices = self._tail_home_pose_qpos_indices
+        tail_home_pose_targets = self._tail_home_pose_targets
         head_clearance_site_id = self._head_clearance_site_id
 
         def step_fn(state: EnvState, action, rng, forward_vel_scale):
@@ -1055,8 +1082,30 @@ class MJXDinoEnv:
                     leg_home_pose_targets,
                     weights.get("leg_home_pose_tolerance", 0.35),
                     leg_home_pose_w,
+                    weights.get("leg_home_pose_broad_fraction", 0.0),
+                    weights.get("leg_home_pose_broad_scale", 6.0),
                 )
                 total_reward = total_reward + r_leg_home_pose
+
+            tail_home_pose_w = weights.get("tail_home_pose_weight", 0.0)
+            if tail_home_pose_w > 0:
+                tail_joint_positions = jnp.take(data.qpos, jnp.asarray(tail_home_pose_qpos_indices))
+                r_tail_home_pose, _, _ = reward_soft_home_pose(
+                    tail_joint_positions,
+                    tail_home_pose_targets,
+                    weights.get("tail_home_pose_tolerance", 0.10),
+                    tail_home_pose_w,
+                )
+                total_reward = total_reward + r_tail_home_pose
+
+            action_saturation_w = weights.get("action_saturation_weight", 0.0)
+            if action_saturation_w > 0:
+                r_action_saturation, _ = reward_action_saturation(
+                    action,
+                    action_saturation_w,
+                    weights.get("action_saturation_threshold", 0.9),
+                )
+                total_reward = total_reward + r_action_saturation
 
             head_clearance_w = weights.get("head_clearance_weight", 0.0)
             if head_clearance_w > 0 and head_clearance_site_id is not None:

--- a/environments/shared/reward_functions.py
+++ b/environments/shared/reward_functions.py
@@ -414,6 +414,8 @@ def reward_soft_home_pose(
     home_positions: Array,
     tolerance: float,
     weight: float,
+    broad_fraction: float = 0.0,
+    broad_scale: float = 6.0,
 ) -> tuple[Array, Array, Array]:
     """Reward a soft joint-space neighbourhood around an XML home pose.
 
@@ -422,6 +424,17 @@ def reward_soft_home_pose(
     shaping on every other joint while the RMS remains an intuitive raw
     diagnostic.
 
+    ``broad_fraction`` > 0 mixes in a second Gaussian ``broad_scale`` times
+    wider: ``(1-f) * exp(-(e/tol)^2) + f * exp(-(e/(s*tol))^2)``.  A single
+    narrow Gaussian's gradient is zero to machine precision a few tolerance
+    widths out, so it can pay a basin it cannot attract anything toward —
+    the 2026-08 narrow-tolerance run drifted from 0.20 to 0.545 rad of home
+    error without ever feeling a restoring force.  The broad component
+    keeps a pull alive at those distances while the narrow one still prices
+    precision near home; at home both components are 1, so the maximum is
+    unchanged.  The default (0.0) preserves the historical single-Gaussian
+    behaviour exactly.
+
     Returns:
         ``(reward, rms_error, mean_pose_quality)``.
     """
@@ -429,8 +442,41 @@ def reward_soft_home_pose(
     safe_tolerance = xp.maximum(tolerance, 1e-8)
     error = joint_positions - home_positions
     rms_error = xp.sqrt(xp.mean(xp.square(error)))
-    pose_quality = xp.mean(xp.exp(-xp.square(error / safe_tolerance)))
+    narrow = xp.exp(-xp.square(error / safe_tolerance))
+    if broad_fraction > 0.0:
+        broad = xp.exp(-xp.square(error / (broad_scale * safe_tolerance)))
+        per_joint = (1.0 - broad_fraction) * narrow + broad_fraction * broad
+    else:
+        per_joint = narrow
+    pose_quality = xp.mean(per_joint)
     return weight * pose_quality, rms_error, pose_quality
+
+
+def reward_action_saturation(
+    action: Array,
+    weight: float,
+    threshold: float = 0.9,
+) -> tuple[Array, Array]:
+    """Penalise commands parked against their range limits.
+
+    Per actuator, the cost ramps linearly from 0 at ``|action| = threshold``
+    to 1 at full saturation, and the term is the mean across actuators.  A
+    saturated command is invisible to the smoothness and jerk penalties —
+    it cannot oscillate — which made "pin the joint at its stop" the
+    cheapest way to be smooth: the 2026-08 narrow-tolerance run parked six
+    of fifteen actuators at hard stops.  This prices that exploit directly.
+    Transient saturation during a genuine correction stays cheap (one
+    actuator briefly saturated costs ``weight/n`` per step); only a parked
+    channel pays the full rate.
+
+    Returns:
+        ``(reward, saturation_fraction)``.
+    """
+    xp = _array_mod(action)
+    span = max(1.0 - threshold, 1e-8)
+    excess = xp.clip((xp.abs(action) - threshold) / span, 0.0, 1.0)
+    saturation_fraction = xp.mean(excess)
+    return -weight * saturation_fraction, saturation_fraction
 
 
 def reward_head_clearance(

--- a/environments/shared/tests/test_reward_functions.py
+++ b/environments/shared/tests/test_reward_functions.py
@@ -15,6 +15,7 @@ from environments.shared.reward_functions import (
     quat_to_forward_z,
     quat_to_tilt,
     reward_action_jerk,
+    reward_action_saturation,
     reward_action_smoothness,
     reward_alive,
     reward_approach_shaping,
@@ -584,3 +585,75 @@ class TestActionJerkIsFrequencyAware:
         buzz = [np.full(self.N, (-1.0) ** t) for t in (0, 1, 2)]
         reward, _ = reward_action_jerk(buzz[2], buzz[1], buzz[0], self.N, 0.0)
         assert float(reward) == pytest.approx(0.0)
+
+
+class TestActionSaturation:
+    def test_zero_below_threshold(self):
+        reward, fraction = reward_action_saturation(np.array([0.0, 0.5, -0.89, 0.9]), 1.0, 0.9)
+        assert float(reward) == pytest.approx(0.0)
+        assert float(fraction) == pytest.approx(0.0)
+
+    def test_full_pin_pays_full_rate(self):
+        reward, fraction = reward_action_saturation(np.array([1.0, -1.0]), 0.5, 0.9)
+        assert float(fraction) == pytest.approx(1.0)
+        assert float(reward) == pytest.approx(-0.5)
+
+    def test_linear_ramp_and_mean_across_actuators(self):
+        # One actuator halfway up the ramp (|a|=0.95 with threshold 0.9),
+        # three quiet: fraction = 0.5/4.
+        action = np.array([0.95, 0.0, 0.0, 0.0])
+        _, fraction = reward_action_saturation(action, 1.0, 0.9)
+        assert float(fraction) == pytest.approx(0.125)
+
+    def test_clip_beyond_range(self):
+        # Raw policy outputs can exceed [-1, 1]; the ramp saturates at 1.
+        _, fraction = reward_action_saturation(np.array([3.0]), 1.0, 0.9)
+        assert float(fraction) == pytest.approx(1.0)
+
+
+class TestSoftHomePoseBroadTail:
+    def test_default_preserves_single_gaussian(self):
+        positions = np.array([0.3, -0.1])
+        home = np.zeros(2)
+        legacy = np.mean(np.exp(-np.square(positions / 0.1)))
+        reward, _, quality = reward_soft_home_pose(positions, home, 0.1, 0.5)
+        assert float(quality) == pytest.approx(legacy)
+        assert float(reward) == pytest.approx(0.5 * legacy)
+
+    def test_maximum_unchanged_at_home(self):
+        home = np.array([0.2, -0.4])
+        _, _, quality = reward_soft_home_pose(home, home, 0.1, 1.0, 0.25, 6.0)
+        assert float(quality) == pytest.approx(1.0)
+
+    def test_broad_tail_keeps_gradient_at_long_range(self):
+        # At 5 tolerance widths the narrow Gaussian is numerically dead;
+        # the mixture must still strictly prefer the closer pose.
+        home = np.zeros(3)
+        far = np.full(3, 0.50)
+        nearer = np.full(3, 0.45)
+        _, _, q_far = reward_soft_home_pose(far, home, 0.1, 1.0, 0.25, 6.0)
+        _, _, q_nearer = reward_soft_home_pose(nearer, home, 0.1, 1.0, 0.25, 6.0)
+        assert float(q_nearer) > float(q_far) + 1e-4
+        # And without the tail, the same comparison is flat to 1e-6.
+        _, _, q_far_n = reward_soft_home_pose(far, home, 0.1, 1.0)
+        _, _, q_nearer_n = reward_soft_home_pose(nearer, home, 0.1, 1.0)
+        assert abs(float(q_nearer_n) - float(q_far_n)) < 1e-6
+
+
+@pytest.mark.skipif(not _has_jax, reason="JAX not installed")
+class TestNewTermsNumpyJaxParity:
+    def test_action_saturation_parity(self):
+        action = np.array([0.97, -1.0, 0.2, -0.85])
+        r_np, f_np = reward_action_saturation(action, 0.5, 0.9)
+        r_jax, f_jax = reward_action_saturation(jnp.array(action), 0.5, 0.9)
+        assert float(r_np) == pytest.approx(float(r_jax), abs=1e-6)
+        assert float(f_np) == pytest.approx(float(f_jax), abs=1e-6)
+
+    def test_soft_home_pose_broad_tail_parity(self):
+        positions = np.array([0.31, -0.52, 0.07, 0.44])
+        home = np.array([-0.045, 0.0, -0.433, 1.342])
+        r_np, e_np, q_np = reward_soft_home_pose(positions, home, 0.1, 0.5, 0.25, 6.0)
+        r_jax, e_jax, q_jax = reward_soft_home_pose(jnp.array(positions), jnp.array(home), 0.1, 0.5, 0.25, 6.0)
+        assert float(r_np) == pytest.approx(float(r_jax), abs=1e-6)
+        assert float(e_np) == pytest.approx(float(e_jax), abs=1e-6)
+        assert float(q_np) == pytest.approx(float(q_jax), abs=1e-6)

--- a/environments/shared/tests/test_species_catalog.py
+++ b/environments/shared/tests/test_species_catalog.py
@@ -153,9 +153,11 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
     # Stage-1 reward gates are COLLAPSE RAILS: 0.60 x each species' zero-action
     # statue standing reward at the 1a operating point (reset noise 0.05),
     # measured over 40 episodes with
-    # environments/shared/scripts/stance_quality_baseline.py -- trex 3241.3
-    # (physics r7 at leg_home_pose_tolerance 0.10; 3270.3 at tolerance 0.20,
-    # 3271.8 on the r6 plant), velociraptor 1745.8, brachiosaurus 1739.1 (on
+    # environments/shared/scripts/stance_quality_baseline.py -- trex 3495.2
+    # (physics r7 with the 20260810 shaping pack: tail_home_pose 0.25 at the
+    # settled-droop targets, action_saturation 0.5, leg broad fraction 0.25;
+    # 3241.3 before the pack, 3270.3 at tolerance 0.20, 3271.8 on the r6
+    # plant), velociraptor 1745.8, brachiosaurus 1739.1 (on
     # the plant repaired by plant_versions notes 7-8), dibothrosuchus 2598.3.
     #
     # A rail sits BELOW its statue deliberately. Section 9 showed the statue
@@ -176,10 +178,10 @@ def test_catalog_exports_effective_early_advancement_gates() -> None:
         # 0.60 x the statue's standing reward at leg_home_pose_weight 0.5.
         # Was briefly 2550 while that weight was 1.5 (statue 4250.4), reverted
         # with it in issue #491. The FRACTION is the invariant, not the reward.
-        # Re-derived when leg_home_pose_tolerance narrowed to 0.10: the
-        # sharper Gaussian prices the statue's own settle sag, statue
-        # 3270.3 -> 3241.3, x0.60 = 1944.8 -> 1940 nearest-10.
-        "trex": 1940.0,
+        # Re-derived at tolerance 0.10 (statue 3241.3 -> rail 1940), then
+        # again for the 20260810 shaping pack: statue 3495.2, x0.60 = 2097.1
+        # -> 2100 nearest-10.
+        "trex": 2100.0,
         "velociraptor": 1050.0,
         "brachiosaurus": 1040.0,
         "dibothrosuchus": 1560.0,

--- a/environments/shared/visualization.py
+++ b/environments/shared/visualization.py
@@ -228,6 +228,8 @@ def plot_diagnostics_graphs(
         "reward_leg_home_pose": ("leg_home_pose_weight",),
         "reward_head_clearance": ("head_clearance_weight",),
         "reward_neck_posture": ("neck_posture_weight",),
+        "reward_tail_home_pose": ("tail_home_pose_weight",),
+        "reward_action_saturation": ("action_saturation_weight",),
         "reward_smoothness": ("smoothness_weight",),
         "reward_heading": ("heading_weight",),
         "reward_lateral": ("lateral_penalty_weight",),

--- a/environments/trex/envs/trex_env.py
+++ b/environments/trex/envs/trex_env.py
@@ -61,6 +61,9 @@ import numpy as np
 
 from environments.shared.base_env import BaseDinoEnv
 from environments.shared.reward_functions import (
+    reward_action_saturation as _reward_action_saturation_pure,
+)
+from environments.shared.reward_functions import (
     reward_bilateral_support as _reward_bilateral_support_pure,
 )
 from environments.shared.reward_functions import (
@@ -81,6 +84,10 @@ class TRexEnv(BaseDinoEnv):
     """Tyrannosaurus Rex bipedal locomotion and bite-attack environment."""
 
     action_mapping = "home-keyframe-residual/v1"
+    # Settled tail pose for the tail_home_pose term, in tail_home_joint_names
+    # order (tail_1_pitch, tail_1_yaw, tail_2_pitch, tail_3_pitch); see the
+    # provenance comment in _cache_ids.
+    _TAIL_SETTLED_QPOS = (-0.2107, 0.0, -0.2029, -0.0926)
     _camera_distance = 3.0
     _camera_azimuth = 135
     _camera_elevation = -20
@@ -133,6 +140,12 @@ class TRexEnv(BaseDinoEnv):
         head_clearance_tolerance: float = 0.48,
         neck_posture_weight: float = 0.0,
         neck_posture_tolerance: float = 0.35,
+        tail_home_pose_weight: float = 0.0,
+        tail_home_pose_tolerance: float = 0.10,
+        action_saturation_weight: float = 0.0,
+        action_saturation_threshold: float = 0.9,
+        leg_home_pose_broad_fraction: float = 0.0,
+        leg_home_pose_broad_scale: float = 6.0,
         nosedive_termination_threshold: float = 0.62,
         # Environment settings
         prey_distance_range: tuple[float, float] = (3.0, 8.0),
@@ -202,6 +215,12 @@ class TRexEnv(BaseDinoEnv):
         self.head_clearance_tolerance = head_clearance_tolerance
         self.neck_posture_weight = neck_posture_weight
         self.neck_posture_tolerance = neck_posture_tolerance
+        self.tail_home_pose_weight = tail_home_pose_weight
+        self.tail_home_pose_tolerance = tail_home_pose_tolerance
+        self.action_saturation_weight = action_saturation_weight
+        self.action_saturation_threshold = action_saturation_threshold
+        self.leg_home_pose_broad_fraction = leg_home_pose_broad_fraction
+        self.leg_home_pose_broad_scale = leg_home_pose_broad_scale
         self.nosedive_termination_threshold = nosedive_termination_threshold
 
         if self.height_target_tolerance < 0.0:
@@ -216,6 +235,14 @@ class TRexEnv(BaseDinoEnv):
             raise ValueError("head_clearance_tolerance must be positive")
         if self.neck_posture_tolerance <= 0.0:
             raise ValueError("neck_posture_tolerance must be positive")
+        if self.tail_home_pose_tolerance <= 0.0:
+            raise ValueError("tail_home_pose_tolerance must be positive")
+        if not 0.0 <= self.action_saturation_threshold < 1.0:
+            raise ValueError("action_saturation_threshold must be in [0, 1)")
+        if not 0.0 <= self.leg_home_pose_broad_fraction <= 1.0:
+            raise ValueError("leg_home_pose_broad_fraction must be in [0, 1]")
+        if self.leg_home_pose_broad_scale <= 1.0:
+            raise ValueError("leg_home_pose_broad_scale must exceed 1 (it widens the narrow Gaussian)")
 
         # Natural forward pitch (~1.55°), measured: the pelvis frame at the home
         # keyframe is level, and under the home controller the plant settles at
@@ -365,11 +392,29 @@ class TRexEnv(BaseDinoEnv):
             "l_ankle",
         )
         neck_home_joint_names = ("neck_pitch", "neck_yaw", "head_pitch")
+        # The tail term prices JOINT positions.  The pre-existing tail
+        # stability term reads only tail-tip angular velocity, which a tail
+        # parked motionless against a hard stop satisfies perfectly -- the
+        # 2026-08 narrow-tolerance run parked all three of tail_1_yaw,
+        # tail_2_pitch and tail_3_pitch that way.
+        tail_home_joint_names = ("tail_1_pitch", "tail_1_yaw", "tail_2_pitch", "tail_3_pitch")
         self._leg_home_qpos_indices = self._joint_qpos_indices(leg_home_joint_names)
         self._neck_home_qpos_indices = self._joint_qpos_indices(neck_home_joint_names)
+        self._tail_home_qpos_indices = self._joint_qpos_indices(tail_home_joint_names)
         home_qpos = self.model.key_qpos[self.home_keyframe_id]
         self._leg_home_qpos = home_qpos[self._leg_home_qpos_indices].copy()
         self._neck_home_qpos = home_qpos[self._neck_home_qpos_indices].copy()
+        # Statue-derived, NOT the keyframe: the passive tail cannot hold the
+        # authored zeros against gravity -- under the home controller it
+        # settles onto its ventral stops (tail_1/tail_2 pitch at
+        # -0.2107/-0.2029 rad against the -0.2094 stop, tail_3 at -0.0926)
+        # with sub-milliradian spread across 40 seeds at reset noise 0.05.
+        # Pricing the keyframe would cap the ideal statue at ~0.25 quality,
+        # so the term targets the settled droop instead (the
+        # target_standing_z = 0.9260 precedent).  Must match the MJX
+        # registry's tail_home_pose_targets (environments/trex/mjx_config.py);
+        # re-measure whenever tail masses, springs, or gains change.
+        self._tail_home_qpos = np.array(self._TAIL_SETTLED_QPOS)
 
     def _joint_qpos_indices(self, joint_names: tuple[str, ...]) -> np.ndarray:
         """Resolve scalar hinge-joint qpos addresses, failing on model drift."""
@@ -422,6 +467,8 @@ class TRexEnv(BaseDinoEnv):
         qpos_indices: np.ndarray,
         target_qpos: np.ndarray,
         tolerance: float,
+        broad_fraction: float = 0.0,
+        broad_scale: float = 6.0,
     ) -> tuple[float, float]:
         """Return RMS joint error and a smooth bounded home-pose quality."""
         _, rms_error, quality = _reward_soft_home_pose_pure(
@@ -429,6 +476,8 @@ class TRexEnv(BaseDinoEnv):
             target_qpos,
             tolerance,
             1.0,
+            broad_fraction,
+            broad_scale,
         )
         return float(rms_error), float(quality)
 
@@ -642,6 +691,19 @@ class TRexEnv(BaseDinoEnv):
         info["neck_posture_quality"] = neck_posture_quality
         info["reward_neck_posture"] = reward_neck_posture
 
+        # 6b. Tail home pose.  The tail stability term (6) reads only the
+        # tail-tip gyro, so a tail frozen against a hard stop is optimal for
+        # it; this prices the joint positions themselves.
+        tail_home_pose_error, tail_home_pose_quality = self._home_pose_quality(
+            self._tail_home_qpos_indices,
+            self._tail_home_qpos,
+            self.tail_home_pose_tolerance,
+        )
+        reward_tail_home_pose = self.tail_home_pose_weight * tail_home_pose_quality
+        info["tail_home_pose_error"] = tail_home_pose_error
+        info["tail_home_pose_quality"] = tail_home_pose_quality
+        info["reward_tail_home_pose"] = reward_tail_home_pose
+
         # 7. Continuous posture reward
         pelvis_quat = self.data.sensordata[self._sensor_quat_start : self._sensor_quat_start + 4]
         reward_posture, tilt_angle = self._compute_posture_reward(pelvis_quat, self.posture_weight)
@@ -699,6 +761,8 @@ class TRexEnv(BaseDinoEnv):
             self._leg_home_qpos_indices,
             self._leg_home_qpos,
             self.leg_home_pose_tolerance,
+            self.leg_home_pose_broad_fraction,
+            self.leg_home_pose_broad_scale,
         )
         reward_leg_home_pose = self.leg_home_pose_weight * leg_home_pose_quality
         info["leg_home_pose_error"] = leg_home_pose_error
@@ -724,6 +788,16 @@ class TRexEnv(BaseDinoEnv):
         reward_smoothness, action_delta = self._reward_action_smoothness(action)
         info["action_delta"] = action_delta
         info["reward_smoothness"] = reward_smoothness
+
+        # 10b. Saturation cost.  A command pinned at a range limit is
+        # invisible to the smoothness/jerk penalties above -- it cannot
+        # oscillate -- so parking joints at stops was the cheapest way to
+        # be smooth.  Price the parked fraction directly.
+        reward_action_saturation, action_saturation = _reward_action_saturation_pure(
+            action, self.action_saturation_weight, self.action_saturation_threshold
+        )
+        info["action_saturation"] = float(action_saturation)
+        info["reward_action_saturation"] = float(reward_action_saturation)
 
         # 11. Heading alignment
         body_forward_2d = self._quat_to_forward_2d(pelvis_quat)
@@ -776,6 +850,7 @@ class TRexEnv(BaseDinoEnv):
             + reward_head_proximity
             + reward_head_clearance
             + reward_neck_posture
+            + reward_tail_home_pose
             + reward_posture
             + reward_nosedive
             + reward_height
@@ -785,6 +860,7 @@ class TRexEnv(BaseDinoEnv):
             + reward_gait
             + reward_smoothness
             + reward_action_jerk
+            + reward_action_saturation
             + reward_heading
             + reward_lateral
             + reward_spin

--- a/environments/trex/mjx_config.py
+++ b/environments/trex/mjx_config.py
@@ -77,6 +77,15 @@ register_species_mjx(
         "l_ankle",
     ),
     neck_posture_joint_names=("neck_pitch", "neck_yaw", "head_pitch"),
+    # Joint-position targets for the tail home-pose term; the tail stability
+    # term reads only the tail-tip gyro, which a tail parked at a stop
+    # satisfies perfectly (2026-08 narrow-tolerance run).
+    tail_home_pose_joint_names=("tail_1_pitch", "tail_1_yaw", "tail_2_pitch", "tail_3_pitch"),
+    # Statue-derived settled droop, NOT the keyframe zeros: the passive tail
+    # rests on its ventral stops under gravity (sub-milliradian spread, 40
+    # seeds, noise 0.05).  Must match TRexEnv._TAIL_SETTLED_QPOS; the stage-1
+    # factory test pins the agreement.
+    tail_home_pose_targets=(-0.2107, 0.0, -0.2029, -0.0926),
     head_clearance_site="head_tip",
     termination_body_heights={
         "skull": 0.45,  # raised from 0.15: skull body origin must stay above ~half standing height
@@ -130,6 +139,12 @@ register_species_mjx(
         "head_clearance_tolerance": 0.48,
         "neck_posture_weight": 0.0,
         "neck_posture_tolerance": 0.35,
+        "tail_home_pose_weight": 0.0,
+        "tail_home_pose_tolerance": 0.10,
+        "action_saturation_weight": 0.0,
+        "action_saturation_threshold": 0.9,
+        "leg_home_pose_broad_fraction": 0.0,
+        "leg_home_pose_broad_scale": 6.0,
         "height_target_tolerance": 0.0,
     },
 )

--- a/environments/trex/tests/test_trex_mjx_reward_parity.py
+++ b/environments/trex/tests/test_trex_mjx_reward_parity.py
@@ -49,6 +49,12 @@ def _stance_only_env():
         head_clearance_tolerance=0.15,
         neck_posture_weight=0.20,
         neck_posture_tolerance=0.35,
+        tail_home_pose_weight=0.25,
+        tail_home_pose_tolerance=0.06,
+        action_saturation_weight=0.5,
+        action_saturation_threshold=0.9,
+        leg_home_pose_broad_fraction=0.25,
+        leg_home_pose_broad_scale=6.0,
     )
 
 
@@ -79,6 +85,12 @@ def test_jax_reward_composer_matches_gymnasium_stance_components():
             "head_clearance_tolerance": env.head_clearance_tolerance,
             "neck_posture_weight": env.neck_posture_weight,
             "neck_posture_tolerance": env.neck_posture_tolerance,
+            "tail_home_pose_weight": env.tail_home_pose_weight,
+            "tail_home_pose_tolerance": env.tail_home_pose_tolerance,
+            "action_saturation_weight": env.action_saturation_weight,
+            "action_saturation_threshold": env.action_saturation_threshold,
+            "leg_home_pose_broad_fraction": env.leg_home_pose_broad_fraction,
+            "leg_home_pose_broad_scale": env.leg_home_pose_broad_scale,
             "height_weight": env.height_weight,
             "height_target_tolerance": env.height_target_tolerance,
         }
@@ -101,6 +113,8 @@ def test_jax_reward_composer_matches_gymnasium_stance_components():
             leg_home_pose_targets=jnp.asarray(env._leg_home_qpos),
             neck_posture_qpos_indices=tuple(int(index) for index in env._neck_home_qpos_indices),
             neck_posture_targets=jnp.asarray(env._neck_home_qpos),
+            tail_home_pose_qpos_indices=tuple(int(index) for index in env._tail_home_qpos_indices),
+            tail_home_pose_targets=jnp.asarray(env._tail_home_qpos),
             head_clearance_site_id=env.head_tip_site_id,
         )
 
@@ -111,6 +125,8 @@ def test_jax_reward_composer_matches_gymnasium_stance_components():
             "reward_leg_home_pose": "leg_home_pose",
             "reward_head_clearance": "head_clearance",
             "reward_neck_posture": "neck_posture",
+            "reward_tail_home_pose": "tail_home_pose",
+            "reward_action_saturation": "action_saturation",
             "reward_height": "height",
         }
         diagnostic_pairs = {
@@ -125,6 +141,9 @@ def test_jax_reward_composer_matches_gymnasium_stance_components():
             "head_clearance_quality": "_head_clearance_quality",
             "neck_posture_error": "_neck_posture_error",
             "neck_posture_quality": "_neck_posture_quality",
+            "tail_home_pose_error": "_tail_home_pose_error",
+            "tail_home_pose_quality": "_tail_home_pose_quality",
+            "action_saturation": "_action_saturation_fraction",
             "height_error": "_height_error",
             "height_quality": "_height_quality",
         }
@@ -154,6 +173,9 @@ def test_mjx_zero_defaults_preserve_p5_p7_policy_dimensions():
     assert weights["leg_home_pose_weight"] == 0.0
     assert weights["head_clearance_weight"] == 0.0
     assert weights["neck_posture_weight"] == 0.0
+    assert weights["tail_home_pose_weight"] == 0.0
+    assert weights["action_saturation_weight"] == 0.0
+    assert weights["leg_home_pose_broad_fraction"] == 0.0
     assert weights["height_target_tolerance"] == 0.0
 
 
@@ -180,9 +202,18 @@ def test_stage1_factory_enables_stance_terms_without_changing_dimensions():
     assert weights["leg_home_pose_weight"] == pytest.approx(0.5)
     assert weights["head_clearance_weight"] == pytest.approx(0.35)
     assert weights["neck_posture_weight"] == pytest.approx(0.20)
+    assert weights["tail_home_pose_weight"] > 0.0
+    assert weights["action_saturation_weight"] > 0.0
+    assert weights["leg_home_pose_broad_fraction"] > 0.0
     assert weights["height_target_tolerance"] == pytest.approx(0.06)
     assert len(env._leg_home_pose_qpos_indices) == 8
     assert len(env._neck_posture_qpos_indices) == 3
+    assert len(env._tail_home_pose_qpos_indices) == 4
+    # The settled-droop targets are duplicated constants (SB3 class attr,
+    # MJX registry); this is the pin that keeps them from drifting apart.
+    from environments.trex.envs.trex_env import TRexEnv
+
+    assert tuple(float(v) for v in env._tail_home_pose_targets) == pytest.approx(TRexEnv._TAIL_SETTLED_QPOS)
     assert env._head_clearance_site_id is not None
 
 

--- a/website/src/data/species.generated.json
+++ b/website/src/data/species.generated.json
@@ -417,7 +417,7 @@
           "config_path": "configs/trex/stage1_balance.toml",
           "timesteps": 10000000,
           "advancement_gate": {
-            "min_avg_reward": 1940.0,
+            "min_avg_reward": 2100.0,
             "min_avg_episode_length": null,
             "min_avg_forward_velocity": null,
             "min_success_rate": null,


### PR DESCRIPTION
## What

Three measured responses to the knee-lock run's reward audit (postmortem in #503), each opt-in with zero registry defaults. Companion to #503 (the 10 Hz filter) — the two PRs are independent and can merge in either order.

1. **`action_saturation` penalty** (weight 0.5, threshold 0.9). A saturated command cannot oscillate, so it's invisible to the smoothness/jerk penalties — "park the joint at its stop" was the cheapest way to be smooth, and the run parked **six of fifteen actuators** (both knees, head_pitch, the whole tail chain). Linear ramp from |action| = 0.9 to 1.0, mean across actuators: the parked stance pays ~−200/episode, one actuator transiently saturating during a genuine correction pays 0.5/15 per step, and the statue (zero commands) pays nothing.

2. **`tail_home_pose` term** (weight 0.25, tolerance 0.05 rad). The tail joints were the one actuator group with no positional term — the existing tail term prices tail-*tip angular velocity*, which a tail frozen against a hard stop satisfies perfectly. The new term prices the joint positions themselves. **Targets are the measured settled droop, not the keyframe**: measurement showed the passive tail cannot hold the authored zeros against gravity — it settles onto its ventral stops (−0.2107 / −0.2029 / −0.0926 rad with sub-milliradian spread across 40 seeds), so a keyframe target would cap the *ideal statue* at ~0.25 quality. The settled targets live plant-side (`TRexEnv._TAIL_SETTLED_QPOS` = MJX registry `tail_home_pose_targets`, same precedent as `target_standing_z = 0.9260`), and the stage-1 factory test pins the two copies equal. At these targets the statue scores ~1.0 and every parked-tail pose from the run scores ~0.

3. **Long-range gradient for `leg_home_pose`** (`broad_fraction` 0.25, `broad_scale` 6). The run falsified the narrowed Gaussian as a capture mechanism: home error rose monotonically 0.20 → 0.545 rad against a numerically zero gradient. The term now mixes in a 6×-wider Gaussian — at the measured crouch distance the mixture still pays 0.44 quality with live gradient, at home both components are 1 (maximum unchanged), and the default (0.0) reproduces the historical single-Gaussian arithmetic exactly.

## Wiring

All four reward sites (SB3 `_get_reward_info` + total sum, the MJX training kernel, `compute_total_reward`, `compute_reward_components` with `_`-prefixed diagnostics), `_KNOWN_REWARD_KEYS`, the construction-time validation pair lists on both backends, `DiagnosticsCallback.REWARD_KEYS`/`INFO_KEYS`, the visualization weight map, and the reward parity test (new component pairs at 1e-6 plus the total-sum check; zero-defaults test extended to pin the new weights at 0.0).

## Rails re-derived

Adding terms moves the statue, so both statue-derived constants are re-measured with the pack (zero_action_baseline.py seed 3042, 40 episodes, noise 0.05; stance_quality_baseline.py agrees):

| constant | before | after |
|---|---|---|
| statue standing reward | 3241.3 ± 14.6 | **3495.2 ± 13.9** |
| `min_avg_reward` (0.60×, nearest 10) | 1940 | **2100** |
| `collapse_peak_floor_reference` | 3241.3 | **3495.2** |

The +254 decomposes exactly: +250 tail term at its settled targets, ~+4 broad-leg component at the statue's own hip-pitch sag, +0 saturation. Physics stays r7; `statue_constants_physics_revision` unchanged; committed species catalog regenerated.

## Tests

Green locally: reward parity + reward functions + species catalog; the full trex suite + diagnostics + stance gate + gate report + jax eval + config; MJX env + species integration + plant contract + statue freshness; velociraptor/brachiosaurus/dibothrosuchus suites (zero defaults preserve their rewards byte-for-byte). Both ruff versions clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb

---
_Generated by [Claude Code](https://claude.ai/code/session_015Lcr2GVvrFJxaRA5THVbEb)_