### PR TITLE
Record the off-distribution and checkpoint-comparison panel results (§6.1, §6.2)

### DIFF
--- a/docs/investigations/TREX_RECOVERY_STAGE_FIRST_RUNS_2026_08.md
+++ b/docs/investigations/TREX_RECOVERY_STAGE_FIRST_RUNS_2026_08.md
@@ -315,9 +315,100 @@ Once §6.1 and §6.2 land, write `gate_resolution.json` with:
 
 ## 8. Not done
 
-* The 5M recovery checkpoint has not been panel-tested (§6.2).
-* No off-distribution schedule has been rolled (§6.1).
+* ~~The 5M recovery checkpoint has not been panel-tested (§6.2).~~ Done 2026-08-28 — see §9.
+* ~~No off-distribution schedule has been rolled (§6.1).~~ Done 2026-08-28 — see §9.
 * `diagnostics.npz` per-step series were not re-analyzed for either run.
 * No MJX/JAX recovery run exists; every number here is SB3.
 * Recovery runs are excluded from result bundles by design — the bundle
   schema remains integer-stage until that migration.
+
+---
+
+## 9. §6.1 off-distribution result and §6.2 comparison — 2026-08-28
+
+**Method.** Ten panels, 40 episodes each, seeds 3042–3081, calibrated
+posture-only safe set (height ref 0.9267 m fixed, height error ≤ 0.0168,
+tilt ≤ 0.0825, speed ≤ 0.3203), `t_recover` 100, dwell 50 — the same judge
+that reproduced the frozen statue panel exactly (2026-08 review §5.1).
+Controllers are each run's `robust_best_model`. Nulls are the frozen statue
+panels of 2026-08-23 (review §5.2), paired per seed.
+
+*Instrumentation note:* `PPO.load` segfaults on Colab's current image
+(Python 3.13 / torch 2.11), while `torch.load` of the checkpoint's tensors
+succeeds. The panels therefore ran through a NumPy reimplementation of the
+SB3 deterministic forward (two tanh layers → linear head → clip to the
+action space), verified against `predict(deterministic=True)` to a maximum
+absolute difference of 6.5e-9 over 200 observations. The numbers are
+SB3-identical; only the inference path differs.
+
+### 9.1 The schedule was NOT memorized — §6.1 is answered
+
+Per-shove recovery, which controls for the differing number of pushes each
+schedule delivers:
+
+| schedule | statue | 3M policy | 5M policy |
+|---|---:|---:|---:|
+| training (165.5 N, 2.0 ± 0.5 s) | 18/50 — 36.0% | 123/147 — **83.7%** | 127/153 — **83.0%** |
+| timing (165.5 N, 3.5 ± 1.5 s) | 14/43 — 32.6% | 73/84 — **86.9%** | 77/86 — **89.5%** |
+| 120 N | 42/81 — 51.9% | 155/158 — 98.1% | 155/160 — 96.9% |
+| 210 N | 4/42 — 9.5% | 46/99 — 46.5% | 64/114 — 56.1% |
+
+**The trained cadence is not the policy's best.** Per-shove recovery is
+*higher* at the never-trained 3.5 ± 1.5 s cadence than at the trained
+2.0 ± 0.5 s, for both checkpoints, and episode success follows (28/40 and
+31/40 vs 20/40 and 19/40). A policy that had learned the training rhythm
+would degrade when the rhythm changed; this one improves. The memorization
+hypothesis is refuted, and success instead orders by disturbance severity —
+what genuine disturbance rejection predicts.
+
+Episode-level success and paired margins over the frozen statue:
+
+| schedule | 3M | 5M | statue | 3M − statue (LCB95) | 5M − statue (LCB95) |
+|---|---:|---:|---:|---:|---:|
+| training | 20/40 | 19/40 | 0/40 | +0.500 (+0.365) | +0.475 (+0.340) |
+| timing | 28/40 | 31/40 | 0/40 | +0.700 (+0.576) | +0.775 (+0.662) |
+| 120 N | 37/40 | 36/40 | 2/40 | +0.875 (+0.786) | +0.850 (+0.754) |
+| 210 N | 2/40 | 4/40 | 0/40 | +0.050 (−0.009) | +0.100 (+0.019) |
+
+### 9.2 The limit is magnitude, not timing
+
+At 210 N (≈1.9× capture velocity) the episode-level margin over the statue
+collapses: the 3M policy's paired LCB is **−0.009 — not significant**, the
+5M policy's +0.019 only marginally so. Control has not vanished (per-shove
+46–56% vs the statue's 9.5%; mean length 606/686 steps vs 315), but the
+episode-level conjunction — full horizon *and* every shove recovered —
+becomes unattainable. **The capability ceiling sits between 165.5 N and
+210 N**, and that, not the push clock, is what limits the stage.
+
+### 9.3 §6.2 — the 5M budget bought nothing
+
+Paired per-seed differences, 5M − 3M: training −0.025 (LCB −0.190), timing
++0.075 (−0.089), 120 N −0.025 (−0.120), 210 N +0.050 (−0.054). All four
+straddle zero: the two checkpoints are statistically indistinguishable on
+every schedule. This confirms the 5M → 3M budget reversion adopted
+2026-08-23 and closes §6.2.
+
+### 9.4 The brace null reproduces
+
+Both brace controllers score 0/40 (UCB95 7.2%) with mean lengths 326 and
+308 steps — again dying *faster* than the statue's 360. §3.1's mechanism
+claim (the policy's stance is held by feedback, not by a stable pose)
+reproduces independently on the calibrated judge.
+
+### 9.5 Consequences for P5
+
+* **The blocking experiment is done.** Rejection generalizes in timing and
+  degrades gracefully in magnitude, so the stage measures control, not
+  schedule familiarity. Per-episode randomization of the push clock is
+  *not* required.
+* **`min_recovery_success_lcb` is now a measured choice.** The attainable
+  training-schedule LCB is 0.361 (3M) / 0.338 (5M) against a null UCB of
+  0.072. The plan's aspirational 0.725 needs a materially stronger policy;
+  freezing a first threshold near 0.30 would certify what the stage can
+  actually do today, with the 210 N ceiling recorded as the known envelope.
+* **Use 20/40, not 21/40**, for the 3M policy at the training schedule: the
+  live judge here measures 20/40 where §4.3's offline re-judge recorded
+  21/40. One episode at the margin; §4's exact-reproduction claim covers the
+  provisional panels only.
+* Per-episode randomization of *magnitude* remains worth considering — not
+  to fix memorization, which does not exist, but to push the 210 N ceiling.

--- a/docs/reviews/TREX_REVIEW_2026_08_MERGES_AND_NEXT_STEPS.md
+++ b/docs/reviews/TREX_REVIEW_2026_08_MERGES_AND_NEXT_STEPS.md
@@ -403,28 +403,26 @@ So 2.0 m/s is defensible as the stage's *capability target* but not as an
 Either way the gate stops being a velociraptor constant, and the floor
 pair (above) lands with it.
 
-### 5.4 Blocked half: the trained-policy panels (A1-on-policy, A2)
+### 5.4 Trained-policy panels — completed 2026-08-28
 
-The checkpoints are owner-private in Drive; the connected Drive tool can
-neither link-share nor carry a 4 MB binary, and unauthenticated download
-returns the sign-in page. Two ways to unblock, either is enough:
+Run in Colab against both recovery checkpoints (the `PPO.load` segfault on
+Colab's torch 2.11 image was bypassed with a NumPy reimplementation of the
+SB3 deterministic forward, verified to 6.5e-9). Full numbers and paired
+statistics are in `docs/investigations/TREX_RECOVERY_STAGE_FIRST_RUNS_2026_08.md`
+§9. Headlines:
 
-1. **Link-share six files** (Drive → Share → "Anyone with the link",
-   Viewer) and the panels run here in minutes:
-   run `20260821_142144/02_recovery/models/`: `robust_best_model.zip`,
-   `robust_best_model_vecnorm.pkl`, `recovery_final.zip`,
-   `recovery_final_vecnorm.pkl`; run `20260819_154702/recovery/models/`:
-   `robust_best_model.zip`, `robust_best_model_vecnorm.pkl` (the 21/40
-   policy — re-rolling it also cross-validates the local judge on a
-   trained controller).
-2. **Run the harness in Colab** where Drive is mounted — the §6.1/§6.2
-   matrix is:
-   `--controller policy --schedule {on,timing,mag120,mag210} --safe-set
-   calibrated` for each checkpoint, plus `--controller brace --schedule on`
-   for the mechanism claim.
-
-The statue halves of every schedule are already frozen above, so the
-policy rolls complete the paired comparison directly.
+* **§6.1 answered — the push schedule was not memorized.** Per-shove
+  recovery is *higher* at the never-trained 3.5 ± 1.5 s cadence (86.9% /
+  89.5%) than at the trained 2.0 ± 0.5 s (83.7% / 83.0%); episode success
+  likewise (28/40, 31/40 vs 20/40, 19/40). Success orders by disturbance
+  severity, not by familiarity.
+* **The ceiling is magnitude.** At 210 N the paired margin over the frozen
+  statue collapses to LCB −0.009 (3M) / +0.019 (5M). The capability limit
+  sits between 165.5 N and 210 N.
+* **§6.2 answered — 5M bought nothing.** Paired 5M − 3M differences straddle
+  zero on all four schedules, confirming the 3M budget reversion.
+* **P5 is unblocked**, with `min_recovery_success_lcb` now a measured
+  choice: attainable LCB 0.361 against a null UCB of 0.072.
 
 ---
 


### PR DESCRIPTION
Docs only. Records the two experiments the first-runs investigation listed as
not done, and that P5 was waiting on.

**Method.** Ten panels, 40 episodes each, seeds 3042–3081, calibrated
posture-only safe set (height reference 0.9267 m fixed, height error ≤ 0.0168,
tilt ≤ 0.0825, speed ≤ 0.3203), `t_recover` 100, dwell 50 — the same judge that
reproduced the frozen statue panel exactly. Controllers are each run's
`robust_best_model`; nulls are the frozen statue panels of 2026-08-23, paired
per seed.

*Instrumentation note:* `PPO.load` segfaults on Colab's current image
(Python 3.13 / torch 2.11) while `torch.load` of the checkpoint tensors
succeeds, so the panels ran through a NumPy reimplementation of the SB3
deterministic forward, verified against `predict(deterministic=True)` to a
maximum absolute difference of 6.5e-9 over 200 observations. The numbers are
SB3-identical; only the inference path differs.

## §6.1 — the push schedule was not memorized

Per-shove recovery, which controls for the differing number of pushes each
schedule delivers:

| schedule | statue | 3M policy | 5M policy |
|---|---:|---:|---:|
| training (165.5 N, 2.0 ± 0.5 s) | 36.0% | 83.7% | 83.0% |
| timing (165.5 N, 3.5 ± 1.5 s) | 32.6% | **86.9%** | **89.5%** |
| 120 N | 51.9% | 98.1% | 96.9% |
| 210 N | 9.5% | 46.5% | 56.1% |

The trained cadence is not the policy's best. Per-shove recovery is *higher* at
the never-trained 3.5 ± 1.5 s cadence than at the trained 2.0 ± 0.5 s, for both
checkpoints, and episode success follows (28/40 and 31/40 vs 20/40 and 19/40).
A policy that had learned the training rhythm would degrade when the rhythm
changed; this one improves. Success orders by disturbance severity instead —
what genuine disturbance rejection predicts.

**The limit is magnitude, not timing.** At 210 N the paired margin over the
statue collapses to LCB −0.009 (3M, not significant) and +0.019 (5M, marginal),
placing the capability ceiling between 165.5 N and 210 N.

## §6.2 — the 5M budget bought nothing

Paired per-seed differences (5M − 3M): training −0.025 (LCB −0.190), timing
+0.075 (−0.089), 120 N −0.025 (−0.120), 210 N +0.050 (−0.054). All four straddle
zero, confirming the 5M → 3M budget reversion.

Both brace nulls scored 0/40 and died *faster* than the statue (326/308 vs 360
steps), independently reproducing the feedback-not-posture mechanism claim.

## Consequences

P5's blocking experiment is done, and `min_recovery_success_lcb` becomes a
measured choice: attainable LCB 0.361 against a null UCB of 0.072, where the
plan's aspirational 0.725 needs a materially stronger policy. Per-episode
randomization of the push *clock* is not required; randomizing *magnitude* is
now the lever for the 210 N ceiling.

One value corrected: the live judge measures the 3M policy at **20/40** where
§4.3's offline re-judge recorded 21/40 — one episode at the margin, and §4's
exact-reproduction claim covers the provisional panels only.

## Changes

- `docs/investigations/TREX_RECOVERY_STAGE_FIRST_RUNS_2026_08.md` — new §9 with
  the full tables, paired statistics and P5 consequences; the two §8 "not done"
  items struck through.
- `docs/reviews/TREX_REVIEW_2026_08_MERGES_AND_NEXT_STEPS.md` — §5.4 now records
  the result instead of the blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbSfeqDdAQnEQsXRTZNnbN

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbSfeqDdAQnEQsXRTZNnbN)_