### PR TITLE
Remove optional Compsognathus model checks from SB3 notebook

### DIFF
--- a/docs/SPECIES_NAMING.md
+++ b/docs/SPECIES_NAMING.md
@@ -29,8 +29,7 @@ result artifacts are not renamed. Regenerate public catalog labels with
 
 Both Compsognathus variants are training selections in the SB3 notebook, with
 separate environment classes, configs, normalization statistics and checkpoint
-identities. Its optional Compsognathus check still runs the standing model
-protocol independently of training. The Ray Tune notebook includes both
+identities. The Ray Tune notebook includes both
 variants with initial PPO/SAC search spaces. JAX/MJX support remains limited to
 the original four species; backend-specific selectors follow the manifest.
 See the [training guide](../environments/compsognathus/README.md#training).

--- a/notebooks/sb3_training.ipynb
+++ b/notebooks/sb3_training.ipynb
@@ -15,7 +15,7 @@
    "metadata": {
     "id": "6kes1b_8h7I1"
    },
-   "source": "# Mesozoic Labs — Stable-Baselines3 Training\n\nTrain one of the registered species through balance, locomotion, and a species-specific simulator task with PPO or SAC. The optional Compsognathus Longipes section inspects and validates the anatomical and robot models.\n\nRun the full Stage 1 → Stage 2 → Stage 3 curriculum in order within one notebook session. Later stages consume model and result objects held in memory; files saved to Drive support analysis and archival, but this SB3 notebook does not reconstruct a cross-session curriculum continuation.\n\nChange `SPECIES` in the configuration cell below. Stage budgets, environment settings, and algorithm hyperparameters are loaded from each species' `configs/<species>/stages.toml` manifest (or legacy `stage*.toml` files); those files and the generated species catalog are authoritative. Values differ by species and stage, so this notebook does not duplicate them.\n\nFor a smoke test, override the budget deliberately. For a full run, start with the configured values, measure memory and throughput on the target machine, and adjust parallel environments only from observed resource use. The repository does not publish a validated hardware-to-runtime or batch-size table."
+   "source": "# Mesozoic Labs — Stable-Baselines3 Training\n\nTrain one of the registered species through balance, locomotion, and a species-specific simulator task with PPO or SAC.\n\nRun the full Stage 1 → Stage 2 → Stage 3 curriculum in order within one notebook session. Later stages consume model and result objects held in memory; files saved to Drive support analysis and archival, but this SB3 notebook does not reconstruct a cross-session curriculum continuation.\n\nChange `SPECIES` in the configuration cell below. Stage budgets, environment settings, and algorithm hyperparameters are loaded from each species' `configs/<species>/stages.toml` manifest (or legacy `stage*.toml` files); those files and the generated species catalog are authoritative. Values differ by species and stage, so this notebook does not duplicate them.\n\nFor a smoke test, override the budget deliberately. For a full run, start with the configured values, measure memory and throughput on the target machine, and adjust parallel environments only from observed resource use. The repository does not publish a validated hardware-to-runtime or batch-size table."
   },
   {
    "cell_type": "markdown",
@@ -238,50 +238,6 @@
     ")\n",
     "print(f\"Run directory: {RUN_DIR}\")\n",
     "print(f\"Provenance:    {PROVENANCE_PATH}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "compsognathus-model-checks"
-   },
-   "source": [
-    "### Optional: Compsognathus Longipes model checks\n",
-    "\n",
-    "Set `CHECK_COMPSOGNATHUS_MODELS = True` to run the 26-trial standing protocol for both the anatomical proxy and robot. The robot has 12 leg motors, a fixed head, a fixed unpowered tail, one forward camera, an IMU and joint encoders.\n",
-    "\n",
-    "This checks fixed-target standing, seeded reset perturbations, 15% mass/inertia growth and motors-off behavior. It does not run SB3 or establish walking performance. Results are saved under `<LOG_BASE>/compsognathus/model_checks/`, separately from the selected species' training run.\n",
-    "\n",
-    "Local setup for this optional cell: `python -m pip install -e \".[test]\"`. The preview is a committed render; these checks do not require a rendering backend. See the [model and training README](../environments/compsognathus/README.md) for the sensor contract and design limits.\n",
-    "\n",
-    "![Compsognathus Longipes anatomical proxy and Rev B robot](https://raw.githubusercontent.com/kuds/mesozoic-labs/main/environments/compsognathus/data/model_preview.png)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "run-compsognathus-model-checks"
-   },
-   "outputs": [],
-   "source": [
-    "# Optional model validation, independent of the SB3 curriculum.\n",
-    "CHECK_COMPSOGNATHUS_MODELS = False  # @param {type:\"boolean\"}\n",
-    "\n",
-    "if CHECK_COMPSOGNATHUS_MODELS:\n",
-    "    import json\n",
-    "\n",
-    "    from environments.compsognathus.scripts.validate_models import validate\n",
-    "\n",
-    "    prototype_report = validate()\n",
-    "    prototype_dir = LOG_BASE / \"compsognathus\" / \"model_checks\"\n",
-    "    prototype_dir.mkdir(parents=True, exist_ok=True)\n",
-    "    prototype_path = prototype_dir / f\"{datetime.now():%Y%m%d_%H%M%S_%f}.json\"\n",
-    "    prototype_path.write_text(json.dumps(prototype_report, indent=2, allow_nan=False) + \"\\n\")\n",
-    "    print(f\"{species_display_name('compsognathus')}: {len(prototype_report['trials'])} model trials; passed={prototype_report['passed']}\")\n",
-    "    print(f\"Model-check report: {prototype_path}\")\n",
-    "    if not prototype_report[\"passed\"]:\n",
-    "        raise RuntimeError(f\"Compsognathus Longipes model checks failed; inspect {prototype_path}\")\n"
    ]
   },
   {


### PR DESCRIPTION
The optional Compsognathus model-validation section adds a preview and a separate standing protocol to the SB3 training notebook. Those checks already have standalone commands and tests, so they clutter the training workflow.

This removes the section's markdown and code cells, its introductory description, and the outdated reference in the species-naming guide. The retained training cells, species selections, baseline and curriculum gates are unchanged.

Validation: all 22 remaining code cells parse; an exact cell comparison confirms retained training cells are unchanged; 18 focused species-selection and notebook-contract checks passed. The published Git tree matches the validated local tree.