### PR TITLE
Fix the recovery-stage crash in Colab: resolve the plant model path against the repo root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   probe did.
 
 ### Fixed
+- **The recovery stage can now start from Colab** (found by three field
+  runs, each dying silently at the stance/recovery boundary). Plant
+  identities record `model_path` repository-relative, and
+  `derive_stage_task_fingerprint` passed it straight to
+  `mujoco.MjModel.from_xml_path`, which resolves against the process cwd —
+  correct in the test suite (cwd = repo root), fatal in Colab, whose
+  notebook adds the clone to `sys.path` without chdir-ing into it. The
+  first pushed-stage fingerprint therefore raised `ParseXML` before the
+  stage directory existed, halting run-all with nothing in Drive to show
+  why; push-free stages never load the model, which is exactly why three
+  full stance runs sailed through the same code. The path now resolves
+  against the repository root (absolute paths pass through), a missing
+  model raises a `TaskFingerprintError` that names both paths, and a
+  regression test pins that the fingerprint is cwd-independent.
 - **The plant contract now records the perturbation engine** (CI caught
   what the pre-merge review missed). Every policy-interface fingerprint
   moved when `BaseDinoEnv.reset`/`step` learned to derive and apply push

--- a/environments/shared/task_fingerprint.py
+++ b/environments/shared/task_fingerprint.py
@@ -53,6 +53,13 @@ MODEL_TASK_ATTRIBUTE = "mesozoic_task_fingerprint"
 #: Warm-start lineage record, persisted the same way on the CHILD checkpoint.
 MODEL_TASK_LINEAGE_ATTRIBUTE = "mesozoic_task_lineage"
 
+#: Plant identities record model_path REPO-RELATIVE (the identity must not
+#: depend on where a checkout lives), so resolving it against the process
+#: cwd only works when that happens to be the repository root — true in the
+#: test suite, false in Colab, whose notebook adds the clone to sys.path
+#: without chdir-ing into it.
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
 LOAD_MODES = ("resume_same_stage", "initialize_next_stage")
 
 _MISSING = object()
@@ -254,7 +261,16 @@ def derive_stage_task_fingerprint(
 
         from .perturbation import derive_push_parameters
 
-        model = mujoco.MjModel.from_xml_path(str(plant_identity["model_path"]))
+        model_path = Path(str(plant_identity["model_path"]))
+        if not model_path.is_absolute():
+            model_path = _REPOSITORY_ROOT / model_path
+        if not model_path.exists():
+            raise TaskFingerprintError(
+                f"pushed task fingerprint cannot find the plant model at {model_path} "
+                f"(identity records {plant_identity['model_path']!r}); the recorded path "
+                "must be repository-relative or absolute"
+            )
+        model = mujoco.MjModel.from_xml_path(str(model_path))
         params = derive_push_parameters(
             model,
             capture_velocity_multiple=multiple,

--- a/environments/shared/tests/test_task_fingerprint.py
+++ b/environments/shared/tests/test_task_fingerprint.py
@@ -188,6 +188,38 @@ class TestDeriveStageFingerprint:
                 plant_identity={"physics_sha256": "sha256:aaaa"},
             )
 
+    def test_pushed_stage_resolves_model_path_from_any_cwd(self, tmp_path, monkeypatch):
+        """The identity's repo-relative model_path must not depend on cwd.
+
+        Regression: Colab adds the clone to sys.path without chdir-ing into
+        it, so the first pushed-stage fingerprint (the notebook's recovery
+        cell) crashed on ParseXML before the stage directory existed —
+        run-all halted at the stance/recovery boundary with no artifact to
+        show why, twice.
+        """
+        pytest.importorskip("mujoco")
+        kwargs = dict(
+            species="trex",
+            stage="recovery",
+            backend="stable-baselines3",
+            env_kwargs={**_ENV, "perturbation_capture_velocity_multiple": 1.5},
+            plant_identity=_PLANT,
+        )
+        at_root = derive_stage_task_fingerprint(**kwargs)
+        monkeypatch.chdir(tmp_path)
+        elsewhere = derive_stage_task_fingerprint(**kwargs)
+        assert elsewhere["task_sha256"] == at_root["task_sha256"]
+
+    def test_pushed_stage_names_a_missing_model_clearly(self):
+        with pytest.raises(TaskFingerprintError, match="cannot find the plant model"):
+            derive_stage_task_fingerprint(
+                species="trex",
+                stage="recovery",
+                backend="stable-baselines3",
+                env_kwargs={"perturbation_capture_velocity_multiple": 1.5},
+                plant_identity={"model_path": "environments/trex/assets/no_such_model.xml"},
+            )
+
 
 class TestStageConfigWiring:
     def test_save_stage_config_writes_the_sidecar(self, tmp_path):


### PR DESCRIPTION
Fixes the silent crash that killed three field runs at the stance→recovery boundary.

## The bug

Plant identities record `model_path` **repository-relative** (`environments/trex/assets/trex.xml`), and `derive_stage_task_fingerprint` passed it straight to `mujoco.MjModel.from_xml_path`, which resolves against the **process cwd**:

- The test suite runs from the repo root, so every test passed.
- The Colab notebook clones the repo to `/content/mesozoic-labs` and adds it to `sys.path` **without chdir-ing into it**, so from `/content` the load raises `ValueError: ParseXML: Error opening file 'environments/trex/assets/trex.xml'`.
- The crash fires *before* `train_stage` creates the stage directory, so nothing syncs to Drive to show why — and it halts run-all, so stage 2 never starts either.
- Push-free stages never load the model (the perturbation branch is the only caller), which is exactly why three full stance runs sailed through the identical code path and only the recovery cell died. Reproduced deterministically by running the recovery fingerprint from any non-repo-root cwd.

## The fix

- `derive_stage_task_fingerprint` resolves a relative `model_path` against the repository root; absolute paths pass through unchanged.
- A genuinely missing model now raises `TaskFingerprintError` naming both the resolved and the recorded path, instead of MuJoCo's bare `ParseXML` error.
- Regression tests pin that the pushed-stage fingerprint is **cwd-independent** (same `task_sha256` from the repo root and from a temp dir) and that the not-found error is legible. CHANGELOG entry included.

## Verification

- `test_task_fingerprint.py`: 20/20 pass (18 existing + 2 new).
- End-to-end from a foreign cwd: the recovery fingerprint now derives the correct r7 constants (165.5 N / 0.20 s).
- `ruff` clean; `mypy` reports zero errors in the changed file.

After merge, the notebook's §5b recovery cell can run against the banked stance checkpoint with no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RoGFEnSMChqVqXSmNE4vZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016RoGFEnSMChqVqXSmNE4vZ)_